### PR TITLE
Update numpy to 1.15+

### DIFF
--- a/environments/core.dependencies.txt
+++ b/environments/core.dependencies.txt
@@ -1,6 +1,6 @@
 python>=3.6
 ipython
-numpy==1.14.*
+numpy==1.15.*
 pandas==0.22
 numba::numba==0.40
 scipy=1.1.*

--- a/environments/support.channels.txt
+++ b/environments/support.channels.txt
@@ -1,1 +1,1 @@
-https://conda.anaconda.org/t/IuO94WfD-JCG/rosettacommons
+https://levinthal:paradox@conda.graylab.jhu.edu

--- a/environments/support.dependencies.txt
+++ b/environments/support.dependencies.txt
@@ -1,1 +1,1 @@
-pyrosetta=2018.51.*
+pyrosetta=2020.1.*

--- a/environments/test.dependencies.txt
+++ b/environments/test.dependencies.txt
@@ -1,7 +1,7 @@
 pytest=3.8.*
 pytest-cov
 
-flake8
+flake8=3.8.3
 uw-ipd::clangdev=7.*
 virtualenv
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     version=git_version(),
     packages=["tmol"],
     setup_requires=pytest_runner,
-    tests_require=[l.strip() for l in open("requirements.tests.txt").readlines()],
-    install_requires=[l.strip() for l in open("requirements.txt").readlines()],
+    tests_require=[line.strip() for line in open("requirements.tests.txt").readlines()],
+    install_requires=[line.strip() for line in open("requirements.txt").readlines()],
     zip_safe=False,
 )

--- a/tmol/kinematics/builder.py
+++ b/tmol/kinematics/builder.py
@@ -138,7 +138,7 @@ class KinematicBuilder:
         # Verify that ids are unique and that all parent references are valid,
         # get_indexer returns -1 if a target value is not present in index.
         assert not id_index.has_duplicates, "Duplicated id in component"
-        assert numpy.all(parent_indices >= 0), "Parent id not present in component."
+        assert numpy.all(parent_indices.numpy() >= 0), "Parent id not present in component."
 
         # Allocate entries for the new subtree and store the provided ids in
         # the kintree id column. All internal kintree references,

--- a/tmol/kinematics/builder.py
+++ b/tmol/kinematics/builder.py
@@ -138,7 +138,9 @@ class KinematicBuilder:
         # Verify that ids are unique and that all parent references are valid,
         # get_indexer returns -1 if a target value is not present in index.
         assert not id_index.has_duplicates, "Duplicated id in component"
-        assert numpy.all(parent_indices.numpy() >= 0), "Parent id not present in component."
+        assert numpy.all(
+            parent_indices.numpy() >= 0
+        ), "Parent id not present in component."
 
         # Allocate entries for the new subtree and store the provided ids in
         # the kintree id column. All internal kintree references,

--- a/tmol/score/cartbonded/params.py
+++ b/tmol/score/cartbonded/params.py
@@ -59,7 +59,7 @@ class CartBondedParamResolver(ValidateAttrs):
         resnames: NDArray(object)[:, :],
         atm1s: NDArray(object)[:, :],
         atm2s: NDArray(object)[:, :],
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         """Resolve string triplets into integer bondlength parameter indices."""
         assert resnames.shape[0] == atm1s.shape[0]
         assert resnames.shape[0] == atm2s.shape[0]
@@ -94,7 +94,7 @@ class CartBondedParamResolver(ValidateAttrs):
         atm1s: NDArray(object)[:, :],
         atm2s: NDArray(object)[:, :],
         atm3s: NDArray(object)[:, :],
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         """Resolve string quads into integer bondangle parameter indices."""
 
         inds = numpy.full(resnames.shape[0:2], -9999, dtype=numpy.int64)
@@ -139,7 +139,7 @@ class CartBondedParamResolver(ValidateAttrs):
         atm2s: NDArray(object)[:, :],
         atm3s: NDArray(object)[:, :],
         atm4s: NDArray(object)[:, :],
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         """Resolve string quints into integer torsion parameter indices."""
 
         inds = numpy.full_like(resnames, -9999, dtype=numpy.int64)
@@ -187,7 +187,7 @@ class CartBondedParamResolver(ValidateAttrs):
         atm2s: NDArray(object),
         atm3s: NDArray(object),
         atm4s: NDArray(object),
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         """Resolve string quints into integer improper torsion parameter indices."""
         # impropers have a defined ordering
 
