### PR TITLE
Fix error in the 4x4 identity matrix used in HT-based kinematics

### DIFF
--- a/tmol/kinematics/compiled/compiled.cuda.cu
+++ b/tmol/kinematics/compiled/compiled.cuda.cu
@@ -190,7 +190,7 @@ struct ForwardKinDispatch {
     auto HTscan_t = TPack<HomogeneousTransform, 1, D>::empty({scanBuffer});
     auto HTscan = HTscan_t.view;
     HTRawBuffer<Real> init = {
-        1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0};  // identity xform
+        1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};  // identity xform
     nvtx_range_pop();
 
     // printf("[0] alloc=%d\n", carryoutBuffer);


### PR DESCRIPTION
Two keystroke bugfix for long-standing, hard-to-find bug in the kinematics layer.