### PR TITLE
Add named torsion and connection metadata to residue system.

### DIFF
--- a/tmol/database/chemical/__init__.py
+++ b/tmol/database/chemical/__init__.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Optional
 
 import attr
 import cattr
@@ -15,13 +15,34 @@ class Atom:
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
+class Connection:
+    name: str
+    atom: str
+
+
+@attr.s(auto_attribs=True, frozen=True, slots=True)
+class ConnectedAtom:
+    atom: str
+    connection: Optional[str] = None
+
+
+@attr.s(auto_attribs=True, frozen=True, slots=True)
+class Torsion:
+    name: str
+    a: ConnectedAtom
+    b: ConnectedAtom
+    c: ConnectedAtom
+    d: ConnectedAtom
+
+
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class Residue:
     name: str
     name3: str
     atoms: Tuple[Atom, ...]
     bonds: Tuple[Tuple[str, str], ...]
-    lower_connect: str
-    upper_connect: str
+    connections: Tuple[Connection, ...]
+    torsions: Tuple[Torsion, ...]
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)

--- a/tmol/database/default/chemical/chemical.yaml
+++ b/tmol/database/default/chemical/chemical.yaml
@@ -57,8 +57,13 @@ residues:
     - [  CB,  1HB]
     - [  CB,  2HB]
     - [  CB,  3HB]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n: down, &a atom: N }
+    - { *n: up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, &c connection: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},                      b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},                     b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
   - name:  ARG
     name3: ARG
     atoms:
@@ -110,8 +115,18 @@ residues:
     - [ NH1, 2HH1]
     - [ NH2, 1HH2]
     - [ NH2, 2HH2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD}}
+    - { *n: chi3,  a: {*a: CB}, b: {*a: CG}, c: {*a: CD}, d: {*a: NE}}
+    - { *n: chi4,  a: {*a: CG}, b: {*a: CD}, c: {*a: NE}, d: {*a: CZ}}
   - name:  ASN
     name3: ASN
     atoms:
@@ -143,8 +158,16 @@ residues:
     - [  CG,  ND2]
     - [ ND2, 1HD2]
     - [ ND2, 2HD2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: OD1}}
   - name:  ASP
     name3: ASP
     atoms:
@@ -172,8 +195,16 @@ residues:
     - [  CB,  2HB]
     - [  CG,  OD1]
     - [  CG,  OD2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CA}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: OD1}}
   - name:  CYS
     name3: CYS
     atoms:
@@ -198,8 +229,16 @@ residues:
     - [  CB,  1HB]
     - [  CB,  2HB]
     - [  SG,   HG]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: SG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: SG}, d: {*a: HG}}
   - name:  GLN
     name3: GLN
     atoms:
@@ -237,8 +276,17 @@ residues:
     - [  CD,  NE2]
     - [ NE2, 1HE2]
     - [ NE2, 2HE2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD}}
+    - { *n: chi3,  a: {*a: CB}, b: {*a: CG}, c: {*a: CD}, d: {*a: OE1}}
   - name:  GLU
     name3: GLU
     atoms:
@@ -272,8 +320,17 @@ residues:
     - [  CD,  OE2]
     - [  CG,  1HG]
     - [  CG,  2HG]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD}}
+    - { *n: chi3,  a: {*a: CB}, b: {*a: CG}, c: {*a: CD}, d: {*a: OE1}}
   - name:  GLY
     name3: GLY
     atoms:
@@ -291,8 +348,13 @@ residues:
     - [   C,    O]
     - [  CA,  1HA]
     - [  CA,  2HA]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
   - name:  HIS
     name3: HIS
     atoms:
@@ -333,8 +395,16 @@ residues:
     - [ CE1,  NE2]
     - [ NE2,  HE2]
     - [ CE1,  HE1]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: ND1}}
   - name:  HIS_D
     name3: HIS
     atoms:
@@ -374,8 +444,16 @@ residues:
     - [ CE1,  NE2]
     - [ CE1,  HE1]
     - [ ND1,  HD1]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: ND1}}
   - name:  ILE
     name3: ILE
     atoms:
@@ -417,8 +495,16 @@ residues:
     - [ CD1, 1HD1]
     - [ CD1, 2HD1]
     - [ CD1, 3HD1]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG1}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG1}, d: {*a: CD1}}
   - name:  LEU
     name3: LEU
     atoms:
@@ -460,8 +546,16 @@ residues:
     - [ CD2, 1HD2]
     - [ CD2, 2HD2]
     - [ CD2, 3HD2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD1}}
   - name:  LYS
     name3: LYS
     atoms:
@@ -509,8 +603,18 @@ residues:
     - [  NZ,  1HZ]
     - [  NZ,  2HZ]
     - [  NZ,  3HZ]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD}}
+    - { *n: chi3,  a: {*a: CB}, b: {*a: CG}, c: {*a: CD}, d: {*a: CE}}
+    - { *n: chi4,  a: {*a: CG}, b: {*a: CD}, c: {*a: CE}, d: {*a: NZ}}
   - name:  MET
     name3: MET
     atoms:
@@ -548,8 +652,17 @@ residues:
     - [  CE,  1HE]
     - [  CE,  2HE]
     - [  CE,  3HE]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: SD}}
+    - { *n: chi3,  a: {*a: CB}, b: {*a: CG}, c: {*a: SD}, d: {*a: CE}}
   - name:  PHE
     name3: PHE
     atoms:
@@ -594,8 +707,16 @@ residues:
     - [ CE1,  HE1]
     - [ CE2,  HE2]
     - [  CZ,   HZ]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD1}}
   - name:  PRO
     name3: PRO
     atoms:
@@ -628,8 +749,16 @@ residues:
     - [  CD,  1HD]
     - [  CD,  2HD]
     - [  CD,    N]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD}}
   - name:  SER
     name3: SER
     atoms:
@@ -655,8 +784,16 @@ residues:
     - [  CB,  1HB]
     - [  CB,  2HB]
     - [  OG,   HG]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: OG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: OG}, d: {*a: HG}}
   - name:  THR
     name3: THR
     atoms:
@@ -688,8 +825,16 @@ residues:
     - [ CG2, 1HG2]
     - [ CG2, 2HG2]
     - [ CG2, 3HG2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB},  d: {*a: OG1}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: OG1}, d: {*a: HG1}}
   - name:  TRP
     name3: TRP
     atoms:
@@ -743,8 +888,16 @@ residues:
     - [ CZ2,  HZ2]
     - [ CZ3,  HZ3]
     - [ CH2,  HH2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD1}}
   - name:  TYR
     name3: TYR
     atoms:
@@ -792,8 +945,17 @@ residues:
     - [ CE2,  HE2]
     - [  CZ,   OH]
     - [  OH,   HH]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG}}
+    - { *n: chi2,  a: {*a: CA}, b: {*a: CB}, c: {*a: CG}, d: {*a: CD1}}
+    - { *n: chi3,  a: {*a: CE2}, b: {*a: CZ}, c: {*a: OH}, d: {*a: HH}}
   - name:  VAL
     name3: VAL
     atoms:
@@ -830,5 +992,12 @@ residues:
     - [ CG2, 1HG2]
     - [ CG2, 2HG2]
     - [ CG2, 3HG2]
-    lower_connect: N
-    upper_connect: C
+    connections:
+    - { *n:  down, *a: N }
+    - { *n:    up, *a: C }
+    torsions:
+    - { *n: phi,   a: {*a: C, *c: down}, b: {*a: N},  c: {*a: CA},        d: {*a: C}         }
+    - { *n: psi,   a: {*a: N},           b: {*a: CA}, c: {*a: C},         d: {*a: N,  *c: up}}
+    - { *n: omega, a: {*a: CA},          b: {*a: C},  c: {*a: N, *c: up}, d: {*a: CA, *c: up}}
+
+    - { *n: chi1,  a: {*a:  N}, b: {*a: CA}, c: {*a: CB}, d: {*a: CG1}}

--- a/tmol/system/residue/io.py
+++ b/tmol/system/residue/io.py
@@ -101,10 +101,10 @@ class ResidueReader(properties.HasProperties, LoggerMixin):
         ]  # yapf: disable
 
 
-def read_pdb(pdb_string: str, **kwargs) -> PackedResidueSystem:
-    res = (ResidueReader().parse_pdb(pdb_string))
+def read_pdb(pdb_string: str) -> PackedResidueSystem:
+    res = ResidueReader().parse_pdb(pdb_string)
 