@@ -219,7 +219,7 @@ class CartBondedParamResolver(ValidateAttrs):
         atm2s: NDArray(object),
         atm3s: NDArray(object),
         atm4s: NDArray(object),
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         """Resolve string quints into integer hydroxyl torsion parameter indices."""
         inds = numpy.full_like(resnames, -9999, dtype=numpy.int64)
         real = resnames.astype(bool)

--- a/tmol/score/chemical_database.py
+++ b/tmol/score/chemical_database.py
@@ -40,7 +40,7 @@ AcceptorHybridization._index = pandas.Index([None, "sp2", "sp3", "ring"])
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class AtomTypeParams(TensorGroup, ValidateAttrs):
     is_acceptor: Tensor(bool)[...]
-    acceptor_hybridization: Tensor("i4")[...]
+    acceptor_hybridization: Tensor(torch.int32)[...]
 
     is_donor: Tensor(bool)[...]
 
@@ -66,7 +66,7 @@ class AtomTypeParamResolver(ValidateAttrs):
 
     device: torch.device
 
-    def type_idx(self, atom_types: NDArray(object)[...]) -> Tensor("i8")[...]:
+    def type_idx(self, atom_types: NDArray(object)[...]) -> Tensor(torch.int64)[...]:
         """Convert array of atom type names to parameter indices.
 
         pandas.Index.get_indexer only operates on 1-d input arrays. Coerces

--- a/tmol/score/elec/params.py
+++ b/tmol/score/elec/params.py
@@ -15,11 +15,11 @@ from tmol.database.scoring.elec import ElecDatabase
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class ElecGlobalParams(TensorGroup, ValidateAttrs):
-    elec_min_dis: Tensor("f")[...]
-    elec_max_dis: Tensor("f")[...]
-    elec_sigmoidal_die_D: Tensor("f")[...]
-    elec_sigmoidal_die_D0: Tensor("f")[...]
-    elec_sigmoidal_die_S: Tensor("f")[...]
+    elec_min_dis: Tensor(torch.float32)[...]
+    elec_max_dis: Tensor(torch.float32)[...]
+    elec_sigmoidal_die_D: Tensor(torch.float32)[...]
+    elec_sigmoidal_die_D0: Tensor(torch.float32)[...]
+    elec_sigmoidal_die_S: Tensor(torch.float32)[...]
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -43,7 +43,7 @@ class ElecParamResolver(ValidateAttrs):
 
     def resolve_partial_charge(
         self, res_names: NDArray(object)[:, :], atom_names: NDArray(object)[:, :]
-    ) -> NDArray("f")[...]:
+    ) -> NDArray(numpy.float32)[...]:
         """Convert array of atom type names to partial charges.
         """
         pcs = numpy.vectorize(

--- a/tmol/score/elec/score_graph.py
+++ b/tmol/score/elec/score_graph.py
@@ -77,7 +77,7 @@ class ElecScoreGraph(BondedAtomScoreGraph, ParamDB, TorchDevice):
     @reactive_property
     # @validate_args
     def repatm_bonded_path_length(
-        bonded_path_length: Tensor("f4")[:, :, :],
+        bonded_path_length: Tensor(torch.float32)[:, :, :],
         res_names: NDArray(object)[:, :],
         res_indices: NDArray(float)[:, :],
         atom_names: NDArray(object)[:, :],

--- a/tmol/score/elec/script_modules.py
+++ b/tmol/score/elec/script_modules.py
@@ -37,18 +37,30 @@ class _ElecScoreModule(torch.jit.ScriptModule):
 
 class ElecInterModule(_ElecScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, J, atom_type_J, bonded_path_lengths):
+    def forward(
+        self, coords_I, atom_type_I, coords_J, atom_type_J, bonded_path_lengths
+    ):
         return torch.ops.tmol.score_elec(
-            I, atom_type_I, J, atom_type_J, bonded_path_lengths, self.global_params
+            coords_I,
+            atom_type_I,
+            coords_J,
+            atom_type_J,
+            bonded_path_lengths,
+            self.global_params,
         )
 
 
 class ElecIntraModule(_ElecScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, bonded_path_lengths):
-        # print("I", I.shape)
+    def forward(self, coords_I, atom_type_I, bonded_path_lengths):
+        # print("coords_I", coords_I.shape)
         # print("atom_type_I", atom_type_I.shape)
         # print("bonded_path_lengths", bonded_path_lengths.shape)
         return torch.ops.tmol.score_elec_triu(
-            I, atom_type_I, I, atom_type_I, bonded_path_lengths, self.global_params
+            coords_I,
+            atom_type_I,
+            coords_I,
+            atom_type_I,
+            bonded_path_lengths,
+            self.global_params,
         )

--- a/tmol/score/hbond/params.py
+++ b/tmol/score/hbond/params.py
@@ -46,9 +46,9 @@ class HBondPolyParams(TensorGroup, ConvertAttrs):
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class HBondPairParams(TensorGroup, ValidateAttrs):
-    donor_weight: Tensor("f")[...]
-    acceptor_weight: Tensor("f")[...]
-    acceptor_hybridization: Tensor("i4")[...]
+    donor_weight: Tensor(torch.float32)[...]
+    acceptor_weight: Tensor(torch.float32)[...]
+    acceptor_hybridization: Tensor(torch.int32)[...]
     AHdist: HBondPolyParams
     cosBAH: HBondPolyParams
     cosAHD: HBondPolyParams

--- a/tmol/score/hbond/score_graph.py
+++ b/tmol/score/hbond/score_graph.py
@@ -29,24 +29,24 @@ from tmol.types.tensor import TensorGroup
 
 @attr.s(auto_attribs=True)
 class HBondDonorIndices(TensorGroup):
-    D: Tensor("i8")[..., 3]
-    H: Tensor("i8")[..., 3]
-    donor_type: Tensor("i4")[...]
+    D: Tensor(torch.int64)[..., 3]
+    H: Tensor(torch.int64)[..., 3]
+    donor_type: Tensor(torch.int32)[...]
 
 
 @attr.s(auto_attribs=True)
 class HBondAcceptorIndices(TensorGroup):
-    A: Tensor("i8")[..., 3]
-    B: Tensor("i8")[..., 3]
-    B0: Tensor("i8")[..., 3]
-    acceptor_type: Tensor("i4")[...]
+    A: Tensor(torch.int64)[..., 3]
+    B: Tensor(torch.int64)[..., 3]
+    B0: Tensor(torch.int64)[..., 3]
+    acceptor_type: Tensor(torch.int32)[...]
 
 
 @attr.s(auto_attribs=True)
 class HBondDescr(TensorGroup):
     donor: HBondDonorIndices
     acceptor: HBondAcceptorIndices
-    score: Tensor("f")[...]
+    score: Tensor(torch.float32)[...]
 
 
 @reactive_attrs

--- a/tmol/score/interatomic_distance.py
+++ b/tmol/score/interatomic_distance.py
@@ -57,8 +57,8 @@ class InteratomicDistanceGraphBase(StackedSystem):
     @reactive_property
     @validate_args
     def atom_pair_delta(
-        coords: Tensor("f4")[:, :, 3], atom_pair_inds: Tensor(torch.long)[:, 3]
-    ) -> Tensor("f4")[:, 3]:
+        coords: Tensor(torch.float32)[:, :, 3], atom_pair_inds: Tensor(torch.long)[:, 3]
+    ) -> Tensor(torch.float32)[:, 3]:
         """inter-atomic pairwise distance within threshold distance"""
         delta = (
             coords[atom_pair_inds[:, 0], atom_pair_inds[:, 1]]
@@ -72,7 +72,9 @@ class InteratomicDistanceGraphBase(StackedSystem):
 
     @reactive_property
     @validate_args
-    def atom_pair_dist(atom_pair_delta: Tensor("f4")[:, 3],) -> Tensor("f4")[:]:
+    def atom_pair_dist(
+        atom_pair_delta: Tensor(torch.float32)[:, 3],
+    ) -> Tensor(torch.float32)[:]:
         return atom_pair_delta.norm(dim=-1)
 
     def atom_pair_to_dense(self, atom_pair_term, null_value=numpy.nan):

--- a/tmol/score/ljlk/params.py
+++ b/tmol/score/ljlk/params.py
@@ -21,35 +21,35 @@ from ..chemical_database import AtomTypeParamResolver
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class LJLKGlobalParams(TensorGroup):
-    max_dis: Tensor("f")[...]
-    spline_start: Tensor("f")[...]
-    lj_hbond_OH_donor_dis: Tensor("f")[...]
-    lj_hbond_dis: Tensor("f")[...]
-    lj_hbond_hdis: Tensor("f")[...]
-    lj_switch_dis2sigma: Tensor("f")[...]
-    lk_min_dis2sigma: Tensor("f")[...]
+    max_dis: Tensor(torch.float32)[...]
+    spline_start: Tensor(torch.float32)[...]
+    lj_hbond_OH_donor_dis: Tensor(torch.float32)[...]
+    lj_hbond_dis: Tensor(torch.float32)[...]
+    lj_hbond_hdis: Tensor(torch.float32)[...]
+    lj_switch_dis2sigma: Tensor(torch.float32)[...]
+    lk_min_dis2sigma: Tensor(torch.float32)[...]
 
     # not clear if this belongs here or in a separate class
-    lkb_water_dist: Tensor("f")[...]
-    lkb_water_angle_sp2: Tensor("f")[...]
-    lkb_water_angle_sp3: Tensor("f")[...]
-    lkb_water_angle_ring: Tensor("f")[...]
-    lkb_water_tors_sp2: Tensor("f")[..., :]
-    lkb_water_tors_sp3: Tensor("f")[..., :]
-    lkb_water_tors_ring: Tensor("f")[..., :]
+    lkb_water_dist: Tensor(torch.float32)[...]
+    lkb_water_angle_sp2: Tensor(torch.float32)[...]
+    lkb_water_angle_sp3: Tensor(torch.float32)[...]
+    lkb_water_angle_ring: Tensor(torch.float32)[...]
+    lkb_water_tors_sp2: Tensor(torch.float32)[..., :]
+    lkb_water_tors_sp3: Tensor(torch.float32)[..., :]
+    lkb_water_tors_ring: Tensor(torch.float32)[..., :]
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class LJLKTypeParams(TensorGroup):
-    lj_radius: Tensor("f")[...]
-    lj_wdepth: Tensor("f")[...]
-    lk_dgfree: Tensor("f")[...]
-    lk_lambda: Tensor("f")[...]
-    lk_volume: Tensor("f")[...]
+    lj_radius: Tensor(torch.float32)[...]
+    lj_wdepth: Tensor(torch.float32)[...]
+    lk_dgfree: Tensor(torch.float32)[...]
+    lk_lambda: Tensor(torch.float32)[...]
+    lk_volume: Tensor(torch.float32)[...]
 
     # Parameters imported from chemical database
     is_acceptor: Tensor(bool)[...]
-    acceptor_hybridization: Tensor("i4")[...]
+    acceptor_hybridization: Tensor(torch.int32)[...]
 
     is_donor: Tensor(bool)[...]
 
@@ -77,7 +77,7 @@ class LJLKParamResolver(ValidateAttrs):
 
     device: torch.device
 
-    def type_idx(self, atom_types: NDArray(object)[...]) -> Tensor("i8")[...]:
+    def type_idx(self, atom_types: NDArray(object)[...]) -> Tensor(torch.int64)[...]:
         """Convert array of atom type names to parameter indices.
 
         pandas.Index.get_indexer only operates on 1-d input arrays. Coerces

