### PR TITLE
Aleaverfay/stack kinematics

### DIFF
--- a/tmol/kinematics/builder.py
+++ b/tmol/kinematics/builder.py
@@ -45,7 +45,7 @@ class KinematicBuilder:
         roots: Union[NDArray(int)[:], int],
         mandatory_bonds: Union[NDArray(int)[:, 3], NDArray(int)[:, 2]],
         all_bonds: Union[NDArray(int)[:, 3], NDArray(int)[:, 2]],
-        system_size: Optional[int] = None
+        system_size: Optional[int] = None,
     ) -> ChildParentTuple:
         assert mandatory_bonds.shape[1] == all_bonds.shape[1]
         if not isinstance(roots, numpy.ndarray):
@@ -55,25 +55,27 @@ class KinematicBuilder:
         # interpret an Nx2 bonds array as representing a single stack
         if mandatory_bonds.shape[1] == 2:
             mandatory_bonds = numpy.concatenate(
-                (numpy.zeros((mandatory_bonds.shape[0],1),dtype=int), mandatory_bonds),
-                axis=1
+                (
+                    numpy.zeros((mandatory_bonds.shape[0], 1), dtype=int),
+                    mandatory_bonds,
+                ),
+                axis=1,
             )
             all_bonds = numpy.concatenate(
-                (numpy.zeros((all_bonds.shape[0],1),dtype=int), all_bonds),
-                axis=1
+                (numpy.zeros((all_bonds.shape[0], 1), dtype=int), all_bonds), axis=1
             )
 
         if not system_size:
-            system_size = max(mandatory_bonds[:, 1:3].max(), all_bonds[:, 1:3].max()) + 1
+            system_size = (
+                max(mandatory_bonds[:, 1:3].max(), all_bonds[:, 1:3].max()) + 1
+            )
 
         weighted_bonds = (
             # All entries must be non-zero or sparse graph tools will entries.
             cls.bonds_to_csgraph(all_bonds, [-1], system_size)
             + cls.bonds_to_csgraph(mandatory_bonds, [-1e-5], system_size)
             + cls.faux_bonds_between_roots(
-                roots=roots,
-                weights=[-1],
-                natoms_total=system_size*roots.shape[0],
+                roots=roots, weights=[-1], natoms_total=system_size * roots.shape[0]
             )
         )
 
@@ -84,8 +86,8 @@ class KinematicBuilder:
             numpy.block([[parents[1:], ids[1:]], [ids[1:], parents[1:]]]).T
         )
         bond_present = component_bond_graph[
-            system_size*mandatory_bonds[:, 0] + mandatory_bonds[:, 1],
-            system_size*mandatory_bonds[:, 0] + mandatory_bonds[:, 2]
+            system_size * mandatory_bonds[:, 0] + mandatory_bonds[:, 1],
+            system_size * mandatory_bonds[:, 0] + mandatory_bonds[:, 2],
         ]
         bond_absent = numpy.array((bond_present == 0), dtype=bool)
 
@@ -99,7 +101,7 @@ class KinematicBuilder:
     @convert_args
     def bonds_to_csgraph(
         cls,
-        bonds: Union[NDArray(int)[:, 3], NDArray(int)[:,2]],
+        bonds: Union[NDArray(int)[:, 3], NDArray(int)[:, 2]],
         weights: NDArray(float)[:] = numpy.ones(1),  # noqa
         system_size: Optional[int] = None,
     ) -> sparse.csr_matrix:
@@ -107,30 +109,26 @@ class KinematicBuilder:
         # interpret an Nx2 bonds array as representing a single stack
         if bonds.shape[1] == 2:
             bonds = numpy.concatenate(
-                (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
-                axis=1
+                (numpy.zeros((bonds.shape[0], 1), dtype=int), bonds), axis=1
             )
 
         if not system_size:
-            system_size = (bonds[:,1:3].max() + 1)
+            system_size = bonds[:, 1:3].max() + 1
 
-        bonds_reindexed = system_size * bonds[:,0][:,None] + bonds[:,1:3]
+        bonds_reindexed = system_size * bonds[:, 0][:, None] + bonds[:, 1:3]
         weights = numpy.broadcast_to(weights, bonds_reindexed[:, 0].shape)
 
-        nats_tot = system_size * (bonds[:,0].max() + 1)
+        nats_tot = system_size * (bonds[:, 0].max() + 1)
         bonds_csr = sparse.csr_matrix(
             (weights, (bonds_reindexed[:, 0], bonds_reindexed[:, 1])),
-            shape=(nats_tot, nats_tot)
+            shape=(nats_tot, nats_tot),
         )
         return bonds_csr
 
     @classmethod
     @convert_args
     def faux_bonds_between_roots(
-        cls,
-        roots: NDArray(int)[:],
-        weights: NDArray(float)[:],
-        natoms_total: int
+        cls, roots: NDArray(int)[:], weights: NDArray(float)[:], natoms_total: int
     ) -> Union[sparse.spmatrix, int]:
         """Construct a csgraph with edges from the first root to all
         other roots, if there are other roots. Otherwise, return 0.
@@ -138,13 +136,11 @@ class KinematicBuilder:
         atoms in all stacks.
         """
         if roots.shape[0] > 1:
-            root_faux_bonds = numpy.full((roots.shape[0]-1, 3), roots[0], dtype=int)
-            root_faux_bonds[:,0] = 0
-            root_faux_bonds[:,1] = roots[1:]
+            root_faux_bonds = numpy.full((roots.shape[0] - 1, 3), roots[0], dtype=int)
+            root_faux_bonds[:, 0] = 0
+            root_faux_bonds[:, 1] = roots[1:]
             return cls.bonds_to_csgraph(
-                root_faux_bonds,
-                weights=weights,
-                system_size=natoms_total
+                root_faux_bonds, weights=weights, system_size=natoms_total
             )
         else:
             return 0
@@ -155,7 +151,7 @@ class KinematicBuilder:
         cls,
         roots: Union[NDArray(int)[:], int],
         bonds: Union[NDArray(int)[:, 3], NDArray(int)[:, 2], sparse.spmatrix],
-        system_size: Optional[int] = None
+        system_size: Optional[int] = None,
     ) -> ChildParentTuple:
 
         if not isinstance(roots, numpy.ndarray):
