### PR TITLE
Fix W605 errors introduced by flake8 update.

### DIFF
--- a/tmol/score/score_components.py
+++ b/tmol/score/score_components.py
@@ -1,4 +1,4 @@
-"""Graph components managing dispatch of "intra" and "inter" layer scoring.
+r"""Graph components managing dispatch of "intra" and "inter" layer scoring.
 
 Score evaluation involves the interaction of three types:
 

--- a/tmol/types/shape.py
+++ b/tmol/types/shape.py
@@ -35,7 +35,7 @@ Stride and Contiguous Dimensions
 
 Memory layout constraints can be used to specify contiguous dimensions and
 their ordering. Dense dimensions are specified in the standard
-\[inner|c|numpy|row-major\] order or or in \[outer|fortran|col-major\] order.
+(inner|c|numpy|row-major) order or or in (outer|fortran|col-major) order.
 Any number of dimensions, starting from either ordering, can be specified as
 dense. Elements of dense dimensions are contiguous support a raveled view.
 


### PR DESCRIPTION
Fix invalid escape sequence errors uncovered by external flake8 update
by (a) using raw string literals in docstrings where '\' is used in
diagrams or (b) removing escape sequences.