### PR TITLE
Improve travis's conda package caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache:
   directories:
     # Cache conda pkg directory
     - $HOME/miniconda/pkgs
+before_cache:
+  - conda clean -tipsy
+  - rm -f $HOME/miniconda/pkgs/urls.txt
+
 install:
   - sudo apt-get update
 
@@ -19,7 +23,6 @@ install:
 
   # Install and update test environment
   - conda env update -f environment.yml
-  - conda clean -tipsy
 
   - source activate tmol
   - pip install -r requirements.tests.txt


### PR DESCRIPTION
Eliminates unneeded repack of conda package cache for travis build cache due to modification of the package source URL listing at `urls.txt`. Moves conda clean step to the "pre-cache" build phase to clarify intended purpose of clean step.