### PR TITLE
Add pytest flake8 error format to `.lvimrc`.

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -1,1 +1,3 @@
 set makeprg=pytest
+" Capture errors of the form 'E    filename:line:column:message' reported by pytest
+let &errorformat = '%t%*[ ]%f:%l:%c:%m,' . &errorformat


### PR DESCRIPTION
Provides support for error highlighting for flake errors returned via `:make`.