### PR TITLE
LKBall dispatch and energetics

### DIFF
--- a/tmol/score/lkball/__init__.py
+++ b/tmol/score/lkball/__init__.py
@@ -1,0 +1,2 @@
+#from .score_graph import LKBallScoreGraph
+#__all__ = (LKBallScoreGraph, )

--- a/tmol/score/lkball/params.py
+++ b/tmol/score/lkball/params.py
@@ -1,0 +1,33 @@
+from typing import Tuple, Sequence
+import attr
+import cattr
+
+import pandas
+import torch
+
+import numpy
+
+from tmol.types.torch import Tensor
+from tmol.types.tensor import TensorGroup
+from tmol.types.array import NDArray
+from tmol.types.attrs import ValidateAttrs
+from tmol.types.functional import validate_args
+
+from tmol.database.scoring.ljlk import LJLKDatabase
+
+from . import potentials
+
+
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class WaterBuildingParams:
+    max_acc_wat: Tensor("f")[...]
+    dists_sp2: Tensor("f")[...]
+    angles_sp2: Tensor("f")[...]
+    tors_sp2: Tensor("f")[...]
+    dists_sp3: Tensor("f")[...]
+    angles_sp3: Tensor("f")[...]
+    tors_sp3: Tensor("f")[...]
+    dists_ring: Tensor("f")[...]
+    angles_ring: Tensor("f")[...]
+    tors_ring: Tensor("f")[...]
+    dist_donor: Tensor("f")[...]

--- a/tmol/tests/score/test_lkball.py
+++ b/tmol/tests/score/test_lkball.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+import attr
+
+from tmol.types.functional import convert_args
+
+from tmol.score.lkball.potentials import (render_waters)
+
+from tmol.score.lkball.params import (WaterBuildingParams)
+
+
+def test_render_waters():
+    # eventually from a database
+    waterparams = WaterBuildingParams(
+        max_acc_wat=2,
+        dists_sp2=torch.tensor([2.65, 2.65]),
+        angles_sp2=torch.tensor([109.5, 109.5]),
+        tors_sp2=torch.tensor([0.0, 180.0]),
+        dists_sp3=torch.tensor([2.65, 2.65]),
+        angles_sp3=torch.tensor([120.0, 120.0]),
+        tors_sp3=torch.tensor([120.0, 240.0]),
+        dists_ring=torch.tensor([2.65]),
+        angles_ring=torch.tensor([180.0]),
+        tors_ring=torch.tensor([0.0]),
+        dist_donor=torch.tensor([2.65])
+    )
+
+    heavyatoms = torch.tensor([[0.0, 0.0, 0.0]])
+    #acc_base = torch.tensor( [[ float('nan'), float('nan'), float('nan') ]] )
+    #acc_base0 = torch.tensor( [[ float('nan'), float('nan'), float('nan') ]] )
+    don_H = torch.full([1, 4, 3], float('nan'))
+    #don_H[0,0,:] = torch.tensor([0,0,1]);
+    #don_H[0,1,:] = torch.tensor([0,1,1]);
+    #don_H[0,2,:] = torch.tensor([0,-1,1]);
+
+    acc_base = torch.tensor([[0.0, 0.0, -1.0]])
+    acc_base0 = torch.tensor([[0.0, -1.0, -1.0]])
+
+    is_sp2_acceptor = torch.tensor([True])
+    is_sp3_acceptor = torch.tensor([False])
+    is_ring_acceptor = torch.tensor([False])
+
+    waters = convert_args(render_waters)(
+        heavyatoms, acc_base, acc_base0, don_H, is_sp2_acceptor,
+        is_sp3_acceptor, is_ring_acceptor, waterparams
+    )


### PR DESCRIPTION
This PR will ultimately contain the LKBall energy term:

- [ ] scoring lk_ball from stacks of hbond_atom_frame:atom pairs (to figure out exactly the minimal parameter set to recapitulate R3)
- [ ] same for lk_ball_bridge
- [ ] write dispatch/parameter resolution layer
- [ ] write LKBallScoreGraph class

While I think this makes sense to ultimately combine lkball with LK to avoid redundant calculations, I will keep it separate for now.  Due to the more complicated dispatching combined lk/lkball scoring will need, it is probably easiest to fold lk into this code once completed than trying to adapt lk.
