### PR TITLE
Add TensorPack::*_like and pybind11 conversion.

### DIFF
--- a/tmol/tests/utility/tensor/tensor_accessor.cpp
+++ b/tmol/tests/utility/tensor/tensor_accessor.cpp
@@ -101,6 +101,48 @@ auto vector_magnitude_eigen_arg_squeeze(
   return output_t;
 }
 
+auto tensor_pack_construct() {
+  typedef tmol::TPack<Eigen::Vector3f, 2, tmol::Device::CPU> T;
+
+  return std::make_tuple(
+      T::empty({2, 5}),
+      T::ones({2, 5}),
+      T::zeros({2, 5}),
+      T::full({2, 5}, NAN));
+}
+
+auto tensor_pack_construct_like_aten(at::Tensor t) {
+  typedef tmol::TPack<Eigen::Vector3f, 2, tmol::Device::CPU> T;
+
+  return std::make_tuple(
+      T::empty_like(t),
+      T::ones_like(t),
+      T::zeros_like(t),
+      T::full_like(t, NAN));
+}
+
+auto tensor_pack_construct_like_tview(
+    tmol::TView<float, 2, tmol::Device::CPU> t) {
+  typedef tmol::TPack<Eigen::Vector3f, 2, tmol::Device::CPU> T;
+
+  return std::make_tuple(
+      T::empty_like(t),
+      T::ones_like(t),
+      T::zeros_like(t),
+      T::full_like(t, NAN));
+}
+
+auto tensor_pack_construct_like_tpack(
+    tmol::TPack<float, 2, tmol::Device::CPU> t) {
+  typedef tmol::TPack<Eigen::Vector3f, 2, tmol::Device::CPU> T;
+
+  return std::make_tuple(
+      T::empty_like(t),
+      T::ones_like(t),
+      T::zeros_like(t),
+      T::full_like(t, NAN));
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
       "aten", &vector_magnitude_aten, "ATen-based vector_magnitude function.");
@@ -132,4 +174,24 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       &vector_magnitude_eigen_arg_squeeze,
       "Tensoreigen-based vector_magnitude function with pybind11 argument "
       "conversion, implictly squeezing minor dimension.");
+
+  m.def(
+      "tensor_pack_construct",
+      &tensor_pack_construct,
+      "Construct {2, 5, 3} tensors via TensorPack constructors.");
+
+  m.def(
+      "tensor_pack_construct_like_aten",
+      &tensor_pack_construct_like_aten,
+      "Construct tensors via TensorPack constructors.");
+
+  m.def(
+      "tensor_pack_construct_like_tview",
+      &tensor_pack_construct_like_tview,
+      "Construct tensors via TensorPack constructors.");
+
+  m.def(
+      "tensor_pack_construct_like_tpack",
+      &tensor_pack_construct_like_tpack,
+      "Construct tensors via TensorPack constructors.");
 }

--- a/tmol/utility/tensor/TensorAccessor.h
+++ b/tmol/utility/tensor/TensorAccessor.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ATen/Device.h>
 #include <stdint.h>
 #include <algorithm>
 #include <cstddef>