@@ -167,19 +163,17 @@ class KinematicBuilder:
             # connectivity from the root is allowed.
             if bonds.shape[1] == 2:
                 bonds = numpy.concatenate(
-                    (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
-                    axis=1
+                    (numpy.zeros((bonds.shape[0], 1), dtype=int), bonds), axis=1
                 )
             if system_size is None:
-                system_size = max(bonds[:,1].max(), bonds[:,2].max()) + 1
+                system_size = max(bonds[:, 1].max(), bonds[:, 2].max()) + 1
 
-            bond_graph = (
-                cls.bonds_to_csgraph(bonds, system_size=system_size) +
-                cls.faux_bonds_between_roots(
-                    roots=roots,
-                    weights=[1],
-                    natoms_total=int(system_size*(1+bonds[:,0].max()))
-                )
+            bond_graph = cls.bonds_to_csgraph(
+                bonds, system_size=system_size
+            ) + cls.faux_bonds_between_roots(
+                roots=roots,
+                weights=[1],
+                natoms_total=int(system_size * (1 + bonds[:, 0].max())),
             )
         else:
             # Sparse graph with per-bond weights, generate the minimum
@@ -206,9 +200,9 @@ class KinematicBuilder:
         parent_ids: Tensor(int)[:],
         component_parent=0,
     ):
-        assert(
+        assert (
             ids.shape == parent_ids.shape,
-            "elements and parents must be of same length"
+            "elements and parents must be of same length",
         )
         assert len(ids) > 3, "Bonded ktree must have at least three entries"
         assert component_parent < len(self.kintree) and component_parent >= -1
@@ -245,11 +239,13 @@ class KinematicBuilder:
         # for rotamers, where (nroots x natoms) is large.
         for root in root_indices:
 
-            int_root, *root_children = [int(i) for i in torch.nonzero(parent_indices == root)]
+            int_root, *root_children = [
+                int(i) for i in torch.nonzero(parent_indices == root)
+            ]
             assert len(root_children) >= 2, "root of bonded tree must have two children"
             assert root == int_root
             root_c1, *root_sibs = root_children
-            root_sibs = torch. LongTensor(root_sibs)
+            root_sibs = torch.LongTensor(root_sibs)
 
             kin_stree.frame_x[[int_root, root_c1]] = root_c1 + kin_start
             kin_stree.frame_y[[int_root, root_c1]] = int_root + kin_start
@@ -263,62 +259,63 @@ class KinematicBuilder:
 
         return attr.evolve(self, kintree=cat((self.kintree, kin_stree)))
 
-
     @convert_args
     def append_connected_component(
         self, ids: Tensor(int)[:], parent_ids: Tensor(int)[:], component_parent=0
     ):
         return self.append_connected_components(
             roots=torch.zeros((1,), dtype=torch.int32),
-            ids=ids, parent_ids=parent_ids,
-            component_parent=component_parent )
+            ids=ids,
+            parent_ids=parent_ids,
+            component_parent=component_parent,
+        )
         #  assert (
         #      ids.shape == parent_ids.shape
         #  ), "elements and parents must be of same length"
         #  assert len(ids) > 3, "Bonded ktree must have at least three entries"
         #  assert component_parent < len(self.kintree) and component_parent >= -1
-        #  
+        #
         #  # Assert that there is a single connected component?
-        #  
+        #
         #  # Root node is self-parented for the purpose of verifying the
         #  # connected component tree structure, will be rewritten with jump to
         #  # the component root frame.
         #  parent_ids[0] = ids[0]
-        #  
+        #
         #  # Create an index of all component ids in the graph and get component
         #  # parent and parent-parent indices
         #  id_index = pandas.Index(ids)
         #  parent_indices = torch.LongTensor(id_index.get_indexer(parent_ids))
         #  grandparent_indices = parent_indices[parent_indices]
-        #  
+        #
         #  # Verify that ids are unique and that all parent references are valid,
         #  # get_indexer returns -1 if a target value is not present in index.
         #  assert not id_index.has_duplicates, "Duplicated id in component"
         #  assert numpy.all(parent_indices >= 0), "Parent id not present in component."
-        #  
+        #
         #  # Allocate entries for the new subtree and store the provided ids in
         #  # the kintree id column. All internal kintree references,
         #  # (parent/frame) will be wrt kinetree indices, not ids.
         #  kin_stree = KinTree.full(len(ids), 0)
         #  kin_stree.id[:] = ids
-        #  
+        #
         #  # Calculate the start index of the kinematic tree block this new
         #  # subtree will occupy, construct all parent & frame references wrt this
         #  # start index.
         #  kin_start = len(self.kintree)
-        #  
+        #
         #  # Start by writing the the standard, non-root entries of the graph.
         #  kin_stree.doftype[:] = NodeType.bond
         #  kin_stree.parent[:] = parent_indices + kin_start
         #  kin_stree.frame_x[:] = torch.arange(len(ids)) + kin_start
         #  kin_stree.frame_y[:] = parent_indices + kin_start
         #  kin_stree.frame_z[:] = grandparent_indices + kin_start
-        #  
+        #
         #  # Go back and rewrite the entries for the root and its children
         #  # Define the jump DOF of the root, connecting back into existing kintree
         #  kin_stree.doftype[0] = NodeType.jump
         #  kin_stree.parent[0] = component_parent
-        #  
+        #
         #  # Fixup the orientation frame of the root and its children.
         #  # The root is self-parented at zero, so drop the first match.
         #  root, *root_children = [int(i) for i in torch.nonzero(parent_indices == 0)]
@@ -326,16 +323,16 @@ class KinematicBuilder:
         #  assert root == 0, "root must be self parented, was set above"
         #  root_c1, *root_sibs = root_children
         #  root_sibs = torch.LongTensor(root_sibs)
-        #  
+        #
         #  kin_stree.frame_x[[root, root_c1]] = root_c1 + kin_start
         #  kin_stree.frame_y[[root, root_c1]] = root + kin_start
         #  kin_stree.frame_z[[root, root_c1]] = (
         #      first(root_sibs).to(dtype=torch.int) + kin_start
         #  )
-        #  
+        #
         #  kin_stree.frame_x[root_sibs] = root_sibs.to(dtype=torch.int) + kin_start
         #  kin_stree.frame_y[root_sibs] = root + kin_start
         #  kin_stree.frame_z[root_sibs] = root_c1 + kin_start
-        #  
+        #
         #  # Append the subtree onto the kintree.
         #  return attr.evolve(self, kintree=cat((self.kintree, kin_stree)))

--- a/tmol/kinematics/builder.py
+++ b/tmol/kinematics/builder.py
@@ -89,7 +89,6 @@ class KinematicBuilder:
             system_size * mandatory_bonds[:, 0] + mandatory_bonds[:, 1],
             system_size * mandatory_bonds[:, 0] + mandatory_bonds[:, 2],
         ]
-        bond_absent = numpy.array((bond_present == 0), dtype=bool)
 
         assert numpy.all(
             bond_present
@@ -200,8 +199,7 @@ class KinematicBuilder:
         parent_ids: Tensor(int)[:],
         component_parent=0,
     ):