--- a/tmol/score/ljlk/script_modules.py
+++ b/tmol/score/ljlk/script_modules.py
@@ -71,11 +71,11 @@ class _LJScoreModule(torch.jit.ScriptModule):
 
 class LJIntraModule(_LJScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, bonded_path_lengths):
+    def forward(self, coords_I, atom_type_I, bonded_path_lengths):
         return torch.ops.tmol.score_ljlk_lj_triu(
-            I,
+            coords_I,
             atom_type_I,
-            I,
+            coords_I,
             atom_type_I,
             bonded_path_lengths,
             self.type_params,
@@ -85,11 +85,13 @@ class LJIntraModule(_LJScoreModule):
 
 class LJInterModule(_LJScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, J, atom_type_J, bonded_path_lengths):
+    def forward(
+        self, coords_I, atom_type_I, coords_J, atom_type_J, bonded_path_lengths
+    ):
         return torch.ops.tmol.score_ljlk_lj(
-            I,
+            coords_I,
             atom_type_I,
-            J,
+            coords_J,
             atom_type_J,
             bonded_path_lengths,
             self.type_params,
@@ -157,11 +159,11 @@ class _LKIsotropicScoreModule(torch.jit.ScriptModule):
 
 class LKIsotropicIntraModule(_LKIsotropicScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, bonded_path_lengths):
+    def forward(self, coords_I, atom_type_I, bonded_path_lengths):
         return torch.ops.tmol.score_ljlk_lk_isotropic_triu(
-            I,
+            coords_I,
             atom_type_I,
-            I,
+            coords_I,
             atom_type_I,
             bonded_path_lengths,
             self.type_params,
@@ -171,11 +173,13 @@ class LKIsotropicIntraModule(_LKIsotropicScoreModule):
 
 class LKIsotropicInterModule(_LKIsotropicScoreModule):
     @torch.jit.script_method
-    def forward(self, I, atom_type_I, J, atom_type_J, bonded_path_lengths):
+    def forward(
+        self, coords_I, atom_type_I, coords_J, atom_type_J, bonded_path_lengths
+    ):
         return torch.ops.tmol.score_ljlk_lk_isotropic(
-            I,
+            coords_I,
             atom_type_I,
-            J,
+            coords_J,
             atom_type_J,
             bonded_path_lengths,
             self.type_params,

--- a/tmol/score/lk_ball/score_graph.py
+++ b/tmol/score/lk_ball/score_graph.py
@@ -19,8 +19,8 @@ from tmol.types.torch import Tensor
 
 @attr.s(auto_attribs=True)
 class LKBallPairs:
-    polars: Tensor("i8")[:, :]
-    occluders: Tensor("i8")[:, :]
+    polars: Tensor(torch.int64)[:, :]
+    occluders: Tensor(torch.int64)[:, :]
 
 
 @reactive_attrs

--- a/tmol/score/lk_ball/script_modules.py
+++ b/tmol/score/lk_ball/script_modules.py
@@ -129,17 +129,17 @@ class LKBallIntraModule(_LKBallScoreModule):
     @torch.jit.script_method
     def forward(
         self,
-        I,
-        polars_I,
-        occulders_I,
-        atom_type_I,
+        coords,
+        polars_inds,
+        occulders_inds,
+        atom_types,
         bonded_path_lengths,
         indexed_bond_bonds,
         indexed_bond_spans,
     ):
-        waters_I = torch.ops.tmol.watergen_lkball(
-            I,
-            atom_type_I,
+        waters = torch.ops.tmol.watergen_lkball(
+            coords,
+            atom_types,
             indexed_bond_bonds,
             indexed_bond_spans,
             self.watergen_type_params,
@@ -150,14 +150,14 @@ class LKBallIntraModule(_LKBallScoreModule):
         )
 
         return torch.ops.tmol.score_lkball(
-            I,
-            polars_I,
-            atom_type_I,
-            waters_I,
-            I,
-            occulders_I,
-            atom_type_I,
-            waters_I,
+            coords,
+            polars_inds,
+            atom_types,
+            waters,
+            coords,
+            occulders_inds,
+            atom_types,
+            waters,
             bonded_path_lengths,
             self.lkball_type_params,
             self.lkball_global_params,
@@ -168,11 +168,11 @@ class LKBallInterModule(_LKBallScoreModule):
     # @torch.jit.script_method
     def forward(
         self,
-        I,
+        coords_I,
         polars_I,
         occulders_I,
         atom_type_I,
-        J,
+        coords_J,
         polars_J,
         occulders_J,
         atom_type_J,
@@ -181,7 +181,7 @@ class LKBallInterModule(_LKBallScoreModule):
         indexed_bond_spans,
     ):
         waters_I = torch.ops.tmol.watergen_lkball(
-            I,
+            coords_I,
             atom_type_I,
             indexed_bond_bonds,
             indexed_bond_spans,
@@ -193,7 +193,7 @@ class LKBallInterModule(_LKBallScoreModule):
         )
 
         waters_J = torch.ops.tmol.watergen_lkball(
-            J,
+            coords_J,
             atom_type_J,
             indexed_bond_bonds,
             indexed_bond_spans,
@@ -205,11 +205,11 @@ class LKBallInterModule(_LKBallScoreModule):
         )
 
         V_ij = torch.ops.tmol.score_lkball(
-            I,
+            coords_I,
             polars_I,
             atom_type_I,
             waters_I,
-            J,
+            coords_J,
             occulders_J,
             atom_type_J,
             waters_J,
@@ -219,11 +219,11 @@ class LKBallInterModule(_LKBallScoreModule):
         )
 
         V_ji = torch.ops.tmol.score_lkball(
-            J,
+            coords_J,
             polars_J,
             atom_type_J,
             waters_J,
-            I,
+            coords_I,
             occulders_I,
             atom_type_I,
             waters_I,

--- a/tmol/score/rama/params.py
+++ b/tmol/score/rama/params.py
@@ -17,6 +17,7 @@ from tmol.numeric.bspline import BSplineInterpolation
 from tmol.database.scoring.rama import RamaDatabase
 from tmol.types.tensor import TensorGroup
 
+
 # rama parameters
 @attr.s(auto_attribs=True)
 class RamaParams(TensorGroup):
@@ -47,7 +48,7 @@ class RamaParamResolver(ValidateAttrs):
 
     def resolve_ramatables(
         self, r1: NDArray(object), r2: NDArray(object)
-    ) -> NDArray("i8")[...]:
+    ) -> NDArray(numpy.int64)[...]:
         l_idx = self.rama_lookup.index.get_indexer([r1, r2])
         wildcard = numpy.full_like(r1, "_")
         l_idx[l_idx == -1] = self.rama_lookup.index.get_indexer(

--- a/tmol/tests/kinematics/test_builder.py
+++ b/tmol/tests/kinematics/test_builder.py
@@ -20,7 +20,7 @@ def test_builder_refold(ubq_system):
     dofs = inverseKin(kintree, kincoords)
     refold_kincoords = forwardKin(kintree, dofs)
 
-    assert numpy.all(refold_kincoords[0] == 0)
+    assert numpy.all(refold_kincoords[0].numpy() == 0)
 
     refold_coords = numpy.full_like(tsys.coords, numpy.nan)
     refold_coords[kintree.id[1:].squeeze()] = refold_kincoords[1:]

--- a/tmol/tests/kinematics/test_operations.py
+++ b/tmol/tests/kinematics/test_operations.py
@@ -150,7 +150,9 @@ def test_perturb(kintree, coords, torch_device):
     pcoords = forwardKin(kintree, t_dofs)
 
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
-    assert numpy.all(coord_changed(pcoords[6:11].cpu().numpy(), coords[6:11].cpu().numpy()))
+    assert numpy.all(
+        coord_changed(pcoords[6:11].cpu().numpy(), coords[6:11].cpu().numpy())
+    )
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)
 
@@ -169,7 +171,10 @@ def test_perturb(kintree, coords, torch_device):
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[6].cpu(), coords[6].cpu(), atol=1e-6)
     assert numpy.all(
-        numpy.any(coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()), axis=-1)
+        numpy.any(
+            coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()),
+            axis=-1,
+        )
     )
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)
@@ -184,7 +189,10 @@ def test_perturb(kintree, coords, torch_device):
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[6].cpu(), coords[6].cpu(), atol=1e-6)
     assert numpy.all(
-        numpy.any(coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()), axis=-1)
+        numpy.any(
+            coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()),
+            axis=-1,
+        )
     )
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)

