### PR TITLE
Apply clang-format to .cpp files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         description: 'Format files with ClangFormat.'
         entry: clang-format
         language: system
-        files: \.(c|cc|h|hh|cu|cuh)$
+        files: \.(c|cc|cpp|h|hh|cu|cuh)$
         exclude: >
             (?x)^(
                 tmol/extern/.* |

--- a/tmol/kinematics/compiled/compiled.cpu.cpp
+++ b/tmol/kinematics/compiled/compiled.cpu.cpp
@@ -22,8 +22,8 @@ struct ForwardKinDispatch {
       TView<Int, 1, D> nodes,
       TView<Int, 1, D> scans,
       TView<KinTreeGenData<Int>, 1, tmol::Device::CPU> gens,
-      TView<KinTreeParams<Int>, 1, D> kintree
-  ) -> std::tuple< TPack<Coord, 1, D>, TPack<HomogeneousTransform, 1, D> > {
+      TView<KinTreeParams<Int>, 1, D> kintree)
+      -> std::tuple<TPack<Coord, 1, D>, TPack<HomogeneousTransform, 1, D> > {
     auto num_atoms = dofs.size(0);
 
     auto HTs_t = TPack<HomogeneousTransform, 1, D>::empty({num_atoms});
@@ -37,9 +37,9 @@ struct ForwardKinDispatch {
       if (doftype == ROOT) {
         HTs[i] = HomogeneousTransform::Identity();
       } else if (doftype == JUMP) {
-        HTs[i] = common<D,Real,Int>::jumpTransform(dofs[i]);
+        HTs[i] = common<D, Real, Int>::jumpTransform(dofs[i]);
       } else if (doftype == BOND) {
-        HTs[i] = common<D,Real,Int>::bondTransform(dofs[i]);
+        HTs[i] = common<D, Real, Int>::bondTransform(dofs[i]);
       }
     });
 
@@ -48,26 +48,27 @@ struct ForwardKinDispatch {
     }
 
     // scan and accumulate HTs down atom tree
-    auto k_compose = ([=] EIGEN_DEVICE_FUNC(int p, int i) {
-        HTs[i] = HTs[i]*HTs[p];
-    });
+    auto k_compose =
+        ([=] EIGEN_DEVICE_FUNC(int p, int i) { HTs[i] = HTs[i] * HTs[p]; });
 
     int ngens = gens.size(0) - 1;
-    for (int gen = 0; gen < ngens; gen++) { // loop over generations
+    for (int gen = 0; gen < ngens; gen++) {  // loop over generations
       int scanstart = gens[gen].scan_start;
-      int scanstop = gens[gen+1].scan_start;
-      for (int j = scanstart; j < scanstop; j++) { // loop over scans
+      int scanstop = gens[gen + 1].scan_start;
+      for (int j = scanstart; j < scanstop; j++) {  // loop over scans
         int nodestart = gens[gen].node_start + scans[j];
-        int nodestop = (j == scanstop-1) ? gens[gen+1].node_start : (gens[gen].node_start + scans[j+1]);
-        for (int k = nodestart; k < nodestop-1; k++) { // loop over path
-            k_compose(nodes[k], nodes[k+1]);
+        int nodestop = (j == scanstop - 1)
+                           ? gens[gen + 1].node_start
+                           : (gens[gen].node_start + scans[j + 1]);
+        for (int k = nodestart; k < nodestop - 1; k++) {  // loop over path
+          k_compose(nodes[k], nodes[k + 1]);
         }
       }
     }
 
     // copy atom positions
     auto k_getcoords = ([=] EIGEN_DEVICE_FUNC(int i) {
-        xs[i] = HTs[i].block(3,0,1,3).transpose();
+      xs[i] = HTs[i].block(3, 0, 1, 3).transpose();
     });
 
     for (int i = 0; i < num_atoms; i++) {
@@ -78,7 +79,6 @@ struct ForwardKinDispatch {
   }
 };
 
-
 template <tmol::Device D, typename Real, typename Int>
 struct InverseKinDispatch {
   static auto f(
@@ -87,51 +87,51 @@ struct InverseKinDispatch {
       TView<Int, 1, D> frame_x,
       TView<Int, 1, D> frame_y,
       TView<Int, 1, D> frame_z,
-      TView<Int, 1, D> doftype
-  ) -> TPack<KintreeDof, 1, D> {
+      TView<Int, 1, D> doftype) -> TPack<KintreeDof, 1, D> {
     auto num_atoms = coords.size(0);
 
-    //fd: we could eliminate HT allocation and calculate on the fly
+    // fd: we could eliminate HT allocation and calculate on the fly
     auto HTs_t = TPack<HomogeneousTransform, 1, D>::empty({num_atoms});
     auto HTs = HTs_t.view;
     auto dofs_t = TPack<KintreeDof, 1, D>::empty({num_atoms});
     auto dofs = dofs_t.view;
 
     auto k_coords2hts = ([=] EIGEN_DEVICE_FUNC(int i) {
-		if (i==0) {
-			HTs[i] = HomogeneousTransform::Identity();
-		} else {
-			HTs[i] = common<D,Real,Int>::hts_from_frames( 
-				coords[i], 
-                coords[frame_x[i]], coords[frame_y[i]], coords[frame_z[i]]
-            );
-		}
-	});
+      if (i == 0) {
+        HTs[i] = HomogeneousTransform::Identity();
+      } else {
+        HTs[i] = common<D, Real, Int>::hts_from_frames(
+            coords[i],
+            coords[frame_x[i]],
+            coords[frame_y[i]],
+            coords[frame_z[i]]);
+      }
+    });
 
     for (int i = 0; i < num_atoms; i++) {
       k_coords2hts(i);
-    }	
+    }
 
     auto k_hts2dofs = ([=] EIGEN_DEVICE_FUNC(int i) {
-	  HomogeneousTransform lclHT;
-	  if (doftype[i] == ROOT) {
-        dofs[i] = KintreeDof::Constant(0); // for num deriv check
+      HomogeneousTransform lclHT;
+      if (doftype[i] == ROOT) {
+        dofs[i] = KintreeDof::Constant(0);  // for num deriv check
       } else {
-		lclHT = HTs[i] * common<D,Real,Int>::ht_inv( HTs[parent[i]] );
+        lclHT = HTs[i] * common<D, Real, Int>::ht_inv(HTs[parent[i]]);
 
         if (doftype[i] == JUMP) {
-          dofs[i] = common<D,Real,Int>::invJumpTransform(lclHT);
+          dofs[i] = common<D, Real, Int>::invJumpTransform(lclHT);
         } else if (doftype[i] == BOND) {
-          dofs[i] = common<D,Real,Int>::invBondTransform(lclHT);
+          dofs[i] = common<D, Real, Int>::invBondTransform(lclHT);
         }
-	  }
-	});
+      }
+    });
 
     for (int i = 0; i < num_atoms; i++) {
       k_hts2dofs(i);
     }
 
-	return dofs_t;
+    return dofs_t;
   }
 };
 