-        assert (
-            ids.shape == parent_ids.shape,
+        assert ids.shape == parent_ids.shape, (
             "elements and parents must be of same length",
         )
         assert len(ids) > 3, "Bonded ktree must have at least three entries"

--- a/tmol/kinematics/compiled/compiled.cuda.cu
+++ b/tmol/kinematics/compiled/compiled.cuda.cu
@@ -165,7 +165,6 @@ struct ForwardKinDispatch {
     using tmol::score::common::tie;
     typedef typename mgpu::launch_params_t<128, 2> launch_t;
     constexpr int nt = launch_t::nt, vt = launch_t::vt;
-
     auto num_atoms = dofs.size(0);
 
     nvtx_range_push("dispatch::alloc");

--- a/tmol/kinematics/datatypes.py
+++ b/tmol/kinematics/datatypes.py
@@ -27,7 +27,7 @@ class KinTree(TensorGroup, ConvertAttrs):
     corresponds to a derived orientation, which an atomic coordinate at the
     center of the frame.
 
-    Each node is the tree is connected by one of two "node types":
+    Each node in the tree is connected by one of two "node types":
 
     1) Jump nodes, representing an arbitrary rigid body transform between two
     reference frames via six degrees of freedom, 3 translational and
@@ -37,13 +37,13 @@ class KinTree(TensorGroup, ConvertAttrs):
     frames via three bond degrees of freedom, bond axis translation, bond axis
     rotation about the parent-grandparent bond and change of bond axis with
     respect to the bond. Bond nodes include an additional, redundent,
-    degree of free representing concerted rotation of all downstream bonds
+    degree of freedom representing concerted rotation of all downstream bonds
     about the parent-self bond.
 
     The `KinTree` data structure itself is frozen and can not be modified post
     construction. The `KinematicBuilder` factory class is responsible for
     construction of a `KinTree` with valid internal structure for atomic
-    system.
+    systems.
 
     Indices::
         id = index for kin-atom in the target coordinate system

--- a/tmol/score/common/stack_condense.py
+++ b/tmol/score/common/stack_condense.py
@@ -206,7 +206,7 @@ def take_values_w_sentineled_dest(
 
 def condense_subset(
     values,  # three dimensional tensor of values
-    values_to_keep,  # two dimensional tensor
+    values_to_keep,  # two dimensional boolean tensor
     default_fill=-1,
 ):
     """Take the values for the third dimension of the 3D "values" tensor,

--- a/tmol/score/coordinates.py
+++ b/tmol/score/coordinates.py
@@ -44,7 +44,9 @@ class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice):
 
 
 @score_graph
-class KinematicAtomicCoordinateProvider(BondedAtomScoreGraph, StackedSystem, TorchDevice):
+class KinematicAtomicCoordinateProvider(
+    BondedAtomScoreGraph, StackedSystem, TorchDevice
+):
     @staticmethod
     @singledispatch
     def factory_for(
@@ -98,7 +100,7 @@ class KinematicAtomicCoordinateProvider(BondedAtomScoreGraph, StackedSystem, Tor
             device=dofs.device,
             requires_grad=False,
         )
-        coords_flat = coords.reshape((-1,3))
+        coords_flat = coords.reshape((-1, 3))
 
         idIdx = kintree.id[1:].to(dtype=torch.long)
         coords_flat[idIdx] = kincoords[1:]

--- a/tmol/score/coordinates.py
+++ b/tmol/score/coordinates.py
@@ -12,6 +12,7 @@ from tmol.utility.reactive import reactive_property
 
 from tmol.types.torch import Tensor
 
+from .bonded_atom import BondedAtomScoreGraph
 from .device import TorchDevice
 from .score_graph import score_graph
 from .stacked_system import StackedSystem
@@ -43,7 +44,7 @@ class CartesianAtomicCoordinateProvider(StackedSystem, TorchDevice):
 
 
 @score_graph
-class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice):
+class KinematicAtomicCoordinateProvider(BondedAtomScoreGraph, StackedSystem, TorchDevice):
     @staticmethod
     @singledispatch
     def factory_for(
@@ -84,23 +85,25 @@ class KinematicAtomicCoordinateProvider(StackedSystem, TorchDevice):
         kintree: KinTree,
         kin_module: KinematicModule,
         system_size: int,
+        stack_depth: int,
     ) -> Tensor(torch.float)[:, :, 3]:
         """System cartesian atomic coordinates."""
         kincoords = kin_module(dofs)
 
         coords = torch.full(
-            (system_size, 3),
+            (stack_depth, system_size, 3),
             math.nan,
             dtype=dofs.dtype,
             layout=dofs.layout,
             device=dofs.device,
             requires_grad=False,
         )
+        coords_flat = coords.reshape((-1,3))
 
         idIdx = kintree.id[1:].to(dtype=torch.long)
-        coords[idIdx] = kincoords[1:]
+        coords_flat[idIdx] = kincoords[1:]
 
-        return coords.to(torch.float)[None, ...]
+        return coords.to(torch.float)
 
     def reset_coords(self):
         """Reset coordinate state in compute graph, clearing dependent properties."""

--- a/tmol/score/omega/potentials/dispatch.hh
+++ b/tmol/score/omega/potentials/dispatch.hh
@@ -26,9 +26,9 @@ template <
     typename Int>
 struct OmegaDispatch {
   static auto f(
-      TView<Vec<Real, 3>, 1, D> coords,
-      TView<OmegaParameters<Real>, 1, D> omega_indices)
-      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D> >;
+      TView<Vec<Real, 3>, 2, D> coords,
+      TView<OmegaParameters<Real>, 2, D> omega_indices)
+      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D> >;
 };
 
 }  // namespace potentials

--- a/tmol/score/omega/potentials/dispatch.impl.hh
+++ b/tmol/score/omega/potentials/dispatch.impl.hh
@@ -32,32 +32,37 @@ template <
     typename Int>
 struct OmegaDispatch {
   static auto f(
-      TView<Vec<Real, 3>, 1, D> coords,
-      TView<OmegaParameters<Real>, 1, D> omega_indices)
-      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 1, D>> {
-    auto V_t = TPack<Real, 1, D>::zeros({1});
-    auto dV_dx_t = TPack<Vec<Real, 3>, 1, D>::zeros({coords.size(0)});
+      TView<Vec<Real, 3>, 2, D> coords,
+      TView<OmegaParameters<Real>, 2, D> omega_indices)
+      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D>> {
+    int const nstacks = coords.size(0);
+    auto V_t = TPack<Real, 1, D>::zeros({nstacks});
+    auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({nstacks, coords.size(1)});
 
     auto V = V_t.view;
     auto dV_dx = dV_dx_t.view;
 
-    auto func = ([=] EIGEN_DEVICE_FUNC(int i) {
-      CoordQuad omegacoords;
-      for (int j = 0; j < 4; ++j) {
-        omegacoords.row(j) = coords[(int)omega_indices[i].atoms[j]];
-      }
-      auto omega = omega_V_dV<D, Real, Int>(omegacoords, omega_indices[i].K);
+    auto func = ([=] EIGEN_DEVICE_FUNC(int stack, int i) {
+      if (omega_indices[stack][i].atoms[0] >= 0) {
+        CoordQuad omegacoords;
+        for (int j = 0; j < 4; ++j) {
+          omegacoords.row(j) =
+              coords[stack][(int)omega_indices[stack][i].atoms[j]];
+        }
+        auto omega =
+            omega_V_dV<D, Real, Int>(omegacoords, omega_indices[stack][i].K);
 
-      accumulate<D, Real>::add(V[0], common::get<0>(omega));
-      for (int j = 0; j < 4; ++j) {
-        accumulate<D, Vec<Real, 3>>::add(
-            dV_dx[(int)omega_indices[i].atoms[j]],
-            common::get<1>(omega).row(j));
+        accumulate<D, Real>::add(V[stack], common::get<0>(omega));
+        for (int j = 0; j < 4; ++j) {
+          accumulate<D, Vec<Real, 3>>::add(
+              dV_dx[stack][(int)omega_indices[stack][i].atoms[j]],
+              common::get<1>(omega).row(j));
+        }
       }
     });
 
-    int num_Vs = omega_indices.size(0);
-    Dispatch<D>::forall(num_Vs, func);
+    int num_Vs = omega_indices.size(1);
+    Dispatch<D>::forall_stacks(nstacks, num_Vs, func);
 
     return {V_t, dV_dx_t};
   }

--- a/tmol/score/omega/score_graph.py
+++ b/tmol/score/omega/score_graph.py
@@ -1,4 +1,3 @@
-import numpy
 import attr
 
 from functools import singledispatch

--- a/tmol/score/omega/score_graph.py
+++ b/tmol/score/omega/score_graph.py
@@ -20,17 +20,19 @@ from tmol.types.array import NDArray
 from tmol.types.torch import Tensor
 from tmol.types.tensor import TensorGroup
 
+from tmol.score.common.stack_condense import condense_subset
+
 
 @attr.s(auto_attribs=True)
 class OmegaParams(TensorGroup):
-    omega_indices: Tensor(torch.int32)[..., 4]
+    omega_indices: Tensor(torch.int32)[:, :, 4]
 
 
 @reactive_attrs
 class OmegaIntraScore(IntraScore):
     @reactive_property
     def total_omega(target):
-        return target.omega_module(target.coords[0, ...])
+        return target.omega_module(target.coords)
 
 
 @score_graph
@@ -46,7 +48,7 @@ class OmegaScoreGraph(BondedAtomScoreGraph, TorchDevice):
     def factory_for(val, device: torch.device, **_):
         return dict(allomegas=val.allomegas, device=device)
 
-    allomegas: NDArray(int)[:, 4]
+    allomegas: NDArray(int)[:, :, 4]
     device: torch.device
 
     @reactive_property
@@ -65,12 +67,11 @@ class OmegaScoreGraph(BondedAtomScoreGraph, TorchDevice):
     @reactive_property
     @validate_args
     def omega_resolve_indices(
-        device: torch.device, allomegas: NDArray(int)[:, 4]
+        device: torch.device, allomegas: NDArray(int)[:, :, 4]
     ) -> OmegaParams:
         # remove undefined indices and send to device
-        omega_defined = numpy.all(allomegas != -1, axis=1)
-        omega_indices = torch.from_numpy(allomegas[omega_defined, :]).to(
-            device=device, dtype=torch.int32
-        )
+        allomegas = torch.tensor(allomegas, device=device)
+        omega_defined = torch.all(allomegas != -1, dim=2)
+        omega_indices = condense_subset(allomegas, omega_defined).to(torch.int32)
 
         return OmegaParams(omega_indices=omega_indices)

--- a/tmol/score/omega/script_modules.py
+++ b/tmol/score/omega/script_modules.py
@@ -13,7 +13,10 @@ class OmegaScoreModule(torch.jit.ScriptModule):
             return tuple(map(lambda t: t.to(torch.float), ts))
 
         self.params = torch.nn.Parameter(
-            torch.cat(_tfloat([indices, K.expand((indices.shape[0], 1))]), dim=1),
+            torch.cat(
+                _tfloat([indices, K.expand((indices.shape[0], indices.shape[1], 1))]),
+                dim=2,
+            ),
             requires_grad=False,
         )
 

--- a/tmol/system/kinematics.py
+++ b/tmol/system/kinematics.py
@@ -35,14 +35,24 @@ class KinematicDescription:
         coordinate. Note that this is a covering of indices within the system
         "non-atom" ids are not present in the tree.
         """
+
+        # right-pad with zeros to denote all bonds within a single system
+        bonds = numpy.concatenate(
+            (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
+            axis=1
+        )
         torsion_pairs = numpy.block(
             [[torsion_metadata["atom_index_b"]], [torsion_metadata["atom_index_c"]]]
         ).T
         torsion_bonds = torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)]
+        torsion_bonds = numpy.concatenate(
+            (numpy.zeros((torsion_bonds.shape[0],1), dtype=int), torsion_bonds),
+             axis=1
+        )
 
         builder = KinematicBuilder().append_connected_component(
             *KinematicBuilder.component_for_prioritized_bonds(
-                root=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
+                roots=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
             )
         )
 

--- a/tmol/system/kinematics.py
+++ b/tmol/system/kinematics.py
@@ -1,3 +1,4 @@
+from typing import Tuple, Union
 import attr
 
 import torch
@@ -25,8 +26,9 @@ class KinematicDescription:
     @validate_args
     def for_system(
         cls,
-        bonds: NDArray(int)[:, 2],
-        torsion_metadata: NDArray(torsion_metadata_dtype)[:],
+        system_size: int,
+        bonds: Union[ NDArray(int)[:, 3], NDArray(int)[:, 2]],
+        torsion_metadata: Tuple[NDArray(torsion_metadata_dtype)[:], ...],
     ):
         """Generate kinematics for system atoms and named torsions.
 
@@ -36,23 +38,39 @@ class KinematicDescription:
         "non-atom" ids are not present in the tree.
         """
 
-        # right-pad with zeros to denote all bonds within a single system
-        bonds = numpy.concatenate(
-            (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
-            axis=1
-        )
-        torsion_pairs = numpy.block(
-            [[torsion_metadata["atom_index_b"]], [torsion_metadata["atom_index_c"]]]
-        ).T
-        torsion_bonds = torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)]
-        torsion_bonds = numpy.concatenate(
-            (numpy.zeros((torsion_bonds.shape[0],1), dtype=int), torsion_bonds),
-             axis=1
-        )
+        if bonds.shape[1] == 2:
+            # right-pad with zeros to denote all bonds within a single system
+            bonds = numpy.concatenate(
+                (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
+                axis=1
+            )
 
-        builder = KinematicBuilder().append_connected_component(
+        # root all the kintrees at the first atom in each system
+        roots = system_size * numpy.arange(1+bonds[:,0].max(), dtype=int)
+
+        # construct torsion_bonds by merging the list of b-c atoms from each
+        # torsion_metadata list and marking each one by the system from
+        # which it originates.
+        torsion_bonds_list = []
+        for tmet in torsion_metadata:
+            torsion_pairs = numpy.block(
+                [[tmet["atom_index_b"]], [tmet["atom_index_c"]]]
+            ).T
+            torsion_bonds_list.append(torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)])
+        torsion_bonds = numpy.zeros((sum(t.shape[0] for t in torsion_bonds_list), 3), dtype=int)
+        start = numpy.cumsum(numpy.array([t.shape[0] for t in torsion_bonds_list], dtype=int))
+        for i, tbonds in enumerate(torsion_bonds_list):
+            range = slice(
+                0 if i == 0 else start[i-1],
+                start[i])
+            torsion_bonds[range,0] = i
+            torsion_bonds[range,1:3] = tbonds
+
+        builder = KinematicBuilder().append_connected_components(
+            roots,
             *KinematicBuilder.component_for_prioritized_bonds(
-                roots=0, mandatory_bonds=torsion_bonds, all_bonds=bonds
+                roots=roots, mandatory_bonds=torsion_bonds, all_bonds=bonds,
+                system_size=system_size,
             )
         )
 
