### PR TITLE
Pin cudatoolkit to version 9.0

### DIFF
--- a/environments/linux.cuda.dependencies.txt
+++ b/environments/linux.cuda.dependencies.txt
@@ -1,3 +1,3 @@
-cudatoolkit
+cudatoolkit=9.0
 pytorch::cuda91
 pytorch::pytorch=0.4.0


### PR DESCRIPTION
cudatoolkit v 9.2 (recently released) is not playing well with numba

```
except CudaAPIError as e:
  | >           raise LinkerError("%s\n%s" % (e, self.error_log))
  | E           numba.cuda.cudadrv.driver.LinkerError: [218] Call to cuLinkAddData results in UNKNOWN_CUDA_ERROR
  | E           ptxas application ptx input, line 9; fatal   : Unsupported .version 6.2; current version is '6.1'
  | E           ptxas fatal   : Ptx assembly aborted due to errors
 ```

