### PR TITLE
Fix graphviz text rendering in docs build.

### DIFF
--- a/environments/test/Dockerfile
+++ b/environments/test/Dockerfile
@@ -43,9 +43,12 @@ RUN conda install -n base --file /environments/test.dependencies.txt && conda cl
 
 COPY environments/docs.dependencies.txt /environments/
 RUN conda install -n base --file /environments/docs.dependencies.txt && conda clean -tipsy
-### Need to install libxrender1 to support graphviz png output
+
+### Packages needed for graphviz png output
+# libxrender: missing package dependency in graphviz conda package
+# gsfonts: fonts for png text rendering
 RUN apt-get update --fix-missing && \
-    apt-get install -y libxrender1 && \
+    apt-get install -y libxrender1 gsfonts && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix graphviz text rendering in docs build by adding `gsfonts` package to
test run environment.