@@ -144,21 +144,20 @@ struct KinDerivDispatch {
       TView<Int, 1, D> nodes,
       TView<Int, 1, D> scans,
       TView<KinTreeGenData<Int>, 1, tmol::Device::CPU> gens,
-      TView<KinTreeParams<Int>, 1, D> kintree
-  ) -> TPack<KintreeDof, 1, D> {
+      TView<KinTreeParams<Int>, 1, D> kintree) -> TPack<KintreeDof, 1, D> {
     auto num_atoms = dVdx.size(0);
 
-    auto f1f2s_t = TPack<Vec<Real,6>, 1, D>::empty({num_atoms});
+    auto f1f2s_t = TPack<Vec<Real, 6>, 1, D>::empty({num_atoms});
     auto f1f2s = f1f2s_t.view;
     auto dsc_ddofs_t = TPack<KintreeDof, 1, D>::empty({num_atoms});
     auto dsc_ddofs = dsc_ddofs_t.view;
 
     // calculate f1s and f2s from dVdx and HT
     auto k_f1f2s = ([=] EIGEN_DEVICE_FUNC(int i) {
-        Coord trans = hts[i].block(3,0,1,3).transpose();
-        Coord f1 = trans.cross( trans - dVdx[i]).transpose();
-        f1f2s[i].topRows(3) = f1;
-        f1f2s[i].bottomRows(3) = dVdx[i];
+      Coord trans = hts[i].block(3, 0, 1, 3).transpose();
+      Coord f1 = trans.cross(trans - dVdx[i]).transpose();
+      f1f2s[i].topRows(3) = f1;
+      f1f2s[i].bottomRows(3) = dVdx[i];
     });
 
     for (int i = 0; i < num_atoms; i++) {
@@ -167,20 +166,22 @@ struct KinDerivDispatch {
 
     // scan and accumulate f1s/f2s up atom tree
     auto k_compose = ([=] EIGEN_DEVICE_FUNC(int p, int i) {
-        f1f2s[i] = f1f2s[i] + f1f2s[p];
+      f1f2s[i] = f1f2s[i] + f1f2s[p];
     });
 
-    // note: if this is parallelized (over j/k) 
+    // note: if this is parallelized (over j/k)
     //   then k_compose needs to be atomic
     int ngens = gens.size(0) - 1;
-    for (int gen = 0; gen < ngens; gen++) { // loop over generations
+    for (int gen = 0; gen < ngens; gen++) {  // loop over generations
       int scanstart = gens[gen].scan_start;
-      int scanstop = gens[gen+1].scan_start;
-      for (int j = scanstart; j < scanstop; j++) { // loop over scans
+      int scanstop = gens[gen + 1].scan_start;
+      for (int j = scanstart; j < scanstop; j++) {  // loop over scans
         int nodestart = gens[gen].node_start + scans[j];
-        int nodestop = (j == scanstop-1) ? gens[gen+1].node_start : (gens[gen].node_start + scans[j+1]);
-        for (int k = nodestart; k < nodestop-1; k++) { // loop over path
-            k_compose(nodes[k], nodes[k+1]);
+        int nodestop = (j == scanstop - 1)
+                           ? gens[gen + 1].node_start
+                           : (gens[gen].node_start + scans[j + 1]);
+        for (int k = nodestart; k < nodestop - 1; k++) {  // loop over path
+          k_compose(nodes[k], nodes[k + 1]);
         }
       }
     }
@@ -191,11 +192,11 @@ struct KinDerivDispatch {
       if (kintree[i].doftype == ROOT) {
         dsc_ddofs[i] = Vec<Real, 9>::Constant(0);
       } else if (kintree[i].doftype == JUMP) {
-        dsc_ddofs[i]= common<D,Real,Int>::jumpDerivatives(
-          dofs[i], hts[i], hts[kintree[i].parent], f1, f2 );
+        dsc_ddofs[i] = common<D, Real, Int>::jumpDerivatives(
+            dofs[i], hts[i], hts[kintree[i].parent], f1, f2);
       } else if (kintree[i].doftype == BOND) {
-        dsc_ddofs[i]= common<D,Real,Int>::bondDerivatives(
-          dofs[i], hts[i], hts[kintree[i].parent], f1, f2 );
+        dsc_ddofs[i] = common<D, Real, Int>::bondDerivatives(
+            dofs[i], hts[i], hts[kintree[i].parent], f1, f2);
       }
     });
 

--- a/tmol/numeric/bspline_compiled/bspline.pybind.cpp
+++ b/tmol/numeric/bspline_compiled/bspline.pybind.cpp
@@ -13,50 +13,49 @@ void bind(pybind11::module& m) {
   using namespace pybind11::literals;
 
   m.def(
-      "computeCoeffs2",
-      &ndspline<2, 3, D, Real, Int>::computeCoeffs,
-      "data"_a);
+      "computeCoeffs2", &ndspline<2, 3, D, Real, Int>::computeCoeffs, "data"_a);
 
   m.def(
       "interpolate2",
-      py::overload_cast< TView<Real, 2, D>, TView<Eigen::Matrix<Real, 2, 1>, 1, D> >(
-        &ndspline<2, 3, D, Real, Int>::interpolate_tv),
+      py::overload_cast<
+          TView<Real, 2, D>,
+          TView<Eigen::Matrix<Real, 2, 1>, 1, D> >(
+          &ndspline<2, 3, D, Real, Int>::interpolate_tv),
       "data"_a,
       "X"_a);
 
   m.def(
-      "computeCoeffs3",
-      &ndspline<3, 3, D, Real, Int>::computeCoeffs,
-      "data"_a);
+      "computeCoeffs3", &ndspline<3, 3, D, Real, Int>::computeCoeffs, "data"_a);
 
   m.def(
       "interpolate3",
-      py::overload_cast< TView<Real, 3, D>, TView<Eigen::Matrix<Real, 3, 1>, 1, D> >(
-        &ndspline<3, 3, D, Real, Int>::interpolate_tv),
+      py::overload_cast<
+          TView<Real, 3, D>,
+          TView<Eigen::Matrix<Real, 3, 1>, 1, D> >(
+          &ndspline<3, 3, D, Real, Int>::interpolate_tv),
       "data"_a,
       "X"_a);
 
   m.def(
-      "computeCoeffs4",
-      &ndspline<4, 3, D, Real, Int>::computeCoeffs,
-      "data"_a);
+      "computeCoeffs4", &ndspline<4, 3, D, Real, Int>::computeCoeffs, "data"_a);
 
   m.def(
       "interpolate4",
-      py::overload_cast< TView<Real, 4, D>, TView<Eigen::Matrix<Real, 4, 1>, 1, D> >(
-        &ndspline<4, 3, D, Real, Int>::interpolate_tv),
+      py::overload_cast<
+          TView<Real, 4, D>,
+          TView<Eigen::Matrix<Real, 4, 1>, 1, D> >(
+          &ndspline<4, 3, D, Real, Int>::interpolate_tv),
       "data"_a,
       "X"_a);
-
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   using namespace pybind11::literals;
 
-  bind<tmol::Device::CPU,float,int32_t>(m);
-  bind<tmol::Device::CPU,double,int32_t>(m);
+  bind<tmol::Device::CPU, float, int32_t>(m);
+  bind<tmol::Device::CPU, double, int32_t>(m);
 }
 
-}
-}
-}
+}  // namespace bspline
+}  // namespace numeric
+}  // namespace tmol

