### PR TITLE
Convert add score_graph decorator, convert bases to mixins.

### DIFF
--- a/tmol/score/__init__.py
+++ b/tmol/score/__init__.py
@@ -1,7 +1,5 @@
 """Composable, scoring components for molecular systems."""
 
-from tmol.utility.reactive import reactive_attrs
-
 from . import (  # noqa: F401
     device,
     bonded_atom,
@@ -10,31 +8,26 @@ from . import (  # noqa: F401
     elec,
     hbond,
     coordinates,
+    score_graph,
     viewer,  # import viewer to register io overloads
 )
 
 
-@reactive_attrs
+@score_graph.score_graph
 class TotalScoreGraph(
-    hbond.HBondScoreGraph,
-    ljlk.LJScoreGraph,
-    ljlk.LKScoreGraph,
-    elec.ElecScoreGraph,
-    interatomic_distance.BlockedInteratomicDistanceGraph,
-    bonded_atom.BondedAtomScoreGraph,
-    device.TorchDevice,
+    ljlk.LJScoreGraph, ljlk.LKScoreGraph, hbond.HBondScoreGraph, elec.ElecScoreGraph
 ):
     pass
 
 
-@reactive_attrs
+@score_graph.score_graph
 class KinematicTotalScoreGraph(
     coordinates.KinematicAtomicCoordinateProvider, TotalScoreGraph
 ):
     pass
 
 
-@reactive_attrs
+@score_graph.score_graph
 class CartesianTotalScoreGraph(
     coordinates.CartesianAtomicCoordinateProvider, TotalScoreGraph
 ):

--- a/tmol/score/bonded_atom.py
+++ b/tmol/score/bonded_atom.py
@@ -6,20 +6,20 @@ import numpy
 import sparse
 import scipy.sparse.csgraph as csgraph
 
-from tmol.utility.reactive import reactive_attrs, reactive_property
+from tmol.utility.reactive import reactive_property
 
 from tmol.types.array import NDArray
 from tmol.types.torch import Tensor
 from tmol.types.functional import validate_args
 
+from .score_graph import score_graph
 from .database import ParamDB
-from .factory import Factory
 from .stacked_system import StackedSystem
 from .device import TorchDevice
 
 
-@reactive_attrs(auto_attribs=True)
-class BondedAtomScoreGraph(StackedSystem, ParamDB, TorchDevice, Factory):
+@score_graph
+class BondedAtomScoreGraph(StackedSystem, ParamDB, TorchDevice):
     """Score graph component describing a system's atom types and bonds.
 
     Attributes:

--- a/tmol/score/coordinates.py
+++ b/tmol/score/coordinates.py
@@ -6,17 +6,17 @@ import math
 
 from tmol.kinematics.torch_op import KinematicOp
 
-from tmol.utility.reactive import reactive_attrs, reactive_property
+from tmol.utility.reactive import reactive_property
 
 from tmol.types.torch import Tensor
 
-from .factory import Factory
-from .stacked_system import StackedSystem
 from .device import TorchDevice
+from .score_graph import score_graph
+from .stacked_system import StackedSystem
 
 
-@reactive_attrs(auto_attribs=True)
-class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice, Factory):
+@score_graph
+class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice):
     @staticmethod
     @singledispatch
     def factory_for(
@@ -40,8 +40,8 @@ class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice, Factory):
         self.coords = self.coords
 
 
-@reactive_attrs(auto_attribs=True)
-class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice, Factory):
+@score_graph
+class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice):
     @staticmethod
     @singledispatch
     def factory_for(

--- a/tmol/score/database.py
+++ b/tmol/score/database.py
@@ -1,14 +1,12 @@
 from typing import Optional
 
-from tmol.utility.reactive import reactive_attrs
-
 from tmol.database import ParameterDatabase
 
-from .factory import Factory
+from .score_graph import score_graph
 
 
-@reactive_attrs(auto_attribs=True)
-class ParamDB(Factory):
+@score_graph
+class ParamDB:
     """Graph component containing the common database.
 
     Attributes:

--- a/tmol/score/device.py
+++ b/tmol/score/device.py
@@ -1,13 +1,11 @@
 from typing import Optional
 
 import torch
-from tmol.utility.reactive import reactive_attrs
-
-from .factory import Factory
+from .score_graph import score_graph
 
 
-@reactive_attrs(auto_attribs=True)
-class TorchDevice(Factory):
+@score_graph
+class TorchDevice:
     """Graph component specifying the target compute device.
 
     Attributes:

--- a/tmol/score/elec/score_graph.py
+++ b/tmol/score/elec/score_graph.py
@@ -15,8 +15,8 @@ from tmol.types.functional import validate_args
 from ..database import ParamDB
 from ..device import TorchDevice
 from ..bonded_atom import BondedAtomScoreGraph
-from ..factory import Factory
-from ..score_components import ScoreComponent, ScoreComponentClasses, IntraScore
+from ..score_components import ScoreComponentClasses, IntraScore
+from ..score_graph import score_graph
 
 from .params import ElecParamResolver
 from .torch_op import ElecOp
@@ -47,10 +47,8 @@ class ElecIntraScore(IntraScore):
         return vals.sum()
 
 
-@reactive_attrs(auto_attribs=True)
-class ElecScoreGraph(
-    BondedAtomScoreGraph, ScoreComponent, ParamDB, TorchDevice, Factory
-):
+@score_graph
+class ElecScoreGraph(BondedAtomScoreGraph, ParamDB, TorchDevice):
     total_score_components = [
         ScoreComponentClasses(
             "elec", intra_container=ElecIntraScore, inter_container=None

--- a/tmol/score/factory_mixin.py
+++ b/tmol/score/factory_mixin.py
@@ -1,7 +1,7 @@
 import tmol.utility.mixins as mixins
 
 
-class Factory:
+class _Factory:
     """Mixin managing cooperative score graph factory functions.
 
     `Factory` manages cooperative evaluation of a set of component-specifc
@@ -29,3 +29,11 @@ class Factory:
     def init_parameters_for(cls, val, **kwargs):
         """Get score graph params for val, defaults to cloning."""
         return mixins.cooperative_superclass_factory(cls, "factory_for", val, **kwargs)
+
+    @classmethod
+    def mixin(cls, target):
+        """Mixin cooperative score graph factory functions into class."""
+        target.build_for = classmethod(cls.build_for.__func__)
+        target.init_parameters_for = classmethod(cls.init_parameters_for.__func__)
+
+        return target

--- a/tmol/score/hbond/score_graph.py
+++ b/tmol/score/hbond/score_graph.py
@@ -7,8 +7,8 @@ import numpy
 from ..database import ParamDB
 from ..device import TorchDevice
 from ..bonded_atom import BondedAtomScoreGraph
-from ..factory import Factory
-from ..score_components import ScoreComponent, ScoreComponentClasses, IntraScore
+from ..score_components import ScoreComponentClasses, IntraScore
+from ..score_graph import score_graph
 
 from .identification import HBondElementAnalysis
 from .params import HBondParamResolver
@@ -98,10 +98,8 @@ class HBondIntraScore(IntraScore):
         )
 
 
