### PR TITLE
Fixup dev_setup and dev environment.

### DIFF
--- a/dev_environment.yml
+++ b/dev_environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - flake8
   - pytest
   - pytest-cov
-  - pyrosetta=2017.48.post.dev+119.fordas.devbase.cce4ea9c848
+  - asford::pyrosetta=2017.48.post.dev+119.fordas.devbase.cce4ea9c848
 
   - pip:
     - yapf

--- a/dev_setup
+++ b/dev_setup
@@ -8,6 +8,10 @@ set -x
 conda env update -f environment.yml
 conda env update -f dev_environment.yml
 
+# Conda 4.4+ compatible activation
+eval "`conda shell.posix activate tmol`"
+pip install -e .
+
 set +e
 pushd .git/hooks
 ln -s ../../.post-checkout post-checkout


### PR DESCRIPTION
Fixes dev_setup script to perform editable install of tmol source via pip
after conda environment update. Requires conda 4.4+.

Update pyrosetta listing in dev environment to point to anaconda.org channel.