--- a/tmol/score/cartbonded/potentials/compiled.cpu.cpp
+++ b/tmol/score/cartbonded/potentials/compiled.cpu.cpp
@@ -9,8 +9,16 @@ namespace score {
 namespace cartbonded {
 namespace potentials {
 
-template struct CartBondedDispatch<common::ForallDispatch, tmol::Device::CPU, float, int64_t>;
-template struct CartBondedDispatch<common::ForallDispatch, tmol::Device::CPU, double, int64_t>;
+template struct CartBondedDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int64_t>;
+template struct CartBondedDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int64_t>;
 
 }  // namespace potentials
 }  // namespace cartbonded

--- a/tmol/score/dunbrack/potentials/compiled.cpu.cpp
+++ b/tmol/score/dunbrack/potentials/compiled.cpu.cpp
@@ -7,11 +7,18 @@ namespace score {
 namespace dunbrack {
 namespace potentials {
 
-template struct DunbrackDispatch<common::ForallDispatch,tmol::Device::CPU,float,int32_t>;
-template struct DunbrackDispatch<common::ForallDispatch,tmol::Device::CPU,double,int32_t>;
-
+template struct DunbrackDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int32_t>;
+template struct DunbrackDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int32_t>;
 
 }  // namespace potentials
-}  // namespace rama
+}  // namespace dunbrack
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/elec/potentials/compiled.cpu.cpp
+++ b/tmol/score/elec/potentials/compiled.cpu.cpp
@@ -8,13 +8,18 @@ namespace score {
 namespace elec {
 namespace potentials {
 
-#define declare_dispatch(Real, Int)                                         \
-  template struct ElecDispatch<ForallDispatch, AABBDispatch, tmol::Device::CPU, Real, Int>; \
-  template struct ElecDispatch<                                             \
-      ForallDispatch,                                                     \
-      AABBTriuDispatch,                                                     \
-      tmol::Device::CPU,                                                    \
-      Real,                                                                 \
+#define declare_dispatch(Real, Int) \
+  template struct ElecDispatch<     \
+      ForallDispatch,               \
+      AABBDispatch,                 \
+      tmol::Device::CPU,            \
+      Real,                         \
+      Int>;                         \
+  template struct ElecDispatch<     \
+      ForallDispatch,               \
+      AABBTriuDispatch,             \
+      tmol::Device::CPU,            \
+      Real,                         \
       Int>;
 
 declare_dispatch(float, int64_t);

--- a/tmol/score/ljlk/potentials/lj.compiled.cpu.cpp
+++ b/tmol/score/ljlk/potentials/lj.compiled.cpu.cpp
@@ -9,11 +9,7 @@ namespace potentials {
 
 #define declare_dispatch(Real, Int)                                       \
   template struct LJDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>; \
-  template struct LJDispatch<                                             \
-      AABBTriuDispatch,                                              \
-      tmol::Device::CPU,                                                  \
-      Real,                                                               \
-      Int>;
+  template struct LJDispatch<AABBTriuDispatch, tmol::Device::CPU, Real, Int>;
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/ljlk/potentials/lk_isotropic.compiled.cpu.cpp
+++ b/tmol/score/ljlk/potentials/lk_isotropic.compiled.cpu.cpp
@@ -7,9 +7,17 @@ namespace score {
 namespace ljlk {
 namespace potentials {
 
-#define declare_dispatch(Real, Int)                                            \
-  template struct LKIsotropicDispatch<AABBDispatch, tmol::Device::CPU, Real, Int>;     \
-  template struct LKIsotropicDispatch<AABBTriuDispatch, tmol::Device::CPU, Real, Int>; \
+#define declare_dispatch(Real, Int)    \
+  template struct LKIsotropicDispatch< \
+      AABBDispatch,                    \
+      tmol::Device::CPU,               \
+      Real,                            \
+      Int>;                            \
+  template struct LKIsotropicDispatch< \
+      AABBTriuDispatch,                \
+      tmol::Device::CPU,               \
+      Real,                            \
+      Int>;
 
 declare_dispatch(float, int64_t);
 declare_dispatch(double, int64_t);

--- a/tmol/score/lk_ball/potentials/compiled.cpu.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.cpu.cpp
@@ -12,19 +12,55 @@ namespace score {
 namespace lk_ball {
 namespace potentials {
 
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, float, int32_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, double, int32_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, float, int64_t>;
-template struct LKBallDispatch<common::AABBDispatch, tmol::Device::CPU, double, int64_t>;
+template struct LKBallDispatch<
+    common::AABBDispatch,
+    tmol::Device::CPU,
+    float,
+    int32_t>;
+template struct LKBallDispatch<
+    common::AABBDispatch,
+    tmol::Device::CPU,
+    double,
+    int32_t>;
+template struct LKBallDispatch<
+    common::AABBDispatch,
+    tmol::Device::CPU,
+    float,
+    int64_t>;
+template struct LKBallDispatch<
+    common::AABBDispatch,
+    tmol::Device::CPU,
+    double,
+    int64_t>;
 
-template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, float, int32_t, 4>;
-template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, double, int32_t, 4>;
-template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, float, int64_t, 4>;
-template struct GenerateWaters<common::ForallDispatch,tmol::Device::CPU, double, int64_t, 4>;
+template struct GenerateWaters<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int32_t,
+    4>;
+template struct GenerateWaters<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int32_t,
+    4>;
+template struct GenerateWaters<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int64_t,
+    4>;
+template struct GenerateWaters<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int64_t,
+    4>;
 
 #undef def
 
 }  // namespace potentials
-}  // namespace hbond
+}  // namespace lk_ball
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/omega/potentials/compiled.cpu.cpp
+++ b/tmol/score/omega/potentials/compiled.cpu.cpp
@@ -7,8 +7,16 @@ namespace score {
 namespace omega {
 namespace potentials {
 
-template struct OmegaDispatch<common::ForallDispatch, tmol::Device::CPU,float,int32_t>;
-template struct OmegaDispatch<common::ForallDispatch, tmol::Device::CPU,double,int32_t>;
+template struct OmegaDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int32_t>;
+template struct OmegaDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int32_t>;
 
 }  // namespace potentials
 }  // namespace omega

--- a/tmol/score/rama/potentials/compiled.cpu.cpp
+++ b/tmol/score/rama/potentials/compiled.cpu.cpp
@@ -7,8 +7,16 @@ namespace score {
 namespace rama {
 namespace potentials {
 
-template struct RamaDispatch<common::ForallDispatch, tmol::Device::CPU,float,int32_t>;
-template struct RamaDispatch<common::ForallDispatch, tmol::Device::CPU,double,int32_t>;
+template struct RamaDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    float,
+    int32_t>;
+template struct RamaDispatch<
+    common::ForallDispatch,
+    tmol::Device::CPU,
+    double,
+    int32_t>;
 
 }  // namespace potentials
 }  // namespace rama

--- a/tmol/tests/score/hbond/potentials/compiled.pybind.cpp
+++ b/tmol/tests/score/hbond/potentials/compiled.pybind.cpp
@@ -8,12 +8,11 @@ namespace pybind11 {
 namespace detail {
 
 using tmol::score::hbond::potentials::hbond_score_V_dV_t;
-using tmol::score::hbond::potentials::Vec;
-using tmol::score::hbond::potentials::HBondPoly;
-using tmol::score::hbond::potentials::HBondPolynomials;
 using tmol::score::hbond::potentials::HBondGlobalParams;
 using tmol::score::hbond::potentials::HBondPairParams;
-
+using tmol::score::hbond::potentials::HBondPoly;
+using tmol::score::hbond::potentials::HBondPolynomials;
+using tmol::score::hbond::potentials::Vec;
 
 template <typename Real>
 struct type_caster<hbond_score_V_dV_t<Real>> {
@@ -35,21 +34,19 @@ struct type_caster<hbond_score_V_dV_t<Real>> {
   }
 };
 
-
 template <typename Real>
 struct type_caster<HBondPoly<Real>> {
   typedef HBondPoly<Real> T;
   PYBIND11_TYPE_CASTER(T, _<T>());
 
   bool load(handle src, bool) {
-   
     Vec<Real, 16> vals = src.cast<Vec<Real, 16>>();
-    for ( int ii = 0; ii < 11; ++ii ) {
+    for (int ii = 0; ii < 11; ++ii) {
       value.coeffs[ii] = vals[ii];
     }
-    for ( int ii = 0; ii < 2; ++ii ) {
-      value.range[ii] = vals[ii+12];
-      value.bound[ii] = vals[ii+14];
+    for (int ii = 0; ii < 2; ++ii) {
+      value.range[ii] = vals[ii + 12];
+      value.bound[ii] = vals[ii + 14];
     }
     return true;
   }
@@ -61,20 +58,19 @@ struct type_caster<HBondPolynomials<Real>> {
   PYBIND11_TYPE_CASTER(T, _<T>());
 
   bool load(handle src, bool) {
-   
     Vec<Real, 48> vals = src.cast<Vec<Real, 48>>();
-    for ( int ii = 0; ii < 11; ++ii ) {
+    for (int ii = 0; ii < 11; ++ii) {
       value.AHdist_poly.coeffs[ii] = vals[ii];
-      value.cosBAH_poly.coeffs[ii] = vals[ii+16];
-      value.cosAHD_poly.coeffs[ii] = vals[ii+32];
+      value.cosBAH_poly.coeffs[ii] = vals[ii + 16];
+      value.cosAHD_poly.coeffs[ii] = vals[ii + 32];
     }
-    for ( int ii = 0; ii < 2; ++ii ) {
-      value.AHdist_poly.range[ii] = vals[ii+12];
-      value.AHdist_poly.bound[ii] = vals[ii+14];
-      value.cosBAH_poly.range[ii] = vals[ii+12+16];
-      value.cosBAH_poly.bound[ii] = vals[ii+14+16];
-      value.cosAHD_poly.range[ii] = vals[ii+12+32];
-      value.cosAHD_poly.bound[ii] = vals[ii+14+32];
+    for (int ii = 0; ii < 2; ++ii) {
+      value.AHdist_poly.range[ii] = vals[ii + 12];
+      value.AHdist_poly.bound[ii] = vals[ii + 14];
+      value.cosBAH_poly.range[ii] = vals[ii + 12 + 16];
+      value.cosBAH_poly.bound[ii] = vals[ii + 14 + 16];
+      value.cosAHD_poly.range[ii] = vals[ii + 12 + 32];
+      value.cosAHD_poly.bound[ii] = vals[ii + 14 + 32];
     }
     return true;
   }
@@ -96,7 +92,6 @@ struct type_caster<HBondGlobalParams<Real>> {
   }
 };
 
-
 template <typename Real>
 struct type_caster<HBondPairParams<Real>> {
   typedef HBondPairParams<Real> T;
@@ -111,7 +106,6 @@ struct type_caster<HBondPairParams<Real>> {
   }
 };
 
-
 }  // namespace detail
 }  // namespace pybind11
 
@@ -124,12 +118,7 @@ template <typename Real>
 void bind_potentials(pybind11::module& m) {
   using namespace pybind11::literals;
 
-  m.def(
-      "AH_dist_V_dV",
-      &AH_dist_V_dV<Real>,
-      "A"_a,
-      "H"_a,
-      "AHdist_poly"_a);
+  m.def("AH_dist_V_dV", &AH_dist_V_dV<Real>, "A"_a, "H"_a, "AHdist_poly"_a);
 
   m.def(
       "AHD_angle_V_dV",

--- a/tmol/tests/utility/cpp_extension/hybrid.cpp
+++ b/tmol/tests/utility/cpp_extension/hybrid.cpp
@@ -27,7 +27,7 @@ struct sum_tensor<Real, tmol::Device::CPU> {
 
 template struct sum_tensor<float, tmol::Device::CPU>;
 template struct sum_tensor<double, tmol::Device::CPU>;
-}
-}
-}
-}
+}  // namespace cpp_extension
+}  // namespace utility
+}  // namespace tests
+}  // namespace tmol

--- a/tmol/tests/utility/cpp_extension/hybrid.pybind.cpp
+++ b/tmol/tests/utility/cpp_extension/hybrid.pybind.cpp
@@ -16,7 +16,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sum", &sum_tensor<float, tmol::Device::CUDA>::f, "t"_a);
 #endif
 }
-}
-}
-}
-}
+}  // namespace cpp_extension
+}  // namespace utility
+}  // namespace tests
+}  // namespace tmol

--- a/tmol/tests/utility/cpp_extension/pure.cpp
+++ b/tmol/tests/utility/cpp_extension/pure.cpp
@@ -36,7 +36,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   using namespace pybind11::literals;
   m.def("sum", &sum<float, tmol::Device::CPU>::f, "t"_a);
 }
