### PR TITLE
Add ignore_unused_kwargs decorator.

### DIFF
--- a/tmol/tests/utility/test_args.py
+++ b/tmol/tests/utility/test_args.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tmol.utility.args import ignore_unused_kwargs
+
+import numba
+import numpy
+
+
+def test_ignore_unused_kwargs_func():
+    """ignore_unused_kwargs allows extra kwargs, not args."""
+
+    @ignore_unused_kwargs
+    def foo(a):
+        return a
+
+    assert foo(1) == 1
+    assert foo(a=1) == 1
+
+    assert foo(a=1, b=2) == 1
+    assert foo(1, b=2) == 1
+
+    with pytest.raises(TypeError):
+        foo(1, 2)
+
+
+def test_ignore_unused_kwargs_numba():
+    """ignore_unused_kwargs support numba jit & vectorize functions."""
+
+    @ignore_unused_kwargs
+    @numba.jit
+    def jit_foo(a):
+        return a
+
+    assert jit_foo(1) == 1
+    assert jit_foo(a=1) == 1
+
+    assert jit_foo(a=1, b=2) == 1
+    assert jit_foo(1, b=2) == 1
+
+    with pytest.raises(TypeError):
+        jit_foo(1, 2)
+
+    @ignore_unused_kwargs
+    @numba.vectorize
+    def vector_foo(a):
+        return a
+
+    v = numpy.arange(10)
+
+    assert (vector_foo(v) == v).all()
+    assert (vector_foo(a=v) == v).all()
+
+    assert (vector_foo(a=v, b=2) == v).all()
+    assert (vector_foo(v, b=2) == v).all()
+
+    with pytest.raises(TypeError):
+        vector_foo(v, 2)

--- a/tmol/utility/args.py
+++ b/tmol/utility/args.py
@@ -1,0 +1,58 @@
+import functools
+import inspect
+import toolz
+
+
+@functools.singledispatch
+def _signature(f):
+    """Resolve inspect.Signature for callable."""
+    return inspect.signature(f)
+
+
+@functools.singledispatch
+def _wraps(f):
+    """Resolve functools.wraps for callable."""
+    return functools.wraps(f)
+
+
+def ignore_unused_kwargs(func):
+    """Ignore kwargs not present in func signature.
+
+    Decorate func with wrapper dropping any kwargs not present in the func
+    signature.
+
+    Example:
+        Allows function invocation with kwargs bags that are a superset
+        of required args::
+
+            >>> @ignore_unused_kwargs(lambda a, b: a + b)(a=1, b=2, c=5)
+            3
+    """
+
+    sig = _signature(func)
+
+    @_wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs = toolz.keyfilter(sig.parameters.__contains__, kwargs)
+        bound_args = sig.bind(*args, **kwargs)
+        return func(*bound_args.args, **bound_args.kwargs)
+
+    return wrapper
+
+
+try:
+    import numba
+
+    @_signature.register(numba.npyufunc.dufunc.DUFunc)
+    def _dufunc_signature(f):
+        """Resolve inspect.Signature for @numba.vectorize."""
+        return inspect.signature(f._dispatcher.py_func)
+
+    @_wraps.register(numba.npyufunc.dufunc.DUFunc)
+    def _dufunc_wraps(f):
+        """Resolve functools.wraps for @numba.vectorize."""
+        return functools.wraps(f._dispatcher.py_func)
+
+
+except ImportError:
+    pass


### PR DESCRIPTION
Add utility decorator to support silently ignoring unused keyword
arguments to a wrapped function. Intended to provide support for kwarg
bags containing a subset of required parameters for target functions.