@@ -64,6 +63,7 @@ class TensorAccessorBase {
 
   AT_HOST_DEVICE int64_t stride(int64_t i) const { return strides_[i]; }
   AT_HOST_DEVICE int64_t size(int64_t i) const { return sizes_[i]; }
+  AT_HOST_DEVICE const int64_t dim() const { return N; }
   AT_HOST_DEVICE T* data() { return data_; }
   AT_HOST_DEVICE const T* data() const { return data_; }
 
@@ -139,8 +139,10 @@ class TViewBase {
     std::copy(sizes_, sizes_ + N, std::begin(this->sizes_));
     std::copy(strides_, strides_ + N, std::begin(this->strides_));
   }
+  AT_HOST_DEVICE const int64_t dim() const { return N; }
   AT_HOST_DEVICE const int64_t& stride(int64_t i) const { return strides_[i]; }
   AT_HOST_DEVICE const int64_t& size(int64_t i) const { return sizes_[i]; }
+
   AT_HOST_DEVICE PtrType data() { return data_; }
   AT_HOST_DEVICE const PtrType data() const { return data_; }
 

--- a/tmol/utility/tensor/TensorPack.h
+++ b/tmol/utility/tensor/TensorPack.h
@@ -24,8 +24,15 @@ struct TPack {
       : tensor(tensor), view(view){};
 
   TPack(at::Tensor tensor)
-      : tensor(tensor), view(view_tensor<T, N, D, P>(tensor)){};
+      : tensor(tensor), view(tmol::view_tensor<T, N, D, P>(tensor)){};
 
+  TPack() : tensor(), view(){};
+
+  int64_t dim() { return view.dim(); }
+  int64_t size(int64_t d) { return view.size(d); }
+  int64_t stride(int64_t d) { return view.stride(d); }
+
+  // Empty
   template <
       typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
   static auto empty(at::IntList size) -> TPack<T, N, D, P> {
@@ -37,6 +44,18 @@ struct TPack {
   }
 
   template <
+      typename Target,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto empty_like(Target& other) -> TPack<T, N, D, P> {
+    return _allocate_like(
+        [](at::IntList size, const at::TensorOptions& options) {
+          return at::empty(size, options);
+        },
+        other);
+  }
+
+  // Ones
+  template <
       typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
   static auto ones(at::IntList size) -> TPack<T, N, D, P> {
     return _allocate(
@@ -47,6 +66,18 @@ struct TPack {
   }
 
   template <
+      typename Target,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto ones_like(Target& other) -> TPack<T, N, D, P> {
+    return _allocate_like(
+        [](at::IntList size, const at::TensorOptions& options) {
+          return at::ones(size, options);
+        },
+        other);
+  }
+
+  // Zeros
+  template <
       typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
   static auto zeros(at::IntList size) -> TPack<T, N, D, P> {
     return _allocate(
@@ -56,6 +87,42 @@ struct TPack {
         size);
   }
 
+  template <
+      typename Target,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto zeros_like(Target& other) -> TPack<T, N, D, P> {
+    return _allocate_like(
+        [](at::IntList size, const at::TensorOptions& options) {
+          return at::zeros(size, options);
+        },
+        other);
+  }
+
+  // Full
+  template <
+      typename Scalar,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto full(at::IntList size, Scalar value) -> TPack<T, N, D, P> {
+    return _allocate(
+        [value = value](at::IntList size, const at::TensorOptions& options) {
+          return at::full(size, value, options);
+        },
+        size);
+  }
+
+  template <
+      typename Scalar,
+      typename Target,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto full_like(Target& other, Scalar value) -> TPack<T, N, D, P> {
+    return _allocate_like(
+        [value = value](at::IntList size, const at::TensorOptions& options) {
+          return at::full(size, value, options);
+        },
+        other);
+  }
+
+  // Tensor allocation interface
   template <
       typename AllocFun,
       typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
@@ -85,7 +152,26 @@ struct TPack {
       tensor = aten_alloc(composite_size, target_type);
     }
 
-    return {tensor, view_tensor<T, N, D, P>(tensor)};
+    return TPack<T, N, D, P>(tensor);
+  }
+
+  template <
+      typename AllocFun,
+      typename Target,
+      typename std::enable_if<enable_tensor_view<T>::enabled>::type* = nullptr>
+  static auto _allocate_like(AllocFun aten_alloc, Target& other)
+      -> TPack<T, N, D, P> {
+    AT_ASSERTM(
+        other.dim() == N, "TPack:::_allocate_like mismatched dimensionality.");
+
+    // Via individual access to dims to support TView. (Does not exposes
+    // "sizes", only dim & size.)
+    int64_t dims[N];
+    for (int i = 0; i < N; i++) {
+      dims[i] = other.size(i);
+    };
+
+    return _allocate(aten_alloc, dims);
   }
 };
 


### PR DESCRIPTION
Add TensorPack::[ones|zeros|empty]_like constructor functions, operating
on objects exposing a `dim` and `size(i)` interface, i.e. at::Tensor,
TPack, TView types. Add dim/size to TView and TPack classes.

Add TensorPack::full[_like] interface, allowing arbitrary scalar-valued
initialization of TPack data containers. Operates on the _primitive_
datatype of composite tensors, not the target datatype. E.g. Can
initialize nan-filled Vector tensors, but can't init with arbitrary
vector values.

Fixup TensorPack pybind11 support to allow TensorPack pybind11 input
arguments. Allows exposing a typed ATen input parameter or a combo
view/tensor interface.