@@ -63,7 +81,7 @@ class KinematicDescription:
         )
 
     def extract_kincoords(
-        self, coords: NDArray(float)[:, 3]
+        self, coords: NDArray(float)[:, :, 3]
     ) -> Tensor(torch.double)[:, 3]:
         """Extract the kinematic-derived coordinates from system coords.
 
@@ -72,7 +90,8 @@ class KinematicDescription:
         """
 
         # Extract current state coordinates to render current dofs
-        kincoords = torch.from_numpy(coords)[self.kintree.id.to(torch.long)]
+        tcoords_flat = torch.from_numpy(coords).reshape(-1,3)
+        kincoords = tcoords_flat[self.kintree.id.to(torch.long)]
 
         # Convert the -1 origin, a nan-coord, to zero
         assert self.kintree.id[0] == -1

--- a/tmol/system/kinematics.py
+++ b/tmol/system/kinematics.py
@@ -27,7 +27,7 @@ class KinematicDescription:
     def for_system(
         cls,
         system_size: int,
-        bonds: Union[ NDArray(int)[:, 3], NDArray(int)[:, 2]],
+        bonds: Union[NDArray(int)[:, 3], NDArray(int)[:, 2]],
         torsion_metadata: Tuple[NDArray(torsion_metadata_dtype)[:], ...],
     ):
         """Generate kinematics for system atoms and named torsions.
@@ -41,12 +41,11 @@ class KinematicDescription:
         if bonds.shape[1] == 2:
             # right-pad with zeros to denote all bonds within a single system
             bonds = numpy.concatenate(
-                (numpy.zeros((bonds.shape[0],1),dtype=int), bonds),
-                axis=1
+                (numpy.zeros((bonds.shape[0], 1), dtype=int), bonds), axis=1
             )
 
         # root all the kintrees at the first atom in each system
-        roots = system_size * numpy.arange(1+bonds[:,0].max(), dtype=int)
+        roots = system_size * numpy.arange(1 + bonds[:, 0].max(), dtype=int)
 
         # construct torsion_bonds by merging the list of b-c atoms from each
         # torsion_metadata list and marking each one by the system from
@@ -56,22 +55,28 @@ class KinematicDescription:
             torsion_pairs = numpy.block(
                 [[tmet["atom_index_b"]], [tmet["atom_index_c"]]]
             ).T
-            torsion_bonds_list.append(torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)])
-        torsion_bonds = numpy.zeros((sum(t.shape[0] for t in torsion_bonds_list), 3), dtype=int)
-        start = numpy.cumsum(numpy.array([t.shape[0] for t in torsion_bonds_list], dtype=int))
+            torsion_bonds_list.append(
+                torsion_pairs[numpy.all(torsion_pairs > 0, axis=-1)]
+            )
+        torsion_bonds = numpy.zeros(
+            (sum(t.shape[0] for t in torsion_bonds_list), 3), dtype=int
+        )
+        start = numpy.cumsum(
+            numpy.array([t.shape[0] for t in torsion_bonds_list], dtype=int)
+        )
         for i, tbonds in enumerate(torsion_bonds_list):
-            range = slice(
-                0 if i == 0 else start[i-1],
-                start[i])
-            torsion_bonds[range,0] = i
-            torsion_bonds[range,1:3] = tbonds
+            range = slice(0 if i == 0 else start[i - 1], start[i])
+            torsion_bonds[range, 0] = i
+            torsion_bonds[range, 1:3] = tbonds
 
         builder = KinematicBuilder().append_connected_components(
             roots,
             *KinematicBuilder.component_for_prioritized_bonds(
-                roots=roots, mandatory_bonds=torsion_bonds, all_bonds=bonds,
+                roots=roots,
+                mandatory_bonds=torsion_bonds,
+                all_bonds=bonds,
                 system_size=system_size,
-            )
+            ),
         )
 
         kintree = builder.kintree
@@ -90,7 +95,7 @@ class KinematicDescription:
         """
 
         # Extract current state coordinates to render current dofs