-@reactive_attrs(auto_attribs=True)
-class HBondScoreGraph(
-    BondedAtomScoreGraph, ScoreComponent, ParamDB, TorchDevice, Factory
-):
+@score_graph
+class HBondScoreGraph(BondedAtomScoreGraph, ParamDB, TorchDevice):
     """Compute graph for the HBond term.
 
     Uses the reactive system to compute the list of donors and acceptors

--- a/tmol/score/interatomic_distance.py
+++ b/tmol/score/interatomic_distance.py
@@ -5,15 +5,15 @@ import torch
 import numpy
 import scipy.sparse.csgraph
 
-from tmol.utility.reactive import reactive_attrs, reactive_property
+from tmol.utility.reactive import reactive_property
 from tmol.utility.mixins import gather_superclass_properies
 
 from tmol.types.functional import validate_args
 from tmol.types.torch import Tensor
 from tmol.types.tensor import TensorGroup
 
+from .score_graph import score_graph
 from .stacked_system import StackedSystem
-from .factory import Factory
 
 
 def _nan_to_num(var):
@@ -22,7 +22,7 @@ def _nan_to_num(var):
     return var.where(~torch.isnan(vals), zeros)
 
 
-@reactive_attrs(auto_attribs=True)
+@score_graph
 class InteratomicDistanceGraphBase(StackedSystem):
     """Base graph for interatomic distances.
 