-}
-}
-}
-}
+}  // namespace cpp_extension
+}  // namespace utility
+}  // namespace tests
+}  // namespace tmol

--- a/tmol/tests/utility/tensor/tensor_accessor.cpp
+++ b/tmol/tests/utility/tensor/tensor_accessor.cpp
@@ -71,7 +71,6 @@ auto vector_magnitude_eigen_arg(
   return output_t;
 }
 
-
 auto matrix_sum_eigen_arg(
     tmol::TView<Eigen::Matrix3f, 1, tmol::Device::CPU> input)
     -> tmol::TPack<float, 1, tmol::Device::CPU> {
@@ -85,7 +84,6 @@ auto matrix_sum_eigen_arg(
 
   return output_t;
 }
-
 
 auto tensor_pack_construct() {
   typedef tmol::TPack<Eigen::Vector3f, 2, tmol::Device::CPU> T;
@@ -138,7 +136,6 @@ auto tensor_pack_construct_eigen_matrix() {
       T::zeros({2, 5}),
       T::full({2, 5}, NAN));
 }
-
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(

--- a/tmol/tests/utility/tensor/tensor_collection.cpp
+++ b/tmol/tests/utility/tensor/tensor_collection.cpp
@@ -3,16 +3,15 @@
 #include <tmol/utility/tensor/TensorCollection.h>
 #include <tmol/utility/tensor/pybind.h>
 
-auto sum_tensor_collection(
-    tmol::TCollection<float,2,tmol::Device::CPU> input) 
- -> tmol::TPack<float,2,tmol::Device::CPU> {
+auto sum_tensor_collection(tmol::TCollection<float, 2, tmol::Device::CPU> input)
+    -> tmol::TPack<float, 2, tmol::Device::CPU> {
   auto output_t =
       tmol::TPack<float, 2, tmol::Device::CPU>::zeros_like(input.view[0]);
   auto output = output_t.view;
 
-  for (int i=0; i<input.tensors.size(); ++i) {
-    for (int j=0; j<input.view[i].size(0); ++j) {
-      for (int k=0; k<input.view[i].size(1); ++k) {
+  for (int i = 0; i < input.tensors.size(); ++i) {
+    for (int j = 0; j < input.view[i].size(0); ++j) {
+      for (int k = 0; k < input.view[i].size(1); ++k) {
         output[j][k] += input.view[i][j][k];
       }
     }
@@ -20,8 +19,6 @@ auto sum_tensor_collection(
   return output_t;
 }
 
-
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def(
-      "sum_tensor_collection", &sum_tensor_collection, "Sum a TCollection.");
+  m.def("sum_tensor_collection", &sum_tensor_collection, "Sum a TCollection.");
 }

--- a/tmol/tests/utility/torchscript/custom_op.cpp
+++ b/tmol/tests/utility/torchscript/custom_op.cpp
@@ -37,4 +37,4 @@ torch::Tensor cpow(torch::Tensor x, double exponent) {
 // Macro indirection to force TORCH_EXTENSION_NAME macro expansion
 // See https://stackoverflow.com/a/3221914
 #define TORCH_LIBRARY_(ns, m) TORCH_LIBRARY(ns, m)
-TORCH_LIBRARY_(TORCH_EXTENSION_NAME, m){ m.def("cpow", &cpow); }
+TORCH_LIBRARY_(TORCH_EXTENSION_NAME, m) { m.def("cpow", &cpow); }


### PR DESCRIPTION
Pre-commit hook had been mistakenly excluding .cpp files from beautification. This very small change updates the pre-commit hook to include .cpp files and then runs clang-format on all of the .cpp files in the source tree and commits the new version.