-        tcoords_flat = torch.from_numpy(coords).reshape(-1,3)
+        tcoords_flat = torch.from_numpy(coords).reshape(-1, 3)
         kincoords = tcoords_flat[self.kintree.id.to(torch.long)]
 
         # Convert the -1 origin, a nan-coord, to zero

--- a/tmol/system/packed.py
+++ b/tmol/system/packed.py
@@ -322,8 +322,8 @@ class PackedResidueSystem:
         torsion_metadata["atom_index_d"] = nan_to_neg1(torsion_index["d.atom_index"])
 
         result = cls(
-            block_size=block_size,
-            system_size=buffer_size,
+            block_size=int(block_size),
+            system_size=int(buffer_size),
             res_start_ind=segment_starts,
             residues=attached_res,
             atom_metadata=atom_metadata,

--- a/tmol/system/score_support.py
+++ b/tmol/system/score_support.py
@@ -22,6 +22,7 @@ from .packed import PackedResidueSystem, PackedResidueSystemStack
 from .kinematics import KinematicDescription
 
 from tmol.database import ParameterDatabase
+from tmol.types.array import NDArray
 
 
 @StackedSystem.factory_for.register(PackedResidueSystem)
@@ -159,12 +160,16 @@ def system_torsion_graph_inputs(
     """
 
     # Initialize kinematic tree for the system
-    sys_kin = KinematicDescription.for_system(system.bonds, system.torsion_metadata)
+    sys_kin = KinematicDescription.for_system(
+        int(system.system_size),
+        system.bonds,
+        (system.torsion_metadata,),
+    )
     tkintree = sys_kin.kintree.to(device)
     tdofmetadata = sys_kin.dof_metadata.to(device)
 
     # compute dofs from xyzs
-    kincoords = sys_kin.extract_kincoords(system.coords).to(device)
+    kincoords = sys_kin.extract_kincoords(system.coords.reshape(1,-1,3)).to(device)
     bkin = inverseKin(tkintree, kincoords)
 
     # dof mask
@@ -175,6 +180,49 @@ def system_torsion_graph_inputs(
         dofmetadata=tdofmetadata,
     )
 
+@KinematicAtomicCoordinateProvider.factory_for.register(PackedResidueSystemStack)
+@validate_args
+def stacked_system_torsion_graph_inputs(
+    system: PackedResidueSystemStack,
+    stack_depth: int,
+    system_size: int,
+    bonds: NDArray(int)[:, 3],
+    device: torch.device,
+    requires_grad: bool = True,
+    **_
+):
+    """Constructor parameters for torsion space scoring.
+
+    Extract constructor kwargs to initialize a `KinematicAtomicCoordinateProvider` and
+    `BondedAtomScoreGraph` subclass supporting torsion-space scoring. This
+    includes only `bond_torsion` dofs, a subset of valid kinematic dofs for the
+    system.
+    """
+
+    torsion_metadata = tuple(sys.torsion_metadata for sys in system.systems)
+    # Initialize kinematic tree for the system
+    sys_kin = KinematicDescription.for_system(
+        system_size,
+        bonds,
+        torsion_metadata,
+    )
+    tkintree = sys_kin.kintree.to(device)
+    tdofmetadata = sys_kin.dof_metadata.to(device)
+
+    # compute dofs from xyzs
+    coords = numpy.full((stack_depth, system_size, 3), numpy.nan, dtype=numpy.float64)
+    for i, sys in enumerate(system.systems):
+        coords[i, :sys.coords.shape[0], :] = sys.coords
+    kincoords = sys_kin.extract_kincoords(coords).to(device)
+    bkin = inverseKin(tkintree, kincoords)
+
+    # dof mask
+
+    return dict(
+        dofs=bkin.raw.clone().requires_grad_(requires_grad),
+        kintree=tkintree,
+        dofmetadata=tdofmetadata,
+    )
 
 @RamaScoreGraph.factory_for.register(PackedResidueSystem)
 @validate_args

--- a/tmol/system/score_support.py
+++ b/tmol/system/score_support.py
@@ -161,15 +161,13 @@ def system_torsion_graph_inputs(
 
     # Initialize kinematic tree for the system
     sys_kin = KinematicDescription.for_system(
-        int(system.system_size),
-        system.bonds,
-        (system.torsion_metadata,),
+        int(system.system_size), system.bonds, (system.torsion_metadata,)
     )
     tkintree = sys_kin.kintree.to(device)
     tdofmetadata = sys_kin.dof_metadata.to(device)
 
     # compute dofs from xyzs
-    kincoords = sys_kin.extract_kincoords(system.coords.reshape(1,-1,3)).to(device)
+    kincoords = sys_kin.extract_kincoords(system.coords.reshape(1, -1, 3)).to(device)
     bkin = inverseKin(tkintree, kincoords)
 
     # dof mask
@@ -180,6 +178,7 @@ def system_torsion_graph_inputs(
         dofmetadata=tdofmetadata,
     )
 
+
 @KinematicAtomicCoordinateProvider.factory_for.register(PackedResidueSystemStack)
 @validate_args
 def stacked_system_torsion_graph_inputs(
@@ -189,7 +188,7 @@ def stacked_system_torsion_graph_inputs(
     bonds: NDArray(int)[:, 3],
     device: torch.device,
     requires_grad: bool = True,
-    **_
+    **_,
 ):
     """Constructor parameters for torsion space scoring.
 
@@ -201,18 +200,14 @@ def stacked_system_torsion_graph_inputs(
 
     torsion_metadata = tuple(sys.torsion_metadata for sys in system.systems)
     # Initialize kinematic tree for the system
-    sys_kin = KinematicDescription.for_system(
-        system_size,
-        bonds,
-        torsion_metadata,
-    )
+    sys_kin = KinematicDescription.for_system(system_size, bonds, torsion_metadata)
     tkintree = sys_kin.kintree.to(device)
     tdofmetadata = sys_kin.dof_metadata.to(device)
 
     # compute dofs from xyzs
     coords = numpy.full((stack_depth, system_size, 3), numpy.nan, dtype=numpy.float64)
     for i, sys in enumerate(system.systems):
-        coords[i, :sys.coords.shape[0], :] = sys.coords
+        coords[i, : sys.coords.shape[0], :] = sys.coords
     kincoords = sys_kin.extract_kincoords(coords).to(device)
     bkin = inverseKin(tkintree, kincoords)
 
@@ -223,6 +218,7 @@ def stacked_system_torsion_graph_inputs(
         kintree=tkintree,
         dofmetadata=tdofmetadata,
     )
+
 
 @RamaScoreGraph.factory_for.register(PackedResidueSystem)
 @validate_args

--- a/tmol/tests/kinematics/test_builder.py
+++ b/tmol/tests/kinematics/test_builder.py
@@ -11,15 +11,10 @@ from tmol.score.bonded_atom import BondedAtomScoreGraph
 def test_builder_refold(ubq_system):
     tsys = ubq_system
 
-    bonds = numpy.concatenate(
-        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
-        axis=1
-    )
-
     kintree = (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, tsys.bonds)
         )
         .kintree
     )
@@ -39,14 +34,10 @@ def test_builder_refold(ubq_system):
 def test_builder_framing(ubq_system):
     """Test first-three-atom framing logic in kinematic builder."""
     tsys = ubq_system
-    bonds = numpy.concatenate(
-        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
-        axis=1
-    )
     kintree = (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, tsys.bonds)
         )
         .kintree
     )

