### PR TITLE
Update test-summary plugin to master.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
 
   - label: ':clipboard: Report'
     plugins:
-      uw-ipd/test-summary#8fa3c9a:
+      uw-ipd/test-summary#master:
         inputs:
           - label: Testing - CUDA
             artifact_path: testing.cuda.junit.xml


### PR DESCRIPTION
Update buildkite test-summary plugin to target uw-ipd/test-summary#master,
allows updates to test summary configuration to be handled via updates
to plugin repo.