### PR TITLE
Add enum/categorical interconversion support functions.

### DIFF
--- a/tmol/tests/utility/test_categorical.py
+++ b/tmol/tests/utility/test_categorical.py
@@ -1,0 +1,41 @@
+import pytest
+
+import pandas
+
+import enum
+from tmol.utility.categorical import names_to_val_cat, vals_to_name_cat
+
+
+def test_categorical_conversion():
+    class TE(enum.IntEnum):
+        a = enum.auto()
+        b = enum.auto()
+        c = enum.auto()
+
+    vals = [TE.a, TE.b, TE.c, TE.a, TE.b, TE.c, TE.a, TE.b, TE.c]
+    names = list("abcabcabc")
+
+    assert list(names_to_val_cat(TE, names)) == vals
+    assert list(vals_to_name_cat(TE, vals)) == names
+
+    missing_names = list("abcd")
+    missing_mask = [False, False, False, True]
+
+    assert list(pandas.isna(names_to_val_cat(
+        TE,
+        missing_names,
+    ))) == missing_mask
+
+    assert list(pandas.isna(vals_to_name_cat(
+        TE,
+        [TE.a, TE.b, TE.c, -1],
+    ))) == missing_mask
+
+
+def test_flag_enum():
+    class TF(enum.IntFlag):
+        a = enum.auto()
+        b = enum.auto()
+
+    with pytest.raises(NotImplementedError):
+        vals_to_name_cat(TF, [TF.a, TF.b])

--- a/tmol/utility/categorical.py
+++ b/tmol/utility/categorical.py
@@ -1,0 +1,57 @@
+"""Support functions for `enum`/`pandas.Categorical` interconversion."""
+import pandas
+import enum
+
+
+def enum_val_catdtype(
+        enum_type: enum.Enum
+) -> pandas.api.types.CategoricalDtype:
+    """Generate categorial dtype convering enumeratation values."""
+    if issubclass(enum_type, enum.Flag):
+        raise NotImplementedError(
+            f"enum.Flag categorical not supported: {enum_type}"
+        )
+
+    return pandas.api.types.CategoricalDtype(
+        categories=list(enum_type.__members__.values())
+    )
+
+
+def enum_name_catdtype(
+        enum_type: enum.Enum
+) -> pandas.api.types.CategoricalDtype:
+    """Generate categorial dtype convering enumeratation member names."""
+    if issubclass(enum_type, enum.Flag):
+        raise NotImplementedError(
+            f"enum.Flag categorical not supported: {enum_type}"
+        )
+
+    return pandas.api.types.CategoricalDtype(
+        categories=list(enum_type.__members__.keys())
+    )
+
+
+def vals_to_val_cat(enum_type: enum.Enum, values) -> pandas.Categorical:
+    """Convert enum values to a categorial."""
+    return pandas.Categorical(values, dtype=enum_val_catdtype(enum_type))
+
+
+def vals_to_name_cat(enum_type: enum.Enum, values) -> pandas.Categorical:
+    """Convert enum values to a categorial of member names."""
+    return (
+        vals_to_val_cat(enum_type, values)
+        .rename_categories(enum_name_catdtype(enum_type).categories)
+    )
+
+
+def names_to_name_cat(enum_type: enum.Enum, values) -> pandas.Categorical:
+    """Convert enum names to a categorial."""
+    return pandas.Categorical(values, dtype=enum_name_catdtype(enum_type))
+
+
+def names_to_val_cat(enum_type: enum.Enum, values) -> pandas.Categorical:
+    """Convert enum names to a categorial of enum values."""
+    return (
+        names_to_name_cat(enum_type, values)
+        .rename_categories(enum_val_catdtype(enum_type).categories)
+    )


### PR DESCRIPTION
Add support functions for interconversion between enum classes and pandas categorical values. Intended to support pandas-based analysis of array data using int-enum encoding.  