@@ -91,7 +91,7 @@ def triu_indices(n, k=0, m=None) -> Tensor(torch.long)[:, 2]:
     return torch.stack((torch.from_numpy(i), torch.from_numpy(j)), dim=-1)
 
 
-@reactive_attrs(auto_attribs=True)
+@score_graph
 class NaiveInteratomicDistanceGraph(InteratomicDistanceGraphBase):
     @reactive_property
     @validate_args
@@ -236,8 +236,8 @@ class InterLayerAtomPairs:
         return cls(torch.nonzero(atom_pair_mask))
 
 
-@reactive_attrs(auto_attribs=True)
-class BlockedInteratomicDistanceGraph(InteratomicDistanceGraphBase, Factory):
+@score_graph
+class BlockedInteratomicDistanceGraph(InteratomicDistanceGraphBase):
     # atom block size for block-neighbor optimization
     atom_pair_block_size: int = attr.ib()
 

--- a/tmol/score/ljlk/score_graph.py
+++ b/tmol/score/ljlk/score_graph.py
@@ -14,8 +14,8 @@ from tmol.database.scoring import LJLKDatabase
 from ..database import ParamDB
 from ..device import TorchDevice
 from ..bonded_atom import BondedAtomScoreGraph
-from ..factory import Factory
-from ..score_components import ScoreComponent, ScoreComponentClasses, IntraScore
+from ..score_components import ScoreComponentClasses, IntraScore
+from ..score_graph import score_graph
 
 from .params import LJLKParamResolver
 from .torch_op import LJOp, LKOp
@@ -71,10 +71,8 @@ class LKIntraScore(IntraScore):
         return score_val.sum()
 
 
