### PR TITLE
Aleaverfay/empty and zero

### DIFF
--- a/tmol/score/cartbonded/potentials/dispatch.impl.hh
+++ b/tmol/score/cartbonded/potentials/dispatch.impl.hh
@@ -41,11 +41,23 @@ struct CartBondedLengthDispatch {
       -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
     auto num_Vs = atom_indices.size(0);
 
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+    auto V_t = TPack<Real, 1, D>::empty({1});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
+
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
+      if (i == 0) {
+	V[i] = 0;
+      }
+      if (i < dV_dx.size(0)) {
+	for (int j = 0; j < 3; ++j) {
+	  dV_dx[i](j) = 0;
+	}
+      }
+    };
+    Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 
     auto f_i = ([=] EIGEN_DEVICE_FUNC(int i) {
       Int ati = atom_indices[i].atom_index_i;
@@ -79,11 +91,23 @@ struct CartBondedAngleDispatch {
       -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
     auto num_Vs = atom_indices.size(0);
 
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+    auto V_t = TPack<Real, 1, D>::empty({1});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
+
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
+      if (i == 0) {
+	V[i] = 0;
+      }
+      if (i < dV_dx.size(0)) {
+	for (int j = 0; j < 3; ++j) {
+	  dV_dx[i](j) = 0;
+	}
+      }
+    };
+    Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 
     auto f_i = ([=] EIGEN_DEVICE_FUNC(int i) {
       Int ati = atom_indices[i].atom_index_i;
@@ -123,11 +147,23 @@ struct CartBondedTorsionDispatch {
       -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
     auto num_Vs = atom_indices.size(0);
 
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+    auto V_t = TPack<Real, 1, D>::empty({1});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
+
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
+      if (i == 0) {
+	V[i] = 0;
+      }
+      if (i < dV_dx.size(0)) {
+	for (int j = 0; j < 3; ++j) {
+	  dV_dx[i](j) = 0;
+	}
+      }
+    };
+    Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 
     auto f_i = ([=] EIGEN_DEVICE_FUNC(int i) {
       Int ati = atom_indices[i].atom_index_i;
@@ -171,11 +207,24 @@ struct CartBondedHxlTorsionDispatch {
       -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
     auto num_Vs = atom_indices.size(0);
 
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+    auto V_t = TPack<Real, 1, D>::empty({1});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
+
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
+      if (i == 0) {
+	V[i] = 0;
+      }
+      if (i < dV_dx.size(0)) {
+	for (int j = 0; j < 3; ++j) {
+	  dV_dx[i](j) = 0;
+	}
+      }
+    };
+    Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
+    
 
     auto f_i = ([=] EIGEN_DEVICE_FUNC(int i) {
       Int ati = atom_indices[i].atom_index_i;

--- a/tmol/score/cartbonded/potentials/dispatch.impl.hh
+++ b/tmol/score/cartbonded/potentials/dispatch.impl.hh
@@ -53,7 +53,7 @@ struct CartBondedLengthDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -101,7 +101,7 @@ struct CartBondedAngleDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dV_dx[i](j) = 0;
         // }
@@ -158,7 +158,7 @@ struct CartBondedTorsionDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dV_dx[i](j) = 0;
         // }
@@ -219,7 +219,7 @@ struct CartBondedHxlTorsionDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dV_dx[i](j) = 0;
         // }

--- a/tmol/score/cartbonded/potentials/dispatch.impl.hh
+++ b/tmol/score/cartbonded/potentials/dispatch.impl.hh
@@ -13,6 +13,7 @@
 #include <tmol/score/common/dispatch.hh>
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <tmol/score/ljlk/potentials/params.hh>
 
@@ -52,9 +53,7 @@ struct CartBondedLengthDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dx[i](j) = 0;
-        }
+	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -102,9 +101,10 @@ struct CartBondedAngleDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dx[i](j) = 0;
-        }
+	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dV_dx[i](j) = 0;
+        // }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -158,9 +158,10 @@ struct CartBondedTorsionDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dx[i](j) = 0;
-        }
+	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dV_dx[i](j) = 0;
+        // }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -218,9 +219,10 @@ struct CartBondedHxlTorsionDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dx[i](j) = 0;
-        }
+	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dV_dx[i](j) = 0;
+        // }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);

--- a/tmol/score/cartbonded/potentials/dispatch.impl.hh
+++ b/tmol/score/cartbonded/potentials/dispatch.impl.hh
@@ -49,12 +49,12 @@ struct CartBondedLengthDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dV_dx[i](j) = 0;
-	}
+        for (int j = 0; j < 3; ++j) {
+          dV_dx[i](j) = 0;
+        }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -99,12 +99,12 @@ struct CartBondedAngleDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dV_dx[i](j) = 0;
-	}
+        for (int j = 0; j < 3; ++j) {
+          dV_dx[i](j) = 0;
+        }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -155,12 +155,12 @@ struct CartBondedTorsionDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dV_dx[i](j) = 0;
-	}
+        for (int j = 0; j < 3; ++j) {
+          dV_dx[i](j) = 0;
+        }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
@@ -215,16 +215,15 @@ struct CartBondedHxlTorsionDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dV_dx[i](j) = 0;
-	}
+        for (int j = 0; j < 3; ++j) {
+          dV_dx[i](j) = 0;
+        }
       }
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
-    
 
     auto f_i = ([=] EIGEN_DEVICE_FUNC(int i) {
       Int ati = atom_indices[i].atom_index_i;

--- a/tmol/score/common/zero.hh
+++ b/tmol/score/common/zero.hh
@@ -7,23 +7,21 @@ namespace score {
 namespace common {
 
 template <tmol::Device D>
-struct zero_array{
+struct zero_array {
   template <class T>
-  static
-  void EIGEN_DEVICE_FUNC go(T * data, int i, int size0, int stride0) {
+  static void EIGEN_DEVICE_FUNC go(T* data, int i, int size0, int stride0) {
     if (D == tmol::Device::CPU) {
       for (int j = 0; j < stride0; ++j) {
-	data[i*stride0 + j] = 0;
+        data[i * stride0 + j] = 0;
       }
     } else {
       for (int j = 0; j < stride0; ++j) {
-	data[j*size0 + i] = 0;
+        data[j * size0 + i] = 0;
       }
     }
   }
-  
 };
 
-}
-}
-}
+}  // namespace common
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/common/zero.hh
+++ b/tmol/score/common/zero.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+
+namespace tmol {
+namespace score {
+namespace common {
+
+template <tmol::Device D>
+struct zero_array{
+  template <class T>
+  static
+  void EIGEN_DEVICE_FUNC go(T * data, int i, int size0, int stride0) {
+    if (D == tmol::Device::CPU) {
+      for (int j = 0; j < stride0; ++j) {
+	data[i*stride0 + j] = 0;
+      }
+    } else {
+      for (int j = 0; j < stride0; ++j) {
+	data[j*size0 + i] = 0;
+      }
+    }
+  }
+  
+};
+
+}
+}
+}

--- a/tmol/score/dunbrack/potentials/dispatch.impl.hh
+++ b/tmol/score/dunbrack/potentials/dispatch.impl.hh
@@ -5,6 +5,7 @@
 #include <tmol/numeric/bspline_compiled/bspline.hh>
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/geom.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <ATen/Tensor.h>
 
@@ -127,25 +128,28 @@ struct DunbrackDispatch {
         V[i] = 0;
       }
       if (i < n_rotameric_res) {
-        for (int j = 0; j < 2; ++j) {
-          for (int k = 0; k < 4; ++k) {
-            dneglnprob_rot_dbb_xyz[i][j](k) = 0;
-          }
-        }
+	common::zero_array<D>::go((Real *) dneglnprob_rot_dbb_xyz.data(), i, dneglnprob_rot_dbb_xyz.size(0), 8);
+        // for (int j = 0; j < 2; ++j) {
+        //   for (int k = 0; k < 4; ++k) {
+        //     dneglnprob_rot_dbb_xyz[i][j](k) = 0;
+        //   }
+        // }
       }
       if (i < n_rotameric_chi) {
-        for (int j = 0; j < 3; ++j) {
-          for (int k = 0; k < 4; ++k) {
-            drotchi_devpen_dtor_xyz[i][j](k) = 0;
-          }
-        }
+	common::zero_array<D>::go((Real *) drotchi_devpen_dtor_xyz.data(), i, drotchi_devpen_dtor_xyz.size(0), 12);
+        // for (int j = 0; j < 3; ++j) {
+        //   for (int k = 0; k < 4; ++k) {
+        //     drotchi_devpen_dtor_xyz[i][j](k) = 0;
+        //   }
+        // }
       }
       if (i < n_semirotameric_res) {
-        for (int j = 0; j < 3; ++j) {
-          for (int k = 0; k < 4; ++k) {
-            dneglnprob_nonrot_dtor_xyz[i][j](k) = 0;
-          }
-        }
+	common::zero_array<D>::go((Real *) dneglnprob_nonrot_dtor_xyz.data(), i, dneglnprob_nonrot_dtor_xyz.size(0), 12);
+        // for (int j = 0; j < 3; ++j) {
+        //   for (int k = 0; k < 4; ++k) {
+        //     dneglnprob_nonrot_dtor_xyz[i][j](k) = 0;
+        //   }
+        // }
       }
     };
 
@@ -277,9 +281,10 @@ struct DunbrackDispatch {
     auto dE_dxyz_tpack = TPack<Real3, 1, D>::empty(natoms);
     auto dE_dxyz = dE_dxyz_tpack.view;
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
-      for (int j = 0; j < 3; ++j) {
-        dE_dxyz[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dE_dxyz.data(), i, dE_dxyz.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dE_dxyz[i](j) = 0;
+      // }
     };
     Dispatch<D>::forall(natoms, zero);
 

--- a/tmol/score/dunbrack/potentials/dispatch.impl.hh
+++ b/tmol/score/dunbrack/potentials/dispatch.impl.hh
@@ -128,7 +128,11 @@ struct DunbrackDispatch {
         V[i] = 0;
       }
       if (i < n_rotameric_res) {
-	common::zero_array<D>::go((Real *) dneglnprob_rot_dbb_xyz.data(), i, dneglnprob_rot_dbb_xyz.size(0), 8);
+        common::zero_array<D>::go(
+            (Real *)dneglnprob_rot_dbb_xyz.data(),
+            i,
+            dneglnprob_rot_dbb_xyz.size(0),
+            8);
         // for (int j = 0; j < 2; ++j) {
         //   for (int k = 0; k < 4; ++k) {
         //     dneglnprob_rot_dbb_xyz[i][j](k) = 0;
@@ -136,7 +140,11 @@ struct DunbrackDispatch {
         // }
       }
       if (i < n_rotameric_chi) {
-	common::zero_array<D>::go((Real *) drotchi_devpen_dtor_xyz.data(), i, drotchi_devpen_dtor_xyz.size(0), 12);
+        common::zero_array<D>::go(
+            (Real *)drotchi_devpen_dtor_xyz.data(),
+            i,
+            drotchi_devpen_dtor_xyz.size(0),
+            12);
         // for (int j = 0; j < 3; ++j) {
         //   for (int k = 0; k < 4; ++k) {
         //     drotchi_devpen_dtor_xyz[i][j](k) = 0;
@@ -144,7 +152,11 @@ struct DunbrackDispatch {
         // }
       }
       if (i < n_semirotameric_res) {
-	common::zero_array<D>::go((Real *) dneglnprob_nonrot_dtor_xyz.data(), i, dneglnprob_nonrot_dtor_xyz.size(0), 12);
+        common::zero_array<D>::go(
+            (Real *)dneglnprob_nonrot_dtor_xyz.data(),
+            i,
+            dneglnprob_nonrot_dtor_xyz.size(0),
+            12);
         // for (int j = 0; j < 3; ++j) {
         //   for (int k = 0; k < 4; ++k) {
         //     dneglnprob_nonrot_dtor_xyz[i][j](k) = 0;
@@ -281,7 +293,7 @@ struct DunbrackDispatch {
     auto dE_dxyz_tpack = TPack<Real3, 1, D>::empty(natoms);
     auto dE_dxyz = dE_dxyz_tpack.view;
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
-      common::zero_array<D>::go((Real *) dE_dxyz.data(), i, dE_dxyz.size(0), 3);
+      common::zero_array<D>::go((Real *)dE_dxyz.data(), i, dE_dxyz.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dE_dxyz[i](j) = 0;
       // }

--- a/tmol/score/dunbrack/potentials/dispatch.impl.hh
+++ b/tmol/score/dunbrack/potentials/dispatch.impl.hh
@@ -276,9 +276,9 @@ struct DunbrackDispatch {
 
     auto dE_dxyz_tpack = TPack<Real3, 1, D>::empty(natoms);
     auto dE_dxyz = dE_dxyz_tpack.view;
-    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       for (int j = 0; j < 3; ++j) {
-	dE_dxyz[i](j) = 0;
+        dE_dxyz[i](j) = 0;
       }
     };
     Dispatch<D>::forall(natoms, zero);

--- a/tmol/score/elec/potentials/compiled.cpu.cpp
+++ b/tmol/score/elec/potentials/compiled.cpu.cpp
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cpu.impl.hh>
 #include <tmol/score/common/simple_dispatch.cpu.impl.hh>
 
 #include "dispatch.impl.hh"
@@ -8,8 +9,11 @@ namespace elec {
 namespace potentials {
 
 #define declare_dispatch(Real, Int)                                         \
-  template struct ElecDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>; \
+  template struct ElecDispatch< \
+      ForallDispatch, \
+      AABBDispatch, tmol::Device::CPU, Real, Int>;				\
   template struct ElecDispatch<                                             \
+      ForallDispatch,                                                     \
       AABBTriuDispatch,                                                     \
       tmol::Device::CPU,                                                    \
       Real,                                                                 \

--- a/tmol/score/elec/potentials/compiled.cuda.cu
+++ b/tmol/score/elec/potentials/compiled.cuda.cu
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cuda.impl.cuh>
 #include <tmol/score/common/simple_dispatch.cuda.impl.cuh>
 
 #include "dispatch.impl.hh"
@@ -8,8 +9,8 @@ namespace elec {
 namespace potentials {
 
 #define declare_dispatch(Real, Int)                                          \
-  template struct ElecDispatch<AABBDispatch, tmol::Device::CUDA, Real, Int>; \
-  template struct ElecDispatch<AABBTriuDispatch, tmol::Device::CUDA, Real, Int>;
+  template struct ElecDispatch<ForallDispatch, AABBDispatch, tmol::Device::CUDA, Real, Int>; \
+  template struct ElecDispatch<ForallDispatch, AABBTriuDispatch, tmol::Device::CUDA, Real, Int>;
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/elec/potentials/compiled.cuda.cu
+++ b/tmol/score/elec/potentials/compiled.cuda.cu
@@ -8,9 +8,19 @@ namespace score {
 namespace elec {
 namespace potentials {
 
-#define declare_dispatch(Real, Int)                                          \
-  template struct ElecDispatch<ForallDispatch, AABBDispatch, tmol::Device::CUDA, Real, Int>; \
-  template struct ElecDispatch<ForallDispatch, AABBTriuDispatch, tmol::Device::CUDA, Real, Int>;
+#define declare_dispatch(Real, Int) \
+  template struct ElecDispatch<     \
+      ForallDispatch,               \
+      AABBDispatch,                 \
+      tmol::Device::CUDA,           \
+      Real,                         \
+      Int>;                         \
+  template struct ElecDispatch<     \
+      ForallDispatch,               \
+      AABBTriuDispatch,             \
+      tmol::Device::CUDA,           \
+      Real,                         \
+      Int>;
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -5,6 +5,7 @@
 #include <tmol/utility/function_dispatch/aten.hh>
 
 #include <tmol/score/common/simple_dispatch.hh>
+#include <tmol/score/common/forall_dispatch.hh>
 
 #include "dispatch.hh"
 
@@ -18,13 +19,17 @@ using torch::Tensor;
 template <
     template <
         template <tmol::Device>
-        class Dispatch,
+        class SingleDispatch,
+        template <tmol::Device>
+        class PairDispatch,
         tmol::Device D,
         typename Real,
         typename Int>
     class ScoreDispatch,
     template <tmol::Device>
-    class DispatchMethod>
+    class SingleDispatchMethod,
+    template <tmol::Device>
+    class PairDispatchMethod>  
 Tensor score_op(
     Tensor I,
     Tensor charge_I,
@@ -46,7 +51,7 @@ Tensor score_op(
         using Real = scalar_t;
         constexpr tmol::Device Dev = device_t;
 
-        auto result = ScoreDispatch<DispatchMethod, Dev, Real, Int>::f(
+        auto result = ScoreDispatch<SingleDispatchMethod, PairDispatchMethod, Dev, Real, Int>::f(
             TCAST(I),
             TCAST(charge_I),
             TCAST(J),
@@ -66,8 +71,8 @@ Tensor score_op(
 
 static auto registry =
     torch::jit::RegisterOperators()
-        .op("tmol::score_elec", &score_op<ElecDispatch, tmol::score::common::AABBDispatch>)
-        .op("tmol::score_elec_triu", &score_op<ElecDispatch, tmol::score::common::AABBTriuDispatch>);
+        .op("tmol::score_elec", &score_op<ElecDispatch, tmol::score::common::ForallDispatch, tmol::score::common::AABBDispatch>)
+        .op("tmol::score_elec_triu", &score_op<ElecDispatch, tmol::score::common::ForallDispatch, tmol::score::common::AABBTriuDispatch>);
 
 }  // namespace potentials
 }  // namespace ljlk

--- a/tmol/score/elec/potentials/dispatch.hh
+++ b/tmol/score/elec/potentials/dispatch.hh
@@ -18,7 +18,9 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 template <
     template <tmol::Device>
-    class Dispatch,
+    class SingleDispatch,
+    template <tmol::Device>
+    class PairDispatch,
     tmol::Device Dev,
     typename Real,
     typename Int>

--- a/tmol/score/elec/potentials/dispatch.impl.hh
+++ b/tmol/score/elec/potentials/dispatch.impl.hh
@@ -47,25 +47,25 @@ struct ElecDispatch {
     auto Vs_t = TPack<Real, 1, Dev>::empty({1});
     auto dVs_dI_t = TPack<Vec<Real, 3>, 1, Dev>::empty({coords_i.size(0)});
     auto dVs_dJ_t = TPack<Vec<Real, 3>, 1, Dev>::empty({coords_j.size(0)});
-    
+
     auto Vs = Vs_t.view;
     auto dVs_dI = dVs_dI_t.view;
     auto dVs_dJ = dVs_dJ_t.view;
 
-    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	Vs[i] = 0;
+        Vs[i] = 0;
       }
       if (i < dVs_dI.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dVs_dI[i](j) = 0;
-	}
+        for (int j = 0; j < 3; ++j) {
+          dVs_dI[i](j) = 0;
+        }
       }
       if (i < dVs_dJ.size(0)) {
-	for (int j = 0; j < 3; ++j) {
-	  dVs_dI[i](j) = 0;
-	}
-      }      
+        for (int j = 0; j < 3; ++j) {
+          dVs_dI[i](j) = 0;
+        }
+      }
     };
     int max_size = std::max(1L, std::max(coords_i.size(0), coords_j.size(0)));
     SingleDispatch<Dev>::forall(max_size, zero);

--- a/tmol/score/elec/potentials/dispatch.impl.hh
+++ b/tmol/score/elec/potentials/dispatch.impl.hh
@@ -11,6 +11,7 @@
 #include <tmol/utility/tensor/TensorAccessor.h>
 #include <tmol/utility/tensor/TensorPack.h>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <tmol/score/elec/potentials/potentials.hh>
 
@@ -57,14 +58,16 @@ struct ElecDispatch {
         Vs[i] = 0;
       }
       if (i < dVs_dI.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dVs_dI[i](j) = 0;
-        }
+	common::zero_array<Dev>::go((Real *) dVs_dI.data(), i, dVs_dI.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dVs_dI[i](j) = 0;
+        // }
       }
       if (i < dVs_dJ.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dVs_dI[i](j) = 0;
-        }
+	common::zero_array<Dev>::go((Real *) dVs_dJ.data(), i, dVs_dJ.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dVs_dI[i](j) = 0;
+        // }
       }
     };
     int max_size = std::max(1L, std::max(coords_i.size(0), coords_j.size(0)));

--- a/tmol/score/elec/potentials/dispatch.impl.hh
+++ b/tmol/score/elec/potentials/dispatch.impl.hh
@@ -58,13 +58,13 @@ struct ElecDispatch {
         Vs[i] = 0;
       }
       if (i < dVs_dI.size(0)) {
-	common::zero_array<Dev>::go((Real *) dVs_dI.data(), i, dVs_dI.size(0), 3);
+        common::zero_array<Dev>::go((Real*)dVs_dI.data(), i, dVs_dI.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dVs_dI[i](j) = 0;
         // }
       }
       if (i < dVs_dJ.size(0)) {
-	common::zero_array<Dev>::go((Real *) dVs_dJ.data(), i, dVs_dJ.size(0), 3);
+        common::zero_array<Dev>::go((Real*)dVs_dJ.data(), i, dVs_dJ.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dVs_dI[i](j) = 0;
         // }

--- a/tmol/score/hbond/potentials/compiled.cpu.cpp
+++ b/tmol/score/hbond/potentials/compiled.cpu.cpp
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cpu.impl.hh>
 #include <tmol/score/common/simple_dispatch.cpu.impl.hh>
 
 #include "dispatch.impl.hh"
@@ -7,8 +8,8 @@ namespace score {
 namespace hbond {
 namespace potentials {
 #define declare_dispatch(Real, Int)                                          \
-  template struct HBondDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>; \
-  template struct HBondDispatch<AABBTriuDispatch, tmol::Device::CPU, Real, Int>;
+  template struct HBondDispatch<ForallDispatch, AABBDispatch, tmol::Device::CPU, Real, Int>; \
+  template struct HBondDispatch<ForallDispatch, AABBTriuDispatch, tmol::Device::CPU, Real, Int>;
 
 declare_dispatch(float, int32_t);
 declare_dispatch(double, int32_t);

--- a/tmol/score/hbond/potentials/compiled.cuda.cu
+++ b/tmol/score/hbond/potentials/compiled.cuda.cu
@@ -7,13 +7,18 @@ namespace tmol {
 namespace score {
 namespace hbond {
 namespace potentials {
-#define declare_dispatch(Real, Int)                                           \
-  template struct HBondDispatch<ForallDispatch, AABBDispatch, tmol::Device::CUDA, Real, Int>; \
-  template struct HBondDispatch< \
-				 ForallDispatch,			\
-      AABBTriuDispatch,                                                       \
-      tmol::Device::CUDA,                                                     \
-      Real,                                                                   \
+#define declare_dispatch(Real, Int) \
+  template struct HBondDispatch<    \
+      ForallDispatch,               \
+      AABBDispatch,                 \
+      tmol::Device::CUDA,           \
+      Real,                         \
+      Int>;                         \
+  template struct HBondDispatch<    \
+      ForallDispatch,               \
+      AABBTriuDispatch,             \
+      tmol::Device::CUDA,           \
+      Real,                         \
       Int>;
 
 declare_dispatch(float, int32_t);

--- a/tmol/score/hbond/potentials/compiled.cuda.cu
+++ b/tmol/score/hbond/potentials/compiled.cuda.cu
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cuda.impl.cuh>
 #include <tmol/score/common/simple_dispatch.cuda.impl.cuh>
 
 #include "dispatch.impl.hh"
@@ -7,8 +8,9 @@ namespace score {
 namespace hbond {
 namespace potentials {
 #define declare_dispatch(Real, Int)                                           \
-  template struct HBondDispatch<AABBDispatch, tmol::Device::CUDA, Real, Int>; \
-  template struct HBondDispatch<                                              \
+  template struct HBondDispatch<ForallDispatch, AABBDispatch, tmol::Device::CUDA, Real, Int>; \
+  template struct HBondDispatch< \
+				 ForallDispatch,			\
       AABBTriuDispatch,                                                       \
       tmol::Device::CUDA,                                                     \
       Real,                                                                   \

--- a/tmol/score/hbond/potentials/dispatch.hh
+++ b/tmol/score/hbond/potentials/dispatch.hh
@@ -20,7 +20,9 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 template <
     template <tmol::Device>
-    class Dispatch,
+    class SingleDispatch,
+    template <tmol::Device>
+    class PairDispatch,
     tmol::Device Dev,
     typename Real,
     typename Int>

--- a/tmol/score/hbond/potentials/dispatch.impl.hh
+++ b/tmol/score/hbond/potentials/dispatch.impl.hh
@@ -92,13 +92,15 @@ auto HBondDispatch<SingleDispatch, PairDispatch, Dev, Real, Int>::f(
       V[i] = 0;
     }
     if (i < dV_d_don.size(0)) {
-      common::zero_array<Dev>::go((Real *) dV_d_don.data(), i, dV_d_don.size(0), 3);
+      common::zero_array<Dev>::go(
+          (Real *)dV_d_don.data(), i, dV_d_don.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_d_don[i](j) = 0;
       // }
     }
     if (i < dV_d_acc.size(0)) {
-      common::zero_array<Dev>::go((Real *) dV_d_acc.data(), i, dV_d_acc.size(0), 3);
+      common::zero_array<Dev>::go(
+          (Real *)dV_d_acc.data(), i, dV_d_acc.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_d_acc[i](j) = 0;
       // }

--- a/tmol/score/hbond/potentials/dispatch.impl.hh
+++ b/tmol/score/hbond/potentials/dispatch.impl.hh
@@ -10,6 +10,7 @@
 #include <tmol/utility/tensor/TensorPack.h>
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/zero.hh>
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/hbond/potentials/potentials.hh>
@@ -90,15 +91,17 @@ auto HBondDispatch<SingleDispatch, PairDispatch, Dev, Real, Int>::f(
     if (i == 0) {
       V[i] = 0;
     }
-    if (i < dV_d_acc.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_d_don[i](j) = 0;
-      }
+    if (i < dV_d_don.size(0)) {
+      common::zero_array<Dev>::go((Real *) dV_d_don.data(), i, dV_d_don.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_d_don[i](j) = 0;
+      // }
     }
     if (i < dV_d_acc.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_d_acc[i](j) = 0;
-      }
+      common::zero_array<Dev>::go((Real *) dV_d_acc.data(), i, dV_d_acc.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_d_acc[i](j) = 0;
+      // }
     }
   };
   int max_size = std::max(1L, std::max(dV_d_don.size(0), dV_d_acc.size(0)));

--- a/tmol/score/hbond/potentials/dispatch.impl.hh
+++ b/tmol/score/hbond/potentials/dispatch.impl.hh
@@ -86,18 +86,18 @@ auto HBondDispatch<SingleDispatch, PairDispatch, Dev, Real, Int>::f(
   auto dV_d_don = dV_d_don_t.view;
   auto dV_d_acc = dV_d_acc_t.view;
 
-  auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+  auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
     if (i == 0) {
       V[i] = 0;
     }
     if (i < dV_d_acc.size(0)) {
       for (int j = 0; j < 3; ++j) {
-	dV_d_don[i](j) = 0;
+        dV_d_don[i](j) = 0;
       }
     }
     if (i < dV_d_acc.size(0)) {
       for (int j = 0; j < 3; ++j) {
-	dV_d_acc[i](j) = 0;
+        dV_d_acc[i](j) = 0;
       }
     }
   };

--- a/tmol/score/ljlk/potentials/lj.compiled.cpu.cpp
+++ b/tmol/score/ljlk/potentials/lj.compiled.cpu.cpp
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cpu.impl.hh>
 #include <tmol/score/common/simple_dispatch.cpu.impl.hh>
 
 #include "lj.dispatch.impl.hh"
@@ -7,13 +8,16 @@ namespace score {
 namespace ljlk {
 namespace potentials {
 
-#define declare_dispatch(Real, Int)                                       \
-  template struct LJDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>; \
-  template struct LJDispatch<                                             \
-      AABBTriuDispatch,                                              \
-      tmol::Device::CPU,                                                  \
-      Real,                                                               \
-      Int>;
+#define declare_dispatch(Real, Int)                                        \
+  template struct LJDispatch<                                              \
+    common::ForallDispatch,                                                \
+    common::AABBDispatch,                                                  \
+    tmol::Device::CPU, Real, Int>;                                         \
+  template struct LJDispatch<                                              \
+    common::ForallDispatch,                                                \
+    common::AABBTriuDispatch,                                              \
+    tmol::Device::CPU, Real, Int>;
+
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/ljlk/potentials/lj.compiled.cuda.cu
+++ b/tmol/score/ljlk/potentials/lj.compiled.cuda.cu
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cuda.impl.cuh>
 #include <tmol/score/common/simple_dispatch.cuda.impl.cuh>
 
 #include "lj.dispatch.impl.hh"
@@ -7,9 +8,19 @@ namespace score {
 namespace ljlk {
 namespace potentials {
 
-#define declare_dispatch(Real, Int)                                        \
-  template struct LJDispatch<AABBDispatch, tmol::Device::CUDA, Real, Int>; \
-  template struct LJDispatch<AABBTriuDispatch, tmol::Device::CUDA, Real, Int>;
+#define declare_dispatch(Real, Int) \
+  template struct LJDispatch<       \
+      common::ForallDispatch,       \
+      common::AABBDispatch,         \
+      tmol::Device::CUDA,           \
+      Real,                         \
+      Int>;                         \
+  template struct LJDispatch<       \
+      common::ForallDispatch,       \
+      common::AABBTriuDispatch,     \
+      tmol::Device::CUDA,           \
+      Real,                         \
+      Int>;
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/ljlk/potentials/lj.dispatch.hh
+++ b/tmol/score/ljlk/potentials/lj.dispatch.hh
@@ -20,7 +20,9 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 template <
     template <tmol::Device>
-    class Dispatch,
+    class SingleDispatch,
+    template <tmol::Device>
+    class PairDispatch,
     tmol::Device D,
     typename Real,
     typename Int>

--- a/tmol/score/ljlk/potentials/lj.dispatch.impl.hh
+++ b/tmol/score/ljlk/potentials/lj.dispatch.impl.hh
@@ -12,6 +12,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/zero.hh>
 
 #include "lj.dispatch.hh"
 #include "lj.hh"
@@ -63,14 +64,16 @@ auto LJDispatch<SingleDispatch, PairDispatch, D, Real, Int>::f(
       V[i] = 0;
     }
     if (i < dV_dI.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_dI[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_dI[i](j) = 0;
+      // }
     }
     if (i < dV_dJ.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_dJ[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_dJ[i](j) = 0;
+      // }
     }
   };
   int largest = std::max(3, (int)std::max(coords_i.size(0), coords_j.size(0)));

--- a/tmol/score/ljlk/potentials/lj.dispatch.impl.hh
+++ b/tmol/score/ljlk/potentials/lj.dispatch.impl.hh
@@ -64,13 +64,13 @@ auto LJDispatch<SingleDispatch, PairDispatch, D, Real, Int>::f(
       V[i] = 0;
     }
     if (i < dV_dI.size(0)) {
-      common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
+      common::zero_array<D>::go((Real*)dV_dI.data(), i, dV_dI.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_dI[i](j) = 0;
       // }
     }
     if (i < dV_dJ.size(0)) {
-      common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
+      common::zero_array<D>::go((Real*)dV_dJ.data(), i, dV_dJ.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_dJ[i](j) = 0;
       // }

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -40,8 +40,9 @@ struct vdw {
     Real sd6 = sd2 * sd2 * sd2;
     Real sd12 = sd6 * sd6;
 
-    return {epsilon * (sd12 - 2.0 * sd6),
-            epsilon * ((-12.0 * sd12 / dist) - (2.0 * -6.0 * sd6 / dist))};
+    return {
+        epsilon * (sd12 - Real(2.0) * sd6),
+        epsilon * ((Real(-12.0) * sd12 / dist) - (Real(-12.0) * sd6 / dist))};
   }
 };
 

--- a/tmol/score/ljlk/potentials/lk_isotropic.compiled.cpu.cpp
+++ b/tmol/score/ljlk/potentials/lk_isotropic.compiled.cpu.cpp
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cpu.impl.hh>
 #include <tmol/score/common/simple_dispatch.cpu.impl.hh>
 
 #include "lk_isotropic.dispatch.impl.hh"
@@ -8,8 +9,8 @@ namespace ljlk {
 namespace potentials {
 
 #define declare_dispatch(Real, Int)                                            \
-  template struct LKIsotropicDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>;     \
-  template struct LKIsotropicDispatch<AABBTriuDispatch, tmol::Device::CPU, Real, Int>; \
+  template struct LKIsotropicDispatch<ForallDispatch, AABBDispatch, tmol::Device::CPU, Real, Int>; \
+  template struct LKIsotropicDispatch<ForallDispatch, AABBTriuDispatch, tmol::Device::CPU, Real, Int>; \
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/ljlk/potentials/lk_isotropic.compiled.cuda.cu
+++ b/tmol/score/ljlk/potentials/lk_isotropic.compiled.cuda.cu
@@ -1,3 +1,4 @@
+#include <tmol/score/common/forall_dispatch.cuda.impl.cuh>
 #include <tmol/score/common/simple_dispatch.cuda.impl.cuh>
 
 #include "lk_isotropic.dispatch.impl.hh"
@@ -10,11 +11,13 @@ namespace potentials {
 #define declare_dispatch(Real, Int)    \
                                        \
   template struct LKIsotropicDispatch< \
+      ForallDispatch,                  \
       AABBDispatch,                    \
       tmol::Device::CUDA,              \
       Real,                            \
       Int>;                            \
   template struct LKIsotropicDispatch< \
+      ForallDispatch,                  \
       AABBTriuDispatch,                \
       tmol::Device::CUDA,              \
       Real,                            \

--- a/tmol/score/ljlk/potentials/lk_isotropic.dispatch.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.dispatch.hh
@@ -21,7 +21,9 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 template <
     template <tmol::Device>
-    class Dispatch,
+    class SingleDispatch,
+    template <tmol::Device>
+    class PairDispatch,
     tmol::Device D,
     typename Real,
     typename Int>

--- a/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
@@ -67,13 +67,13 @@ auto LKIsotropicDispatch<SingleDispatch, PairDispatch, D, Real, Int>::f(
       V[i] = 0;
     }
     if (i < dV_dI.size(0)) {
-      common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
+      common::zero_array<D>::go((Real*)dV_dI.data(), i, dV_dI.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_dI[i](j) = 0;
       // }
     }
     if (i < dV_dJ.size(0)) {
-      common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
+      common::zero_array<D>::go((Real*)dV_dJ.data(), i, dV_dJ.size(0), 3);
       // for (int j = 0; j < 3; ++j) {
       //   dV_dJ[i](j) = 0;
       // }

--- a/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
@@ -12,6 +12,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/zero.hh>
 
 #include "lk_isotropic.dispatch.hh"
 #include "lk_isotropic.hh"
@@ -51,9 +52,9 @@ auto LKIsotropicDispatch<SingleDispatch, PairDispatch, D, Real, Int>::f(
 
   NVTXRange _allocate("allocate");
 
-  auto V_t = TPack<Real, 1, D>::zeros({1});
-  auto dV_dI_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords_i.size(0)});
-  auto dV_dJ_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords_j.size(0)});
+  auto V_t = TPack<Real, 1, D>::empty({1});
+  auto dV_dI_t = TPack<Vec<Real, 3>, 1, D>::empty({coords_i.size(0)});
+  auto dV_dJ_t = TPack<Vec<Real, 3>, 1, D>::empty({coords_j.size(0)});
 
   auto V = V_t.view;
   auto dV_dI = dV_dI_t.view;
@@ -66,14 +67,16 @@ auto LKIsotropicDispatch<SingleDispatch, PairDispatch, D, Real, Int>::f(
       V[i] = 0;
     }
     if (i < dV_dI.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_dI[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_dI[i](j) = 0;
+      // }
     }
     if (i < dV_dJ.size(0)) {
-      for (int j = 0; j < 3; ++j) {
-        dV_dJ[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
+      // for (int j = 0; j < 3; ++j) {
+      //   dV_dJ[i](j) = 0;
+      // }
     }
   };
   int largest = std::max(3, (int)std::max(coords_i.size(0), coords_j.size(0)));

--- a/tmol/score/lk_ball/potentials/compiled.cpu.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.cpu.cpp
@@ -12,10 +12,10 @@ namespace score {
 namespace lk_ball {
 namespace potentials {
 
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, float, int32_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, double, int32_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, float, int64_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, double, int64_t>;
+template struct LKBallDispatch<common::ForallDispatch, common::AABBDispatch, tmol::Device::CPU, float, int32_t>;
+template struct LKBallDispatch<common::ForallDispatch, common::AABBDispatch, tmol::Device::CPU, double, int32_t>;
+template struct LKBallDispatch<common::ForallDispatch, common::AABBDispatch, tmol::Device::CPU, float, int64_t>;
+template struct LKBallDispatch<common::ForallDispatch, common::AABBDispatch, tmol::Device::CPU, double, int64_t>;
 
 template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, float, int32_t, 4>;
 template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, double, int32_t, 4>;

--- a/tmol/score/lk_ball/potentials/compiled.cuda.cu
+++ b/tmol/score/lk_ball/potentials/compiled.cuda.cu
@@ -15,11 +15,13 @@ namespace lk_ball {
 namespace potentials {
 
 template struct LKBallDispatch<
+    common::ForallDispatch,
     common::AABBDispatch,
     tmol::Device::CUDA,
     float,
     int64_t>;
 template struct LKBallDispatch<
+    common::ForallDispatch,
     common::AABBDispatch,
     tmol::Device::CUDA,
     double,

--- a/tmol/score/lk_ball/potentials/dispatch.hh
+++ b/tmol/score/lk_ball/potentials/dispatch.hh
@@ -21,7 +21,9 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 template <
     template <tmol::Device>
-    class Dispatch,
+    class SingleDispatch,
+    template <tmol::Device>
+    class PairDispatch,
     tmol::Device D,
     typename Real,
     typename Int>

--- a/tmol/score/lk_ball/potentials/dispatch.impl.hh
+++ b/tmol/score/lk_ball/potentials/dispatch.impl.hh
@@ -57,9 +57,7 @@ struct LKBallDispatch {
     auto Vs_t = TPack<Real, 1, D>::empty({4});
     auto Vs = Vs_t.view;
 
-    auto zero = [=] EIGEN_DEVICE_FUNC(int idx) {
-      Vs[idx] = 0;
-    };
+    auto zero = [=] EIGEN_DEVICE_FUNC(int idx) { Vs[idx] = 0; };
     SingleDispatch<D>::forall(4, zero);
     nvtx_range_pop();
 
@@ -143,26 +141,26 @@ struct LKBallDispatch {
     auto dW_dI = dW_dI_t.view;
     auto dW_dJ = dW_dJ_t.view;
 
-    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i < dV_dI.size(0)) {
         for (int j = 0; j < 3; ++j) {
           dV_dI[i](j) = 0;
           for (int j = 0; j < 4; ++j) {
-	    for (int k = 0; k <3; ++k) {
+            for (int k = 0; k < 3; ++k) {
               dW_dI[i][j](k) = 0;
-	    }
+            }
           }
-	}
+        }
       }
       if (i < dV_dJ.size(0)) {
         for (int j = 0; j < 3; ++j) {
           dV_dJ[i](j) = 0;
           for (int j = 0; j < 4; ++j) {
-	    for (int k = 0; k < 3; ++k) {
+            for (int k = 0; k < 3; ++k) {
               dW_dJ[i][j](k) = 0;
-	    }
+            }
           }
-	}
+        }
       }
     };
     int const max_ats = std::max(dV_dI.size(0), dV_dJ.size(0));

--- a/tmol/score/lk_ball/potentials/dispatch.impl.hh
+++ b/tmol/score/lk_ball/potentials/dispatch.impl.hh
@@ -144,12 +144,12 @@ struct LKBallDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i < dV_dI.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
-	common::zero_array<D>::go((Real *) dW_dI.data(), i, dW_dI.size(0), 12);
+        common::zero_array<D>::go((Real *)dV_dI.data(), i, dV_dI.size(0), 3);
+        common::zero_array<D>::go((Real *)dW_dI.data(), i, dW_dI.size(0), 12);
       }
       if (i < dV_dJ.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
-	common::zero_array<D>::go((Real *) dW_dJ.data(), i, dV_dJ.size(0), 12);
+        common::zero_array<D>::go((Real *)dV_dJ.data(), i, dV_dJ.size(0), 3);
+        common::zero_array<D>::go((Real *)dW_dJ.data(), i, dV_dJ.size(0), 12);
       }
     };
 

--- a/tmol/score/lk_ball/potentials/dispatch.impl.hh
+++ b/tmol/score/lk_ball/potentials/dispatch.impl.hh
@@ -12,6 +12,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/dispatch.hh>
 #include <tmol/score/common/geom.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <tmol/score/ljlk/potentials/params.hh>
 
@@ -143,26 +144,15 @@ struct LKBallDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i < dV_dI.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dI[i](j) = 0;
-          for (int j = 0; j < 4; ++j) {
-            for (int k = 0; k < 3; ++k) {
-              dW_dI[i][j](k) = 0;
-            }
-          }
-        }
+	common::zero_array<D>::go((Real *) dV_dI.data(), i, dV_dI.size(0), 3);
+	common::zero_array<D>::go((Real *) dW_dI.data(), i, dW_dI.size(0), 12);
       }
       if (i < dV_dJ.size(0)) {
-        for (int j = 0; j < 3; ++j) {
-          dV_dJ[i](j) = 0;
-          for (int j = 0; j < 4; ++j) {
-            for (int k = 0; k < 3; ++k) {
-              dW_dJ[i][j](k) = 0;
-            }
-          }
-        }
+	common::zero_array<D>::go((Real *) dV_dJ.data(), i, dV_dJ.size(0), 3);
+	common::zero_array<D>::go((Real *) dW_dJ.data(), i, dV_dJ.size(0), 12);
       }
     };
+
     int const max_ats = std::max(dV_dI.size(0), dV_dJ.size(0));
     SingleDispatch<D>::forall(max_ats, zero);
 

--- a/tmol/score/lk_ball/potentials/gen_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_waters.impl.hh
@@ -155,8 +155,14 @@ struct GenerateWaters {
     int num_Vs = coords.size(0);
 
     auto dE_d_coord_t =
-        TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0), MAX_WATER});
+        TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
     auto dE_d_coord = dE_d_coord_t.view;
+    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+      for (int j = 0; j < 3; ++j) {
+	dE_d_coord[i](j) = 0;
+      }      
+    };
+    Dispatch<D>::forall(coords.size(0), zero);
 
     tmol::score::bonded_atom::IndexedBonds<Int, D> indexed_bonds;
     indexed_bonds.bonds = indexed_bond_bonds;

--- a/tmol/score/lk_ball/potentials/gen_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_waters.impl.hh
@@ -10,6 +10,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/dispatch.hh>
 #include <tmol/score/common/geom.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <tmol/score/hbond/identification.hh>
 #include <tmol/score/ljlk/potentials/params.hh>
@@ -157,9 +158,7 @@ struct GenerateWaters {
     auto dE_d_coord_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
     auto dE_d_coord = dE_d_coord_t.view;
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
-      for (int j = 0; j < 3; ++j) {
-        dE_d_coord[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dE_d_coord.data(), i, dE_d_coord.size(0), 3);
     };
     Dispatch<D>::forall(coords.size(0), zero);
 

--- a/tmol/score/lk_ball/potentials/gen_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_waters.impl.hh
@@ -158,7 +158,8 @@ struct GenerateWaters {
     auto dE_d_coord_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
     auto dE_d_coord = dE_d_coord_t.view;
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
-      common::zero_array<D>::go((Real *) dE_d_coord.data(), i, dE_d_coord.size(0), 3);
+      common::zero_array<D>::go(
+          (Real *)dE_d_coord.data(), i, dE_d_coord.size(0), 3);
     };
     Dispatch<D>::forall(coords.size(0), zero);
 

--- a/tmol/score/lk_ball/potentials/gen_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_waters.impl.hh
@@ -154,13 +154,12 @@ struct GenerateWaters {
 
     int num_Vs = coords.size(0);
 
-    auto dE_d_coord_t =
-        TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
+    auto dE_d_coord_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
     auto dE_d_coord = dE_d_coord_t.view;
-    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       for (int j = 0; j < 3; ++j) {
-	dE_d_coord[i](j) = 0;
-      }      
+        dE_d_coord[i](j) = 0;
+      }
     };
     Dispatch<D>::forall(coords.size(0), zero);
 

--- a/tmol/score/omega/potentials/dispatch.impl.hh
+++ b/tmol/score/omega/potentials/dispatch.impl.hh
@@ -46,7 +46,7 @@ struct OmegaDispatch {
       if (i == 0) {
         V[i] = 0;
       }
-      common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+      common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 

--- a/tmol/score/omega/potentials/dispatch.impl.hh
+++ b/tmol/score/omega/potentials/dispatch.impl.hh
@@ -41,16 +41,16 @@ struct OmegaDispatch {
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
 
-    auto zero = [=] EIGEN_DEVICE_FUNC (int i) {
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       for (int j = 0; j < 3; ++j) {
-	dV_dx[i](j) = 0;
-      }	
+        dV_dx[i](j) = 0;
+      }
     };
     Dispatch<D>::forall(std::max(1L, V.size(0)), zero);
-    
+
     auto func = ([=] EIGEN_DEVICE_FUNC(int i) {
       CoordQuad omegacoords;
       for (int j = 0; j < 4; ++j) {

--- a/tmol/score/omega/potentials/dispatch.impl.hh
+++ b/tmol/score/omega/potentials/dispatch.impl.hh
@@ -49,7 +49,7 @@ struct OmegaDispatch {
         dV_dx[i](j) = 0;
       }
     };
-    Dispatch<D>::forall(std::max(1L, V.size(0)), zero);
+    Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 
     auto func = ([=] EIGEN_DEVICE_FUNC(int i) {
       CoordQuad omegacoords;

--- a/tmol/score/omega/potentials/dispatch.impl.hh
+++ b/tmol/score/omega/potentials/dispatch.impl.hh
@@ -8,6 +8,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/tuple.hh>
 #include <tmol/score/common/tuple_operators.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <ATen/Tensor.h>
 
@@ -45,9 +46,7 @@ struct OmegaDispatch {
       if (i == 0) {
         V[i] = 0;
       }
-      for (int j = 0; j < 3; ++j) {
-        dV_dx[i](j) = 0;
-      }
+      common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
     };
     Dispatch<D>::forall(std::max(1L, dV_dx.size(0)), zero);
 

--- a/tmol/score/rama/potentials/dispatch.impl.hh
+++ b/tmol/score/rama/potentials/dispatch.impl.hh
@@ -44,10 +44,10 @@ struct RamaDispatch {
 
     auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
       if (i == 0) {
-	V[i] = 0;
+        V[i] = 0;
       }
       for (int j = 0; j < 3; ++j) {
-	dV_dx[i](j) = 0;
+        dV_dx[i](j) = 0;
       }
     };
     Dispatch<D>::forall(std::max(1L, coords.size(0)), zero);

--- a/tmol/score/rama/potentials/dispatch.impl.hh
+++ b/tmol/score/rama/potentials/dispatch.impl.hh
@@ -36,11 +36,21 @@ struct RamaDispatch {
       TView<Real, 3, D> tables,
       TView<RamaTableParams<Real>, 1, D> table_params)
       -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+    auto V_t = TPack<Real, 1, D>::empty({1});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::empty({coords.size(0)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
+
+    auto zero = [=] EIGEN_DEVICE_FUNC(int i) {
+      if (i == 0) {
+	V[i] = 0;
+      }
+      for (int j = 0; j < 3; ++j) {
+	dV_dx[i](j) = 0;
+      }
+    };
+    Dispatch<D>::forall(std::max(1L, coords.size(0)), zero);
 
     auto func = ([=] EIGEN_DEVICE_FUNC(int i) {
       CoordQuad phicoords;

--- a/tmol/score/rama/potentials/dispatch.impl.hh
+++ b/tmol/score/rama/potentials/dispatch.impl.hh
@@ -7,6 +7,7 @@
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/tuple.hh>
 #include <tmol/score/common/tuple_operators.hh>
+#include <tmol/score/common/zero.hh>
 
 #include <ATen/Tensor.h>
 
@@ -46,8 +47,11 @@ struct RamaDispatch {
       if (i == 0) {
         V[i] = 0;
       }
-      for (int j = 0; j < 3; ++j) {
-        dV_dx[i](j) = 0;
+      if (i < dV_dx.size(0)) {
+	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        // for (int j = 0; j < 3; ++j) {
+        //   dV_dx[i](j) = 0;
+        // }
       }
     };
     Dispatch<D>::forall(std::max(1L, coords.size(0)), zero);

--- a/tmol/score/rama/potentials/dispatch.impl.hh
+++ b/tmol/score/rama/potentials/dispatch.impl.hh
@@ -48,7 +48,7 @@ struct RamaDispatch {
         V[i] = 0;
       }
       if (i < dV_dx.size(0)) {
-	common::zero_array<D>::go((Real *) dV_dx.data(), i, dV_dx.size(0), 3);
+        common::zero_array<D>::go((Real *)dV_dx.data(), i, dV_dx.size(0), 3);
         // for (int j = 0; j < 3; ++j) {
         //   dV_dx[i](j) = 0;
         // }


### PR DESCRIPTION
Allocate empty (uninitialized) arrays for the terms, and then launch a kernel to set the values of this array to zero. This is broadly faster than cudaMemset.