--- a/tmol/tests/kinematics/test_builder.py
+++ b/tmol/tests/kinematics/test_builder.py
@@ -83,8 +83,9 @@ def test_builder_framing(ubq_system):
         kintree.parent[kintree.parent[normal_atoms].to(dtype=torch.long)],
     )
 
+
 def test_build_two_system_kinematics(ubq_system, torch_device):
-    natoms = numpy.sum(numpy.logical_not(numpy.isnan(ubq_system.coords[:,0])))
+    natoms = numpy.sum(numpy.logical_not(numpy.isnan(ubq_system.coords[:, 0])))
 
     twoubq = PackedResidueSystemStack((ubq_system, ubq_system))
     bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
@@ -101,9 +102,7 @@ def test_build_two_system_kinematics(ubq_system, torch_device):
 
     builder = KinematicBuilder()
     tree = builder.append_connected_components(
-        roots=tworoots,
-        ids=ids,
-        parent_ids=parents,
+        roots=tworoots, ids=ids, parent_ids=parents
     ).kintree
 
     assert tree.id.shape[0] == 2 * natoms + 1
@@ -111,12 +110,12 @@ def test_build_two_system_kinematics(ubq_system, torch_device):
     assert tree.parent[1 + root_index[0]] == 0
     assert tree.parent[1 + root_index[1]] == 0
 
+
 def test_build_jagged_system(ubq_res, torch_device):
     ubq40 = PackedResidueSystem.from_residues(ubq_res[:40])
     ubq60 = PackedResidueSystem.from_residues(ubq_res[:60])
