### PR TITLE
Add autograd test utility for vector-valued functions.

### DIFF
--- a/tmol/tests/autograd.py
+++ b/tmol/tests/autograd.py
@@ -252,7 +252,7 @@ class VectorizedOp:
                 *[_prep_grad(*v) for v in zip(tensor_args, raw_dv_di)]
             )
 
-            assert v.dim() == 1
+            assert v.dim() <= 1, "Expected scalar output."
 
             return v.sum()
 


### PR DESCRIPTION
Add "VectorizedOp" test utility, providing an autograd harness over gufunc
vectorized vector-valued functions. Intended to support simplified autograd
gradchecks for tensor-valued functions calculating a value & derivative wrt
tensor inputs.