### PR TITLE
Fix deprecation warnings by pinning pytest.

### DIFF
--- a/environments/test.dependencies.txt
+++ b/environments/test.dependencies.txt
@@ -1,4 +1,4 @@
-pytest
+pytest=3.7.*
 pytest-cov
 
 flake8


### PR DESCRIPTION
pytest 3.8 issues a number of deprecation warnings related to how marks
are used within pytest-benchmark. Quiet these warnings by pinning
pytest; this issue is currently tracked upstream at:

https://github.com/ionelmc/pytest-benchmark/issues/122