### PR TITLE
Pin core numpy/scipy versions.

### DIFF
--- a/environments/core.dependencies.txt
+++ b/environments/core.dependencies.txt
@@ -1,9 +1,9 @@
 python>=3.6
 ipython
-numpy
+numpy==1.14.*
 pandas==0.22
 numba==0.38.1
-scipy
+scipy=1.1.*
 requests
 toolz
 pyyaml


### PR DESCRIPTION
Resolves test failures with numpy 1.15 upgrade by pinning to 1.14.* numpy
release series.