-@reactive_attrs(auto_attribs=True)
-class _LJLKCommonScoreGraph(
-    BondedAtomScoreGraph, ScoreComponent, ParamDB, TorchDevice, Factory
-):
+@score_graph
+class _LJLKCommonScoreGraph(BondedAtomScoreGraph, ParamDB, TorchDevice):
     @staticmethod
     def factory_for(
         val,

--- a/tmol/score/score_graph.py
+++ b/tmol/score/score_graph.py
@@ -1,0 +1,21 @@
+from toolz import compose
+from tmol.utility.reactive import reactive_attrs
+
+from .factory_mixin import _Factory
+from .score_components import _ScoreComponent
+
+
+def score_graph(cls=None, *, auto_attribs=True):
+    """Decorate a reactive score graph class."""
+
+    def _wrap(cls):
+        return compose(
+            reactive_attrs(auto_attribs=auto_attribs),
+            _Factory.mixin,
+            _ScoreComponent.mixin,
+        )(cls)
+
+    if cls is None:
+        return _wrap
+    else:
+        return _wrap(cls)

--- a/tmol/score/stacked_system.py
+++ b/tmol/score/stacked_system.py
@@ -1,12 +1,10 @@
 from functools import singledispatch
 
-from tmol.utility.reactive import reactive_attrs
-
-from .factory import Factory
+from .score_graph import score_graph
 
 
-@reactive_attrs(auto_attribs=True)
-class StackedSystem(Factory):
+@score_graph
+class StackedSystem:
     """Score graph component describing stacked system's "depth" and "size".
 
     A score graph is defined over a set of independent system layers. The

--- a/tmol/tests/score/elec/test_baseline.py
+++ b/tmol/tests/score/elec/test_baseline.py
@@ -1,12 +1,12 @@
 from pytest import approx
 
-from tmol.utility.reactive import reactive_attrs
 
+from tmol.score.score_graph import score_graph
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.elec import ElecScoreGraph
 
 
-@reactive_attrs
+@score_graph
 class ElecGraph(CartesianAtomicCoordinateProvider, ElecScoreGraph):
     pass
 

--- a/tmol/tests/score/hbond/test_baseline.py
+++ b/tmol/tests/score/hbond/test_baseline.py
@@ -3,10 +3,10 @@ import toolz
 import numpy
 import pandas
 
-from tmol.utility.reactive import reactive_attrs
 
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.hbond import HBondScoreGraph
+from tmol.score.score_graph import score_graph
 
 from tmol.system.packed import PackedResidueSystem
 
@@ -14,7 +14,7 @@ from tmol.system.packed import PackedResidueSystem
 def hbond_score_comparison(rosetta_baseline):
     test_system = PackedResidueSystem.from_residues(rosetta_baseline.tmol_residues)
 
-    @reactive_attrs
+    @score_graph
     class HBGraph(CartesianAtomicCoordinateProvider, HBondScoreGraph):
         pass
 

--- a/tmol/tests/score/hbond/test_score_graph.py
+++ b/tmol/tests/score/hbond/test_score_graph.py
@@ -9,10 +9,10 @@ from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.hbond import HBondScoreGraph
 from tmol.score.device import TorchDevice
 
-from tmol.utility.reactive import reactive_attrs
+from tmol.score.score_graph import score_graph
 
 
-@reactive_attrs
+@score_graph
 class HBGraph(CartesianAtomicCoordinateProvider, HBondScoreGraph, TorchDevice):
     pass
 

--- a/tmol/tests/score/interatomic_distance/conftest.py
+++ b/tmol/tests/score/interatomic_distance/conftest.py
@@ -4,22 +4,16 @@ import pytest
 
 import torch
 
-from tmol.score.factory import Factory
-
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
-from tmol.score.score_components import (
-    ScoreComponent,
-    ScoreComponentClasses,
-    InterScore,
-    IntraScore,
-)
+from tmol.score.score_components import ScoreComponentClasses, InterScore, IntraScore
 from tmol.score.interatomic_distance import (
     InteratomicDistanceGraphBase,
     BlockedInteratomicDistanceGraph,
     InterLayerAtomPairs,
 )
 
-from tmol.utility.reactive import reactive_attrs, reactive_property
+from tmol.utility.reactive import reactive_property
+from tmol.score.score_graph import score_graph
 
 
 @pytest.fixture(scope="function")
@@ -85,7 +79,7 @@ def multilayer_test_coords(multilayer_test_offsets):
     return coords.reshape((4, 8 * 3, 3))
 
 
-@reactive_attrs(auto_attribs=True)
+@score_graph
 class ThresholdDistanceCountIntraScore(IntraScore):
     @reactive_property
     def total_threshold_count(target):
@@ -105,7 +99,7 @@ class ThresholdDistanceCountIntraScore(IntraScore):
         )
 
 
-@reactive_attrs(auto_attribs=True)
+@score_graph
 class ThresholdDistanceCountInterScore(InterScore):
     @reactive_property
     def total_threshold_count(target_i, target_j):
@@ -136,12 +130,9 @@ class ThresholdDistanceCountInterScore(InterScore):
         )
 
 
-@reactive_attrs(auto_attribs=True)
+@score_graph
 class ThresholdDistanceCount(
-    CartesianAtomicCoordinateProvider,
-    InteratomicDistanceGraphBase,
-    ScoreComponent,
-    Factory,
+    CartesianAtomicCoordinateProvider, InteratomicDistanceGraphBase
 ):
     total_score_components = ScoreComponentClasses(
         name="threshold_count",
@@ -163,7 +154,7 @@ class ThresholdDistanceCount(
 def threshold_distance_score_class(request):
     interatomic_distance_component = request.param
 
-    @reactive_attrs
+    @score_graph
     class TestGraph(ThresholdDistanceCount, interatomic_distance_component):
         pass
 

--- a/tmol/tests/score/ljlk/test_baseline.py
+++ b/tmol/tests/score/ljlk/test_baseline.py
@@ -1,18 +1,18 @@
 import pytest
 from pytest import approx
 
-from tmol.utility.reactive import reactive_attrs
+from tmol.score.score_graph import score_graph
 
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.ljlk import LJScoreGraph, LKScoreGraph
 
 
-@reactive_attrs
+@score_graph
 class LJGraph(CartesianAtomicCoordinateProvider, LJScoreGraph):
     pass
 
 
-@reactive_attrs
+@score_graph
 class LKGraph(CartesianAtomicCoordinateProvider, LKScoreGraph):
     pass
 

--- a/tmol/tests/score/ljlk/test_score_graph.py
+++ b/tmol/tests/score/ljlk/test_score_graph.py
@@ -4,13 +4,13 @@ import pytest
 import torch
 
 from tmol.database import ParameterDatabase
+
+from tmol.score.score_graph import score_graph
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.ljlk import LJScoreGraph
 
-from tmol.utility.reactive import reactive_attrs
 
-
-@reactive_attrs
+@score_graph
 class LJGraph(CartesianAtomicCoordinateProvider, LJScoreGraph):
     pass
 

--- a/tmol/tests/score/test_dof_space.py
+++ b/tmol/tests/score/test_dof_space.py
@@ -8,17 +8,17 @@ from tmol.score.coordinates import (
     KinematicAtomicCoordinateProvider,
 )
 
-from tmol.utility.reactive import reactive_attrs
+from tmol.score.score_graph import score_graph
 
 from tmol.tests.autograd import gradcheck
 
 
-@reactive_attrs
+@score_graph
 class RealSpaceScore(CartesianAtomicCoordinateProvider, TotalScoreGraph):
     pass
 
 
-@reactive_attrs
+@score_graph
 class DofSpaceScore(KinematicAtomicCoordinateProvider, TotalScoreGraph):
     pass
 

--- a/tmol/tests/score/test_score_benchmarks.py
+++ b/tmol/tests/score/test_score_benchmarks.py
@@ -1,18 +1,13 @@
 import pytest
 
-from tmol.utility.reactive import reactive_attrs, reactive_property
+from tmol.utility.reactive import reactive_property
 
 from tmol.score import TotalScoreGraph
 
+from tmol.score.score_graph import score_graph
 from tmol.score.device import TorchDevice
-
-
 from tmol.score.bonded_atom import BondedAtomScoreGraph
-from tmol.score.score_components import (
-    ScoreComponent,
-    ScoreComponentClasses,
-    IntraScore,
-)
+from tmol.score.score_components import ScoreComponentClasses, IntraScore
 
 from tmol.score.coordinates import (
     CartesianAtomicCoordinateProvider,
@@ -24,48 +19,48 @@ from tmol.score.hbond import HBondScoreGraph
 from tmol.score.elec import ElecScoreGraph
 
 
-@reactive_attrs
+@score_graph
 class DummyIntra(IntraScore):
     @reactive_property
     def total_dummy(target):
         return target.coords.sum()
 
 
-@reactive_attrs
+@score_graph
 class DofSpaceDummy(
-    KinematicAtomicCoordinateProvider, BondedAtomScoreGraph, ScoreComponent, TorchDevice
+    KinematicAtomicCoordinateProvider, BondedAtomScoreGraph, TorchDevice
 ):
     total_score_components = [
         ScoreComponentClasses("dummy", intra_container=DummyIntra, inter_container=None)
     ]
 
 
-@reactive_attrs
+@score_graph
 class DofSpaceTotal(KinematicAtomicCoordinateProvider, TotalScoreGraph, TorchDevice):
     pass
 
 
-@reactive_attrs
+@score_graph
 class TotalScore(CartesianAtomicCoordinateProvider, TotalScoreGraph, TorchDevice):
     pass
 
 
-@reactive_attrs
+@score_graph
 class HBondScore(CartesianAtomicCoordinateProvider, HBondScoreGraph, TorchDevice):
     pass
 
 
-@reactive_attrs
+@score_graph
 class ElecScore(CartesianAtomicCoordinateProvider, ElecScoreGraph, TorchDevice):
     pass
 
 
-@reactive_attrs
+@score_graph
 class LJScore(CartesianAtomicCoordinateProvider, LJScoreGraph, TorchDevice):
     pass
 
 
-@reactive_attrs
+@score_graph
 class LKScore(CartesianAtomicCoordinateProvider, LKScoreGraph, TorchDevice):
     pass
 

--- a/tmol/tests/score/test_score_components.py
+++ b/tmol/tests/score/test_score_components.py
@@ -4,7 +4,7 @@ import attr
 from tmol.utility.reactive import reactive_attrs, reactive_property
 
 from tmol.score.score_components import (
-    ScoreComponent,
+    _ScoreComponent,
     ScoreComponentClasses,
     IntraScore,
     InterScore,
@@ -26,7 +26,8 @@ class InterFoo(InterScore):
 
 
 @attr.s
-class Foo(ScoreComponent):
+@_ScoreComponent.mixin
+class Foo:
     total_score_components = ScoreComponentClasses(
         name="foo", intra_container=IntraFoo, inter_container=InterFoo
     )
@@ -35,7 +36,8 @@ class Foo(ScoreComponent):
 
 
 @attr.s
-class JustInterFoo(ScoreComponent):
+@_ScoreComponent.mixin
+class JustInterFoo:
     total_score_components = ScoreComponentClasses(
         name="foo", intra_container=None, inter_container=InterFoo
     )
@@ -44,7 +46,8 @@ class JustInterFoo(ScoreComponent):
 
 
 @attr.s
-class JustIntraFoo(ScoreComponent):
+@_ScoreComponent.mixin
+class JustIntraFoo:
     total_score_components = ScoreComponentClasses(
         name="foo", intra_container=IntraFoo, inter_container=None
     )
@@ -67,7 +70,8 @@ class InterBar(InterScore):
 
 
 @attr.s
-class Bar(ScoreComponent):
+@_ScoreComponent.mixin
+class Bar:
     total_score_components = ScoreComponentClasses(
         name="bar", intra_container=IntraBar, inter_container=InterBar
     )

--- a/tmol/tests/score/test_total_gradcheck.py
+++ b/tmol/tests/score/test_total_gradcheck.py
@@ -3,21 +3,21 @@ import torch
 from tmol.system.packed import PackedResidueSystem
 
 from tmol.score import TotalScoreGraph
+from tmol.score.score_graph import score_graph
 from tmol.score.coordinates import (
     CartesianAtomicCoordinateProvider,
     KinematicAtomicCoordinateProvider,
 )
 
-from tmol.utility.reactive import reactive_attrs
 from tmol.tests.autograd import gradcheck
 
 
-@reactive_attrs
+@score_graph
 class RealSpaceScore(CartesianAtomicCoordinateProvider, TotalScoreGraph):
     pass
 
 
-@reactive_attrs
+@score_graph
 class DofSpaceScore(KinematicAtomicCoordinateProvider, TotalScoreGraph):
     pass
 

--- a/tmol/tests/viewer/test_viewer.py
+++ b/tmol/tests/viewer/test_viewer.py
@@ -6,7 +6,7 @@ from tmol.viewer import SystemViewer
 from tmol.score.bonded_atom import BondedAtomScoreGraph
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 
-from tmol.utility.reactive import reactive_attrs
+from tmol.score.score_graph import score_graph
 
 from argparse import Namespace
 
@@ -28,7 +28,7 @@ def test_residue_viewer_smoke(ubq_res):
 def test_score_graph_viewer_smoke(ubq_system):
     """Viewer can render score graph of depth 1 as cdjson or pdb."""
 
-    @reactive_attrs
+    @score_graph
     class MinGraph(BondedAtomScoreGraph, CartesianAtomicCoordinateProvider):
         pass
 


### PR DESCRIPTION
Add explicit "score_graph" decorator, handling reactive_attrs
initialization of score graph component classes. Convert "Factory" and
"ScoreComponent" abstract bases into explicit mixin classes, simplifying
definition of score graph hierarchies with valid method resolution
orders. Will likely simplify composite class definition by moving more
truly common components (TorchDevice, etc) into pure mixins, but this
will require some rethinking of how these properties and factories are
added to the cooperative factory interface.