--- a/tmol/tests/kinematics/test_operations.py
+++ b/tmol/tests/kinematics/test_operations.py
@@ -150,7 +150,7 @@ def test_perturb(kintree, coords, torch_device):
     pcoords = forwardKin(kintree, t_dofs)
 
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
-    assert numpy.all(coord_changed(pcoords[6:11].cpu(), coords[6:11].cpu()))
+    assert numpy.all(coord_changed(pcoords[6:11].cpu().numpy(), coords[6:11].cpu().numpy()))
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)
 
@@ -169,7 +169,7 @@ def test_perturb(kintree, coords, torch_device):
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[6].cpu(), coords[6].cpu(), atol=1e-6)
     assert numpy.all(
-        numpy.any(coord_changed(pcoords[7:11].cpu(), coords[7:11].cpu()), axis=-1)
+        numpy.any(coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()), axis=-1)
     )
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)
@@ -184,7 +184,7 @@ def test_perturb(kintree, coords, torch_device):
     numpy.testing.assert_allclose(pcoords[1:6].cpu(), coords[1:6].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[6].cpu(), coords[6].cpu(), atol=1e-6)
     assert numpy.all(
-        numpy.any(coord_changed(pcoords[7:11].cpu(), coords[7:11].cpu()), axis=-1)
+        numpy.any(coord_changed(pcoords[7:11].cpu().numpy(), coords[7:11].cpu().numpy()), axis=-1)
     )
     numpy.testing.assert_allclose(pcoords[11:16].cpu(), coords[11:16].cpu(), atol=1e-6)
     numpy.testing.assert_allclose(pcoords[16:21].cpu(), coords[16:21].cpu(), atol=1e-6)

