### PR TITLE
Change numeric/dihedrals.py to use torch and doubles (from PR #79)

### DIFF
--- a/tmol/numeric/dihedrals.py
+++ b/tmol/numeric/dihedrals.py
@@ -1,15 +1,15 @@
-import numpy
+import torch
 
 from tmol.types.functional import validate_args
-from tmol.types.array import NDArray
+from tmol.types.torch import Tensor
 
-CoordArray = NDArray(float)[:, 3]
-Angles = NDArray(float)[:]
+Coord64Array = Tensor(torch.double)[:, 3]
+Angles = Tensor(float)[:]
 
 
 @validate_args
 def coord_dihedrals(
-    a: CoordArray, b: CoordArray, c: CoordArray, d: CoordArray
+    a: Coord64Array, b: Coord64Array, c: Coord64Array, d: Coord64Array
 ) -> Angles:
     """Dihedral angle in [-pi, pi] over the planes defined by {a, b, c} & {b, c, d}.
 
@@ -26,18 +26,18 @@ def coord_dihedrals(
     bc = c - b
     cd = d - c
 
-    ubc = bc / numpy.linalg.norm(bc, axis=-1).reshape((-1, 1))
+    ubc = bc / torch.norm(bc, 2, dim=1, keepdim=True)
 
     # v = projection of ba onto plane perpendicular to bc
     #     minus component that aligns with bc
     # w = projection of cd onto plane perpendicular to bc
     #     cd minus component that aligns with bc
-    v = ba - numpy.sum(ba * ubc, axis=-1).reshape((-1, 1)) * ubc
-    w = cd - numpy.sum(cd * ubc, axis=-1).reshape((-1, 1)) * ubc
+    v = ba - torch.sum(ba * ubc, dim=1).reshape((-1, 1)) * ubc
+    w = cd - torch.sum(cd * ubc, dim=1).reshape((-1, 1)) * ubc
 
     # angle between v and w in a plane is the torsion angle
     # v and w may not be normalized but that's fine since tan is y/x
-    x = numpy.sum(v * w, axis=-1)
-    y = numpy.sum(numpy.cross(ubc, v) * w, axis=-1)
+    x = torch.einsum("ij,ij->i", (v, w))
+    y = torch.einsum("ij,ij->i", (torch.cross(ubc, v), w))
 
-    return numpy.arctan2(y, x)
+    return torch.atan2(y, x).type(torch.float)

--- a/tmol/tests/numeric/test_dihedrals.py
+++ b/tmol/tests/numeric/test_dihedrals.py
@@ -1,12 +1,13 @@
 from toolz.curried import compose, map
 import numpy
+import torch
 
 from tmol.numeric.dihedrals import coord_dihedrals
 from tmol.utility.units import parse_angle
 
 
 def test_coord_dihedrals():
-    coords = numpy.array(
+    coords = torch.tensor(
         [
             [24.969, 13.428, 30.692],  # N
             [24.044, 12.661, 29.808],  # CA
@@ -17,11 +18,12 @@ def test_coord_dihedrals():
             [23.691, 9.935, 28.389],  # CD1
             [22.557, 9.096, 30.459],  # CD2
             [numpy.nan, numpy.nan, numpy.nan],
-        ]
+        ],
+        dtype=torch.float64,
     )
 
-    dihedral_atoms = numpy.array(
-        [[0, 1, 2, 3], [0, 1, 4, 5], [1, 4, 5, 6], [1, 4, 5, 7], [-1, 0, 1, 3]]
+    dihedral_atoms = torch.LongTensor(
+        [[0, 1, 2, 3], [0, 1, 4, 5], [1, 4, 5, 6], [1, 4, 5, 7], [8, 0, 1, 3]]
     )
 
     dihedrals = compose(numpy.array, list, map(parse_angle))(
@@ -29,10 +31,10 @@ def test_coord_dihedrals():
     )
 
     calc_dihedrals = coord_dihedrals(
-        coords[dihedral_atoms][:, 0],
-        coords[dihedral_atoms][:, 1],
-        coords[dihedral_atoms][:, 2],
-        coords[dihedral_atoms][:, 3],
+        coords.index_select(0, dihedral_atoms[:, 0].squeeze()),
+        coords.index_select(0, dihedral_atoms[:, 1].squeeze()),
+        coords.index_select(0, dihedral_atoms[:, 2].squeeze()),
+        coords.index_select(0, dihedral_atoms[:, 3].squeeze()),
     )
 
-    numpy.testing.assert_allclose(dihedrals, calc_dihedrals, atol=1e-5)
+    numpy.testing.assert_allclose(calc_dihedrals.numpy(), dihedrals, atol=1e-5)


### PR DESCRIPTION
Instead of computing dihedrals using numpy, use torch operations.

This code currently only works using doubles; it previously only worked using floats. I believe Alex was working on a typing framework with numeric hierarchies we could use. I don't know where that ended up, though.