### PR TITLE
Add "atom metadata" buffer to packed residue system.

### DIFF
--- a/tmol/score/__init__.py
+++ b/tmol/score/__init__.py
@@ -20,7 +20,7 @@ def system_graph_params(system, drop_missing_atoms=False, requires_grad=True):
     coords = torch.autograd.Variable(
         RealTensor(system.coords), requires_grad=requires_grad
     )
-    atom_types = system.atom_types.copy()
+    atom_types = system.atom_metadata["atom_type"].copy()
 
     if drop_missing_atoms:
         atom_types[numpy.any(numpy.isnan(system.coords), axis=-1)] = None
@@ -29,7 +29,7 @@ def system_graph_params(system, drop_missing_atoms=False, requires_grad=True):
         system_size=len(coords),
         bonds=bonds,
         coords=coords,
-        atom_types=atom_types
+        atom_types=atom_types,
     )
 
 

--- a/tmol/system/residue/restypes.py
+++ b/tmol/system/residue/restypes.py
@@ -1,43 +1,20 @@
 from frozendict import frozendict
 from toolz.curried import concat, map, compose
-from typing import Mapping, Tuple
+from typing import Mapping
 import attr
 
 import numpy
 
-import collections
-
 import tmol.database.chemical
 
 
-class AttrMapping(collections.abc.Mapping):
-    @classmethod
-    def from_dict(cls, d):
-        return cls(**d)
-
-    def __getitem__(self, k):
-        return getattr(self, k)
-
-    def __iter__(self):
-        return iter(self.__slots__)
-
-    def __len__(self):
-        return len(self.__slots__)
-
-
 @attr.s(slots=True, frozen=True)
-class ResidueType(tmol.database.chemical.Residue, AttrMapping):
+class ResidueType(tmol.database.chemical.Residue):
     atom_to_idx: Mapping[str, int] = attr.ib()
 
     @atom_to_idx.default
     def _setup_atom_to_idx(self):
         return frozendict((a.name, i) for i, a in enumerate(self.atoms))
-
-    qualified_atom_types: Tuple[str] = attr.ib()
-
-    @qualified_atom_types.default
-    def _setup_qualified_atom_types(self):
-        return tuple("/".join((self.name, a.atom_type)) for a in self.atoms)
 
     coord_dtype: numpy.dtype = attr.ib()
 
@@ -103,7 +80,7 @@ class Residue:
     def _repr_pretty_(self, p, cycle):
         p.text("Residue")
         with p.group(1, "(", ")"):
-            p.text("type=")
+            p.text("residue_type=")
             p.pretty(self.residue_type)
             p.text(", coords=")
             p.break_()


### PR DESCRIPTION
Replace atom type array with generic atom metadata buffer containing
residue, name and type information. Convert score graph initialization
to extract type data from atom metadata.

Minor cleanup of restypes objects.