### PR TITLE
Add vim syntax entries for numeric template args.

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -14,4 +14,4 @@ let g:formatters_cpp = ['clangformat']
 
 call add(g:ycm_extra_conf_globlist, g:localvimrc_script_dir . "/.ycm_extra_conf.py")
 
-syntax keyword cType Real Int
+syntax keyword cType Real Real3 Int


### PR DESCRIPTION
Add vim syntax entries for "Real", "Real3", Int", which are used as
generic type parameters in template functions.