-    return PackedResidueSystem(**kwargs).from_residues(res)
+    return PackedResidueSystem.from_residues(res)
 
 
 @tmol.io.generic.to_cdjson.register(Residue)

--- a/tmol/system/residue/packed.py
+++ b/tmol/system/residue/packed.py
@@ -1,7 +1,11 @@
+import toolz
+import cattr
+
 from properties import HasProperties, List, Integer, Instance
 from tmol.properties.array import Array
 
 import numpy
+import pandas
 
 from typing import Sequence
 
@@ -12,7 +16,6 @@ class PackedResidueSystem(HasProperties):
 
     block_size: int = Integer(
         "coord buffer block size, residue start indicies are aligned to block boundries",
-        default=8,
         min=1,
         cast=True
     )
@@ -50,78 +53,252 @@ class PackedResidueSystem(HasProperties):
         "atom metada", dtype=atom_metadata_dtype
     )[:]
 
+    torsion_metadata_dtype = numpy.dtype([
+        ("residue_index", int),
+        ("name", object),
+        ("atom_index_a", float),
+        ("atom_index_b", float),
+        ("atom_index_c", float),
+        ("atom_index_d", float),
+    ])
+
+    torsion_metadata: numpy.ndarray = Array(
+        "torsion metada", dtype=torsion_metadata_dtype
+    )[:]
+
+    connection_metadata_dtype = numpy.dtype([
+        ("from_residue_index", int),
+        ("from_connection_name", object),
+        ("to_residue_index", int),
+        ("to_connection_name", object),
+    ])
+
+    connection_metadata: numpy.ndarray = Array(
+        "connection metada", dtype=connection_metadata_dtype
+    )[:]
+
     @staticmethod
     def _ceil_to_size(size, val):
         d, m = numpy.divmod(val, size)
         return (d + (m != 0).astype(int)) * size
 
-    def from_residues(self, res):
+    @classmethod
+    def from_residues(cls, res: Sequence[Residue], block_size=8):
         """Initialize a packed residue system from list of residue containers."""
 
+        ### Pack residues within the coordinate system
+
+        # Align residue starts to block boundries
+        #
+        # Ceil each residue's size to generate residue segments
         res_lengths = numpy.array([len(r.coords) for r in res])
-        res_segment_lengths = self._ceil_to_size(self.block_size, res_lengths)
+        res_segment_lengths = cls._ceil_to_size(block_size, res_lengths)
 
         segment_ends = res_segment_lengths.cumsum()
-        buffer_size = segment_ends[-1]
-
         segment_starts = numpy.empty_like(segment_ends)
         segment_starts[0] = 0
         segment_starts[1:] = segment_ends[:-1]
 
+        res_aidx = segment_starts
+
+        # Allocate the coordinate system and attach residues
+        buffer_size = segment_ends[-1]
         cbuff = numpy.full((buffer_size, 3), numpy.nan)
 
         attached_res = [
             r.attach_to(cbuff[start:start + len(r.coords)])
-            for r, start in zip(res, segment_starts)
+            for r, start in zip(res, res_aidx)
         ]
 
-        res_by_start = list(zip(segment_starts, res))
+        ### Generate atom metadata
 
-        intra_res_bonds = numpy.concatenate([
-            r.residue_type.bond_indicies + start for start, r in res_by_start
-        ])
+        atom_metadata = numpy.empty(buffer_size, cls.atom_metadata_dtype)
+        atom_metadata["atom_index"] = numpy.arange(len(atom_metadata))
+        atom_metadata["residue_index"] = None
 
