### PR TITLE
Pin conda to version 4.6 in test environment.

### DIFF
--- a/environments/test/Dockerfile
+++ b/environments/test/Dockerfile
@@ -12,9 +12,10 @@ RUN apt-get update --fix-missing && \
 ENV PATH /opt/conda/bin:$PATH
 
 # Updated to miniconda 4.5.1
-RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.5.1-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
+    echo "conda =4.6" >> /opt/conda/conda-meta/pinned && \
     /opt/conda/bin/conda clean -tipsy && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \


### PR DESCRIPTION
Fixes errors in test environment due to file format changes in conda 4.7 release series. Pinning to conda to version 4.6 as a workaround.