-    natoms = (
-        numpy.sum(numpy.logical_not(numpy.isnan(ubq40.coords[:,0]))) +
-        numpy.sum(numpy.logical_not(numpy.isnan(ubq60.coords[:,0])))
+    natoms = numpy.sum(numpy.logical_not(numpy.isnan(ubq40.coords[:, 0]))) + numpy.sum(
+        numpy.logical_not(numpy.isnan(ubq60.coords[:, 0]))
     )
     twoubq = PackedResidueSystemStack((ubq40, ubq60))
     bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
@@ -133,9 +132,7 @@ def test_build_jagged_system(ubq_res, torch_device):
 
     builder = KinematicBuilder()
     tree = builder.append_connected_components(
-        roots=tworoots,
-        ids=ids,
-        parent_ids=parents,
+        roots=tworoots, ids=ids, parent_ids=parents
     ).kintree
 
     assert tree.id.shape[0] == natoms + 1

--- a/tmol/tests/kinematics/test_gpu_operations.py
+++ b/tmol/tests/kinematics/test_gpu_operations.py
@@ -10,10 +10,15 @@ from tmol.tests.torch import requires_cuda
 
 
 def system_kintree(target_system):
+    tsys = target_system
+    bonds = numpy.concatenate(
+        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
+        axis=1
+    )    
     return (
         KinematicBuilder()
         .append_connected_component(
-            *KinematicBuilder.bonds_to_connected_component(0, target_system.bonds)
+            *KinematicBuilder.bonds_to_connected_component(0, bonds)
         )
         .kintree
     )

--- a/tmol/tests/kinematics/test_gpu_operations.py
+++ b/tmol/tests/kinematics/test_gpu_operations.py
@@ -12,9 +12,8 @@ from tmol.tests.torch import requires_cuda
 def system_kintree(target_system):
     tsys = target_system
     bonds = numpy.concatenate(
-        (numpy.zeros((tsys.bonds.shape[0],1),dtype=int), tsys.bonds),
-        axis=1
-    )    
+        (numpy.zeros((tsys.bonds.shape[0], 1), dtype=int), tsys.bonds), axis=1
+    )
     return (
         KinematicBuilder()
         .append_connected_component(

--- a/tmol/tests/kinematics/test_metadata.py
+++ b/tmol/tests/kinematics/test_metadata.py
@@ -9,7 +9,7 @@ from tmol.system.kinematics import KinematicDescription
 
 def test_metadata_dataframe_smoke(ubq_system):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
 
     restored = DOFMetadata.from_frame(tkin.dof_metadata.to_frame())
 

--- a/tmol/tests/kinematics/test_metadata.py
+++ b/tmol/tests/kinematics/test_metadata.py
@@ -9,7 +9,9 @@ from tmol.system.kinematics import KinematicDescription
 
 def test_metadata_dataframe_smoke(ubq_system):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
+    tkin = KinematicDescription.for_system(
+        tsys.system_size, tsys.bonds, (tsys.torsion_metadata,)
+    )
 
     restored = DOFMetadata.from_frame(tkin.dof_metadata.to_frame())
 

--- a/tmol/tests/kinematics/test_operations.py
+++ b/tmol/tests/kinematics/test_operations.py
@@ -4,8 +4,11 @@ import numpy.testing
 
 import pytest
 
+from tmol.kinematics.builder import KinematicBuilder
 from tmol.kinematics.operations import inverseKin, forwardKin
 from tmol.kinematics.script_modules import KinematicModule
+from tmol.system.packed import PackedResidueSystem, PackedResidueSystemStack
+from tmol.score.bonded_atom import BondedAtomScoreGraph
 
 from tmol.kinematics.datatypes import NodeType, KinTree
 
@@ -254,3 +257,65 @@ def compute_verify_derivs(kintree, coords):
     )
 
     torch.testing.assert_allclose(analytical, numerical)
+
+def test_forward_refold_two_systems(ubq_system, torch_device):
+    twoubq = PackedResidueSystemStack((ubq_system, ubq_system))
+    bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
+    tworoots = numpy.array((0, twoubq.systems[0].system_size), dtype=int)
+
+    coords_raw = torch.tensor(numpy.concatenate(
+        (twoubq.systems[0].coords, twoubq.systems[1].coords), axis=0
+    ), dtype=torch.float64, device=torch_device )
+
+    kintree = KinematicBuilder().append_connected_components(
+        tworoots,
+        *KinematicBuilder.bonds_to_connected_component(
+            roots=tworoots,
+            bonds=bonds.bonds,
+            system_size=int(twoubq.systems[0].system_size),
+        ),
+    ).kintree.to(torch_device)
+
+    ids = kintree.id.type(torch.long)
+    coords = coords_raw[ids]
+    coords[0,:] = 0
+
+    dofs = inverseKin(kintree, coords)
+    refold_kincoords = forwardKin(kintree, dofs)
+    refold_kincoords[0,:] = 0
+
+    numpy.testing.assert_allclose(coords.cpu(), refold_kincoords.cpu(), atol=1e-6)
+
+def test_forward_refold_w_jagged_system(ubq_res, torch_device):
+    # torch_device = torch.device("cpu")
+    ubq40 = PackedResidueSystem.from_residues(ubq_res[:40])
+    ubq60 = PackedResidueSystem.from_residues(ubq_res[:60])
+    system_size = max(ubq40.system_size, ubq60.system_size)
+
+    twoubq = PackedResidueSystemStack((ubq40, ubq60))
+    bonds = BondedAtomScoreGraph.build_for(twoubq, device=torch_device)
+    tworoots = numpy.array((0, twoubq.systems[1].system_size), dtype=int)
+
+    coords_raw = torch.zeros((2, system_size, 3), dtype=torch.float64, device=torch_device)
+    coords_raw[0,0:ubq40.system_size,:] = torch.tensor(ubq40.coords, dtype=torch.float64, device=torch_device)
+    coords_raw[1,0:ubq60.system_size,:] = torch.tensor(ubq60.coords, dtype=torch.float64, device=torch_device)
+    coords_raw = coords_raw.reshape(2*system_size, 3)
+
+    kintree = KinematicBuilder().append_connected_components(
+        tworoots,
+        *KinematicBuilder.bonds_to_connected_component(
+            roots=tworoots,
+            bonds=bonds.bonds,
+            system_size=int(system_size),
+        ),
+    ).kintree.to(torch_device)
+
+    ids = kintree.id.type(torch.long)
+    coords = coords_raw[ids,:]
+    coords[0,:] = 0
+
+    dofs = inverseKin(kintree, coords)
+    refold_kincoords = forwardKin(kintree, dofs)
+    refold_kincoords[0,:] = 0
+
+    numpy.testing.assert_allclose(coords.cpu(), refold_kincoords.cpu(), atol=1e-6)

--- a/tmol/tests/kinematics/test_script_modules.py
+++ b/tmol/tests/kinematics/test_script_modules.py
@@ -19,7 +19,7 @@ from tmol.tests.torch import requires_cuda
 @pytest.mark.benchmark(group="kinematic_forward_op")
 def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -37,7 +37,7 @@ def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
 @pytest.mark.benchmark(group="kinematic_backward_op")
 def test_kinematic_torch_op_backward_benchmark(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -60,7 +60,7 @@ def gradcheck_test_system(
     ubq_res: typing.Sequence[Residue],
 ) -> typing.Tuple[KinTree, Tensor("f8")[:, 3]]:
     tsys = PackedResidueSystem.from_residues(ubq_res[:4])
-    tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
+    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
 
     return (tkin.kintree, tkin.extract_kincoords(tsys.coords))
 

--- a/tmol/tests/kinematics/test_script_modules.py
+++ b/tmol/tests/kinematics/test_script_modules.py
@@ -19,7 +19,9 @@ from tmol.tests.torch import requires_cuda
 @pytest.mark.benchmark(group="kinematic_forward_op")
 def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
+    tkin = KinematicDescription.for_system(
+        tsys.system_size, tsys.bonds, (tsys.torsion_metadata,)
+    )
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -37,7 +39,9 @@ def test_kinematic_torch_op_forward(benchmark, ubq_system, torch_device):
 @pytest.mark.benchmark(group="kinematic_backward_op")
 def test_kinematic_torch_op_backward_benchmark(benchmark, ubq_system, torch_device):
     tsys = ubq_system
-    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
+    tkin = KinematicDescription.for_system(
+        tsys.system_size, tsys.bonds, (tsys.torsion_metadata,)
+    )
     kincoords = tkin.extract_kincoords(tsys.coords).to(torch_device)
     tkintree = tkin.kintree.to(torch_device)
 
@@ -60,7 +64,9 @@ def gradcheck_test_system(
     ubq_res: typing.Sequence[Residue],
 ) -> typing.Tuple[KinTree, Tensor("f8")[:, 3]]:
     tsys = PackedResidueSystem.from_residues(ubq_res[:4])
-    tkin = KinematicDescription.for_system(tsys.system_size, tsys.bonds, (tsys.torsion_metadata,))
+    tkin = KinematicDescription.for_system(
+        tsys.system_size, tsys.bonds, (tsys.torsion_metadata,)
+    )
 
     return (tkin.kintree, tkin.extract_kincoords(tsys.coords))
 

--- a/tmol/tests/score/lk_ball/test_score_graph.py
+++ b/tmol/tests/score/lk_ball/test_score_graph.py
@@ -42,5 +42,6 @@ def test_jagged_scoring(ubq_res, default_database, torch_device):
     total60 = score60.intra_score().total_lk_ball
     total_both = score_both.intra_score().total_lk_ball
 
-    assert total_both[0].item() == pytest.approx(total40[0].item())
-    assert total_both[1].item() == pytest.approx(total60[0].item())
+    # assert 79.03907775878906 == pytest.approx(79.03899383544922, rel=1e-5, abs=1e-4)
+    assert total_both[0].item() == pytest.approx(total40[0].item(), rel=1e-5, abs=1e-4)
+    assert total_both[1].item() == pytest.approx(total60[0].item(), rel=1e-5, abs=1e-4)

--- a/tmol/tests/score/omega/test_score_graph.py
+++ b/tmol/tests/score/omega/test_score_graph.py
@@ -1,6 +1,9 @@
+import torch
+
 from tmol.score.coordinates import CartesianAtomicCoordinateProvider
 from tmol.score.omega import OmegaScoreGraph
 from tmol.score.score_graph import score_graph
+from tmol.system.packed import PackedResidueSystem, PackedResidueSystemStack
 
 
 @score_graph
@@ -10,4 +13,45 @@ class OmegaGraph(CartesianAtomicCoordinateProvider, OmegaScoreGraph):
 
 def test_omega_smoke(ubq_system, torch_device):
     omega_graph = OmegaGraph.build_for(ubq_system, device=torch_device)
-    assert omega_graph.allomegas.shape[0] == 76
+    assert omega_graph.allomegas.shape == (1, 76, 4)
+
+
+def test_jagged_scoring(ubq_res, default_database, torch_device):
+    ubq40 = PackedResidueSystem.from_residues(ubq_res[:40])
+    ubq60 = PackedResidueSystem.from_residues(ubq_res[:60])
+    twoubq = PackedResidueSystemStack((ubq40, ubq60))
+
+    score40 = OmegaGraph.build_for(ubq40, device=torch_device)
+    score60 = OmegaGraph.build_for(ubq60, device=torch_device)
+    score_both = OmegaGraph.build_for(twoubq, device=torch_device)
+
+    total40 = score40.intra_score().total
+    total60 = score60.intra_score().total
+    total_both = score_both.intra_score().total
+
+    torch.testing.assert_allclose(total_both[0], total40[0])
+    torch.testing.assert_allclose(total_both[1], total60[0])
+
+    # smoke
+    torch.sum(total_both).backward()
+
+
+def test_jagged_scoring2(ubq_res, default_database, torch_device):
+    ubq1050 = PackedResidueSystem.from_residues(ubq_res[10:50])
+    ubq60 = PackedResidueSystem.from_residues(ubq_res[:60])
+    ubq40 = PackedResidueSystem.from_residues(ubq_res[:40])
+    threeubq = PackedResidueSystemStack((ubq1050, ubq60, ubq40))
+
+    score1050 = OmegaGraph.build_for(ubq1050, device=torch_device)
+    score40 = OmegaGraph.build_for(ubq40, device=torch_device)
+    score60 = OmegaGraph.build_for(ubq60, device=torch_device)
+    score_all = OmegaGraph.build_for(threeubq, device=torch_device)
+
+    total1050 = score1050.intra_score().total
+    total60 = score60.intra_score().total
+    total40 = score40.intra_score().total
+    total_all = score_all.intra_score().total
+
+    torch.testing.assert_allclose(total_all[0], total1050[0])
+    torch.testing.assert_allclose(total_all[1], total60[0])
+    torch.testing.assert_allclose(total_all[2], total40[0])

--- a/tmol/tests/score/omega/test_script_modules.py
+++ b/tmol/tests/score/omega/test_script_modules.py
@@ -18,7 +18,7 @@ class ScoreSetup:
             torch.from_numpy(coords)
             .to(device=torch_device, dtype=torch.float)
             .requires_grad_(True)
-        )
+        )[None, :]
 
         omegas = numpy.array(
             [
@@ -37,7 +37,7 @@ class ScoreSetup:
         omega_defined = numpy.all(omegas != -1, axis=1)
         tomega_atom_indices = torch.from_numpy(omegas[omega_defined, :]).to(
             device=torch_device, dtype=torch.int32
-        )
+        )[None, :]
         tK = torch.tensor(32.8, device=torch_device, dtype=torch.float)
 
         return cls(tcoords=tcoords, tomega_atom_indices=tomega_atom_indices, tK=tK)
@@ -67,11 +67,11 @@ def test_omega_intra_gradcheck(default_database, ubq_system, torch_device):
 
     def eval_omega(coords_subset):
         coords = s.tcoords.clone()
-        coords[t_atm_indices] = coords_subset
+        coords[:, t_atm_indices] = coords_subset
         v = op(coords)
         return v
 
-    masked_coords = s.tcoords[t_atm_indices]
+    masked_coords = s.tcoords[:, t_atm_indices]
     torch.autograd.gradcheck(
         eval_omega, (masked_coords.requires_grad_(True),), eps=1e-3, atol=1e-2
     )

--- a/tmol/tests/score/test_coordinates.py
+++ b/tmol/tests/score/test_coordinates.py
@@ -121,8 +121,10 @@ def test_coord_clone_factory(ubq_system):
 def test_coord_clone_factory_from_stacked_systems(ubq_system: PackedResidueSystem):
     twoubq = PackedResidueSystemStack((ubq_system, ubq_system))
     cacp = CartesianAtomicCoordinateProvider.build_for(twoubq)
+    kacp = KinematicAtomicCoordinateProvider.build_for(twoubq)
 
     assert cacp.coords.shape == (2, cacp.system_size, 3)
+    assert kacp.coords.shape == (2, kacp.system_size, 3)
 
 
 def test_non_uniform_sized_stacked_system_coord_factory(ubq_res):
@@ -130,7 +132,9 @@ def test_non_uniform_sized_stacked_system_coord_factory(ubq_res):
     sys2 = PackedResidueSystem.from_residues(ubq_res[:8])
     sys3 = PackedResidueSystem.from_residues(ubq_res[:4])
 
-    twoubq = PackedResidueSystemStack((sys1, sys2, sys3))
-    cacp = CartesianAtomicCoordinateProvider.build_for(twoubq)
+    three_ubq = PackedResidueSystemStack((sys1, sys2, sys3))
+    cacp = CartesianAtomicCoordinateProvider.build_for(three_ubq)
+    kacp = KinematicAtomicCoordinateProvider.build_for(three_ubq)
 
     assert cacp.coords.shape == (3, sys2.coords.shape[0], 3)
+    assert kacp.coords.shape == (3, sys2.coords.shape[0], 3)

--- a/tmol/tests/score/test_totalscore_benchmarks.py
+++ b/tmol/tests/score/test_totalscore_benchmarks.py
@@ -24,16 +24,16 @@ class TotalScore(KinematicAtomicCoordinateProvider, TotalScoreGraph, TorchDevice
 
 
 # the
-@score_graph
-class StackScoreGraph(
-    CartesianAtomicCoordinateProvider,
-    LJScoreGraph,
-    LKScoreGraph,
-    LKBallScoreGraph,
-    RamaScoreGraph,
-    TorchDevice,
-):
-    pass
+# @score_graph
+# class StackScoreGraph(
+#     CartesianAtomicCoordinateProvider,
+#     LJScoreGraph,
+#     LKScoreGraph,
+#     LKBallScoreGraph,
+#     RamaScoreGraph,
+#     TorchDevice,
+# ):
+#     pass
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def test_stacked_full(
     benchmark, ubq_system, nstacks, torch_device, default_component_weights
 ):
     stack = PackedResidueSystemStack((ubq_system,) * nstacks)
-    score_graph = StackScoreGraph.build_for(
+    score_graph = TotalScore.build_for(
         stack,
         requires_grad=True,
         device=torch_device,

--- a/tmol/tests/system/test_kinematics.py
+++ b/tmol/tests/system/test_kinematics.py
@@ -31,9 +31,7 @@ def test_system_kinematics(ubq_system):
     tsys = ubq_system
 
     tsys_kinematics = KinematicDescription.for_system(
-        tsys.system_size,
-        ubq_system.bonds,
-        (ubq_system.torsion_metadata,),
+        tsys.system_size, ubq_system.bonds, (ubq_system.torsion_metadata,)
     )
 
     kinematic_tree_results = report_tree_coverage(tsys, tsys_kinematics.kintree)

--- a/tmol/tests/system/test_kinematics.py
+++ b/tmol/tests/system/test_kinematics.py
@@ -31,7 +31,9 @@ def test_system_kinematics(ubq_system):
     tsys = ubq_system
 
     tsys_kinematics = KinematicDescription.for_system(
-        ubq_system.bonds, ubq_system.torsion_metadata
+        tsys.system_size,
+        ubq_system.bonds,
+        (ubq_system.torsion_metadata,),
     )
 
     kinematic_tree_results = report_tree_coverage(tsys, tsys_kinematics.kintree)


### PR DESCRIPTION
Construct a kinematic tree for a stack of systems.

The kinematics code has a "flattened" view of the atoms in the system, with the system-indices of the kintree atoms being their row-major index;

ie. if there are 3 systems with at most 50 atoms each, then atom 5 in system 2 (indexing from zero) would be:

50 * 2 + 5

so that 

    coords = torch.zeros( (nstacks, system_size, 3), dtype=float)

can be written to by a view

    coords_flattened = coords.reshape((-1, 3))

Within the kintree, there's a single root at position 0 (as before) and this root connects to the first atom (atom 0) for each of the systems. Within the `KinematicBuilder` code, this is accomplished by creating faux bonds between the root of the first system to the roots of all the other systems, ahead of the call to `csgraph.breadth_first_order`. 

The messiest part of this conversion is that I'm tolerating the two descriptions of bonds:
as either a nbonds x 2 array of atom index pairs, or a nbonds x 3 array of (stack-index, at1, at2) triples. There are several access points, it seems, into the `KinematicBuilder` code, (at least as far as testing goes) and I've had to make Unions of the n x 2 and n x 3 inputs and then paste on a column of 0's in case the user has passed an n x 2 array (corresponding to "everything is in a single stack").