-        upchain_inter_res_bonds = numpy.array([
-            [
-                i.residue_type.upper_connect_idx + si,
-                j.residue_type.lower_connect_idx + sj
-            ]
-            for (si, i), (sj, j) in zip(res_by_start[:-1], res_by_start[1:])
-        ])  # yapf: disable
-
-        downchain_inter_res_bonds = numpy.flip(
-            upchain_inter_res_bonds, axis=-1
-        )
-
-        bonds = numpy.concatenate([
-            intra_res_bonds, upchain_inter_res_bonds, downchain_inter_res_bonds
-        ])
-
-        self.residues = attached_res
-        self.res_start_ind = segment_starts
-        self.system_size = buffer_size
-
-        self.coords = cbuff
-        self.bonds = bonds
-
-        self.atom_metadata = numpy.empty(
-            self.system_size, self.atom_metadata_dtype
-        )
-        self.atom_metadata["atom_index"] = numpy.arange(
-            len(self.atom_metadata)
-        )
-        self.atom_metadata["residue_index"] = None
-
-        for ri, (rs, r) in enumerate(zip(self.res_start_ind, self.residues)):
+        for ri, (rs, r) in enumerate(zip(res_aidx, res)):
             rt = r.residue_type
-            residue_block = self.atom_metadata[rs:rs + len(rt.atoms)]
+            residue_block = atom_metadata[rs:rs + len(rt.atoms)]
             residue_block["residue_name"] = rt.name
             residue_block["atom_name"] = [a.name for a in rt.atoms]
             residue_block["atom_type"] = [a.atom_type for a in rt.atoms]
             residue_block["residue_index"] = ri
 
-        self.atom_metadata.flags.writeable = False
+        ### Index residue connectivity
+        # Generate a table of residue connections, with "from" and "to" entries
+        # for *both* directions across the connection.
+        #
+        # Just a linear set of connections up<->down for now.
+        residue_connections = pandas.DataFrame.from_records(
+            [(i, "up", i + 1, "down") for i in range(len(res) - 1)],
+            columns=pandas.MultiIndex.from_tuples([
+                ("from", "resi"),
+                ("from", "cname"),
+                ("to", "resi"),
+                ("to", "cname"),
+            ])
+        )
+        connection_index = pandas.concat((
+                residue_connections,
+                residue_connections.rename(
+                    columns={"from": "to", "to": "from"}
+                )),
+            ignore_index=True,
+        ) # yapf: disable
 
-        self.validate()
+        # Unpack the connection metadata table
+        connection_metadata = numpy.empty(
+            len(connection_index), dtype=cls.connection_metadata_dtype
+        )
 
