### PR TITLE
Aleaverfay/stacked performance

### DIFF
--- a/tmol/kinematics/compiled/compiled.cuda.cu
+++ b/tmol/kinematics/compiled/compiled.cuda.cu
@@ -165,7 +165,6 @@ struct ForwardKinDispatch {
     using tmol::score::common::tie;
     typedef typename mgpu::launch_params_t<128, 2> launch_t;
     constexpr int nt = launch_t::nt, vt = launch_t::vt;
-
     auto num_atoms = dofs.size(0);
 
     nvtx_range_push("dispatch::alloc");

--- a/tmol/kinematics/datatypes.py
+++ b/tmol/kinematics/datatypes.py
@@ -27,7 +27,7 @@ class KinTree(TensorGroup, ConvertAttrs):
     corresponds to a derived orientation, which an atomic coordinate at the
     center of the frame.
 
-    Each node is the tree is connected by one of two "node types":
+    Each node in the tree is connected by one of two "node types":
 
     1) Jump nodes, representing an arbitrary rigid body transform between two
     reference frames via six degrees of freedom, 3 translational and
@@ -37,13 +37,13 @@ class KinTree(TensorGroup, ConvertAttrs):
     frames via three bond degrees of freedom, bond axis translation, bond axis
     rotation about the parent-grandparent bond and change of bond axis with
     respect to the bond. Bond nodes include an additional, redundent,
-    degree of free representing concerted rotation of all downstream bonds
+    degree of freedom representing concerted rotation of all downstream bonds
     about the parent-self bond.
 
     The `KinTree` data structure itself is frozen and can not be modified post
     construction. The `KinematicBuilder` factory class is responsible for
     construction of a `KinTree` with valid internal structure for atomic
-    system.
+    systems.
 
     Indices::
         id = index for kin-atom in the target coordinate system

--- a/tmol/score/coordinates.py
+++ b/tmol/score/coordinates.py
@@ -12,6 +12,7 @@ from tmol.utility.reactive import reactive_property
 
 from tmol.types.torch import Tensor
 
+from .bonded_atom import BondedAtomScoreGraph
 from .device import TorchDevice
 from .score_graph import score_graph
 from .stacked_system import StackedSystem
@@ -43,7 +44,7 @@ class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice):
 
 
 @score_graph
-class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice):
+class KinematicAtomicCoordinateProvider(BondedAtomScoreGraph, StackedSystem, TorchDevice):
     @staticmethod
     @singledispatch
     def factory_for(
@@ -84,23 +85,25 @@ class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice):
         kintree: KinTree,
         kin_module: KinematicModule,
         system_size: int,
+        stack_depth: int,
     ) -> Tensor(torch.float)[:, :, 3]:
         """System cartesian atomic coordinates."""
         kincoords = kin_module(dofs)
 
         coords = torch.full(
-            (system_size, 3),
+            (stack_depth, system_size, 3),
             math.nan,
             dtype=dofs.dtype,
             layout=dofs.layout,
             device=dofs.device,
             requires_grad=False,
         )
+        coords_flat = coords.reshape((-1,3))
 
         idIdx = kintree.id[1:].to(dtype=torch.long)
-        coords[idIdx] = kincoords[1:]
+        coords_flat[idIdx] = kincoords[1:]
 
-        return coords.to(torch.float)[None, ...]
+        return coords.to(torch.float)
 
     def reset_coords(self):
         """Reset coordinate state in compute graph, clearing dependent properties."""

--- a/tmol/score/dunbrack/potentials/dispatch.impl.hh
+++ b/tmol/score/dunbrack/potentials/dispatch.impl.hh
@@ -190,7 +190,9 @@ struct DunbrackDispatch {
             dneglnprob_rot_dbb_xyz[stack],
             ddihe_dxyz[stack],
             i);
-        common::accumulate<D, Real>::add(V[stack][0], Erot);
+	auto Vslice0 = V.slice_one(1, 0);
+        common::accumulate<D, Real>::add_one_dst(Vslice0, stack, Erot);
+	// common::accumulate<D, Real>::add(V[stack][0], Erot);
       }
     });
     Dispatch<D>::forall_stacks(nstacks, n_rotameric_res, func_rotameric_prob);
@@ -216,7 +218,9 @@ struct DunbrackDispatch {
             drotchi_devpen_dtor_xyz[stack],
             ddihe_dxyz[stack],
             i);
-        common::accumulate<D, Real>::add(V[stack][1], Erotdev);
+	auto Vslice1 = V.slice_one(1, 1);
+        common::accumulate<D, Real>::add_one_dst(Vslice1, stack, Erotdev);
+	//common::accumulate<D, Real>::add(V[stack][1], Erotdev);
       }
     });
     Dispatch<D>::forall_stacks(nstacks, n_rotameric_chi, func_chidevpen);
@@ -238,7 +242,9 @@ struct DunbrackDispatch {
             i,
             dneglnprob_nonrot_dtor_xyz[stack],
             ddihe_dxyz[stack]);
-        common::accumulate<D, Real>::add(V[stack][2], Esemi);
+	auto Vslice2 = V.slice_one(1, 2);
+        common::accumulate<D, Real>::add_one_dst(Vslice2, stack, Esemi);
+	// common::accumulate<D, Real>::add(V[stack][2], Esemi);
       }
     });
     Dispatch<D>::forall_stacks(nstacks, n_semirotameric_res, func_semirot);

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -26,7 +26,7 @@ template <
     class ScoreDispatch,
     template <tmol::Device>
     class DispatchMethod>
-Tensor score_op(
+Tensor lj_score_op(
     Tensor I,
     Tensor atom_type_I,
     Tensor J,
@@ -67,14 +67,69 @@ Tensor score_op(
   });
 };
 