--- a/tmol/tests/kinematics/test_script_modules.py
+++ b/tmol/tests/kinematics/test_script_modules.py
@@ -58,7 +58,7 @@ def test_kinematic_torch_op_backward_benchmark(benchmark, ubq_system, torch_devi
 @pytest.fixture
 def gradcheck_test_system(
     ubq_res: typing.Sequence[Residue],
-) -> typing.Tuple[KinTree, Tensor("f8")[:, 3]]:
+) -> typing.Tuple[KinTree, Tensor(torch.float64)[:, 3]]:
     tsys = PackedResidueSystem.from_residues(ubq_res[:4])
     tkin = KinematicDescription.for_system(tsys.bonds, tsys.torsion_metadata)
 

--- a/tmol/tests/score/interatomic_distance/test_score_graph.py
+++ b/tmol/tests/score/interatomic_distance/test_score_graph.py
@@ -14,7 +14,7 @@ def test_interatomic_distance_stacked(
     tc = multilayer_test_coords
 
     intra_layer_counts = [
-        numpy.nansum(pdist(tc[l]) < threshold_distance) for l in range(len(tc))
+        numpy.nansum(pdist(tc[layer]) < threshold_distance) for layer in range(len(tc))
     ]
 
     inter_layer_counts = [

--- a/tmol/tests/score/lk_ball/potentials/compiled.py
+++ b/tmol/tests/score/lk_ball/potentials/compiled.py
@@ -17,22 +17,22 @@ _compiled = load(modulename(__name__), relpaths(__file__, ["compiled.pybind.cpp"
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class LKBallTypeParams(TensorGroup):
-    lj_radius: Tensor("f")[...]
-    lk_dgfree: Tensor("f")[...]
-    lk_lambda: Tensor("f")[...]
-    lk_volume: Tensor("f")[...]
-    is_donor: Tensor("f")[...]
-    is_hydroxyl: Tensor("f")[...]
-    is_polarh: Tensor("f")[...]
-    is_acceptor: Tensor("f")[...]
+    lj_radius: Tensor(torch.float32)[...]
+    lk_dgfree: Tensor(torch.float32)[...]
+    lk_lambda: Tensor(torch.float32)[...]
+    lk_volume: Tensor(torch.float32)[...]
+    is_donor: Tensor(torch.float32)[...]
+    is_hydroxyl: Tensor(torch.float32)[...]
+    is_polarh: Tensor(torch.float32)[...]
+    is_acceptor: Tensor(torch.float32)[...]
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class LKBallGlobalParams(TensorGroup):
-    lj_hbond_dis: Tensor("f")[...]
-    lj_hbond_OH_donor_dis: Tensor("f")[...]
-    lj_hbond_hdis: Tensor("f")[...]
-    lkb_water_dist: Tensor("f")[...]
+    lj_hbond_dis: Tensor(torch.float32)[...]
+    lj_hbond_OH_donor_dis: Tensor(torch.float32)[...]
+    lj_hbond_hdis: Tensor(torch.float32)[...]
+    lkb_water_dist: Tensor(torch.float32)[...]
 
 
 def detach_maybe_requires_grad(

--- a/tmol/tests/score/test_bonded_atom.py
+++ b/tmol/tests/score/test_bonded_atom.py
@@ -74,11 +74,15 @@ def test_bonded_path_length(ubq_system: PackedResidueSystem):
 
         assert src.bonded_path_length.shape == (1, src.system_size, src.system_size)
         assert numpy.all(
-            src.bonded_path_length[0][distance_table > src.MAX_BONDED_PATH_LENGTH].numpy()
+            src.bonded_path_length[0][
+                distance_table > src.MAX_BONDED_PATH_LENGTH
+            ].numpy()
             == numpy.inf
         )
         assert numpy.all(
-            src.bonded_path_length[0][distance_table < src.MAX_BONDED_PATH_LENGTH].numpy()
+            src.bonded_path_length[0][
+                distance_table < src.MAX_BONDED_PATH_LENGTH
+            ].numpy()
             == distance_table[distance_table < src.MAX_BONDED_PATH_LENGTH].numpy()
         )
 

--- a/tmol/tests/score/test_bonded_atom.py
+++ b/tmol/tests/score/test_bonded_atom.py
@@ -74,12 +74,12 @@ def test_bonded_path_length(ubq_system: PackedResidueSystem):
 
         assert src.bonded_path_length.shape == (1, src.system_size, src.system_size)
         assert numpy.all(
-            src.bonded_path_length[0][distance_table > src.MAX_BONDED_PATH_LENGTH]
+            src.bonded_path_length[0][distance_table > src.MAX_BONDED_PATH_LENGTH].numpy()
             == numpy.inf
         )
         assert numpy.all(
-            src.bonded_path_length[0][distance_table < src.MAX_BONDED_PATH_LENGTH]
-            == distance_table[distance_table < src.MAX_BONDED_PATH_LENGTH]
+            src.bonded_path_length[0][distance_table < src.MAX_BONDED_PATH_LENGTH].numpy()
+            == distance_table[distance_table < src.MAX_BONDED_PATH_LENGTH].numpy()
         )
 
     inds = src.indexed_bonds

--- a/tmol/tests/types/test_tensor.py
+++ b/tmol/tests/types/test_tensor.py
@@ -277,12 +277,12 @@ def test_tensorgroup_cat():
 def test_tensorgroup_to_dtypes():
     @attr.s(auto_attribs=True, frozen=True)
     class STG(TensorGroup):
-        s: Tensor("f4")[..., 3, 3]
+        s: Tensor(torch.float32)[..., 3, 3]
 
     @attr.s(auto_attribs=True, frozen=True)
     class TG(TensorGroup):
-        s: Tensor("f4")[..., 3]
-        d: Tensor("f8")[...]
+        s: Tensor(torch.float32)[..., 3]
+        d: Tensor(torch.float64)[...]
         sub: STG
 
     cpu_float = dict(
@@ -317,12 +317,12 @@ def test_tensorgroup_to_dtypes():
 def test_tensorgroup_to_device():
     @attr.s(auto_attribs=True, frozen=True)
     class STG(TensorGroup):
-        s: Tensor("f4")[..., 3, 3]
+        s: Tensor(torch.float32)[..., 3, 3]
 
     @attr.s(auto_attribs=True, frozen=True)
     class TG(TensorGroup):
-        s: Tensor("f4")[..., 3]
-        d: Tensor("f8")[...]
+        s: Tensor(torch.float32)[..., 3]
+        d: Tensor(torch.float64)[...]
         sub: STG
 
     cpu_float = dict(

--- a/tmol/tests/types/test_torch.py
+++ b/tmol/tests/types/test_torch.py
@@ -62,7 +62,7 @@ validation_examples = [
         ],
     },
     {
-        "spec": Tensor("f")[:],
+        "spec": Tensor(torch.float32)[:],
         "valid": [torch.zeros(30), torch.Tensor([1, 2, 3])],
         "invalid": [
             # bad shape

--- a/tmol/types/functional.py
+++ b/tmol/types/functional.py
@@ -31,7 +31,7 @@ def validate_args(f):
             try:
                 validator(retval)
             except Exception as vexec:
-                raise TypeError(f"Invalid return value") from vexec
+                raise TypeError("Invalid return value") from vexec
 
         return retval
 
@@ -61,7 +61,7 @@ def convert_args(f):
             try:
                 retval = converter(retval)
             except Exception as vexec:
-                raise TypeError(f"Invalid return value") from vexec
+                raise TypeError("Invalid return value") from vexec
         return retval
 
     return decorate(f, convert_f)


### PR DESCRIPTION
This version offers access to a function, take_along_axis, which
is needed in branch aleaverfay/build_rotamers to sort the indices
of the rotamers in the input rotamer library by decreasing
probability.

Frustratingly, there is a bug in numpy above 1.14 that causes
calls to numpy.all and numpy.any which pass a torch tensor to
fail with the error:

```
TypeError: any() missing 1 required positional arguments: "dim"
```

as noted here: https://github.com/pytorch/pytorch/issues/15810

The workaround is to simply ask for the torch tensor as a numpy
array.