-        return self
+        connection_metadata['from_residue_index'] = \
+                connection_index["from"]["resi"]
+        connection_metadata['from_connection_name'] = \
+                connection_index["from"]["cname"]
+
+        connection_metadata['to_residue_index'] = \
+                connection_index["to"]["resi"]
+        connection_metadata['to_connection_name'] = \
+                connection_index["to"]["cname"]
+
+        # Generate an index of all the connection atoms in the system,
+        # resolving the internal and global index of the connection atoms
+        connection_atoms = pandas.DataFrame.from_records([
+                (ri, cname, c_aidx, c_aidx + r_g_aidx)
+                for (ri, (r_g_aidx, r)) in enumerate(zip(res_aidx, res))
+                for cname, c_aidx in r.residue_type.connection_to_idx.items()
+            ],
+            columns=["resi", "cname", "internal_aidx", "aidx"]
+        ) # yapf: disable
+
+        # Merge against the connection table to generate a connection entry
+        # with the residue index, the connection name, the local atom index,
+        # and the global atom index for the connection by merging on the
+        # "cname", "resi" columns.
+        #
+        # columns:
+        # cname resi internal_aidx  aidx
+        from_connections = pandas.merge(
+            connection_index["from"], connection_atoms
+        )
+        to_connections = pandas.merge(connection_index["to"], connection_atoms)
+
+        for c in from_connections.columns:
+            connection_index["from", c] = from_connections[c]
+        for c in to_connections.columns:
+            connection_index["to", c] = to_connections[c]
+
+        ### Generate the bond graph
+
+        # Offset the internal bond graph by the residue start idx
+        intra_res_bonds = numpy.concatenate([
+            r.residue_type.bond_indicies + start
+            for start, r in zip(segment_starts, res)
+        ])
+
+        # Join the connection global atom indices
+        inter_res_bonds = numpy.vstack([
+            from_connections["aidx"].values, to_connections["aidx"].values
+        ]).T
+
+        bonds = numpy.concatenate([
+            intra_res_bonds,
+            inter_res_bonds,
+        ])
+
+        ### Generate dihedral metadata for all named torsions
+
+        # Generate a lookup from residue/connection name to connected residue
+        connection_lookup = pandas.concat(
+            (
+                pandas.DataFrame( # All the named connections
+                    dict(
+                        residue_index=connection_index["from", "resi"],
+                        cname=connection_index["from", "cname"],
+                        to_residue=connection_index["to", "resi"],
+                    )
+                ),
+                pandas.DataFrame( # Loop-back to self for "None" connections
+                    dict(
+                        cname=None,
+                        residue_index=numpy.arange(len(res)),
+                        to_residue=numpy.arange(len(res)),
+                    )
+                ),
+            ),
+            ignore_index=True,
+        )
+
+        # Generate a lookup from residue index and atom name to global atom index.
+        atom_lookup = pandas.DataFrame(
+            dict(
+                residue_index=atom_metadata["residue_index"],
+                atom_name=atom_metadata["atom_name"],
+                atom_index=numpy.arange(len(atom_metadata)),
+            )
+        )
+        atom_lookup = atom_lookup[~atom_lookup.residue_index.isna()]
+
+        # Unpack all the residue type torsion entries, and tag with the
+        # source residue index
+        torsion_entries = [
+            dict(
+                residue_index=ri,
+                **torsion_entry,
+            )
+            for ri, r in enumerate(res)
+            for torsion_entry in cattr.unstructure(r.residue_type.torsions)
+        ]
+
+        # Left merge the residue/connection name into a target residue, and
+        # then the target residue and atom name into a global atom index
+        # for all atoms in the torsion (a, b, c, d).
+
+        # This yields a global torsion table every torsion, the torsion name,
+        # and the associated global atom indices.
+        torsion_index = toolz.reduce(toolz.curry(pandas.merge)(how="left", copy=False), (
+            pandas.io.json.json_normalize(torsion_entries),
+            connection_lookup.rename(
+                columns={"cname": "a.connection", "to_residue": "a.residue"}),
+            atom_lookup.rename(
+                columns={"residue_index": "a.residue", "atom_name": "a.atom", "atom_index": "a.atom_index"}),
+            connection_lookup.rename(
+                columns={"cname": "b.connection", "to_residue": "b.residue"}),
+            atom_lookup.rename(
+                columns={"residue_index": "b.residue", "atom_name": "b.atom", "atom_index": "b.atom_index"}),
+            connection_lookup.rename(
+                columns={"cname": "c.connection", "to_residue": "c.residue"}),
+            atom_lookup.rename(
+                columns={"residue_index": "c.residue", "atom_name": "c.atom", "atom_index": "c.atom_index"}),
+            connection_lookup.rename(
+                columns={"cname": "d.connection", "to_residue": "d.residue"}),
+            atom_lookup.rename(
+                columns={"residue_index": "d.residue", "atom_name": "d.atom", "atom_index": "d.atom_index"}),
+        )).sort_index("columns") # yapf: disable
+
+        ### Unpack the merge frame into atomic indices
+        torsion_metadata = numpy.empty(
+            len(torsion_index), cls.torsion_metadata_dtype
+        )
+        torsion_metadata["residue_index"] = torsion_index["residue_index"]
+        torsion_metadata["name"] = torsion_index["name"]
+        torsion_metadata["atom_index_a"] = torsion_index["a.atom_index"]
+        torsion_metadata["atom_index_b"] = torsion_index["b.atom_index"]
+        torsion_metadata["atom_index_c"] = torsion_index["c.atom_index"]
+        torsion_metadata["atom_index_d"] = torsion_index["d.atom_index"]
+
+        result = cls(
+            block_size=block_size,
+            system_size=buffer_size,
+            res_start_ind=segment_starts,
+            residues=attached_res,
+            atom_metadata=atom_metadata,
+            torsion_metadata=torsion_metadata,
+            connection_metadata=connection_metadata,
+            bonds=bonds,
+            coords=cbuff,
+        )
+
+        result.validate()
+
+        return result

--- a/tmol/system/residue/restypes.py
+++ b/tmol/system/residue/restypes.py
@@ -1,16 +1,19 @@
 from frozendict import frozendict
 from toolz.curried import concat, map, compose
-from typing import Mapping
+from typing import Mapping, Optional, NewType
 import attr
 
 import numpy
 
 import tmol.database.chemical
 