+template <
+    template <
+        template <tmol::Device>
+        class Dispatch,
+        tmol::Device D,
+        typename Real,
+        typename Int>
+    class ScoreDispatch,
+    template <tmol::Device>
+    class DispatchMethod>
+Tensor lk_score_op(
+    Tensor I,
+    Tensor atom_type_I,
+    Tensor heavyatom_inds_I,
+    Tensor J,
+    Tensor atom_type_J,
+    Tensor heavyatom_inds_J,
+    Tensor bonded_path_lengths,
+    Tensor type_params,
+    Tensor global_params) {
+  using tmol::utility::connect_backward_pass;
+  using tmol::utility::StackedSavedGradsBackward;
+
+  at::Tensor score;
+  at::Tensor dScore_dI;
+  at::Tensor dScore_dJ;
+
+  using Int = int64_t;
+
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      I.type(), "score_op", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+
+        auto result = ScoreDispatch<DispatchMethod, Dev, Real, Int>::f(
+            TCAST(I),
+            TCAST(atom_type_I),
+            TCAST(heavyatom_inds_I),
+            TCAST(J),
+            TCAST(atom_type_J),
+            TCAST(heavyatom_inds_J),
+            TCAST(bonded_path_lengths),
+            TCAST(type_params),
+            TCAST(global_params));
+
+        score = std::get<0>(result).tensor;
+        dScore_dI = std::get<1>(result).tensor;
+        dScore_dJ = std::get<2>(result).tensor;
+      }));
+
+  return connect_backward_pass({I, J}, score, [&]() {
+    return StackedSavedGradsBackward::create({dScore_dI, dScore_dJ});
+  });
+};
+
 static auto registry =
     torch::jit::RegisterOperators()
-        .op("tmol::score_ljlk_lj", &score_op<LJDispatch, AABBDispatch>)
-        .op("tmol::score_ljlk_lj_triu", &score_op<LJDispatch, AABBTriuDispatch>)
+        .op("tmol::score_ljlk_lj", &lj_score_op<LJDispatch, AABBDispatch>)
+        .op("tmol::score_ljlk_lj_triu", &lj_score_op<LJDispatch, AABBTriuDispatch>)
         .op("tmol::score_ljlk_lk_isotropic",
-            &score_op<LKIsotropicDispatch, AABBDispatch>)
+            &lk_score_op<LKIsotropicDispatch, AABBDispatch>)
         .op("tmol::score_ljlk_lk_isotropic_triu",
-            &score_op<LKIsotropicDispatch, AABBTriuDispatch>);
+            &lk_score_op<LKIsotropicDispatch, AABBTriuDispatch>);
 
 }  // namespace potentials
 }  // namespace ljlk