+AtomIndex = NewType("AtomIndex", int)
+ConnectionIndex = NewType("ConnectionIndex", int)
+
 
 @attr.s(slots=True, frozen=True)
 class ResidueType(tmol.database.chemical.Residue):
-    atom_to_idx: Mapping[str, int] = attr.ib()
+    atom_to_idx: Mapping[str, AtomIndex] = attr.ib()
 
     @atom_to_idx.default
     def _setup_atom_to_idx(self):
@@ -36,17 +39,20 @@ class ResidueType(tmol.database.chemical.Residue):
         bond_array.flags.writeable = False
         return bond_array
 
-    lower_connect_idx: int = attr.ib()
+    connection_to_idx: Mapping[str, AtomIndex] = attr.ib()
 
-    @lower_connect_idx.default
-    def _setup_lower_connect_idx(self):
-        return self.atom_to_idx[self.lower_connect]
+    @connection_to_idx.default
+    def _setup_connection_to_idx(self):
+        return frozendict((c.name, self.atom_to_idx[c.atom])
+                          for c in self.connections)
 
-    upper_connect_idx: int = attr.ib()
+    connection_to_cidx: Mapping[Optional[str], ConnectionIndex] = attr.ib()
 
-    @upper_connect_idx.default
-    def _setup_upper_connect_idx(self):
-        return self.atom_to_idx[self.upper_connect]
+    @connection_to_cidx.default
+    def _setup_connection_to_cidx(self):
+        centries = [(None, -1)] + [(c.name, i)
+                                   for i, c in enumerate(self.connections)]
+        return frozendict(centries)
 
     def _repr_pretty_(self, p, cycle):
         p.text(f'ResidueType(name={self.name},...)')

--- a/tmol/tests/database/test_chemical.py
+++ b/tmol/tests/database/test_chemical.py
@@ -6,9 +6,29 @@ class TestChemicalDatabase(unittest.TestCase):
         from tmol.database import default
 
         atom_types = set(default.chemical.atom_types)
-        assert len(default.chemical.atom_types
-                   ) == len(atom_types), "Duplicate atom types."
+        assert len(default.chemical.atom_types) == len(atom_types), \
+            "Duplicate atom types."
 
         for r in default.chemical.residues:
             for a in r.atoms:
-                assert a.atom_type in atom_types, f"Invalid atom type. res: {r.name3} atom: {a}"
+                assert a.atom_type in atom_types, \
+                    f"Invalid atom type. res: {r.name3} atom: {a}"
+
+            atom_names = {a.name for a in r.atoms}
+            assert len(atom_names) == len(r.atoms), "atom names not unique."
+
+            connection_names = {c.name for c in r.connections}
+            assert len(connection_names) == len(r.connections), \
+                "connection names not unique."
+
+            torsion_names = {t.name for t in r.torsions}
+            assert len(torsion_names) == len(r.torsions), \
+                "torsion names not unique"
+
+            for t in r.torsions:
+                for catom in (t.a, t.b, t.c, t.d):
+                    assert catom.atom in atom_names
+                    assert (
+                        catom.connection is None or
+                        catom.connection in connection_names
+                    ) # yapf: disable


### PR DESCRIPTION
*Partial cherry-pick of features from #21*

Converts residue connection information to tuple of named connection
points, giving a connection name and the associated atom. Intended to
allow introduction of arbitrary residue connection points, oh hai cys,
and provide "nameable" references through connections.

Renames the "LOWER" and "UPPER" within chemical database for the sake of
keeping things punchy. Updates residue system creation logic to use the
named connections while generating polymer systems.

Adds named torsions to chemical information database. Torsions are
defined over "connected atoms", a named atom identity that *may* be
reached through a residue connection. Update chemical database to define
standard backbone torsions. Adds standard backbone and chi torsion
definitions.

Add connection points as a named, indexable component of a packed
residue type. Packed residue system currently relies on the explicit
"up" and "down" connection points to connect residues during system
construction. Add mappings from connection name to the connected atom
index and from connection name to the "connection index". Connection
index contains an implicit "None" connection at the -1 index.

Adds structured arrays of torsion and connection metadata to packed
residue system definition. Update packed residue system factory to
generate a full torsion and connection index for residues within the
system.

Update packed from_residues to class factory function.