--- a/tmol/score/ljlk/potentials/lk_isotropic.dispatch.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.dispatch.hh
@@ -29,9 +29,11 @@ struct LKIsotropicDispatch {
   static auto f(
       TView<Vec<Real, 3>, 2, D> coords_i,
       TView<Int, 2, D> atom_type_i,
+      TView<Int, 2, D> heavyatom_inds_i,
 
       TView<Vec<Real, 3>, 2, D> coords_j,
       TView<Int, 2, D> atom_type_j,
+      TView<Int, 2, D> heavyatom_inds_j,
 
       TView<Real, 3, D> bonded_path_lengths,
 

--- a/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.dispatch.impl.hh
@@ -33,9 +33,11 @@ template <
 auto LKIsotropicDispatch<Dispatch, D, Real, Int>::f(
     TView<Vec<Real, 3>, 2, D> coords_i,
     TView<Int, 2, D> atom_type_i,
+    TView<Int, 2, D> heavyatom_inds_i,
 
     TView<Vec<Real, 3>, 2, D> coords_j,
     TView<Int, 2, D> atom_type_j,
+    TView<Int, 2, D> heavyatom_inds_j,
 
     TView<Real, 3, D> bonded_path_lengths,
 
@@ -63,11 +65,16 @@ auto LKIsotropicDispatch<Dispatch, D, Real, Int>::f(
 
   nvtx_range_push("dispatch::score");
   Real threshold_distance = 6.0;
-  Dispatch<D>::forall_stacked_pairs(
+  Dispatch<D>::forall_stacked_idx_pairs(
       threshold_distance,
       coords_i,
       coords_j,
-      [=] EIGEN_DEVICE_FUNC(int stack, int i, int j) {
+      heavyatom_inds_i,
+      heavyatom_inds_j,
+      [=] EIGEN_DEVICE_FUNC(int stack, int i_idx, int j_idx) {
+	Int i = heavyatom_inds_i[stack][i_idx];
+	Int j = heavyatom_inds_j[stack][j_idx];
+	  
         Int ati = atom_type_i[stack][i];
         Int atj = atom_type_j[stack][j];
 

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -80,7 +80,7 @@ struct f_desolv {
       * lk_dgfree_i
       / (2 * pi_pow1p5 * lk_lambda_i)
       / (dist * dist)
-      * fastexp(-fastpow((dist - lj_radius_i) / lk_lambda_i, 2))
+      * exp(-1 * (dist - lj_radius_i) * (dist - lj_radius_i) / (lk_lambda_i * lk_lambda_i))
     );
     // clang-format on
   }
@@ -97,27 +97,28 @@ struct f_desolv {
     static const Real pi = EIGEN_PI;
     static const Real pi_pow1p5 = 5.56832799683f; // pow(pi,3.0/2.0);
 
+    Real const exp_val = exp(-1 * (dist - lj_radius_i) * (dist - lj_radius_i)/ (lk_lambda_i * lk_lambda_i));
+
     // clang-format off
     Real desolv = (
       -lk_volume_j
       * lk_dgfree_i
       / (2 * pi_pow1p5 * lk_lambda_i)
       / (dist * dist)
-      * fastexp(-fastpow((dist - lj_radius_i) / lk_lambda_i, 2))
+      * exp_val
     );
 
     Real d_desolv_d_dist = (
       -lk_volume_j
       * lk_dgfree_i
       / (2 * pi_pow1p5 * lk_lambda_i)
-      * ((  // (f * fastexp(g))' = f' * fastexp(g) + f g' fastexp(g)
+      * exp_val
+      * ((  // (f * exp(g))' = f' * exp(g) + f g' exp(g)
           -2 / (dist * dist * dist)
-          * fastexp(-fastpow(dist - lj_radius_i, 2) / fastpow(lk_lambda_i, 2))
         ) + (
           1 / (dist * dist)
           * -(2 * dist - 2 * lj_radius_i)
           / (lk_lambda_i * lk_lambda_i)
-          * fastexp(-pow(dist - lj_radius_i, 2) / fastpow(lk_lambda_i, 2))
         )
       )
     );

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -15,40 +15,7 @@ namespace score {
 namespace ljlk {
 namespace potentials {
 
-
-
 #define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
-
-
-
-// fast math -- from https://code.google.com/p/fastapprox/downloads/detail?name=fastapprox-0.3.2.tar.gz
-
-def
-fastpow2 (float p) -> float {
-        float offset = (p < 0.0) ? 1.0f : 0.0f;
-        float clipp = (p < -126.0) ? -126.0f : p;
-        auto w = (int)(clipp);
-        float z = clipp - (float)(w) + offset;
-        union { uint32_t i; float f; } v = { (uint32_t) ( (1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) ) };
-
-        return v.f;
-}
-
-def
-fastlog2 (float x) -> float {
-        union { float f; uint32_t i; } vx = { x };
-        union { uint32_t i; float f; } mx = { (vx.i & 0x007FFFFF) | 0x3f000000 };
-        float y = vx.i;
-        y *= 1.1920928955078125e-7f;
-
-        return y - 124.22551499f
-                - 1.498030302f * mx.f
-                - 1.72587999f / (0.3520887068f + mx.f);
-}
-
-def fastexp (float p) -> float { return fastpow2 (1.442695040f * p); }
-def fastpow (float x, float p) -> float { return fastpow2 (p * fastlog2 (x)); }
-
 
 using namespace tmol::score::common;
 
@@ -70,17 +37,16 @@ struct f_desolv {
       ->Real {
     using std::exp;
     using std::pow;
-    static const Real pi = EIGEN_PI;
-    static const Real pi_pow1p5 = 5.56832799683f; // pow(pi,3.0/2.0);
-    
-    
+    const Real pi = EIGEN_PI;
+    static const Real pi_pow1p5 = 5.56832799683f;
+
     // clang-format off
     return (
       -lk_volume_j
       * lk_dgfree_i
       / (2 * pi_pow1p5 * lk_lambda_i)
       / (dist * dist)
-      * exp(-1 * (dist - lj_radius_i) * (dist - lj_radius_i) / (lk_lambda_i * lk_lambda_i))
+      * exp(-(dist - lj_radius_i)*(dist - lj_radius_i) / (lk_lambda_i*lk_lambda_i))
     );
     // clang-format on
   }
@@ -94,11 +60,10 @@ struct f_desolv {
       ->V_dV_t {
     using std::exp;
     using std::pow;
-    static const Real pi = EIGEN_PI;
-    static const Real pi_pow1p5 = 5.56832799683f; // pow(pi,3.0/2.0);
+    const Real pi = EIGEN_PI;
+    static const Real pi_pow1p5 = 5.56832799683f;
 
-    Real const exp_val = exp(-1 * (dist - lj_radius_i) * (dist - lj_radius_i)/ (lk_lambda_i * lk_lambda_i));
-
+    Real const exp_val = exp(-(dist - lj_radius_i)*(dist - lj_radius_i) / (lk_lambda_i*lk_lambda_i));
     // clang-format off
     Real desolv = (
       -lk_volume_j

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -70,13 +70,15 @@ struct f_desolv {
       ->Real {
     using std::exp;
     using std::pow;
-    const Real pi = EIGEN_PI;
-
+    static const Real pi = EIGEN_PI;
+    static const Real pi_pow1p5 = 5.56832799683f; // pow(pi,3.0/2.0);
+    
+    
     // clang-format off
     return (
       -lk_volume_j
       * lk_dgfree_i
-      / (2 * fastpow(pi, 3.0 / 2.0) * lk_lambda_i)
+      / (2 * pi_pow1p5 * lk_lambda_i)
       / (dist * dist)
       * fastexp(-fastpow((dist - lj_radius_i) / lk_lambda_i, 2))
     );
@@ -92,13 +94,14 @@ struct f_desolv {
       ->V_dV_t {
     using std::exp;
     using std::pow;
-    const Real pi = EIGEN_PI;
+    static const Real pi = EIGEN_PI;
+    static const Real pi_pow1p5 = 5.56832799683f; // pow(pi,3.0/2.0);
 
     // clang-format off
     Real desolv = (
       -lk_volume_j
       * lk_dgfree_i
-      / (2 * fastpow(pi, 3.0 / 2.0) * lk_lambda_i)
+      / (2 * pi_pow1p5 * lk_lambda_i)
       / (dist * dist)
       * fastexp(-fastpow((dist - lj_radius_i) / lk_lambda_i, 2))
     );
@@ -106,7 +109,7 @@ struct f_desolv {
     Real d_desolv_d_dist = (
       -lk_volume_j
       * lk_dgfree_i
-      / (2 * fastpow(pi, 3.0 / 2.0) * lk_lambda_i)
+      / (2 * pi_pow1p5 * lk_lambda_i)
       * ((  // (f * fastexp(g))' = f' * fastexp(g) + f g' fastexp(g)
           -2 / (dist * dist * dist)
           * fastexp(-fastpow(dist - lj_radius_i, 2) / fastpow(lk_lambda_i, 2))

--- a/tmol/score/ljlk/score_graph.py
+++ b/tmol/score/ljlk/score_graph.py
@@ -11,6 +11,7 @@ from tmol.types.array import NDArray
 from tmol.database import ParameterDatabase
 from tmol.database.scoring import LJLKDatabase
 
+from ..common.stack_condense import condense_torch_inds
 from ..database import ParamDB
 from ..chemical_database import ChemicalDB, AtomTypeParamResolver
 from ..device import TorchDevice
@@ -38,7 +39,8 @@ class LKIntraScore(IntraScore):
     # @validate_args
     def total_lk(target):
         return target.lk_intra_module(
-            target.coords, target.ljlk_atom_types, target.bonded_path_length
+            target.coords, target.ljlk_atom_types, target.heavyatom_inds,
+            target.bonded_path_length,
         )
 
 
@@ -65,8 +67,8 @@ class _LJLKCommonScoreGraph(BondedAtomScoreGraph, ChemicalDB, ParamDB, TorchDevi
 
         return dict(ljlk_database=ljlk_database)
 
-    ljlk_database: LJLKDatabase
-
+    ljlk_database: LJLKDatabase   
+    
     @reactive_property
     @validate_args
     def ljlk_param_resolver(
@@ -106,3 +108,13 @@ class LKScoreGraph(_LJLKCommonScoreGraph):
         ljlk_param_resolver: LJLKParamResolver
     ) -> LKIsotropicIntraModule:
         return LKIsotropicIntraModule(ljlk_param_resolver)
+
+    @reactive_property
+    @validate_args
+    def heavyatom_inds(
+            ljlk_atom_types: Tensor(torch.int64)[:,:],
+            atom_type_params: AtomTypeParamResolver,
+            device: torch.device
+            )-> Tensor(torch.int64)[:,:]:
+        are_heavyatoms = 1 - atom_type_params.params.is_hydrogen[ljlk_atom_types]
+        return condense_torch_inds(are_heavyatoms, device)

--- a/tmol/score/ljlk/script_modules.py
+++ b/tmol/score/ljlk/script_modules.py
@@ -85,7 +85,7 @@ class LJIntraModule(_LJScoreModule):
 
 class LJInterModule(_LJScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, J, atom_type_J, bonded_path_lengths):
+    def forward(self, I, atom_type_I,  J, atom_type_J, bonded_path_lengths):
         return torch.ops.tmol.score_ljlk_lj(
             I,
             atom_type_I,
@@ -140,7 +140,7 @@ class _LKIsotropicScoreModule(torch.jit.ScriptModule):
                 dim=1,
             )
         )
-
+        
         self.global_params = _p(
             torch.stack(
                 _t(
@@ -157,12 +157,14 @@ class _LKIsotropicScoreModule(torch.jit.ScriptModule):
 
 class LKIsotropicIntraModule(_LKIsotropicScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, bonded_path_lengths):
+    def forward(self, I, atom_type_I, heavyat_inds_I, bonded_path_lengths):
         return torch.ops.tmol.score_ljlk_lk_isotropic_triu(
             I,
             atom_type_I,
+            heavyat_inds_I,
             I,
             atom_type_I,
+            heavyat_inds_I,
             bonded_path_lengths,
             self.type_params,
             self.global_params,
@@ -171,12 +173,14 @@ class LKIsotropicIntraModule(_LKIsotropicScoreModule):
 
 class LKIsotropicInterModule(_LKIsotropicScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, J, atom_type_J, bonded_path_lengths):
+    def forward(self, I, atom_type_I, heavyat_inds_I, J, atom_type_J, heavyat_inds_J, bonded_path_lengths):
         return torch.ops.tmol.score_ljlk_lk_isotropic(
             I,
             atom_type_I,
+            heavyat_inds_I,
             J,
             atom_type_J,
+            heavyat_inds_J,
             bonded_path_lengths,
             self.type_params,
             self.global_params,

--- a/tmol/system/kinematics.py
+++ b/tmol/system/kinematics.py
@@ -35,14 +35,24 @@ class KinematicDescription:
         coordinate. Note that this is a covering of indices within the system
         "non-atom" ids are not present in the tree.
         """
+
+        # right-pad with zeros to denote all bonds within a single system
+        bonds = numpy.concatenate(
+            (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
+            axis=1
+        )
         torsion_pairs = numpy.block(
             [[torsion_metadata["atom_index_b"]], [torsion_metadata["atom_index_c"]]]
         ).T
         torsion_bonds = torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)]
+        torsion_bonds = numpy.concatenate(
+            (numpy.zeros((torsion_bonds.shape[0],1), dtype=int), torsion_bonds),
+             axis=1
+        )
 
         builder = KinematicBuilder().append_connected_component(
             *KinematicBuilder.component_for_prioritized_bonds(
-                root=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
+                roots=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
             )
         )
 

--- a/tmol/system/kinematics.py
+++ b/tmol/system/kinematics.py
@@ -1,3 +1,4 @@
+from typing import Tuple, Union
 import attr
 
 import torch
@@ -25,8 +26,9 @@ class KinematicDescription:
     @validate_args
     def for_system(
         cls,
-        bonds: NDArray(int)[:, 2],
-        torsion_metadata: NDArray(torsion_metadata_dtype)[:],
+        system_size: int,
+        bonds: Union[ NDArray(int)[:, 3], NDArray(int)[:, 2]],
+        torsion_metadata: Tuple[NDArray(torsion_metadata_dtype)[:], ...],
     ):
         """Generate kinematics for system atoms and named torsions.
 
@@ -36,23 +38,39 @@ class KinematicDescription:
         "non-atom" ids are not present in the tree.
         """
 
-        # right-pad with zeros to denote all bonds within a single system
-        bonds = numpy.concatenate(
-            (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
-            axis=1
-        )
-        torsion_pairs = numpy.block(
-            [[torsion_metadata["atom_index_b"]], [torsion_metadata["atom_index_c"]]]
-        ).T
-        torsion_bonds = torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)]
-        torsion_bonds = numpy.concatenate(
-            (numpy.zeros((torsion_bonds.shape[0],1), dtype=int), torsion_bonds),
-             axis=1
-        )
+        if bonds.shape[1] == 2:
+            # right-pad with zeros to denote all bonds within a single system
+            bonds = numpy.concatenate(
+                (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
+                axis=1
+            )
 
-        builder = KinematicBuilder().append_connected_component(
+        # root all the kintrees at the first atom in each system
+        roots = system_size * numpy.arange(1+bonds[:,0].max(), dtype=int)
+
+        # construct torsion_bonds by merging the list of b-c atoms from each
+        # torsion_metadata list and marking each one by the system from
+        # which it originates.
+        torsion_bonds_list = []
+        for tmet in torsion_metadata:
+            torsion_pairs = numpy.block(
+                [[tmet["atom_index_b"]], [tmet["atom_index_c"]]]
+            ).T
+            torsion_bonds_list.append(torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)])
+        torsion_bonds = numpy.zeros((sum(t.shape[0] for t in torsion_bonds_list), 3), dtype=int)
+        start = numpy.cumsum(numpy.array([t.shape[0] for t in torsion_bonds_list], dtype=int))
+        for i, tbonds in enumerate(torsion_bonds_list):
+            range = slice(
+                0 if i == 0 else start[i-1],
+                start[i])
+            torsion_bonds[range,0] = i
+            torsion_bonds[range,1:3] = tbonds
+
+        builder = KinematicBuilder().append_connected_components(
+            roots,
             *KinematicBuilder.component_for_prioritized_bonds(
-                roots=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
+                roots=roots, mandatory_bonds=torsion_bonds, all_bonds=bonds,
+                system_size=system_size,
             )
         )
 
@@ -63,7 +81,7 @@ class KinematicDescription:
         )
 
     def extract_kincoords(
-        self, coords: NDArray(float)[:, 3]
+        self, coords: NDArray(float)[:, :, 3]
     ) -> Tensor(torch.double)[:, 3]:
         """Extract the kinematic-derived coordinates from system coords.
 
@@ -72,7 +90,8 @@ class KinematicDescription:
         """
 
         # Extract current state coordinates to render current dofs
-        kincoords = torch.from_numpy(coords)[self.kintree.id.to(torch.long)]
+        tcoords_flat = torch.from_numpy(coords).reshape(-1,3)
+        kincoords = tcoords_flat[self.kintree.id.to(torch.long)]
 
         # Convert the -1 origin, a nan-coord, to zero
         assert self.kintree.id[0] == -1

--- a/tmol/system/packed.py
+++ b/tmol/system/packed.py
@@ -322,8 +322,8 @@ class PackedResidueSystem:
         torsion_metadata["atom_index_d"] = nan_to_neg1(torsion_index["d.atom_index"])
 
         result = cls(
-            block_size=block_size,
-            system_size=buffer_size,
+            block_size=int(block_size),
+            system_size=int(buffer_size),
             res_start_ind=segment_starts,
             residues=attached_res,
             atom_metadata=atom_metadata,

--- a/tmol/system/score_support.py
+++ b/tmol/system/score_support.py
@@ -22,6 +22,7 @@ from .packed import PackedResidueSystem, PackedResidueSystemStack
 from .kinematics import KinematicDescription
 
 from tmol.database import ParameterDatabase
+from tmol.types.array import NDArray
 
 
 @StackedSystem.factory_for.register(PackedResidueSystem)
@@ -159,12 +160,16 @@ def system_torsion_graph_inputs(
     """
 
     # Initialize kinematic tree for the system
-    sys_kin = KinematicDescription.for_system(system.bonds, system.torsion_metadata)
+    sys_kin = KinematicDescription.for_system(
+        int(system.system_size),
+        system.bonds,
+        (system.torsion_metadata,),
+    )
     tkintree = sys_kin.kintree.to(device)
     tdofmetadata = sys_kin.dof_metadata.to(device)
 
     # compute dofs from xyzs
-    kincoords = sys_kin.extract_kincoords(system.coords).to(device)
+    kincoords = sys_kin.extract_kincoords(system.coords.reshape(1,-1,3)).to(device)
     bkin = inverseKin(tkintree, kincoords)
 
     # dof mask
@@ -175,6 +180,49 @@ def system_torsion_graph_inputs(
         dofmetadata=tdofmetadata,
     )
 
+@KinematicAtomicCoordinateProvider.factory_for.register(PackedResidueSystemStack)
+@validate_args
+def stacked_system_torsion_graph_inputs(
+    system: PackedResidueSystemStack,
+    stack_depth: int,
+    system_size: int,
+    bonds: NDArray(int)[:, 3],
+    device: torch.device,
+    requires_grad: bool = True,
+    **_
+):
+    """Constructor parameters for torsion space scoring.
+
+    Extract constructor kwargs to initialize a `KinematicAtomicCoordinateProvider` and
+    `BondedAtomScoreGraph` subclass supporting torsion-space scoring. This
+    includes only `bond_torsion` dofs, a subset of valid kinematic dofs for the
+    system.
+    """
+
+    torsion_metadata = tuple(sys.torsion_metadata for sys in system.systems)
+    # Initialize kinematic tree for the system
+    sys_kin = KinematicDescription.for_system(
+        system_size,
+        bonds,
+        torsion_metadata,
+    )
+    tkintree = sys_kin.kintree.to(device)
+    tdofmetadata = sys_kin.dof_metadata.to(device)
+
+    # compute dofs from xyzs
+    coords = numpy.full((stack_depth, system_size, 3), numpy.nan, dtype=numpy.float64)
+    for i, sys in enumerate(system.systems):
+        coords[i, :sys.coords.shape[0], :] = sys.coords
+    kincoords = sys_kin.extract_kincoords(coords).to(device)
+    bkin = inverseKin(tkintree, kincoords)
+
+    # dof mask
+
+    return dict(
+        dofs=bkin.raw.clone().requires_grad_(requires_grad),
+        kintree=tkintree,
+        dofmetadata=tdofmetadata,
+    )
 
 @RamaScoreGraph.factory_for.register(PackedResidueSystem)
 @validate_args

--- a/tmol/tests/kinematics/test_builder.py
+++ b/tmol/tests/kinematics/test_builder.py
@@ -11,15 +11,10 @@ from tmol.score.bonded_atom import BondedAtomScoreGraph
 def test_builder_refold(ubq_system):
     tsys = ubq_system
 
-    bonds = numpy.concatenate(
-        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
-        axis=1
-    )
-
     kintree = (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, tsys.bonds)
         )
         .kintree
     )
@@ -39,14 +34,10 @@ def test_builder_refold(ubq_system):
 def test_builder_framing(ubq_system):
     """Test first-three-atom framing logic in kinematic builder."""
     tsys = ubq_system
-    bonds = numpy.concatenate(
-        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
-        axis=1
-    )
     kintree = (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, tsys.bonds)
         )
         .kintree
     )

--- a/tmol/tests/kinematics/test_gpu_operations.py
+++ b/tmol/tests/kinematics/test_gpu_operations.py
@@ -10,10 +10,15 @@ from tmol.tests.torch import requires_cuda
 
 
 def system_kintree(target_system):
+    tsys = target_system
+    bonds = numpy.concatenate(
+        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
+        axis=1
+    )    
     return (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, target_system.bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, bonds)
         )
         .kintree
     )

--- a/tmol/tests/kinematics/test_metadata.py
+++ b/tmol/tests/kinematics/test_metadata.py
@@ -9,7 +9,7 @@ from tmol.system.kinematics import KinematicDescription
 
 def test_metadata_dataframe_smoke(ubq_system):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
 
     restored = DOFMetadata.from_frame(tkin.dof_metadata.to_frame())
 

--- a/tmol/tests/kinematics/test_operations.py
+++ b/tmol/tests/kinematics/test_operations.py
@@ -4,8 +4,11 @@ import numpy.testing
 
 import pytest
 
+from tmol.kinematics.builder import KinematicBuilder
 from tmol.kinematics.operations import inverseKin, forwardKin
 from tmol.kinematics.script_modules import KinematicModule
+from tmol.system.packed import PackedResidueSystem, PackedResidueSystemStack
+from tmol.score.bonded_atom import BondedAtomScoreGraph
 
 from tmol.kinematics.datatypes import NodeType, KinTree
 
@@ -254,3 +257,65 @@ def compute_verify_derivs(kintree, coords):
     )
 
     torch.testing.assert_allclose(analytical, numerical)
+
+def test_forward_refold_two_systems(ubq_system, torch_device):
+    twoubq = PackedResidueSystemStack((ubq_system, ubq_system))
+    bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
+    tworoots = numpy.array((0, twoubq.systems[0].system_size), dtype=int)
+
+    coords_raw = torch.tensor(numpy.concatenate(
+        (twoubq.systems[0].coords, twoubq.systems[1].coords), axis=0
+    ), dtype=torch.float64, device=torch_device )
+
+    kintree = KinematicBuilder().append_connected_components(
+        tworoots,
+        *KinematicBuilder.bonds_to_connected_component(
+            roots=tworoots,
+            bonds=bonds.bonds,
+            system_size=int(twoubq.systems[0].system_size),
+        ),
+    ).kintree.to(torch_device)
+
+    ids = kintree.id.type(torch.long)
+    coords = coords_raw[ids]
+    coords[0,:] = 0
+
+    dofs = inverseKin(kintree, coords)
+    refold_kincoords = forwardKin(kintree, dofs)
+    refold_kincoords[0,:] = 0
+
+    numpy.testing.assert_allclose(coords.cpu(), refold_kincoords.cpu(), atol=1e-6)
+
+def test_forward_refold_w_jagged_system(ubq_res, torch_device):
+    # torch_device = torch.device("cpu")
+    ubq40 = PackedResidueSystem.from_residues(ubq_res[:40])
+    ubq60 = PackedResidueSystem.from_residues(ubq_res[:60])
+    system_size = max(ubq40.system_size, ubq60.system_size)
+
+    twoubq = PackedResidueSystemStack((ubq40, ubq60))
+    bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
+    tworoots = numpy.array((0, twoubq.systems[1].system_size), dtype=int)
+
+    coords_raw = torch.zeros((2, system_size, 3), dtype=torch.float64, device=torch_device)
+    coords_raw[0,0:ubq40.system_size,:] = torch.tensor(ubq40.coords, dtype=torch.float64, device=torch_device)
+    coords_raw[1,0:ubq60.system_size,:] = torch.tensor(ubq60.coords, dtype=torch.float64, device=torch_device)
+    coords_raw = coords_raw.reshape(2*system_size, 3)
+
+    kintree = KinematicBuilder().append_connected_components(
+        tworoots,
+        *KinematicBuilder.bonds_to_connected_component(
+            roots=tworoots,
+            bonds=bonds.bonds,
+            system_size=int(system_size),
+        ),
+    ).kintree.to(torch_device)
+
+    ids = kintree.id.type(torch.long)
+    coords = coords_raw[ids,:]
+    coords[0,:] = 0
+
+    dofs = inverseKin(kintree, coords)
+    refold_kincoords = forwardKin(kintree, dofs)
+    refold_kincoords[0,:] = 0
+
+    numpy.testing.assert_allclose(coords.cpu(), refold_kincoords.cpu(), atol=1e-6)

--- a/tmol/tests/kinematics/test_script_modules.py
+++ b/tmol/tests/kinematics/test_script_modules.py
@@ -19,7 +19,7 @@ from tmol.tests.torch import requires_cuda
 @pytest.mark.benchmark(group="kinematic_forward_op")
 def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -37,7 +37,7 @@ def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
 @pytest.mark.benchmark(group="kinematic_backward_op")
 def test_kinematic_torch_op_backward_benchmark(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -60,7 +60,7 @@ def gradcheck_test_system(
     ubq_res: typing.Sequence[Residue],
 ) -> typing.Tuple[KinTree, Tensor("f8")[:, 3]]:
     tsys = PackedResidueSystem.from_residues(ubq_res[:4])
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
 
     return (tkin.kintree, tkin.extract_kincoords(tsys.coords))
 

--- a/tmol/tests/score/ljlk/potentials/test_compiled_lk_isotropic_potential.py
+++ b/tmol/tests/score/ljlk/potentials/test_compiled_lk_isotropic_potential.py
@@ -37,7 +37,9 @@ def test_lk_isotropic_gradcheck(params, iname, jname, bonded_path_length):
             dist, bonded_path_length, i_params, j_params, global_params
         ).sum(),
         (torch.linspace(1, 8, 20, dtype=torch.double).requires_grad_(True),),
-        eps=1e-4,
+        eps=3e-4,
+        atol=1e-5,
+        rtol=1e-3,
     )
 
 

--- a/tmol/tests/score/ljlk/test_script_modules.py
+++ b/tmol/tests/score/ljlk/test_script_modules.py
@@ -21,6 +21,9 @@ from tmol.score.ljlk.script_modules import (
     LKIsotropicInterModule,
 )
 
+from tmol.score.common.stack_condense import condense_torch_inds
+from tmol.score.chemical_database import AtomTypeParamResolver
+
 
 @attr.s(auto_attribs=True)
 class ScoreSetup:
@@ -31,6 +34,7 @@ class ScoreSetup:
 
     tcoords: torch.Tensor
     ttype: torch.Tensor
+    thvy_at_inds: torch.Tensor
     tbpl: torch.Tensor
 
     @classmethod
@@ -53,6 +57,12 @@ class ScoreSetup:
             .requires_grad_(True)
         )
         ttype = atom_type_idx[:]
+
+        atype_params = AtomTypeParamResolver.from_database(
+            database.chemical, torch_device)
+        thvy_at_inds = condense_torch_inds(
+            1 - atype_params.params.is_hydrogen[ttype], torch_device)
+        
         tbpl = torch.from_numpy(atom_pair_bpl).to(device=torch_device)[:, :]
 
         return cls(
@@ -62,6 +72,7 @@ class ScoreSetup:
             atom_pair_bpl=atom_pair_bpl,
             tcoords=tcoords,
             ttype=ttype,
+            thvy_at_inds=thvy_at_inds,
             tbpl=tbpl,
         )
 
@@ -236,7 +247,7 @@ def test_lk_intra_op(benchmark, default_database, ubq_system, torch_device):
 
     @subfixture(benchmark)
     def op_val():
-        return op(s.tcoords, s.ttype, s.tbpl)
+        return op(s.tcoords, s.ttype, s.thvy_at_inds, s.tbpl)
 
     torch.testing.assert_allclose(
         op_val, torch.tensor(expected_dense).to(torch_device).sum()
@@ -244,7 +255,7 @@ def test_lk_intra_op(benchmark, default_database, ubq_system, torch_device):
 
     @subfixture(benchmark)
     def op_full():
-        res = op(s.tcoords, s.ttype, s.tbpl)
+        res = op(s.tcoords, s.ttype, s.thvy_at_inds, s.tbpl)
         res.backward()
 
         return res
@@ -259,7 +270,7 @@ def test_lk_intra_op(benchmark, default_database, ubq_system, torch_device):
         fcoords = s.tcoords.clone()
         fcoords[:, subind] = c
 
-        return op(fcoords, s.ttype, s.tbpl)
+        return op(fcoords, s.ttype, s.thvy_at_inds, s.tbpl)
 
     gradcheck(op_subset, (s.tcoords[:, subind].requires_grad_(True),), eps=1e-3)
 
@@ -279,11 +290,16 @@ def test_lk_inter_op(default_database, torch_device, ubq_system):
     op = LKIsotropicInterModule(s.param_resolver)
     op.to(s.tcoords)
 
+    inds_part_lo = s.thvy_at_inds[:,s.thvy_at_inds[0,:] < part]
+    inds_part_hi = s.thvy_at_inds[:,s.thvy_at_inds[0,:] >= part] - part
+    
     val = op(
         s.tcoords[:, :part],
         s.ttype[:, :part],
+        inds_part_lo,
         s.tcoords[:, part:],
         s.ttype[:, part:],
+        inds_part_hi,
         s.tbpl[:, :part, part:],
     )
 
@@ -300,8 +316,10 @@ def test_lk_inter_op(default_database, torch_device, ubq_system):
         return op(
             fcoords[:, :part],
             s.ttype[:, :part],
+            inds_part_lo,
             fcoords[:, part:],
             s.ttype[:, part:],
+            inds_part_hi,
             s.tbpl[:, :part, part:],
         )
 

--- a/tmol/tests/score/test_coordinates.py
+++ b/tmol/tests/score/test_coordinates.py
@@ -121,8 +121,10 @@ def test_coord_clone_factory(ubq_system):
 def test_coord_clone_factory_from_stacked_systems(ubq_system: PackedResidueSystem):
     twoubq = PackedResidueSystemStack((ubq_system, ubq_system))
     cacp = CartesianAtomicCoordinateProvider.build_for(twoubq)
+    kacp = KinematicAtomicCoordinateProvider.build_for(twoubq)
 
     assert cacp.coords.shape == (2, cacp.system_size, 3)
+    assert kacp.coords.shape == (2, kacp.system_size, 3)
 
 
 def test_non_uniform_sized_stacked_system_coord_factory(ubq_res):
@@ -130,7 +132,9 @@ def test_non_uniform_sized_stacked_system_coord_factory(ubq_res):
     sys2 = PackedResidueSystem.from_residues(ubq_res[:8])
     sys3 = PackedResidueSystem.from_residues(ubq_res[:4])
 
-    twoubq = PackedResidueSystemStack((sys1, sys2, sys3))
-    cacp = CartesianAtomicCoordinateProvider.build_for(twoubq)
+    three_ubq = PackedResidueSystemStack((sys1, sys2, sys3))
+    cacp = CartesianAtomicCoordinateProvider.build_for(three_ubq)
+    kacp = KinematicAtomicCoordinateProvider.build_for(three_ubq)
 
     assert cacp.coords.shape == (3, sys2.coords.shape[0], 3)
+    assert kacp.coords.shape == (3, sys2.coords.shape[0], 3)

--- a/tmol/tests/score/test_scoreterm_benchmarks.py
+++ b/tmol/tests/score/test_scoreterm_benchmarks.py
@@ -1,6 +1,10 @@
 import pytest
+import tmol
+import torch
 
 from tmol.utility.reactive import reactive_property
+
+from tmol.system.packed import PackedResidueSystemStack
 
 from tmol.score import TotalScoreGraph
 
@@ -110,7 +114,7 @@ def benchmark_score_pass(benchmark, score_graph, benchmark_pass):
             total = score_graph.intra_score().total
             total.backward()
 
-            float(total)
+            float(torch.sum(total))
 
             return total
 
@@ -122,7 +126,7 @@ def benchmark_score_pass(benchmark, score_graph, benchmark_pass):
 
             total = score_graph.intra_score().total
 
-            float(total)
+            float(torch.sum(total))
 
             return total
 
@@ -179,6 +183,66 @@ def test_end_to_end_score_graph(
 
     score_graph = graph_class.build_for(
         target_system, requires_grad=True, device=torch_device
+    )
+
+    run = benchmark_score_pass(benchmark, score_graph, benchmark_pass)
+
+    assert run.device == torch_device
+
+
+@pytest.mark.parametrize(
+    "term_to_exclude",
+    [
+        HBondScoreGraph,
+        ElecScoreGraph,
+        RamaScoreGraph,
+        OmegaScoreGraph,
+        DunbrackScoreGraph,
+        CartBondedScoreGraph,
+        LJScoreGraph,
+        LKScoreGraph,
+        LKBallScoreGraph,
+    ],
+    ids=[
+        "hbond",
+        "elec",
+        "rama",
+        "omega",
+        "dun",
+        "cartbonded",
+        "lj",
+        "lk",
+        "lk_ball",
+    ],
+)
+@pytest.mark.parametrize("benchmark_pass", ["forward"])
+@pytest.mark.benchmark(group="score_wo_component")
+def test_exclude_term_from_score_graph(
+    benchmark, benchmark_pass, term_to_exclude, torch_device, ubq_system
+):
+    stack = PackedResidueSystemStack((ubq_system,) * 30)
+
+    base_classes = [
+        CartesianAtomicCoordinateProvider,
+        LJScoreGraph,
+        LKScoreGraph,
+        LKBallScoreGraph,
+        HBondScoreGraph,
+        DunbrackScoreGraph,
+        RamaScoreGraph,
+        OmegaScoreGraph,
+        ElecScoreGraph,
+        CartBondedScoreGraph,
+    ]
+
+    base_classes.remove(term_to_exclude)
+    base_classes = tuple(base_classes)
+
+    graph_class = type("TempGraph", base_classes, {})
+    graph_class = tmol.score.score_graph.score_graph(graph_class)
+    
+    score_graph = graph_class.build_for(
+        stack, requires_grad=True, device=torch_device
     )
 
     run = benchmark_score_pass(benchmark, score_graph, benchmark_pass)

--- a/tmol/tests/score/test_totalscore_benchmarks.py
+++ b/tmol/tests/score/test_totalscore_benchmarks.py
@@ -27,10 +27,11 @@ class TotalScore(KinematicAtomicCoordinateProvider, TotalScoreGraph, TorchDevice
 @score_graph
 class StackScoreGraph(
     CartesianAtomicCoordinateProvider,
-    LJScoreGraph,
-    LKScoreGraph,
-    LKBallScoreGraph,
-    RamaScoreGraph,
+    # LJScoreGraph,
+    # LKScoreGraph,
+    # LKBallScoreGraph,
+    # RamaScoreGraph,
+    TotalScoreGraph,
     TorchDevice,
 ):
     pass
@@ -124,8 +125,8 @@ def test_stacked_full(
     def forward_backward():
         score_graph.reset_coords()
         total = score_graph.intra_score().total
-        tsum = torch.sum(total)
-        tsum.backward(retain_graph=True)
+        # tsum = torch.sum(total)
+        # tsum.backward(retain_graph=True)
         return total
 
     forward_backward

--- a/tmol/tests/score/test_totalscore_benchmarks.py
+++ b/tmol/tests/score/test_totalscore_benchmarks.py
@@ -23,20 +23,6 @@ class TotalScore(KinematicAtomicCoordinateProvider, TotalScoreGraph, TorchDevice
     pass
 
 
-# the
-@score_graph
-class StackScoreGraph(
-    CartesianAtomicCoordinateProvider,
-    # LJScoreGraph,
-    # LKScoreGraph,
-    # LKBallScoreGraph,
-    # RamaScoreGraph,
-    TotalScoreGraph,
-    TorchDevice,
-):
-    pass
-
-
 @pytest.fixture
 def default_component_weights(torch_device):
     return {
@@ -113,7 +99,7 @@ def test_stacked_full(
     benchmark, ubq_system, nstacks, torch_device, default_component_weights
 ):
     stack = PackedResidueSystemStack((ubq_system,) * nstacks)
-    score_graph = StackScoreGraph.build_for(
+    score_graph = TotalScore.build_for(
         stack,
         requires_grad=True,
         device=torch_device,

--- a/tmol/tests/utility/tensor/tensor_accessor.cpp
+++ b/tmol/tests/utility/tensor/tensor_accessor.cpp
@@ -139,6 +139,27 @@ auto tensor_pack_construct_eigen_matrix() {
       T::full({2, 5}, NAN));
 }
 
+auto tensor_view_take_slice_one() {
+  auto Vp = tmol::TPack<int, 2, tmol::Device::CPU>::empty({4, 10});
+  auto V = Vp.view;
+
+  int count = 0;
+  for (int i = 0; i < 4; ++i ) {
+    for (int j=0; j < 10; ++j) {
+      V[i][j] = count;
+      ++count;
+    }
+  }
+
+  auto Outp = tmol::TPack<int, 1, tmol::Device::CPU>::zeros({4});
+  auto Out = Outp.view;
+
+  auto Vslice = V.slice_one(1, 5);
+  for (int i = 0; i < 4; ++i ) {
+    Out[i] = Vslice[i];
+  }
+  return Outp;
+}
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
@@ -189,4 +210,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       "tensor_pack_construct_like_tpack",
       &tensor_pack_construct_like_tpack,
       "Construct tensors via TensorPack constructors.");
+
+  m.def(
+      "tensor_view_take_slice_one",
+      &tensor_view_take_slice_one,
+      "Construct 2D tensor and take a 1D slice of it");
 }

--- a/tmol/tests/utility/tensor/test_tensor_accessor.py
+++ b/tmol/tests/utility/tensor/test_tensor_accessor.py
@@ -125,3 +125,10 @@ def test_tensor_pack_constructors(tensor_accessor):
 
     with pytest.raises(TypeError):
         tensor_accessor.tensor_pack_construct_like_tpack(torch.empty(10))
+
+def test_tview_slice(tensor_accessor):
+    sliced = tensor_accessor.tensor_view_take_slice_one()
+    gold = torch.tensor([5,15,25,35], dtype=torch.int32)
+    torch.testing.assert_allclose(sliced, gold)
+    
+    


### PR DESCRIPTION
Beginning to tinker with performance following the addition of stacked scoring.

So far:
1. LK-isotropic dispatch over heavy atom pairs --> ~4x speedup for LK.
2. `score::common::accumulate<Real>::add_one_dst` performs a (safe) cooperative-group reduction before performing atomicAdd to get a 2x speedup.

I probably won't merge this branch and am only creating the PR so you two can look at what I've got so far.