### PR TITLE
Aleaverfay/res centric elec

### DIFF
--- a/tmol/score/elec/elec_energy_term.py
+++ b/tmol/score/elec/elec_energy_term.py
@@ -1,0 +1,387 @@
+import torch
+
+from ..atom_type_dependent_term import AtomTypeDependentTerm
+from ..bond_dependent_term import BondDependentTerm
+from .params import LJLKTypeParams, LJLKGlobalParams
+
+from tmol.database import ParameterDatabase
+from tmol.score.common.stack_condense import tile_subset_indices
+from tmol.score.ljlk.params import LJLKParamResolver
+from tmol.score.ljlk.ljlk_whole_pose_module import LJLKWholePoseScoringModule
+
+from tmol.chemical.restypes import RefinedResidueType
+from tmol.pose.packed_block_types import PackedBlockTypes
+from tmol.pose.pose_stack import PoseStack
+from tmol.types.torch import Tensor
+
+from tmol.score.ljlk.potentials.compiled import (
+    score_ljlk_inter_system_scores,
+    register_lj_lk_rotamer_pair_energy_eval,
+)
+
+
+class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
+    type_params: LJLKTypeParams
+    global_params: LJLKGlobalParams
+    tile_size: int = 32
+
+    def __init__(self, param_db: ParameterDatabase, device: torch.device):
+        ljlk_param_resolver = LJLKParamResolver.from_database(
+            param_db.chemical, param_db.scoring.ljlk, device=device
+        )
+        super(LJLKEnergyTerm, self).__init__(param_db=param_db, device=device)
+        self.type_params = ljlk_param_resolver.type_params
+        self.global_params = ljlk_param_resolver.global_params
+        self.tile_size = LJLKEnergyTerm.tile_size
+
+    @classmethod
+    def score_types(cls):
+        import tmol.score.terms.ljlk_creator
+
+        return tmol.score.terms.ljlk_creator.LJLKTermCreator.score_types()
+
+    def n_bodies(self):
+        return 2
+
+    def setup_block_type(self, block_type: RefinedResidueType):
+        super(LJLKEnergyTerm, self).setup_block_type(block_type)
+        if hasattr(block_type, "ljlk_heavy_atoms_in_tile"):
+            assert hasattr(block_type, "ljlk_n_heavy_atoms_in_tile")
+            return
+        heavy_atoms_in_tile, n_in_tile = tile_subset_indices(
+            block_type.heavy_atom_inds, self.tile_size
+        )
+        setattr(block_type, "ljlk_heavy_atoms_in_tile", heavy_atoms_in_tile)
+        setattr(block_type, "ljlk_n_heavy_atoms_in_tile", n_in_tile)
+
+    def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
+        super(LJLKEnergyTerm, self).setup_packed_block_types(packed_block_types)
+        if hasattr(packed_block_types, "ljlk_heavy_atoms_in_tile"):
+            assert hasattr(packed_block_types, "ljlk_n_heavy_atoms_in_tile")
+            return
+        max_n_tiles = (packed_block_types.max_n_atoms - 1) // self.tile_size + 1
+        heavy_atoms_in_tile = torch.full(
+            (packed_block_types.n_types, max_n_tiles * self.tile_size),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        n_heavy_ats_in_tile = torch.full(
+            (packed_block_types.n_types, max_n_tiles),
+            0,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        def _t(arr):
+            return torch.tensor(arr, dtype=torch.int32, device=self.device)
+
+        for i, rt in enumerate(packed_block_types.active_block_types):
+            i_n_tiles = rt.ljlk_n_heavy_atoms_in_tile.shape[0]
+            i_n_tile_ats = i_n_tiles * self.tile_size
+            heavy_atoms_in_tile[i, :i_n_tile_ats] = _t(rt.ljlk_heavy_atoms_in_tile)
+            n_heavy_ats_in_tile[i, :i_n_tiles] = _t(rt.ljlk_n_heavy_atoms_in_tile)
+
+        setattr(packed_block_types, "ljlk_heavy_atoms_in_tile", heavy_atoms_in_tile)
+        setattr(packed_block_types, "ljlk_n_heavy_atoms_in_tile", n_heavy_ats_in_tile)
+
+    def setup_poses(self, poses: PoseStack):
+        super(LJLKEnergyTerm, self).setup_poses(poses)
+
+    def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
+        pbt = pose_stack.packed_block_types
+        return LJLKWholePoseScoringModule(
+            pose_stack_block_coord_offset=pose_stack.block_coord_offset,
+            pose_stack_block_types=pose_stack.block_type_ind,
+            pose_stack_min_block_bondsep=pose_stack.min_block_bondsep,
+            pose_stack_inter_block_bondsep=pose_stack.inter_block_bondsep,
+            bt_n_atoms=pbt.n_atoms,
+            bt_n_heavy_atoms=pbt.n_heavy_atoms,
+            bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
+            bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
+            bt_atom_types=pbt.atom_types,
+            bt_heavy_atom_inds=pbt.heavy_atom_inds,
+            bt_n_interblock_bonds=pbt.n_interblock_bonds,
+            bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
+            bt_path_distance=pbt.bond_separation,
+            ljlk_type_params=self.type_params,
+            global_params=self.global_params,
+        )
+
+    def render_inter_module(
+        self,
+        packed_block_types: PackedBlockTypes,
+        systems: PoseStack,
+        context_system_ids: Tensor[int][:, :],
+        system_bounding_spheres: Tensor[float][:, :, 4],
+        weights,  # map string->Real
+    ):
+        system_neighbor_list = self.create_block_neighbor_lists(
+            systems, system_bounding_spheres
+        )
+        lj_lk_weights = torch.zeros((2,), dtype=torch.float32, device=self.device)
+        lj_lk_weights[0] = weights["lj"] if "lj" in weights else 0
+        lj_lk_weights[1] = weights["lk"] if "lk" in weights else 0
+
+        pbt = packed_block_types
+        return LJLKInterSystemModule(
+            context_system_ids=context_system_ids,
+            system_min_block_bondsep=systems.min_block_bondsep,
+            system_inter_block_bondsep=systems.inter_block_bondsep,
+            system_neighbor_list=system_neighbor_list,
+            bt_n_atoms=pbt.n_atoms,
+            bt_n_heavy_atoms=pbt.n_heavy_atoms,
+            bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
+            bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
+            bt_atom_types=pbt.atom_types,
+            bt_heavy_atom_inds=pbt.heavy_atom_inds,
+            bt_n_interblock_bonds=pbt.n_interblock_bonds,
+            bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
+            bt_path_distance=pbt.bond_separation,
+            type_params=self.type_params,
+            global_params=self.global_params,
+            lj_lk_weights=lj_lk_weights,
+        )
+
+    def create_block_neighbor_lists(
+        self, systems: PoseStack, system_bounding_spheres: Tensor[float][:, :, 4]
+    ):
+        # we need to make lists of all block pairs within
+        # striking distances of each other that we will use to
+        # decide which atom-pair calculations to perform during
+        # rotamer substititions
+        sphere_centers = system_bounding_spheres[:, :, :3].clone().detach()
+        n_sys = system_bounding_spheres.shape[0]
+        max_n_blocks = system_bounding_spheres.shape[1]
+        sphere_centers_1 = sphere_centers.view((n_sys, -1, max_n_blocks, 3))
+        sphere_centers_2 = sphere_centers.view((n_sys, max_n_blocks, -1, 3))
+        sphere_dists = torch.norm(sphere_centers_1 - sphere_centers_2, dim=3)
+        expanded_radii = (
+            system_bounding_spheres[:, :, 3] + self.global_params.max_dis / 2
+        )
+        expanded_radii_1 = expanded_radii.view(n_sys, -1, max_n_blocks)
+        expanded_radii_2 = expanded_radii.view(n_sys, max_n_blocks, -1)
+        radii_sum = expanded_radii_1 + expanded_radii_2
+        spheres_overlap = sphere_dists < radii_sum
+
+        # great -- now how tf are we going to condense this into the lists
+        # of neighbors for each block?
+
+        neighbor_counts = torch.sum(spheres_overlap, dim=2)
+        max_n_neighbors = torch.max(neighbor_counts)
+
+        neighbor_list = torch.full(
+            (n_sys, max_n_blocks, max_n_neighbors),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        nz_spheres_overlap = torch.nonzero(spheres_overlap)
+        inc_inds = (
+            torch.arange(max_n_neighbors, device=self.device)
+            .repeat(n_sys * max_n_blocks)
+            .view(n_sys, max_n_blocks, max_n_neighbors)
+        )
+        store_neighbor = inc_inds < neighbor_counts.view(n_sys, max_n_blocks, 1)
+
+        neighbor_list[
+            nz_spheres_overlap[:, 0],
+            nz_spheres_overlap[:, 1],
+            inc_inds[store_neighbor].view(-1),
+        ] = nz_spheres_overlap[:, 2].type(torch.int32)
+
+        return neighbor_list
+
+
+# class LJLKInterSystemModule(torch.jit.ScriptModule):
+class LJLKInterSystemModule:
+    def __init__(
+        self,
+        context_system_ids,
+        system_min_block_bondsep,
+        system_inter_block_bondsep,
+        system_neighbor_list,
+        bt_n_atoms,
+        bt_n_heavy_atoms,
+        bt_n_heavy_atoms_in_tile,
+        bt_heavy_atoms_in_tile,
+        bt_atom_types,
+        bt_heavy_atom_inds,
+        bt_n_interblock_bonds,
+        bt_atoms_forming_chemical_bonds,
+        bt_path_distance,
+        type_params,
+        global_params,
+        lj_lk_weights,
+    ):
+        super().__init__()
+
+        def _p(t):
+            return torch.nn.Parameter(t, requires_grad=False)
+
+        def _t(ts):
+            return tuple(map(lambda t: t.to(torch.float), ts))
+
+        self.context_system_ids = _p(context_system_ids)
+        self.system_min_block_bondsep = _p(system_min_block_bondsep)
+        self.system_inter_block_bondsep = _p(system_inter_block_bondsep)
+        self.system_neighbor_list = _p(system_neighbor_list)
+        self.bt_n_atoms = _p(bt_n_atoms)
+        self.bt_n_heavy_atoms = _p(bt_n_heavy_atoms)
+        self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
+        self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
+        self.bt_atom_types = _p(bt_atom_types)
+        self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
+        self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
+        self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
+        self.bt_path_distance = _p(bt_path_distance)
+
+        # Pack parameters into dense tensor. Parameter ordering must match
+        # struct layout declared in `potentials/params.hh`.
+        self.lj_type_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        type_params.lj_radius,
+                        type_params.lj_wdepth,
+                        type_params.is_donor,
+                        type_params.is_hydroxyl,
+                        type_params.is_polarh,
+                        type_params.is_acceptor,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+
+        # Pack parameters into dense tensor. Parameter ordering must match
+        # struct layout declared in `potentials/params.hh`.
+        self.lk_type_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        type_params.lj_radius,
+                        type_params.lk_dgfree,
+                        type_params.lk_lambda,
+                        type_params.lk_volume,
+                        type_params.is_donor,
+                        type_params.is_hydroxyl,
+                        type_params.is_polarh,
+                        type_params.is_acceptor,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+
+        self.ljlk_type_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        type_params.lj_radius,
+                        type_params.lj_wdepth,
+                        type_params.lk_dgfree,
+                        type_params.lk_lambda,
+                        type_params.lk_volume,
+                        type_params.is_donor,
+                        type_params.is_hydroxyl,
+                        type_params.is_polarh,
+                        type_params.is_acceptor,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+
+        self.global_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        global_params.lj_hbond_dis,
+                        global_params.lj_hbond_OH_donor_dis,
+                        global_params.lj_hbond_hdis,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+        self.lj_lk_weights = _p(lj_lk_weights)
+
+    def register_with_sim_annealer(
+        self,
+        context_coords,
+        context_coord_offsets,
+        context_block_type,
+        alternate_coords,
+        alternate_coord_offsets,
+        alternate_ids,
+        output_energies,
+        score_event_tensor,
+        annealer_event_tensor,
+        annealer,
+    ):
+        register_lj_lk_rotamer_pair_energy_eval(
+            context_coords,
+            context_coord_offsets,
+            context_block_type,
+            alternate_coords,
+            alternate_coord_offsets,
+            alternate_ids,
+            self.context_system_ids,
+            self.system_min_block_bondsep,
+            self.system_inter_block_bondsep,
+            self.system_neighbor_list,
+            self.bt_n_atoms,
+            self.bt_n_heavy_atoms,
+            self.bt_n_heavy_atoms_in_tile,
+            self.bt_heavy_atoms_in_tile,
+            self.bt_atom_types,
+            self.bt_heavy_atom_inds,
+            self.bt_n_interblock_bonds,
+            self.bt_atoms_forming_chemical_bonds,
+            self.bt_path_distance,
+            self.ljlk_type_params,
+            self.global_params,
+            self.lj_lk_weights,
+            output_energies,
+            score_event_tensor,
+            annealer_event_tensor,
+            annealer,
+        )
+
+    # deprecated
+    # @torch.jit.script_method
+    # def forward(
+    def go(
+        self,
+        context_coords,
+        context_coord_offsets,
+        context_block_type,
+        alternate_coords,
+        alternate_coord_offsets,
+        alternate_ids,
+    ):
+        return score_ljlk_inter_system_scores(
+            context_coords,
+            context_coord_offsets,
+            context_block_type,
+            alternate_coords,
+            alternate_coord_offsets,
+            alternate_ids,
+            self.context_system_ids,
+            self.system_min_block_bondsep,
+            self.system_inter_block_bondsep,
+            self.system_neighbor_list,
+            self.bt_n_atoms,
+            self.bt_n_heavy_atoms,
+            self.bt_n_heavy_atoms_in_tile,
+            self.bt_heavy_atoms_in_tile,
+            self.bt_atom_types,
+            self.bt_heavy_atom_inds,
+            self.bt_n_interblock_bonds,
+            self.bt_atoms_forming_chemical_bonds,
+            self.bt_path_distance,
+            self.ljlk_type_params,
+            self.global_params,
+            self.lj_lk_weights,
+        )

--- a/tmol/score/elec/elec_energy_term.py
+++ b/tmol/score/elec/elec_energy_term.py
@@ -1,387 +1,465 @@
 import torch
+import numpy
 
 from ..atom_type_dependent_term import AtomTypeDependentTerm
 from ..bond_dependent_term import BondDependentTerm
-from .params import LJLKTypeParams, LJLKGlobalParams
 
 from tmol.database import ParameterDatabase
 from tmol.score.common.stack_condense import tile_subset_indices
-from tmol.score.ljlk.params import LJLKParamResolver
-from tmol.score.ljlk.ljlk_whole_pose_module import LJLKWholePoseScoringModule
+from tmol.score.elec.params import ElecParamResolver, ElecGlobalParams
+from tmol.score.elec.elec_whole_pose_module import ElecWholePoseScoringModule
 
 from tmol.chemical.restypes import RefinedResidueType
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.pose.pose_stack import PoseStack
 from tmol.types.torch import Tensor
 
-from tmol.score.ljlk.potentials.compiled import (
-    score_ljlk_inter_system_scores,
-    register_lj_lk_rotamer_pair_energy_eval,
-)
+# from tmol.score.ljlk.potentials.compiled import (
+#     score_ljlk_inter_system_scores,
+#     register_lj_lk_rotamer_pair_energy_eval,
+# )
 
 
-class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
-    type_params: LJLKTypeParams
-    global_params: LJLKGlobalParams
-    tile_size: int = 32
+class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
+    param_resolver: ElecParamResolver
+    global_params: ElecGlobalParams
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
-        ljlk_param_resolver = LJLKParamResolver.from_database(
-            param_db.chemical, param_db.scoring.ljlk, device=device
+        param_resolver = ElecParamResolver.from_database(
+            param_db.scoring.elec, device=device
         )
-        super(LJLKEnergyTerm, self).__init__(param_db=param_db, device=device)
-        self.type_params = ljlk_param_resolver.type_params
-        self.global_params = ljlk_param_resolver.global_params
-        self.tile_size = LJLKEnergyTerm.tile_size
+        super(ElecEnergyTerm, self).__init__(param_db=param_db, device=device)
+        self.param_resolver = param_resolver
+        self.global_params = self.param_resolver.global_params
 
     @classmethod
     def score_types(cls):
-        import tmol.score.terms.ljlk_creator
+        import tmol.score.terms.elec_creator
 
-        return tmol.score.terms.ljlk_creator.LJLKTermCreator.score_types()
+        return tmol.score.terms.elec_creator.ElecTermCreator.score_types()
 
     def n_bodies(self):
         return 2
 
     def setup_block_type(self, block_type: RefinedResidueType):
-        super(LJLKEnergyTerm, self).setup_block_type(block_type)
-        if hasattr(block_type, "ljlk_heavy_atoms_in_tile"):
-            assert hasattr(block_type, "ljlk_n_heavy_atoms_in_tile")
+        super(ElecEnergyTerm, self).setup_block_type(block_type)
+        if hasattr(block_type, "elec_inter_repr_path_distance"):
+            assert hasattr(block_type, "elec_intra_repr_path_distance")
+            assert hasattr(block_type, "elec_partial_charge")
             return
-        heavy_atoms_in_tile, n_in_tile = tile_subset_indices(
-            block_type.heavy_atom_inds, self.tile_size
-        )
-        setattr(block_type, "ljlk_heavy_atoms_in_tile", heavy_atoms_in_tile)
-        setattr(block_type, "ljlk_n_heavy_atoms_in_tile", n_in_tile)
+        partial_charge = numpy.zeros((block_type.n_atoms,), dtype=numpy.float32)
+
+        for i, atname in enumerate(block_type.atoms):
+            if (block_type.name, atname.name) in self.param_resolver.partial_charges:
+                partial_charge[i] = self.param_resolver.partial_charges[
+                    (block_type.name, atname.name)
+                ]
+        # print("partial_charge", block_type.name)
+        # print(partial_charge)
+
+        # count pair representative logic:
+        # decide whether or not two atoms i and j should have their interaction counted
+        # on the basis of the number of chemical bonds that separate their respective
+        # representative atoms r(i) and r(j).
+        # We will create a tensor to measure the distance of all representative atoms to:
+        # all connection atoms.
+        # let rpd be the acronym for "representative_path_distance"
+        # rpd[a,b] will be the number of chemical bonds between atom a and atom r(b). Then
+        # we can answer how far apart the representative atoms are for atoms i and j on
+        # residues k and l by computinging:
+        # min(ci cj, rpd_i[ci, i] + rpd_j[cj, j] + sep(ci, cj))
+        # over all pairs of connection atoms ci and cj on residues i and j
+        # NOTE: the connection atoms must be their own representatives for this to work
+
+        representative_mapping = numpy.arange(block_type.n_atoms, dtype=numpy.int32)
+        if block_type.name in self.param_resolver.cp_reps_by_res:
+            for outer, inner in self.param_resolver.cp_reps_by_res[
+                block_type.name
+            ].items():
+                if (
+                    outer not in block_type.atom_to_idx
+                    or inner not in block_type.atom_to_idx
+                ):
+                    continue
+                representative_mapping[
+                    block_type.atom_to_idx[inner]
+                ] = block_type.atom_to_idx[outer]
+
+        # print("representative_mapping")
+        # print(representative_mapping)
+        # inter_rep_path_dist = numpy.copy(block_type.path_distance)
+        # intra_rep_path_dist = numpy.copy(block_type.path_distance)
+        # inter_rep_path_dist[:, representative_mapping] = block_type.path_distance
+        # intra_rep_path_dist[representative_mapping, :] = inter_rep_path_dist
+
+        inter_rep_path_dist = block_type.path_distance[:, representative_mapping]
+        intra_rep_path_dist = inter_rep_path_dist[representative_mapping, :]
+
+        # representative_path_distance1 = block_type.path_distance[:, representative_mapping]
+        # representative_path_distance = representative_path_distance1[representative_mapping, :]
+
+        # print("path_distance", block_type.name)
+        # print([(i, n.name) for i, n in enumerate(block_type.atoms)])
+        # print(block_type.path_distance)
+        #
+        # print("inter_representative_path_distance", block_type.name)
+        # print(inter_rep_path_dist)
+        # print("intra_representative_path_distance", block_type.name)
+        # print(intra_rep_path_dist)
+
+        setattr(block_type, "elec_partial_charge", partial_charge)
+        setattr(block_type, "elec_inter_repr_path_distance", inter_rep_path_dist)
+        setattr(block_type, "elec_intra_repr_path_distance", intra_rep_path_dist)
 
     def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
-        super(LJLKEnergyTerm, self).setup_packed_block_types(packed_block_types)
-        if hasattr(packed_block_types, "ljlk_heavy_atoms_in_tile"):
-            assert hasattr(packed_block_types, "ljlk_n_heavy_atoms_in_tile")
+        super(ElecEnergyTerm, self).setup_packed_block_types(packed_block_types)
+        if hasattr(packed_block_types, "elec_inter_repr_path_distance"):
+            assert hasattr(packed_block_types, "elec_intra_repr_path_distance")
+            assert hasattr(packed_block_types, "elec_partial_charge")
             return
-        max_n_tiles = (packed_block_types.max_n_atoms - 1) // self.tile_size + 1
-        heavy_atoms_in_tile = torch.full(
-            (packed_block_types.n_types, max_n_tiles * self.tile_size),
-            -1,
-            dtype=torch.int32,
-            device=self.device,
-        )
-        n_heavy_ats_in_tile = torch.full(
-            (packed_block_types.n_types, max_n_tiles),
-            0,
-            dtype=torch.int32,
-            device=self.device,
-        )
 
-        def _t(arr):
+        def _ti(arr):
             return torch.tensor(arr, dtype=torch.int32, device=self.device)
 
-        for i, rt in enumerate(packed_block_types.active_block_types):
-            i_n_tiles = rt.ljlk_n_heavy_atoms_in_tile.shape[0]
-            i_n_tile_ats = i_n_tiles * self.tile_size
-            heavy_atoms_in_tile[i, :i_n_tile_ats] = _t(rt.ljlk_heavy_atoms_in_tile)
-            n_heavy_ats_in_tile[i, :i_n_tiles] = _t(rt.ljlk_n_heavy_atoms_in_tile)
+        def _tf(arr):
+            return torch.tensor(arr, dtype=torch.float32, device=self.device)
 
-        setattr(packed_block_types, "ljlk_heavy_atoms_in_tile", heavy_atoms_in_tile)
-        setattr(packed_block_types, "ljlk_n_heavy_atoms_in_tile", n_heavy_ats_in_tile)
+        pbt = packed_block_types
+        elec_partial_charge = torch.zeros(
+            (pbt.n_types, pbt.max_n_atoms), dtype=torch.float32, device=self.device
+        )
+        elec_inter_repr_path_distance = torch.zeros(
+            (pbt.n_types, pbt.max_n_atoms, pbt.max_n_atoms),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        elec_intra_repr_path_distance = torch.zeros(
+            (pbt.n_types, pbt.max_n_atoms, pbt.max_n_atoms),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        for i, bt in enumerate(packed_block_types.active_block_types):
+            elec_partial_charge[i, : bt.n_atoms] = _tf(bt.elec_partial_charge)
+            elec_inter_repr_path_distance[i, : bt.n_atoms, : bt.n_atoms] = _ti(
+                bt.elec_inter_repr_path_distance
+            )
+            elec_intra_repr_path_distance[i, : bt.n_atoms, : bt.n_atoms] = _ti(
+                bt.elec_intra_repr_path_distance
+            )
+
+        # print("elec_partial_charge")
+        # print(elec_partial_charge)
+        # print("elec_inter_representative_path_distance")
+        # print(elec_inter_repr_path_distance)
+        # print("elec_intra_representative_path_distance")
+        # print(elec_intra_repr_path_distance)
+
+        setattr(packed_block_types, "elec_partial_charge", elec_partial_charge)
+        setattr(
+            packed_block_types,
+            "elec_inter_repr_path_distance",
+            elec_inter_repr_path_distance,
+        )
+        setattr(
+            packed_block_types,
+            "elec_intra_repr_path_distance",
+            elec_intra_repr_path_distance,
+        )
 
     def setup_poses(self, poses: PoseStack):
-        super(LJLKEnergyTerm, self).setup_poses(poses)
+        super(ElecEnergyTerm, self).setup_poses(poses)
 
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
         pbt = pose_stack.packed_block_types
-        return LJLKWholePoseScoringModule(
+        return ElecWholePoseScoringModule(
             pose_stack_block_coord_offset=pose_stack.block_coord_offset,
             pose_stack_block_types=pose_stack.block_type_ind,
             pose_stack_min_block_bondsep=pose_stack.min_block_bondsep,
             pose_stack_inter_block_bondsep=pose_stack.inter_block_bondsep,
             bt_n_atoms=pbt.n_atoms,
-            bt_n_heavy_atoms=pbt.n_heavy_atoms,
-            bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
-            bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
-            bt_atom_types=pbt.atom_types,
-            bt_heavy_atom_inds=pbt.heavy_atom_inds,
+            bt_partial_charge=pbt.elec_partial_charge,
             bt_n_interblock_bonds=pbt.n_interblock_bonds,
             bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
-            bt_path_distance=pbt.bond_separation,
-            ljlk_type_params=self.type_params,
+            bt_inter_repr_path_distance=pbt.elec_inter_repr_path_distance,
+            bt_intra_repr_path_distance=pbt.elec_intra_repr_path_distance,
             global_params=self.global_params,
         )
 
-    def render_inter_module(
-        self,
-        packed_block_types: PackedBlockTypes,
-        systems: PoseStack,
-        context_system_ids: Tensor[int][:, :],
-        system_bounding_spheres: Tensor[float][:, :, 4],
-        weights,  # map string->Real
-    ):
-        system_neighbor_list = self.create_block_neighbor_lists(
-            systems, system_bounding_spheres
-        )
-        lj_lk_weights = torch.zeros((2,), dtype=torch.float32, device=self.device)
-        lj_lk_weights[0] = weights["lj"] if "lj" in weights else 0
-        lj_lk_weights[1] = weights["lk"] if "lk" in weights else 0
+    # def render_inter_module(
+    #     self,
+    #     packed_block_types: PackedBlockTypes,
+    #     systems: PoseStack,
+    #     context_system_ids: Tensor[int][:, :],
+    #     system_bounding_spheres: Tensor[float][:, :, 4],
+    #     weights,  # map string->Real
+    # ):
+    #     system_neighbor_list = self.create_block_neighbor_lists(
+    #         systems, system_bounding_spheres
+    #     )
+    #     lj_lk_weights = torch.zeros((2,), dtype=torch.float32, device=self.device)
+    #     lj_lk_weights[0] = weights["lj"] if "lj" in weights else 0
+    #     lj_lk_weights[1] = weights["lk"] if "lk" in weights else 0
+    #
+    #     pbt = packed_block_types
+    #     return LJLKInterSystemModule(
+    #         context_system_ids=context_system_ids,
+    #         system_min_block_bondsep=systems.min_block_bondsep,
+    #         system_inter_block_bondsep=systems.inter_block_bondsep,
+    #         system_neighbor_list=system_neighbor_list,
+    #         bt_n_atoms=pbt.n_atoms,
+    #         bt_n_heavy_atoms=pbt.n_heavy_atoms,
+    #         bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
+    #         bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
+    #         bt_atom_types=pbt.atom_types,
+    #         bt_heavy_atom_inds=pbt.heavy_atom_inds,
+    #         bt_n_interblock_bonds=pbt.n_interblock_bonds,
+    #         bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
+    #         bt_path_distance=pbt.bond_separation,
+    #         type_params=self.type_params,
+    #         global_params=self.global_params,
+    #         lj_lk_weights=lj_lk_weights,
+    #     )
 
-        pbt = packed_block_types
-        return LJLKInterSystemModule(
-            context_system_ids=context_system_ids,
-            system_min_block_bondsep=systems.min_block_bondsep,
-            system_inter_block_bondsep=systems.inter_block_bondsep,
-            system_neighbor_list=system_neighbor_list,
-            bt_n_atoms=pbt.n_atoms,
-            bt_n_heavy_atoms=pbt.n_heavy_atoms,
-            bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
-            bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
-            bt_atom_types=pbt.atom_types,
-            bt_heavy_atom_inds=pbt.heavy_atom_inds,
-            bt_n_interblock_bonds=pbt.n_interblock_bonds,
-            bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
-            bt_path_distance=pbt.bond_separation,
-            type_params=self.type_params,
-            global_params=self.global_params,
-            lj_lk_weights=lj_lk_weights,
-        )
-
-    def create_block_neighbor_lists(
-        self, systems: PoseStack, system_bounding_spheres: Tensor[float][:, :, 4]
-    ):
-        # we need to make lists of all block pairs within
-        # striking distances of each other that we will use to
-        # decide which atom-pair calculations to perform during
-        # rotamer substititions
-        sphere_centers = system_bounding_spheres[:, :, :3].clone().detach()
-        n_sys = system_bounding_spheres.shape[0]
-        max_n_blocks = system_bounding_spheres.shape[1]
-        sphere_centers_1 = sphere_centers.view((n_sys, -1, max_n_blocks, 3))
-        sphere_centers_2 = sphere_centers.view((n_sys, max_n_blocks, -1, 3))
-        sphere_dists = torch.norm(sphere_centers_1 - sphere_centers_2, dim=3)
-        expanded_radii = (
-            system_bounding_spheres[:, :, 3] + self.global_params.max_dis / 2
-        )
-        expanded_radii_1 = expanded_radii.view(n_sys, -1, max_n_blocks)
-        expanded_radii_2 = expanded_radii.view(n_sys, max_n_blocks, -1)
-        radii_sum = expanded_radii_1 + expanded_radii_2
-        spheres_overlap = sphere_dists < radii_sum
-
-        # great -- now how tf are we going to condense this into the lists
-        # of neighbors for each block?
-
-        neighbor_counts = torch.sum(spheres_overlap, dim=2)
-        max_n_neighbors = torch.max(neighbor_counts)
-
-        neighbor_list = torch.full(
-            (n_sys, max_n_blocks, max_n_neighbors),
-            -1,
-            dtype=torch.int32,
-            device=self.device,
-        )
-        nz_spheres_overlap = torch.nonzero(spheres_overlap)
-        inc_inds = (
-            torch.arange(max_n_neighbors, device=self.device)
-            .repeat(n_sys * max_n_blocks)
-            .view(n_sys, max_n_blocks, max_n_neighbors)
-        )
-        store_neighbor = inc_inds < neighbor_counts.view(n_sys, max_n_blocks, 1)
-
-        neighbor_list[
-            nz_spheres_overlap[:, 0],
-            nz_spheres_overlap[:, 1],
-            inc_inds[store_neighbor].view(-1),
-        ] = nz_spheres_overlap[:, 2].type(torch.int32)
-
-        return neighbor_list
+    # def create_block_neighbor_lists(
+    #     self, systems: PoseStack, system_bounding_spheres: Tensor[float][:, :, 4]
+    # ):
+    #     # we need to make lists of all block pairs within
+    #     # striking distances of each other that we will use to
+    #     # decide which atom-pair calculations to perform during
+    #     # rotamer substititions
+    #     sphere_centers = system_bounding_spheres[:, :, :3].clone().detach()
+    #     n_sys = system_bounding_spheres.shape[0]
+    #     max_n_blocks = system_bounding_spheres.shape[1]
+    #     sphere_centers_1 = sphere_centers.view((n_sys, -1, max_n_blocks, 3))
+    #     sphere_centers_2 = sphere_centers.view((n_sys, max_n_blocks, -1, 3))
+    #     sphere_dists = torch.norm(sphere_centers_1 - sphere_centers_2, dim=3)
+    #     expanded_radii = (
+    #         system_bounding_spheres[:, :, 3] + self.global_params.max_dis / 2
+    #     )
+    #     expanded_radii_1 = expanded_radii.view(n_sys, -1, max_n_blocks)
+    #     expanded_radii_2 = expanded_radii.view(n_sys, max_n_blocks, -1)
+    #     radii_sum = expanded_radii_1 + expanded_radii_2
+    #     spheres_overlap = sphere_dists < radii_sum
+    #
+    #     # great -- now how tf are we going to condense this into the lists
+    #     # of neighbors for each block?
+    #
+    #     neighbor_counts = torch.sum(spheres_overlap, dim=2)
+    #     max_n_neighbors = torch.max(neighbor_counts)
+    #
+    #     neighbor_list = torch.full(
+    #         (n_sys, max_n_blocks, max_n_neighbors),
+    #         -1,
+    #         dtype=torch.int32,
+    #         device=self.device,
+    #     )
+    #     nz_spheres_overlap = torch.nonzero(spheres_overlap)
+    #     inc_inds = (
+    #         torch.arange(max_n_neighbors, device=self.device)
+    #         .repeat(n_sys * max_n_blocks)
+    #         .view(n_sys, max_n_blocks, max_n_neighbors)
+    #     )
+    #     store_neighbor = inc_inds < neighbor_counts.view(n_sys, max_n_blocks, 1)
+    #
+    #     neighbor_list[
+    #         nz_spheres_overlap[:, 0],
+    #         nz_spheres_overlap[:, 1],
+    #         inc_inds[store_neighbor].view(-1),
+    #     ] = nz_spheres_overlap[:, 2].type(torch.int32)
+    #
+    #     return neighbor_list
 
 
 # class LJLKInterSystemModule(torch.jit.ScriptModule):
-class LJLKInterSystemModule:
-    def __init__(
-        self,
-        context_system_ids,
-        system_min_block_bondsep,
-        system_inter_block_bondsep,
-        system_neighbor_list,
-        bt_n_atoms,
-        bt_n_heavy_atoms,
-        bt_n_heavy_atoms_in_tile,
-        bt_heavy_atoms_in_tile,
-        bt_atom_types,
-        bt_heavy_atom_inds,
-        bt_n_interblock_bonds,
-        bt_atoms_forming_chemical_bonds,
-        bt_path_distance,
-        type_params,
-        global_params,
-        lj_lk_weights,
-    ):
-        super().__init__()
-
-        def _p(t):
-            return torch.nn.Parameter(t, requires_grad=False)
-
-        def _t(ts):
-            return tuple(map(lambda t: t.to(torch.float), ts))
-
-        self.context_system_ids = _p(context_system_ids)
-        self.system_min_block_bondsep = _p(system_min_block_bondsep)
-        self.system_inter_block_bondsep = _p(system_inter_block_bondsep)
-        self.system_neighbor_list = _p(system_neighbor_list)
-        self.bt_n_atoms = _p(bt_n_atoms)
-        self.bt_n_heavy_atoms = _p(bt_n_heavy_atoms)
-        self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
-        self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
-        self.bt_atom_types = _p(bt_atom_types)
-        self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
-        self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
-        self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
-        self.bt_path_distance = _p(bt_path_distance)
-
-        # Pack parameters into dense tensor. Parameter ordering must match
-        # struct layout declared in `potentials/params.hh`.
-        self.lj_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        type_params.lj_radius,
-                        type_params.lj_wdepth,
-                        type_params.is_donor,
-                        type_params.is_hydroxyl,
-                        type_params.is_polarh,
-                        type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        # Pack parameters into dense tensor. Parameter ordering must match
-        # struct layout declared in `potentials/params.hh`.
-        self.lk_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        type_params.lj_radius,
-                        type_params.lk_dgfree,
-                        type_params.lk_lambda,
-                        type_params.lk_volume,
-                        type_params.is_donor,
-                        type_params.is_hydroxyl,
-                        type_params.is_polarh,
-                        type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        self.ljlk_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        type_params.lj_radius,
-                        type_params.lj_wdepth,
-                        type_params.lk_dgfree,
-                        type_params.lk_lambda,
-                        type_params.lk_volume,
-                        type_params.is_donor,
-                        type_params.is_hydroxyl,
-                        type_params.is_polarh,
-                        type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        self.global_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        global_params.lj_hbond_dis,
-                        global_params.lj_hbond_OH_donor_dis,
-                        global_params.lj_hbond_hdis,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-        self.lj_lk_weights = _p(lj_lk_weights)
-
-    def register_with_sim_annealer(
-        self,
-        context_coords,
-        context_coord_offsets,
-        context_block_type,
-        alternate_coords,
-        alternate_coord_offsets,
-        alternate_ids,
-        output_energies,
-        score_event_tensor,
-        annealer_event_tensor,
-        annealer,
-    ):
-        register_lj_lk_rotamer_pair_energy_eval(
-            context_coords,
-            context_coord_offsets,
-            context_block_type,
-            alternate_coords,
-            alternate_coord_offsets,
-            alternate_ids,
-            self.context_system_ids,
-            self.system_min_block_bondsep,
-            self.system_inter_block_bondsep,
-            self.system_neighbor_list,
-            self.bt_n_atoms,
-            self.bt_n_heavy_atoms,
-            self.bt_n_heavy_atoms_in_tile,
-            self.bt_heavy_atoms_in_tile,
-            self.bt_atom_types,
-            self.bt_heavy_atom_inds,
-            self.bt_n_interblock_bonds,
-            self.bt_atoms_forming_chemical_bonds,
-            self.bt_path_distance,
-            self.ljlk_type_params,
-            self.global_params,
-            self.lj_lk_weights,
-            output_energies,
-            score_event_tensor,
-            annealer_event_tensor,
-            annealer,
-        )
-
-    # deprecated
-    # @torch.jit.script_method
-    # def forward(
-    def go(
-        self,
-        context_coords,
-        context_coord_offsets,
-        context_block_type,
-        alternate_coords,
-        alternate_coord_offsets,
-        alternate_ids,
-    ):
-        return score_ljlk_inter_system_scores(
-            context_coords,
-            context_coord_offsets,
-            context_block_type,
-            alternate_coords,
-            alternate_coord_offsets,
-            alternate_ids,
-            self.context_system_ids,
-            self.system_min_block_bondsep,
-            self.system_inter_block_bondsep,
-            self.system_neighbor_list,
-            self.bt_n_atoms,
-            self.bt_n_heavy_atoms,
-            self.bt_n_heavy_atoms_in_tile,
-            self.bt_heavy_atoms_in_tile,
-            self.bt_atom_types,
-            self.bt_heavy_atom_inds,
-            self.bt_n_interblock_bonds,
-            self.bt_atoms_forming_chemical_bonds,
-            self.bt_path_distance,
-            self.ljlk_type_params,
-            self.global_params,
-            self.lj_lk_weights,
-        )
+# class LJLKInterSystemModule:
+#     def __init__(
+#         self,
+#         context_system_ids,
+#         system_min_block_bondsep,
+#         system_inter_block_bondsep,
+#         system_neighbor_list,
+#         bt_n_atoms,
+#         bt_n_heavy_atoms,
+#         bt_n_heavy_atoms_in_tile,
+#         bt_heavy_atoms_in_tile,
+#         bt_atom_types,
+#         bt_heavy_atom_inds,
+#         bt_n_interblock_bonds,
+#         bt_atoms_forming_chemical_bonds,
+#         bt_path_distance,
+#         type_params,
+#         global_params,
+#         lj_lk_weights,
+#     ):
+#         super().__init__()
+#
+#         def _p(t):
+#             return torch.nn.Parameter(t, requires_grad=False)
+#
+#         def _t(ts):
+#             return tuple(map(lambda t: t.to(torch.float), ts))
+#
+#         self.context_system_ids = _p(context_system_ids)
+#         self.system_min_block_bondsep = _p(system_min_block_bondsep)
+#         self.system_inter_block_bondsep = _p(system_inter_block_bondsep)
+#         self.system_neighbor_list = _p(system_neighbor_list)
+#         self.bt_n_atoms = _p(bt_n_atoms)
+#         self.bt_n_heavy_atoms = _p(bt_n_heavy_atoms)
+#         self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
+#         self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
+#         self.bt_atom_types = _p(bt_atom_types)
+#         self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
+#         self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
+#         self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
+#         self.bt_path_distance = _p(bt_path_distance)
+#
+#         # Pack parameters into dense tensor. Parameter ordering must match
+#         # struct layout declared in `potentials/params.hh`.
+#         self.lj_type_params = _p(
+#             torch.stack(
+#                 _t(
+#                     [
+#                         type_params.lj_radius,
+#                         type_params.lj_wdepth,
+#                         type_params.is_donor,
+#                         type_params.is_hydroxyl,
+#                         type_params.is_polarh,
+#                         type_params.is_acceptor,
+#                     ]
+#                 ),
+#                 dim=1,
+#             )
+#         )
+#
+#         # Pack parameters into dense tensor. Parameter ordering must match
+#         # struct layout declared in `potentials/params.hh`.
+#         self.lk_type_params = _p(
+#             torch.stack(
+#                 _t(
+#                     [
+#                         type_params.lj_radius,
+#                         type_params.lk_dgfree,
+#                         type_params.lk_lambda,
+#                         type_params.lk_volume,
+#                         type_params.is_donor,
+#                         type_params.is_hydroxyl,
+#                         type_params.is_polarh,
+#                         type_params.is_acceptor,
+#                     ]
+#                 ),
+#                 dim=1,
+#             )
+#         )
+#
+#         self.ljlk_type_params = _p(
+#             torch.stack(
+#                 _t(
+#                     [
+#                         type_params.lj_radius,
+#                         type_params.lj_wdepth,
+#                         type_params.lk_dgfree,
+#                         type_params.lk_lambda,
+#                         type_params.lk_volume,
+#                         type_params.is_donor,
+#                         type_params.is_hydroxyl,
+#                         type_params.is_polarh,
+#                         type_params.is_acceptor,
+#                     ]
+#                 ),
+#                 dim=1,
+#             )
+#         )
+#
+#         self.global_params = _p(
+#             torch.stack(
+#                 _t(
+#                     [
+#                         global_params.lj_hbond_dis,
+#                         global_params.lj_hbond_OH_donor_dis,
+#                         global_params.lj_hbond_hdis,
+#                     ]
+#                 ),
+#                 dim=1,
+#             )
+#         )
+#         self.lj_lk_weights = _p(lj_lk_weights)
+#
+#     def register_with_sim_annealer(
+#         self,
+#         context_coords,
+#         context_coord_offsets,
+#         context_block_type,
+#         alternate_coords,
+#         alternate_coord_offsets,
+#         alternate_ids,
+#         output_energies,
+#         score_event_tensor,
+#         annealer_event_tensor,
+#         annealer,
+#     ):
+#         register_lj_lk_rotamer_pair_energy_eval(
+#             context_coords,
+#             context_coord_offsets,
+#             context_block_type,
+#             alternate_coords,
+#             alternate_coord_offsets,
+#             alternate_ids,
+#             self.context_system_ids,
+#             self.system_min_block_bondsep,
+#             self.system_inter_block_bondsep,
+#             self.system_neighbor_list,
+#             self.bt_n_atoms,
+#             self.bt_n_heavy_atoms,
+#             self.bt_n_heavy_atoms_in_tile,
+#             self.bt_heavy_atoms_in_tile,
+#             self.bt_atom_types,
+#             self.bt_heavy_atom_inds,
+#             self.bt_n_interblock_bonds,
+#             self.bt_atoms_forming_chemical_bonds,
+#             self.bt_path_distance,
+#             self.ljlk_type_params,
+#             self.global_params,
+#             self.lj_lk_weights,
+#             output_energies,
+#             score_event_tensor,
+#             annealer_event_tensor,
+#             annealer,
+#         )
+#
+#     # deprecated
+#     # @torch.jit.script_method
+#     # def forward(
+#     def go(
+#         self,
+#         context_coords,
+#         context_coord_offsets,
+#         context_block_type,
+#         alternate_coords,
+#         alternate_coord_offsets,
+#         alternate_ids,
+#     ):
+#         return score_ljlk_inter_system_scores(
+#             context_coords,
+#             context_coord_offsets,
+#             context_block_type,
+#             alternate_coords,
+#             alternate_coord_offsets,
+#             alternate_ids,
+#             self.context_system_ids,
+#             self.system_min_block_bondsep,
+#             self.system_inter_block_bondsep,
+#             self.system_neighbor_list,
+#             self.bt_n_atoms,
+#             self.bt_n_heavy_atoms,
+#             self.bt_n_heavy_atoms_in_tile,
+#             self.bt_heavy_atoms_in_tile,
+#             self.bt_atom_types,
+#             self.bt_heavy_atom_inds,
+#             self.bt_n_interblock_bonds,
+#             self.bt_atoms_forming_chemical_bonds,
+#             self.bt_path_distance,
+#             self.ljlk_type_params,
+#             self.global_params,
+#             self.lj_lk_weights,
+#         )

--- a/tmol/score/elec/elec_energy_term.py
+++ b/tmol/score/elec/elec_energy_term.py
@@ -14,11 +14,6 @@ from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.pose.pose_stack import PoseStack
 from tmol.types.torch import Tensor
 
-# from tmol.score.ljlk.potentials.compiled import (
-#     score_ljlk_inter_system_scores,
-#     register_lj_lk_rotamer_pair_energy_eval,
-# )
-
 
 class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
     param_resolver: ElecParamResolver
@@ -54,8 +49,6 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
                 partial_charge[i] = self.param_resolver.partial_charges[
                     (block_type.name, atname.name)
                 ]
-        # print("partial_charge", block_type.name)
-        # print(partial_charge)
 
         # count pair representative logic:
         # decide whether or not two atoms i and j should have their interaction counted
@@ -81,31 +74,27 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
                     or inner not in block_type.atom_to_idx
                 ):
                     continue
+                # note that the "inner" and "outer" atoms are flipped relative to
+                # the natural interpretation in the file. That if one inner:outer
+                # pair is "N": "1H" and another inner:outer pair is "N": "2H", one
+                # would naturally conclude that 1H's representative is N and that
+                # 2H's representative is also N. However, in actuallity, N's
+                # representative will be 2H; N's representative starts out 1H, but
+                # then it is overwritten when the 2H entry is parsed.
+                #
+                # In general, the approach is to use the further atom for the closer
+                # atom so that more interactions are counted (because the closer atom
+                # will interact with fewer other atoms; the further out something is,
+                # the more other atoms will be at least 4 chemical bonds from it.
+                # As long as all the atoms j that are listed as representatives for
+                # a particular atom i are chemically bound to i, then one atom
+                # overriding another as the representative will have no effect.
                 representative_mapping[
                     block_type.atom_to_idx[inner]
                 ] = block_type.atom_to_idx[outer]
 
-        # print("representative_mapping")
-        # print(representative_mapping)
-        # inter_rep_path_dist = numpy.copy(block_type.path_distance)
-        # intra_rep_path_dist = numpy.copy(block_type.path_distance)
-        # inter_rep_path_dist[:, representative_mapping] = block_type.path_distance
-        # intra_rep_path_dist[representative_mapping, :] = inter_rep_path_dist
-
         inter_rep_path_dist = block_type.path_distance[:, representative_mapping]
         intra_rep_path_dist = inter_rep_path_dist[representative_mapping, :]
-
-        # representative_path_distance1 = block_type.path_distance[:, representative_mapping]
-        # representative_path_distance = representative_path_distance1[representative_mapping, :]
-
-        # print("path_distance", block_type.name)
-        # print([(i, n.name) for i, n in enumerate(block_type.atoms)])
-        # print(block_type.path_distance)
-        #
-        # print("inter_representative_path_distance", block_type.name)
-        # print(inter_rep_path_dist)
-        # print("intra_representative_path_distance", block_type.name)
-        # print(intra_rep_path_dist)
 
         setattr(block_type, "elec_partial_charge", partial_charge)
         setattr(block_type, "elec_inter_repr_path_distance", inter_rep_path_dist)
@@ -148,13 +137,6 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
                 bt.elec_intra_repr_path_distance
             )
 
-        # print("elec_partial_charge")
-        # print(elec_partial_charge)
-        # print("elec_inter_representative_path_distance")
-        # print(elec_inter_repr_path_distance)
-        # print("elec_intra_representative_path_distance")
-        # print(elec_intra_repr_path_distance)
-
         setattr(packed_block_types, "elec_partial_charge", elec_partial_charge)
         setattr(
             packed_block_types,
@@ -185,281 +167,3 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             bt_intra_repr_path_distance=pbt.elec_intra_repr_path_distance,
             global_params=self.global_params,
         )
-
-    # def render_inter_module(
-    #     self,
-    #     packed_block_types: PackedBlockTypes,
-    #     systems: PoseStack,
-    #     context_system_ids: Tensor[int][:, :],
-    #     system_bounding_spheres: Tensor[float][:, :, 4],
-    #     weights,  # map string->Real
-    # ):
-    #     system_neighbor_list = self.create_block_neighbor_lists(
-    #         systems, system_bounding_spheres
-    #     )
-    #     lj_lk_weights = torch.zeros((2,), dtype=torch.float32, device=self.device)
-    #     lj_lk_weights[0] = weights["lj"] if "lj" in weights else 0
-    #     lj_lk_weights[1] = weights["lk"] if "lk" in weights else 0
-    #
-    #     pbt = packed_block_types
-    #     return LJLKInterSystemModule(
-    #         context_system_ids=context_system_ids,
-    #         system_min_block_bondsep=systems.min_block_bondsep,
-    #         system_inter_block_bondsep=systems.inter_block_bondsep,
-    #         system_neighbor_list=system_neighbor_list,
-    #         bt_n_atoms=pbt.n_atoms,
-    #         bt_n_heavy_atoms=pbt.n_heavy_atoms,
-    #         bt_n_heavy_atoms_in_tile=pbt.ljlk_n_heavy_atoms_in_tile,
-    #         bt_heavy_atoms_in_tile=pbt.ljlk_heavy_atoms_in_tile,
-    #         bt_atom_types=pbt.atom_types,
-    #         bt_heavy_atom_inds=pbt.heavy_atom_inds,
-    #         bt_n_interblock_bonds=pbt.n_interblock_bonds,
-    #         bt_atoms_forming_chemical_bonds=pbt.atoms_for_interblock_bonds,
-    #         bt_path_distance=pbt.bond_separation,
-    #         type_params=self.type_params,
-    #         global_params=self.global_params,
-    #         lj_lk_weights=lj_lk_weights,
-    #     )
-
-    # def create_block_neighbor_lists(
-    #     self, systems: PoseStack, system_bounding_spheres: Tensor[float][:, :, 4]
-    # ):
-    #     # we need to make lists of all block pairs within
-    #     # striking distances of each other that we will use to
-    #     # decide which atom-pair calculations to perform during
-    #     # rotamer substititions
-    #     sphere_centers = system_bounding_spheres[:, :, :3].clone().detach()
-    #     n_sys = system_bounding_spheres.shape[0]
-    #     max_n_blocks = system_bounding_spheres.shape[1]
-    #     sphere_centers_1 = sphere_centers.view((n_sys, -1, max_n_blocks, 3))
-    #     sphere_centers_2 = sphere_centers.view((n_sys, max_n_blocks, -1, 3))
-    #     sphere_dists = torch.norm(sphere_centers_1 - sphere_centers_2, dim=3)
-    #     expanded_radii = (
-    #         system_bounding_spheres[:, :, 3] + self.global_params.max_dis / 2
-    #     )
-    #     expanded_radii_1 = expanded_radii.view(n_sys, -1, max_n_blocks)
-    #     expanded_radii_2 = expanded_radii.view(n_sys, max_n_blocks, -1)
-    #     radii_sum = expanded_radii_1 + expanded_radii_2
-    #     spheres_overlap = sphere_dists < radii_sum
-    #
-    #     # great -- now how tf are we going to condense this into the lists
-    #     # of neighbors for each block?
-    #
-    #     neighbor_counts = torch.sum(spheres_overlap, dim=2)
-    #     max_n_neighbors = torch.max(neighbor_counts)
-    #
-    #     neighbor_list = torch.full(
-    #         (n_sys, max_n_blocks, max_n_neighbors),
-    #         -1,
-    #         dtype=torch.int32,
-    #         device=self.device,
-    #     )
-    #     nz_spheres_overlap = torch.nonzero(spheres_overlap)
-    #     inc_inds = (
-    #         torch.arange(max_n_neighbors, device=self.device)
-    #         .repeat(n_sys * max_n_blocks)
-    #         .view(n_sys, max_n_blocks, max_n_neighbors)
-    #     )
-    #     store_neighbor = inc_inds < neighbor_counts.view(n_sys, max_n_blocks, 1)
-    #
-    #     neighbor_list[
-    #         nz_spheres_overlap[:, 0],
-    #         nz_spheres_overlap[:, 1],
-    #         inc_inds[store_neighbor].view(-1),
-    #     ] = nz_spheres_overlap[:, 2].type(torch.int32)
-    #
-    #     return neighbor_list
-
-
-# class LJLKInterSystemModule(torch.jit.ScriptModule):
-# class LJLKInterSystemModule:
-#     def __init__(
-#         self,
-#         context_system_ids,
-#         system_min_block_bondsep,
-#         system_inter_block_bondsep,
-#         system_neighbor_list,
-#         bt_n_atoms,
-#         bt_n_heavy_atoms,
-#         bt_n_heavy_atoms_in_tile,
-#         bt_heavy_atoms_in_tile,
-#         bt_atom_types,
-#         bt_heavy_atom_inds,
-#         bt_n_interblock_bonds,
-#         bt_atoms_forming_chemical_bonds,
-#         bt_path_distance,
-#         type_params,
-#         global_params,
-#         lj_lk_weights,
-#     ):
-#         super().__init__()
-#
-#         def _p(t):
-#             return torch.nn.Parameter(t, requires_grad=False)
-#
-#         def _t(ts):
-#             return tuple(map(lambda t: t.to(torch.float), ts))
-#
-#         self.context_system_ids = _p(context_system_ids)
-#         self.system_min_block_bondsep = _p(system_min_block_bondsep)
-#         self.system_inter_block_bondsep = _p(system_inter_block_bondsep)
-#         self.system_neighbor_list = _p(system_neighbor_list)
-#         self.bt_n_atoms = _p(bt_n_atoms)
-#         self.bt_n_heavy_atoms = _p(bt_n_heavy_atoms)
-#         self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
-#         self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
-#         self.bt_atom_types = _p(bt_atom_types)
-#         self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
-#         self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
-#         self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
-#         self.bt_path_distance = _p(bt_path_distance)
-#
-#         # Pack parameters into dense tensor. Parameter ordering must match
-#         # struct layout declared in `potentials/params.hh`.
-#         self.lj_type_params = _p(
-#             torch.stack(
-#                 _t(
-#                     [
-#                         type_params.lj_radius,
-#                         type_params.lj_wdepth,
-#                         type_params.is_donor,
-#                         type_params.is_hydroxyl,
-#                         type_params.is_polarh,
-#                         type_params.is_acceptor,
-#                     ]
-#                 ),
-#                 dim=1,
-#             )
-#         )
-#
-#         # Pack parameters into dense tensor. Parameter ordering must match
-#         # struct layout declared in `potentials/params.hh`.
-#         self.lk_type_params = _p(
-#             torch.stack(
-#                 _t(
-#                     [
-#                         type_params.lj_radius,
-#                         type_params.lk_dgfree,
-#                         type_params.lk_lambda,
-#                         type_params.lk_volume,
-#                         type_params.is_donor,
-#                         type_params.is_hydroxyl,
-#                         type_params.is_polarh,
-#                         type_params.is_acceptor,
-#                     ]
-#                 ),
-#                 dim=1,
-#             )
-#         )
-#
-#         self.ljlk_type_params = _p(
-#             torch.stack(
-#                 _t(
-#                     [
-#                         type_params.lj_radius,
-#                         type_params.lj_wdepth,
-#                         type_params.lk_dgfree,
-#                         type_params.lk_lambda,
-#                         type_params.lk_volume,
-#                         type_params.is_donor,
-#                         type_params.is_hydroxyl,
-#                         type_params.is_polarh,
-#                         type_params.is_acceptor,
-#                     ]
-#                 ),
-#                 dim=1,
-#             )
-#         )
-#
-#         self.global_params = _p(
-#             torch.stack(
-#                 _t(
-#                     [
-#                         global_params.lj_hbond_dis,
-#                         global_params.lj_hbond_OH_donor_dis,
-#                         global_params.lj_hbond_hdis,
-#                     ]
-#                 ),
-#                 dim=1,
-#             )
-#         )
-#         self.lj_lk_weights = _p(lj_lk_weights)
-#
-#     def register_with_sim_annealer(
-#         self,
-#         context_coords,
-#         context_coord_offsets,
-#         context_block_type,
-#         alternate_coords,
-#         alternate_coord_offsets,
-#         alternate_ids,
-#         output_energies,
-#         score_event_tensor,
-#         annealer_event_tensor,
-#         annealer,
-#     ):
-#         register_lj_lk_rotamer_pair_energy_eval(
-#             context_coords,
-#             context_coord_offsets,
-#             context_block_type,
-#             alternate_coords,
-#             alternate_coord_offsets,
-#             alternate_ids,
-#             self.context_system_ids,
-#             self.system_min_block_bondsep,
-#             self.system_inter_block_bondsep,
-#             self.system_neighbor_list,
-#             self.bt_n_atoms,
-#             self.bt_n_heavy_atoms,
-#             self.bt_n_heavy_atoms_in_tile,
-#             self.bt_heavy_atoms_in_tile,
-#             self.bt_atom_types,
-#             self.bt_heavy_atom_inds,
-#             self.bt_n_interblock_bonds,
-#             self.bt_atoms_forming_chemical_bonds,
-#             self.bt_path_distance,
-#             self.ljlk_type_params,
-#             self.global_params,
-#             self.lj_lk_weights,
-#             output_energies,
-#             score_event_tensor,
-#             annealer_event_tensor,
-#             annealer,
-#         )
-#
-#     # deprecated
-#     # @torch.jit.script_method
-#     # def forward(
-#     def go(
-#         self,
-#         context_coords,
-#         context_coord_offsets,
-#         context_block_type,
-#         alternate_coords,
-#         alternate_coord_offsets,
-#         alternate_ids,
-#     ):
-#         return score_ljlk_inter_system_scores(
-#             context_coords,
-#             context_coord_offsets,
-#             context_block_type,
-#             alternate_coords,
-#             alternate_coord_offsets,
-#             alternate_ids,
-#             self.context_system_ids,
-#             self.system_min_block_bondsep,
-#             self.system_inter_block_bondsep,
-#             self.system_neighbor_list,
-#             self.bt_n_atoms,
-#             self.bt_n_heavy_atoms,
-#             self.bt_n_heavy_atoms_in_tile,
-#             self.bt_heavy_atoms_in_tile,
-#             self.bt_atom_types,
-#             self.bt_heavy_atom_inds,
-#             self.bt_n_interblock_bonds,
-#             self.bt_atoms_forming_chemical_bonds,
-#             self.bt_path_distance,
-#             self.ljlk_type_params,
-#             self.global_params,
-#             self.lj_lk_weights,
-#         )

--- a/tmol/score/elec/elec_whole_pose_module.py
+++ b/tmol/score/elec/elec_whole_pose_module.py
@@ -1,9 +1,9 @@
 import torch
 
-from tmol.score.ljlk.potentials.compiled import ljlk_pose_scores
+from tmol.score.elec.potentials.compiled import elec_pose_scores
 
 
-class LJLKWholePoseScoringModule(torch.nn.Module):
+class ElecWholePoseScoringModule(torch.nn.Module):
     def __init__(
         self,
         pose_stack_block_coord_offset,
@@ -11,18 +11,14 @@ class LJLKWholePoseScoringModule(torch.nn.Module):
         pose_stack_min_block_bondsep,
         pose_stack_inter_block_bondsep,
         bt_n_atoms,
-        bt_n_heavy_atoms,
-        bt_n_heavy_atoms_in_tile,
-        bt_heavy_atoms_in_tile,
-        bt_atom_types,
-        bt_heavy_atom_inds,
+        bt_partial_charge,
         bt_n_interblock_bonds,
         bt_atoms_forming_chemical_bonds,
-        bt_path_distance,
-        ljlk_type_params,
+        bt_inter_repr_path_distance,
+        bt_intra_repr_path_distance,
         global_params,
     ):
-        super(LJLKWholePoseScoringModule, self).__init__()
+        super(ElecWholePoseScoringModule, self).__init__()
 
         def _p(t):
             return torch.nn.Parameter(t, requires_grad=False)
@@ -35,77 +31,38 @@ class LJLKWholePoseScoringModule(torch.nn.Module):
         self.pose_stack_min_block_bondsep = _p(pose_stack_min_block_bondsep)
         self.pose_stack_inter_block_bondsep = _p(pose_stack_inter_block_bondsep)
         self.bt_n_atoms = _p(bt_n_atoms)
-        self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
-        self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
-        self.bt_atom_types = _p(bt_atom_types)
-        self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
+        self.bt_partial_charge = _p(bt_partial_charge)
         self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
         self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
-        self.bt_path_distance = _p(bt_path_distance)
-
-        self.ljlk_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        ljlk_type_params.lj_radius,
-                        ljlk_type_params.lj_wdepth,
-                        ljlk_type_params.lk_dgfree,
-                        ljlk_type_params.lk_lambda,
-                        ljlk_type_params.lk_volume,
-                        ljlk_type_params.is_donor,
-                        ljlk_type_params.is_hydroxyl,
-                        ljlk_type_params.is_polarh,
-                        ljlk_type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
+        self.bt_inter_repr_path_distance = _p(bt_inter_repr_path_distance)
+        self.bt_intra_repr_path_distance = _p(bt_intra_repr_path_distance)
 
         self.global_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        global_params.lj_hbond_dis,
-                        global_params.lj_hbond_OH_donor_dis,
-                        global_params.lj_hbond_hdis,
-                    ]
-                ),
-                dim=1,
-            )
+            torch.tensor(
+                [
+                    global_params.elec_sigmoidal_die_D,
+                    global_params.elec_sigmoidal_die_D0,
+                    global_params.elec_sigmoidal_die_S,
+                    global_params.elec_min_dis,
+                    global_params.elec_max_dis,
+                ],
+                dtype=torch.float32,
+                device=pose_stack_block_coord_offset.device,
+            )[None, :]
         )
 
-        # n_poses = pose_stack_block_types.shape[0]
-        # max_n_blocks = pose_stack_block_types.shape[1]
-        # device = pose_stack_block_types.device
-        # self.scratch_block_spheres = _p(
-        #     torch.zeros(
-        #         (n_poses, max_n_blocks, 4),
-        #         dtype=torch.float32, device=device
-        #     )
-        # )
-        # self.scratch_blocks_are_neighbors = _p(
-        #     torch.zeros(n_poses, max_n_blocks, max_n_blocks),
-        #     dtype=torch.int32, device=device
-        # )
-
-        # self.ljlk_type_params = ljlk_type_params
-        # self.global_params = global_params
-
     def forward(self, coords):
-        return ljlk_pose_scores(
+        return elec_pose_scores(
             coords,
             self.pose_stack_block_coord_offset,
             self.pose_stack_block_types,
             self.pose_stack_min_block_bondsep,
             self.pose_stack_inter_block_bondsep,
             self.bt_n_atoms,
-            self.bt_n_heavy_atoms_in_tile,
-            self.bt_heavy_atoms_in_tile,
-            self.bt_atom_types,
+            self.bt_partial_charge,
             self.bt_n_interblock_bonds,
             self.bt_atoms_forming_chemical_bonds,
-            self.bt_path_distance,
-            self.ljlk_type_params,
+            self.bt_inter_repr_path_distance,
+            self.bt_intra_repr_path_distance,
             self.global_params,
         )

--- a/tmol/score/elec/elec_whole_pose_module.py
+++ b/tmol/score/elec/elec_whole_pose_module.py
@@ -1,0 +1,111 @@
+import torch
+
+from tmol.score.ljlk.potentials.compiled import ljlk_pose_scores
+
+
+class LJLKWholePoseScoringModule(torch.nn.Module):
+    def __init__(
+        self,
+        pose_stack_block_coord_offset,
+        pose_stack_block_types,
+        pose_stack_min_block_bondsep,
+        pose_stack_inter_block_bondsep,
+        bt_n_atoms,
+        bt_n_heavy_atoms,
+        bt_n_heavy_atoms_in_tile,
+        bt_heavy_atoms_in_tile,
+        bt_atom_types,
+        bt_heavy_atom_inds,
+        bt_n_interblock_bonds,
+        bt_atoms_forming_chemical_bonds,
+        bt_path_distance,
+        ljlk_type_params,
+        global_params,
+    ):
+        super(LJLKWholePoseScoringModule, self).__init__()
+
+        def _p(t):
+            return torch.nn.Parameter(t, requires_grad=False)
+
+        def _t(ts):
+            return tuple(map(lambda t: t.to(torch.float), ts))
+
+        self.pose_stack_block_coord_offset = _p(pose_stack_block_coord_offset)
+        self.pose_stack_block_types = _p(pose_stack_block_types)
+        self.pose_stack_min_block_bondsep = _p(pose_stack_min_block_bondsep)
+        self.pose_stack_inter_block_bondsep = _p(pose_stack_inter_block_bondsep)
+        self.bt_n_atoms = _p(bt_n_atoms)
+        self.bt_n_heavy_atoms_in_tile = _p(bt_n_heavy_atoms_in_tile)
+        self.bt_heavy_atoms_in_tile = _p(bt_heavy_atoms_in_tile)
+        self.bt_atom_types = _p(bt_atom_types)
+        self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
+        self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
+        self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
+        self.bt_path_distance = _p(bt_path_distance)
+
+        self.ljlk_type_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        ljlk_type_params.lj_radius,
+                        ljlk_type_params.lj_wdepth,
+                        ljlk_type_params.lk_dgfree,
+                        ljlk_type_params.lk_lambda,
+                        ljlk_type_params.lk_volume,
+                        ljlk_type_params.is_donor,
+                        ljlk_type_params.is_hydroxyl,
+                        ljlk_type_params.is_polarh,
+                        ljlk_type_params.is_acceptor,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+
+        self.global_params = _p(
+            torch.stack(
+                _t(
+                    [
+                        global_params.lj_hbond_dis,
+                        global_params.lj_hbond_OH_donor_dis,
+                        global_params.lj_hbond_hdis,
+                    ]
+                ),
+                dim=1,
+            )
+        )
+
+        # n_poses = pose_stack_block_types.shape[0]
+        # max_n_blocks = pose_stack_block_types.shape[1]
+        # device = pose_stack_block_types.device
+        # self.scratch_block_spheres = _p(
+        #     torch.zeros(
+        #         (n_poses, max_n_blocks, 4),
+        #         dtype=torch.float32, device=device
+        #     )
+        # )
+        # self.scratch_blocks_are_neighbors = _p(
+        #     torch.zeros(n_poses, max_n_blocks, max_n_blocks),
+        #     dtype=torch.int32, device=device
+        # )
+
+        # self.ljlk_type_params = ljlk_type_params
+        # self.global_params = global_params
+
+    def forward(self, coords):
+        return ljlk_pose_scores(
+            coords,
+            self.pose_stack_block_coord_offset,
+            self.pose_stack_block_types,
+            self.pose_stack_min_block_bondsep,
+            self.pose_stack_inter_block_bondsep,
+            self.bt_n_atoms,
+            self.bt_n_heavy_atoms_in_tile,
+            self.bt_heavy_atoms_in_tile,
+            self.bt_atom_types,
+            self.bt_n_interblock_bonds,
+            self.bt_atoms_forming_chemical_bonds,
+            self.bt_path_distance,
+            self.ljlk_type_params,
+            self.global_params,
+        )

--- a/tmol/score/elec/params.py
+++ b/tmol/score/elec/params.py
@@ -85,16 +85,10 @@ class ElecParamResolver(ValidateAttrs):
             )(res_indices[i, ...], mapped_atoms[i, ...], numpy.arange(natms))
 
             # fmt: off
-            print("remap_bonded_path_lengths[i] before")
-            print(remap_bonded_path_lengths[i])
-            print("mapped_indices")
-            print(mapped_indices)
             remap_bonded_path_lengths[i, mapped_indices, :] = (
                 remap_bonded_path_lengths[i, ...])
             remap_bonded_path_lengths[i, :, mapped_indices] = (
                 remap_bonded_path_lengths[i, ...])
-            print("remap_bonded_path_lengths[i] after")
-            print(remap_bonded_path_lengths[i])
             # fmt: on
 
         return remap_bonded_path_lengths

--- a/tmol/score/elec/params.py
+++ b/tmol/score/elec/params.py
@@ -38,6 +38,8 @@ class ElecParamResolver(ValidateAttrs):
     # map (AA,atom) to atom
     cp_reps: dict
 
+    cp_reps_by_res: dict
+
     # map (AA,atom) to partial charge
     partial_charges: dict
 
@@ -83,10 +85,16 @@ class ElecParamResolver(ValidateAttrs):
             )(res_indices[i, ...], mapped_atoms[i, ...], numpy.arange(natms))
 
             # fmt: off
+            print("remap_bonded_path_lengths[i] before")
+            print(remap_bonded_path_lengths[i])
+            print("mapped_indices")
+            print(mapped_indices)
             remap_bonded_path_lengths[i, mapped_indices, :] = (
                 remap_bonded_path_lengths[i, ...])
             remap_bonded_path_lengths[i, :, mapped_indices] = (
                 remap_bonded_path_lengths[i, ...])
+            print("remap_bonded_path_lengths[i] after")
+            print(remap_bonded_path_lengths[i])
             # fmt: on
 
         return remap_bonded_path_lengths
@@ -109,6 +117,11 @@ class ElecParamResolver(ValidateAttrs):
             (x.res, x.atm_outer): x.atm_inner
             for x in elec_database.atom_cp_reps_parameters
         }
+        cp_reps_by_res = {}
+        for x in elec_database.atom_cp_reps_parameters:
+            if x.res not in cp_reps_by_res:
+                cp_reps_by_res[x.res] = {}
+            cp_reps_by_res[x.res][x.atm_outer] = x.atm_inner
 
         # Read partial charges
         partial_charges = {
@@ -120,5 +133,6 @@ class ElecParamResolver(ValidateAttrs):
             global_params=global_params,
             partial_charges=partial_charges,
             cp_reps=cp_reps,
+            cp_reps_by_res=cp_reps_by_res,
             device=device,
         )

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -6,8 +6,10 @@
 
 #include <tmol/score/common/simple_dispatch.hh>
 #include <tmol/score/common/forall_dispatch.hh>
+#include <tmol/score/common/device_operations.hh>
 
 #include "dispatch.hh"
+#include "elec_pose_score.hh"
 
 namespace tmol {
 namespace score {
@@ -135,6 +137,107 @@ Tensor score_op(
       apply(I, charge_I, J, charge_J, bonded_path_lengths, global_params);
 }
 
+template <template <tmol::Device> class DispatchMethod>
+class ElecPoseScoreOp
+    : public torch::autograd::Function<ElecPoseScoreOp<DispatchMethod>> {
+ public:
+  static Tensor forward(
+      AutogradContext* ctx,
+      Tensor coords,
+      Tensor posck_stack_block_coord_offset,
+
+      Tensor pose_stack_block_type,
+      Tensor pose_stack_min_bond_separation,
+      Tensor pose_stack_inter_block_bondsep,
+      Tensor block_type_n_atoms,
+      Tensor block_type_n_heavy_atoms_in_tile,
+
+      Tensor block_type_heavy_atoms_in_tile,
+      Tensor block_type_atom_types,
+      Tensor block_type_n_interblock_bonds,
+      Tensor block_type_atoms_forming_chemical_bonds,
+      Tensor block_type_path_distance,
+
+      Tensor type_params,
+      Tensor global_params) {
+    at::Tensor score;
+    at::Tensor dscore_dcoords;
+
+    using Int = int32_t;
+
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        coords.type(), "pose_score_op", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+
+          auto result =
+              ElecPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::f(
+                  TCAST(coords),
+                  TCAST(posck_stack_block_coord_offset),
+
+                  TCAST(pose_stack_block_type),
+                  TCAST(pose_stack_min_bond_separation),
+                  TCAST(pose_stack_inter_block_bondsep),
+                  TCAST(block_type_n_atoms),
+                  TCAST(block_type_n_heavy_atoms_in_tile),
+
+                  TCAST(block_type_heavy_atoms_in_tile),
+                  TCAST(block_type_atom_types),
+                  TCAST(block_type_n_interblock_bonds),
+                  TCAST(block_type_atoms_forming_chemical_bonds),
+                  TCAST(block_type_path_distance),
+
+                  TCAST(type_params),
+                  TCAST(global_params),
+                  coords.requires_grad());
+
+          score = std::get<0>(result).tensor;
+          dscore_dcoords = std::get<1>(result).tensor;
+        }));
+
+    ctx->save_for_backward({dscore_dcoords});
+    return score;
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    auto saved_grads = ctx->get_saved_variables();
+
+    tensor_list result;
+
+    for (auto& saved_grad : saved_grads) {
+      auto ingrad = grad_outputs[0];
+      while (ingrad.dim() < saved_grad.dim()) {
+        ingrad = ingrad.unsqueeze(-1);
+      }
+
+      result.emplace_back(saved_grad * ingrad);
+    }
+
+    int i = 0;
+    auto dscore_dcoords = result[i++];
+
+    return {
+        dscore_dcoords,
+        torch::Tensor(),
+
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+        torch::Tensor(),
+
+        torch::Tensor(),
+        torch::Tensor(),
+    };
+  }
+};
+
 // Macro indirection to force TORCH_EXTENSION_NAME macro expansion
 // See https://stackoverflow.com/a/3221914
 #define TORCH_LIBRARY_(ns, m) TORCH_LIBRARY(ns, m)
@@ -151,6 +254,7 @@ TORCH_LIBRARY_(TORCH_EXTENSION_NAME, m) {
           ElecDispatch,
           tmol::score::common::ForallDispatch,
           tmol::score::common::AABBTriuDispatch>);
+  m.def("elec_pose_scores", &elec_pose_scores_op<DeviceOperations>);
 }
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/compiled.py
+++ b/tmol/score/elec/potentials/compiled.py
@@ -4,7 +4,16 @@ from tmol.utility.cpp_extension import load, relpaths, modulename, cuda_if_avail
 load(
     modulename(__name__),
     cuda_if_available(
-        relpaths(__file__, ["compiled.ops.cpp", "compiled.cpu.cpp", "compiled.cuda.cu"])
+        relpaths(
+            __file__,
+            [
+                "compiled.ops.cpp",
+                "compiled.cpu.cpp",
+                "compiled.cuda.cu",
+                "elec_pose_score.cpu.cpp",
+                "elec_pose_score.cuda.cu",
+            ],
+        )
     ),
     is_python_module=False,
 )
@@ -13,3 +22,4 @@ _ops = getattr(torch.ops, modulename(__name__))
 
 score_elec = _ops.score_elec
 score_elec_triu = _ops.score_elec_triu
+elec_pose_scores = _ops.elec_pose_scores

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -425,7 +425,7 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
     int start_atom2,
     ElecScoringData<Real> const &score_dat,
     int cp_separation,
-    TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords) {
+    TView<Eigen::Matrix<Real, 3, 1>, 3, D> dV_dcoords) {
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
@@ -452,7 +452,7 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
   for (int j = 0; j < 3; ++j) {
     if (elec_dxyz_at1[j] != 0) {
       accumulate<D, Real>::add(
-          dV_dcoords[score_dat.pose_ind]
+          dV_dcoords[0][score_dat.pose_ind]
                     [score_dat.r1.block_coord_offset + atom_tile_ind1
                      + start_atom1][j],
           elec_dxyz_at1[j]);
@@ -464,7 +464,7 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
   for (int j = 0; j < 3; ++j) {
     if (elec_dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(
-          dV_dcoords[score_dat.pose_ind]
+          dV_dcoords[0][score_dat.pose_ind]
                     [score_dat.r2.block_coord_offset + atom_tile_ind2
                      + start_atom2][j],
           elec_dxyz_at2[j]);

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -6,10 +6,6 @@
 #include <tmol/score/elec/potentials/params.hh>
 #include <tmol/score/elec/potentials/potentials.hh>
 
-// #include <tmol/score/ljlk/potentials/common.hh>
-// #include <tmol/score/ljlk/potentials/lj.hh>
-// #include <tmol/score/ljlk/potentials/lk_isotropic.hh>
-
 namespace tmol {
 namespace score {
 namespace elec {
@@ -43,9 +39,9 @@ class ElecScoringData {
 
 template <typename Real, int TILE_SIZE, int MAX_N_CONN>
 struct ElecBlockPairSharedData {
-  Real coords1[TILE_SIZE * 3];  // 786 bytes for coords
+  Real coords1[TILE_SIZE * 3];  // 768 bytes for coords
   Real coords2[TILE_SIZE * 3];
-  Real charges1[TILE_SIZE];  // 1536 bytes for params
+  Real charges1[TILE_SIZE];  // 256 bytes for params
   Real charges2[TILE_SIZE];
   unsigned char conn_ats1[MAX_N_CONN];  // 8 bytes
   unsigned char conn_ats2[MAX_N_CONN];
@@ -274,13 +270,6 @@ void TMOL_DEVICE_FUNC elec_load_interres2_tile_data_to_shared(
       shared_m.conn_ats2);
 }
 
-// template <int TILE_SIZE, int MAX_N_CONN, typename Real>
-// void TMOL_DEVICE_FUNC elec_load_interres_data_from_shared(
-//     ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m,
-//     ElecScoringData<Real> &inter_dat) {
-//
-// }
-
 template <
     template <tmol::Device>
     class DeviceDispatch,
@@ -315,9 +304,8 @@ void TMOL_DEVICE_FUNC elec_load_tile_invariant_intrares_data(
 
   intra_dat.r1.n_atoms = n_atoms1;
   intra_dat.r2.n_atoms = n_atoms1;
-  intra_dat.r1.n_conn =
-      0;  // not used! block_type_n_interblock_bonds[block_type1];
-  intra_dat.r2.n_conn = 0;  // not used! intra_dat.r1.n_conn;
+  intra_dat.r1.n_conn = 0;
+  intra_dat.r2.n_conn = 0;
 
   // set the pointers in intra_dat to point at the
   // shared-memory arrays. Note that these arrays will be reset
@@ -447,12 +435,6 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
   auto &dist = dist_r.V;
   auto &ddist_dat1 = dist_r.dV_dA;
   auto &ddist_dat2 = dist_r.dV_dB;
-  // auto lj = lj_score<Real>::V_dV(
-  //     dist,
-  //     cp_separation,
-  //     score_dat.r1.params[atom_tile_ind1].lj_params(),
-  //     score_dat.r2.params[atom_tile_ind2].lj_params(),
-  //     score_dat.global_params);
   Real V(0.0), dV_ddist(0.0);
   tie(V, dV_ddist) = elec_delec_ddist(
       dist,

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -1,0 +1,507 @@
+#pragma once
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+
+#include <tmol/score/common/data_loading.hh>
+#include <tmol/score/elec/potentials/potentials.hh>
+
+// #include <tmol/score/ljlk/potentials/common.hh>
+// #include <tmol/score/ljlk/potentials/lj.hh>
+// #include <tmol/score/ljlk/potentials/lk_isotropic.hh>
+
+namespace tmol {
+namespace score {
+namespace elec {
+namespace potentials {
+
+template <typename Real>
+class ElecSingleResData {
+ public:
+  int block_type;
+  int block_coord_offset;
+  int n_atoms;
+  int n_conn;
+  Real *coords;
+  Real *charges;
+  unsigned char *path_dist;
+};
+
+template <typename Real>
+class ElecScoringData {
+ public:
+  int pose_ind;
+  ElecSingleResData<Real> r1;
+  ElecSingleResData<Real> r2;
+  int max_important_bond_separation;
+  int min_separation;
+  bool in_count_pair_striking_dist;
+  unsigned char *conn_seps;
+  ElecGlobalParams<Real> global_params;
+  Real total_elec;
+};
+
+template <typename Real, int TILE_SIZE, int MAX_N_CONN>
+struct ElecBlockPairSharedData {
+  Real coords1[TILE_SIZE * 3];  // 786 bytes for coords
+  Real coords2[TILE_SIZE * 3];
+  Real charges1[TILE_SIZE];  // 1536 bytes for params
+  Real charges2[TILE_SIZE];
+  unsigned char conn_ats1[MAX_N_CONN];  // 8 bytes
+  unsigned char conn_ats2[MAX_N_CONN];
+  unsigned char path_dist1[MAX_N_CONN * TILE_SIZE];  // 256 bytes
+  unsigned char path_dist2[MAX_N_CONN * TILE_SIZE];
+  unsigned char conn_seps[MAX_N_CONN * MAX_N_CONN];  // 64 bytes
+};
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_block_coords_and_charges_into_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    int pose_ind,
+    ElecSingleResData<Real> &r_dat,
+    int n_atoms_to_load,
+    int start_atom) {
+  // pre-condition: n_atoms_to_load < TILE_SIZE
+  // Note that TILE_SIZE is not explicitly passed in, but is "present"
+  // in r_dat.coords allocation
+  DeviceDispatch<D>::template copy_contiguous_data<nt, 3>(
+      r_dat.coords,
+      reinterpret_cast<Real *>(
+          &coords[pose_ind][r_dat.block_coord_offset + start_atom]),
+      n_atoms_to_load * 3);
+  DeviceDispatch<D>::template copy_contiguous_data<nt, 1>(
+      r_dat.charges,
+      &block_type_partial_charges[r_dat.block_type]
+                                 [r_dat.block_coord_offset + start_atom],
+      n_atoms_to_load);
+  DeviceDispatch<D>::template for_each_in_workgroup<nt>(copy_atom_types);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    int TILE_SIZE,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_block_into_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    TView<Int, 3, D> block_type_representative_path_distance,
+    int pose_ind,
+    ElecSingleResData<Real> &r_dat,
+    int n_atoms_to_load,
+    int start_atom,
+    bool count_pair_striking_dist,
+    unsigned char *__restrict__ conn_ats) {
+  elec_load_block_coords_and_charges_into_shared<DeviceDispatch, D, nt>(
+      coords,
+      block_type_partial_charges,
+      type_params,
+      block_type_heavy_atoms_in_tile,
+      pose_ind,
+      r_dat,
+      n_atoms_to_load,
+      start_atom);
+
+  auto copy_path_dists = ([=](int tid) {
+    for (int count = tid; count < n_atoms_to_load; count += nt) {
+      int const atid = start_atom + count;
+      for (int j = 0; j < r_dat.n_conn; ++j) {
+        unsigned char ij_path_dist =
+            block_type_representative_path_distance[r_dat.block_type]
+                                                   [conn_ats[j]][atid];
+        r_dat.path_dist[j * TILE_SIZE + count] = ij_path_dist;
+      }
+    }
+  });
+  if (count_pair_striking_dist) {
+    DeviceDispatch<D>::template for_each_in_workgroup<nt>(copy_path_dists);
+  }
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    typename Int,
+    typename Real,
+    int TILE_SIZE,
+    int MAX_N_CONN>
+void TMOL_DEVICE_FUNC elec_load_tile_invariant_interres_data(
+    TView<Int, 2, D> pose_stack_block_coord_offset,
+    TView<Int, 3, D> pose_stack_min_bond_separation,
+    TView<Int, 1, D> block_type_n_interblock_bonds,
+    TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+    TView<Int, 5, D> pose_stack_inter_block_bondsep,
+    TView<ElecGlobalParams<Real>, 1, D> global_params,
+    int const max_important_bond_separation,
+    int pose_ind,
+    int block_ind1,
+    int block_ind2,
+    int block_type1,
+    int block_type2,
+    int n_atoms1,
+    int n_atoms2,
+    ElecScoringData<Real> &inter_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  inter_dat.pose_ind = pose_ind;
+  inter_dat.r1.block_type = block_type1;
+  inter_dat.r2.block_type = block_type2;
+  inter_dat.r1.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind1];
+  inter_dat.r2.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind2];
+  inter_dat.max_important_bond_separation = max_important_bond_separation;
+  inter_dat.min_separation =
+      pose_stack_min_bond_separation[pose_ind][block_ind1][block_ind2];
+  inter_dat.in_count_pair_striking_dist =
+      inter_dat.min_separation <= max_important_bond_separation;
+  inter_dat.r1.n_atoms = n_atoms1;
+  inter_dat.r2.n_atoms = n_atoms2;
+  inter_dat.r1.n_conn = block_type_n_interblock_bonds[block_type1];
+  inter_dat.r2.n_conn = block_type_n_interblock_bonds[block_type2];
+
+  // set the pointers in inter_dat to point at the shared-memory arrays
+  inter_dat.r1.coords = shared_m.coords1;
+  inter_dat.r2.coords = shared_m.coords2;
+  inter_dat.r1.charges = shared_m.charges1;
+  inter_dat.r2.charges = shared_m.charges2;
+  inter_dat.r1.path_dist = shared_m.path_dist1;
+  inter_dat.r2.path_dist = shared_m.path_dist2;
+  inter_dat.conn_seps = shared_m.conn_seps;
+
+  // Count pair setup that does not depend on which tile we are
+  // operating on
+  if (inter_dat.in_count_pair_striking_dist) {
+    // Load data into shared arrays
+    auto load_count_pair_conn_at_data = ([&](int tid) {
+      int n_conn_tot = inter_dat.r1.n_conn + inter_dat.r2.n_conn
+                       + inter_dat.r1.n_conn * inter_dat.r2.n_conn;
+      for (int count = tid; count < n_conn_tot; count += nt) {
+        if (count < inter_dat.r1.n_conn) {
+          int const conn_ind = count;
+          shared_m.conn_ats1[conn_ind] =
+              block_type_atoms_forming_chemical_bonds[block_type1][conn_ind];
+        } else if (count < inter_dat.r1.n_conn + inter_dat.r2.n_conn) {
+          int const conn_ind = count - inter_dat.r1.n_conn;
+          shared_m.conn_ats2[conn_ind] =
+              block_type_atoms_forming_chemical_bonds[block_type2][conn_ind];
+        } else {
+          int const conn_ind =
+              count - inter_dat.r1.n_conn - inter_dat.r2.n_conn;
+          int conn1 = conn_ind / inter_dat.r2.n_conn;
+          int conn2 = conn_ind % inter_dat.r2.n_conn;
+          shared_m.conn_seps[conn_ind] =
+              pose_stack_inter_block_bondsep[pose_ind][block_ind1][block_ind2]
+                                            [conn1][conn2];
+        }
+      }
+    });
+    // On CPU: a for loop executed once; on GPU threads within the
+    // workgroup working in parallel will just continue to work in
+    // parallel
+    DeviceDispatch<D>::template for_each_in_workgroup<nt>(
+        load_count_pair_conn_at_data);
+  }
+
+  // Final data members
+  inter_dat.global_params = global_params[0];
+  inter_dat.total_elec = 0;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_interres1_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    TView<Int, 3, D> block_type_representative_path_distance,
+    int tile_ind,
+    int start_atom1,
+    int n_atoms_to_load1,
+    ElecScoringData<Real> &inter_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  elec_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
+      coords,
+      block_type_atom_types,
+      block_type_partial_charges,
+      block_type_representative_path_distance,
+      inter_dat.pose_ind,
+      inter_dat.r1,
+      n_atoms_to_load1,
+      start_atom1,
+      inter_dat.in_count_pair_striking_dist,
+      shared_m.conn_ats1);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_interres2_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    TView<Int, 3, D> block_type_represntative_path_distance,
+    int tile_ind,
+    int start_atom2,
+    int n_atoms_to_load2,
+    ElecScoringData<Real> &inter_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  elec_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
+      coords,
+      block_type_atom_types,
+      block_type_partial_charges,
+      block_type_representative_path_distance,
+      inter_dat.pose_ind,
+      inter_dat.r2,
+      n_atoms_to_load2,
+      start_atom2,
+      inter_dat.in_count_pair_striking_dist,
+      shared_m.conn_ats2);
+}
+
+// template <int TILE_SIZE, int MAX_N_CONN, typename Real>
+// void TMOL_DEVICE_FUNC elec_load_interres_data_from_shared(
+//     ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m,
+//     ElecScoringData<Real> &inter_dat) {
+//
+// }
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    typename Int,
+    typename Real,
+    int TILE_SIZE,
+    int MAX_N_CONN>
+void TMOL_DEVICE_FUNC elec_load_tile_invariant_intrares_data(
+    TView<Int, 2, D> pose_stack_block_coord_offset,
+    TView<ElecGlobalParams<Real>, 1, D> global_params,
+    int const max_important_bond_separation,
+    int pose_ind,
+    int block_ind1,
+    int block_type1,
+    int n_atoms1,
+    ElecScoringData<Real> &intra_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  intra_dat.pose_ind = pose_ind;
+  intra_dat.r1.block_type = block_type1;
+  intra_dat.r2.block_type = block_type1;
+  intra_dat.r1.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind1];
+  intra_dat.r2.block_coord_offset = intra_dat.r1.block_coord_offset;
+  intra_dat.max_important_bond_separation = max_important_bond_separation;
+
+  // we are not going to load count pair data into shared memory because
+  // we are not going to use that data from shared memory
+  intra_dat.min_separation = 0;
+  intra_dat.in_count_pair_striking_dist = false;
+
+  intra_dat.r1.n_atoms = n_atoms1;
+  intra_dat.r2.n_atoms = n_atoms1;
+  intra_dat.r1.n_conn =
+      0;  // not used! block_type_n_interblock_bonds[block_type1];
+  intra_dat.r2.n_conn = 0;  // not used! intra_dat.r1.n_conn;
+
+  // set the pointers in intra_dat to point at the
+  // shared-memory arrays. Note that these arrays will be reset
+  // later because which shared memory arrays we will use depends on
+  // which tile pair we are evaluating!
+  intra_dat.r1.coords = shared_m.coords1;    // depends on tile pair!
+  intra_dat.r2.coords = shared_m.coords2;    // depends on tile pair!
+  intra_dat.r1.charges = shared_m.charges1;  // depends on tile pair!
+  intra_dat.r2.charges = shared_m.charges2;  // depends on tile pair!
+
+  // these count pair arrays are not going to be used
+  intra_dat.r1.path_dist = 0;
+  intra_dat.r2.path_dist = 0;
+  intra_dat.conn_seps = 0;
+
+  // Final data members
+  intra_dat.global_params = global_params[0];
+  intra_dat.total_elec = 0;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_intrares1_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    int tile_ind,
+    int start_atom1,
+    int n_atoms_to_load1,
+    ElecScoringData<Real> &intra_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  elec_load_block_coords_and_charges_into_shared<DeviceDispatch, D, nt>(
+      coords,
+      block_type_atom_types,
+      block_type_partial_charges,
+      intra_dat.pose_ind,
+      intra_dat.r1,
+      n_atoms_to_load1,
+      start_atom1);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC elec_load_intrares2_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Real, 2, D> block_type_partial_charges,
+    int tile_ind,
+    int start_atom2,
+    int n_atoms_to_load2,
+    ElecScoringData<Real> &intra_dat,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  elec_load_block_coords_and_charges_into_shared<DeviceDispatch, D, nt>(
+      coords,
+      block_type_atom_types,
+      block_type_partial_charges,
+      intra_dat.pose_ind,
+      intra_dat.r2,
+      n_atoms_to_load2,
+      start_atom2);
+}
+
+template <int TILE_SIZE, int MAX_N_CONN, typename Real>
+void TMOL_DEVICE_FUNC elec_load_intrares_data_from_shared(
+    int tile_ind1,
+    int tile_ind2,
+    ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m,
+    ElecScoringData<Real> &intra_dat) {
+  // set the pointers in intra_dat to point at the shared-memory arrays
+  // If we are evaluating the energies between atoms in the same tile
+  // then only the "1" shared-memory arrays will be loaded with data;
+  // we will point the "2" memory pointers at the "1" arrays
+  bool same_tile = tile_ind1 == tile_ind2;
+  intra_dat.r1.coords = shared_m.coords1;
+  intra_dat.r2.coords = (same_tile ? shared_m.coords1 : shared_m.coords2);
+  intra_dat.r1.charges = shared_m.charges1;
+  intra_dat.r2.charges = (same_tile ? shared_m.charges1 : shared_m.charges2);
+}
+
+template <typename Real>
+TMOL_DEVICE_FUNC Real elec_atom_energy(
+    int atom_tile_ind1,
+    int atom_tile_ind2,
+    ElecScoringData<Real> const &score_dat,
+    int cp_separation) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
+  Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
+
+  Real const dist = distance<Real>::V(coord1, coord2);
+  return elec(
+      dist,
+      cp_separation,
+      score_dat.r1.charges[atom_tile_ind1],
+      score_dat.r2.charges[atom_tile_ind2],
+      score_dat.global_params[0].D,
+      score_dat.global_params[0].D0,
+      score_dat.global_params[0].S,
+      score_dat.global_params[0].min_dis,
+      score_dat.global_params[0].max_dis);
+}
+
+template <typename Real, tmol::Device D>
+TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
+    int atom_tile_ind1,
+    int atom_tile_ind2,
+    int start_atom1,
+    int start_atom2,
+    ElecScoringData<Real> const &score_dat,
+    int cp_separation,
+    TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
+  Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
+
+  auto dist_r = distance<Real>::V_dV(coord1, coord2);
+  auto &dist = dist_r.V;
+  auto &ddist_dat1 = dist_r.dV_dA;
+  auto &ddist_dat2 = dist_r.dV_dB;
+  // auto lj = lj_score<Real>::V_dV(
+  //     dist,
+  //     cp_separation,
+  //     score_dat.r1.params[atom_tile_ind1].lj_params(),
+  //     score_dat.r2.params[atom_tile_ind2].lj_params(),
+  //     score_dat.global_params);
+  Real V(0.0), dV_ddist(0.0);
+  std::tie(V, dV_ddist) = elec_delec_ddist(
+      dist,
+      cp_separation,
+      score_dat.r1.charges[atom_tile_ind1],
+      score_dat.r2.charges[atom_tile_ind2],
+      score_dat.global_params[0].D,
+      score_dat.global_params[0].D0,
+      score_dat.global_params[0].S,
+      score_dat.global_params[0].min_dis,
+      score_dat.global_params[0].max_dis);
+
+  // all threads accumulate derivatives for atom 1 to global memory
+  Vec<Real, 3> elec_dxyz_at1 = dV_ddist * ddist_dat1;
+  for (int j = 0; j < 3; ++j) {
+    if (elec_dxyz_at1[j] != 0) {
+      accumulate<D, Real>::add(
+          dV_dcoords[score_dat.pose_ind]
+                    [score_dat.r1.block_coord_offset + atom_tile_ind1
+                     + start_atom1][j],
+          elec_dxyz_at1[j]);
+    }
+  }
+
+  // all threads accumulate derivatives for atom 2 to global memory
+  Vec<Real, 3> elec_dxyz_at2 = dV_ddist * ddist_dat2;
+  for (int j = 0; j < 3; ++j) {
+    if (elec_dxyz_at2[j] != 0) {
+      accumulate<D, Real>::add(
+          dV_dcoords[score_dat.pose_ind]
+                    [score_dat.r2.block_coord_offset + atom_tile_ind2
+                     + start_atom2][j],
+          elec_dxyz_at2[j]);
+    }
+  }
+  return V;
+}
+
+}  // namespace potentials
+}  // namespace elec
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.cpu.cpp
+++ b/tmol/score/elec/potentials/elec_pose_score.cpu.cpp
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cpu.impl.hh>
+#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace ljlk {
+namespace potentials {
+
+template struct LJLKPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CPU,
+    float,
+    int>;
+template struct LJLKPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CPU,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace ljlk
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.cpu.cpp
+++ b/tmol/score/elec/potentials/elec_pose_score.cpu.cpp
@@ -1,23 +1,23 @@
 #include <tmol/score/common/device_operations.cpu.impl.hh>
-#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+#include <tmol/score/elec/potentials/elec_pose_score.impl.hh>
 
 namespace tmol {
 namespace score {
-namespace ljlk {
+namespace elec {
 namespace potentials {
 
-template struct LJLKPoseScoreDispatch<
+template struct ElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CPU,
     float,
     int>;
-template struct LJLKPoseScoreDispatch<
+template struct ElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CPU,
     double,
     int>;
 
 }  // namespace potentials
-}  // namespace ljlk
+}  // namespace elec
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.cuda.cu
+++ b/tmol/score/elec/potentials/elec_pose_score.cuda.cu
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cuda.impl.cuh>
+#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace ljlk {
+namespace potentials {
+
+template struct LJLKPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CUDA,
+    float,
+    int>;
+template struct LJLKPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CUDA,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace ljlk
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.cuda.cu
+++ b/tmol/score/elec/potentials/elec_pose_score.cuda.cu
@@ -1,23 +1,23 @@
 #include <tmol/score/common/device_operations.cuda.impl.cuh>
-#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+#include <tmol/score/elec/potentials/elec_pose_score.impl.hh>
 
 namespace tmol {
 namespace score {
-namespace ljlk {
+namespace elec {
 namespace potentials {
 
-template struct LJLKPoseScoreDispatch<
+template struct ElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CUDA,
     float,
     int>;
-template struct LJLKPoseScoreDispatch<
+template struct ElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CUDA,
     double,
     int>;
 
 }  // namespace potentials
-}  // namespace ljlk
+}  // namespace elec
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -13,9 +13,7 @@
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/tuple.hh>
 
-// #include "elec.hh"
 #include <tmol/score/elec/potentials/params.hh>
-// #include "rotamer_pair_energy_lj.hh"
 
 namespace tmol {
 namespace score {

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -14,7 +14,7 @@
 #include <tmol/score/common/tuple.hh>
 
 // #include "elec.hh"
-#include "params.hh"
+#include <tmol/score/elec/potentials/params.hh>
 // #include "rotamer_pair_energy_lj.hh"
 
 namespace tmol {
@@ -37,7 +37,7 @@ struct ElecPoseScoreDispatch {
       TView<Int, 2, D> pose_stack_block_coord_offset,
       TView<Int, 2, D> pose_stack_block_type,
 
-      // dims: n-systems x max-n-blocks x max-n-blocks
+      // dims: n-poses x max-n-blocks x max-n-blocks
       // Quick lookup: given the inds of two blocks, ask: what is the minimum
       // number of chemical bonds that separate any pair of atoms in those
       // blocks? If this minimum is greater than the crossover, then no further
@@ -46,7 +46,7 @@ struct ElecPoseScoreDispatch {
       // (possibly) fit in constant cache
       TView<Int, 3, D> pose_stack_min_bond_separation,
 
-      // dims: n-systems x max-n-blocks x max-n-blocks x
+      // dims: n-poses x max-n-blocks x max-n-blocks x
       // max-n-interblock-connections x max-n-interblock-connections
       TView<Int, 5, D> pose_stack_inter_block_bondsep,
 
@@ -56,12 +56,7 @@ struct ElecPoseScoreDispatch {
       // Dimsize n_block_types
       TView<Int, 1, D> block_type_n_atoms,
 
-      TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
-      TView<Int, 2, D> block_type_heavy_atoms_in_tile,
-
-      // what are the atom types for these atoms
-      // Dimsize: n_block_types x max_n_atoms
-      TView<Int, 2, D> block_type_atom_types,
+      TView<Real, 2, D> block_type_partial_charge,
 
       // how many inter-block chemical bonds are there
       // Dimsize: n_block_types
@@ -72,16 +67,24 @@ struct ElecPoseScoreDispatch {
       TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
 
       // what is the path distance between pairs of atoms in the block
+      // denormalized by their count-pair representative; used for
+      // inter-block chemical-bond separation determination. Entry
+      // i, j stores path_dist[i, rep(j)]
       // Dimsize: n_block_types x max_n_atoms x max_n_atoms
-      TView<Int, 3, D> block_type_path_distance,
+      TView<Int, 3, D> block_type_inter_repr_path_distance,
+
+      // what is the path distance between pairs of atoms in the block
+      // denormalized (twice!) by their count-pair representative;
+      // used for intra-block chemical-bond separation determination.
+      // Entry i, j stores path_dist[rep(i), rep(j)]
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, D> block_type_intra_repr_path_distance,
       //////////////////////
 
       // LJ parameters
-      TView<ElecTypeParams<Real>, 1, D> type_params,
-      TView<LJGlobalParams<Real>, 1, D> global_params,
-      bool compute_derivs
-
-      ) -> std::tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 3, D>>;
+      TView<ElecGlobalParams<Real>, 1, D> global_params,
+      bool compute_derivs)
+      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D>>;
 };
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -82,7 +82,7 @@ struct ElecPoseScoreDispatch {
       // LJ parameters
       TView<ElecGlobalParams<Real>, 1, D> global_params,
       bool compute_derivs)
-      -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D>>;
+      -> std::tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 3, D>>;
 };
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/TensorStruct.h>
+#include <tmol/utility/tensor/TensorUtil.h>
+#include <tmol/utility/nvtx.hh>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/geom.hh>
+#include <tmol/score/common/tuple.hh>
+
+// #include "elec.hh"
+#include "params.hh"
+// #include "rotamer_pair_energy_lj.hh"
+
+namespace tmol {
+namespace score {
+namespace elec {
+namespace potentials {
+
+template <typename Real, int N>
+using Vec = Eigen::Matrix<Real, N, 1>;
+
+template <
+    template <tmol::Device>
+    class DeviceOps,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+struct ElecPoseScoreDispatch {
+  static auto f(
+      TView<Vec<Real, 3>, 2, D> coords,
+      TView<Int, 2, D> pose_stack_block_coord_offset,
+      TView<Int, 2, D> pose_stack_block_type,
+
+      // dims: n-systems x max-n-blocks x max-n-blocks
+      // Quick lookup: given the inds of two blocks, ask: what is the minimum
+      // number of chemical bonds that separate any pair of atoms in those
+      // blocks? If this minimum is greater than the crossover, then no further
+      // logic for deciding whether two atoms in those blocks should have their
+      // interaction energies calculated: all should. intentionally small to
+      // (possibly) fit in constant cache
+      TView<Int, 3, D> pose_stack_min_bond_separation,
+
+      // dims: n-systems x max-n-blocks x max-n-blocks x
+      // max-n-interblock-connections x max-n-interblock-connections
+      TView<Int, 5, D> pose_stack_inter_block_bondsep,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, D> block_type_n_atoms,
+
+      TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
+      TView<Int, 2, D> block_type_heavy_atoms_in_tile,
+
+      // what are the atom types for these atoms
+      // Dimsize: n_block_types x max_n_atoms
+      TView<Int, 2, D> block_type_atom_types,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, D> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+
+      // what is the path distance between pairs of atoms in the block
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, D> block_type_path_distance,
+      //////////////////////
+
+      // LJ parameters
+      TView<ElecTypeParams<Real>, 1, D> type_params,
+      TView<LJGlobalParams<Real>, 1, D> global_params,
+      bool compute_derivs
+
+      ) -> std::tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 3, D>>;
+};
+
+}  // namespace potentials
+}  // namespace elec
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -121,7 +121,7 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
     TView<ElecGlobalParams<Real>, 1, D> global_params,
     bool compute_derivs
 
-    ) -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D>> {
+    ) -> std::tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 3, D>> {
   using tmol::score::common::accumulate;
   using Real3 = Vec<Real, 3>;
 
@@ -158,11 +158,11 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
   assert(block_type_intra_repr_path_distance.size(1) == max_n_block_atoms);
   assert(block_type_intra_repr_path_distance.size(2) == max_n_block_atoms);
 
-  auto output_t = TPack<Real, 1, D>::zeros({n_poses});
+  auto output_t = TPack<Real, 2, D>::zeros({1, n_poses});
   auto output = output_t.view;
 
   auto dV_dcoords_t =
-      TPack<Vec<Real, 3>, 2, D>::zeros({n_poses, max_n_pose_atoms});
+      TPack<Vec<Real, 3>, 3, D>::zeros({1, n_poses, max_n_pose_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_block_spheres_t =
@@ -401,7 +401,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
                 score_dat.total_elec, shared, mgpu::plus_t<Real>());
 
         if (tid == 0) {
-          accumulate<D, Real>::add(output[score_dat.pose_ind], cta_total_elec);
+          accumulate<D, Real>::add(
+              output[0][score_dat.pose_ind], cta_total_elec);
         }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
@@ -721,7 +722,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
                 score_dat.total_elec, shared, mgpu::plus_t<Real>());
 
         if (tid == 0) {
-          accumulate<D, Real>::add(output[score_dat.pose_ind], cta_total_elec);
+          accumulate<D, Real>::add(
+              output[0][score_dat.pose_ind], cta_total_elec);
         }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -1,0 +1,919 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/TensorStruct.h>
+#include <tmol/utility/tensor/TensorUtil.h>
+#include <tmol/utility/nvtx.hh>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/data_loading.hh>
+#include <tmol/score/common/diamond_macros.hh>
+#include <tmol/score/common/geom.hh>
+#include <tmol/score/common/launch_box_macros.hh>
+#include <tmol/score/common/sphere_overlap.impl.hh>
+#include <tmol/score/common/tile_atom_pair_evaluation.hh>
+#include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/warp_segreduce.hh>
+#include <tmol/score/common/warp_stride_reduce.hh>
+
+#include <tmol/score/elec/potentials/elec.hh>
+// #include <tmol/score/ljlk/potentials/lj.hh>
+// #include <tmol/score/ljlk/potentials/ljlk.hh>
+// #include <tmol/score/ljlk/potentials/ljlk_pose_score.hh>
+// #include <tmol/score/ljlk/potentials/lk_isotropic.hh>
+
+// Operator definitions; safe for CPU compilation
+#include <moderngpu/operators.hxx>
+
+#include <chrono>
+
+// The maximum number of inter-residue chemical bonds
+#define MAX_N_CONN 4
+#define TILE_SIZE 32
+
+namespace tmol {
+namespace score {
+namespace elec {
+namespace potentials {
+
+template <typename Real, int N>
+using Vec = Eigen::Matrix<Real, N, 1>;
+
+template <int TILE, template <typename> typename InterEnergyData, typename Real>
+EIGEN_DEVICE_FUNC int interres_count_pair_separation(
+    InterEnergyData<Real> const &inter_dat,
+    int atom_tile_ind1,
+    int atom_tile_ind2) {
+  int separation = inter_dat.min_separation;
+  if (separation <= inter_dat.max_important_bond_separation) {
+    separation = common::count_pair::shared_mem_inter_block_separation<TILE>(
+        inter_dat.max_important_bond_separation,
+        atom_tile_ind1,
+        atom_tile_ind2,
+        inter_dat.r1.n_conn,
+        inter_dat.r2.n_conn,
+        inter_dat.r1.path_dist,
+        inter_dat.r2.path_dist,
+        inter_dat.conn_seps);
+  }
+  return separation;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
+    TView<Vec<Real, 3>, 2, D> coords,
+    TView<Int, 2, D> pose_stack_block_coord_offset,
+    TView<Int, 2, D> pose_stack_block_type,
+
+    // dims: n-poses x max-n-blocks x max-n-blocks
+    // Quick lookup: given the inds of two blocks, ask: what is the minimum
+    // number of chemical bonds that separate any pair of atoms in those
+    // blocks? If this minimum is greater than the crossover, then no further
+    // logic for deciding whether two atoms in those blocks should have their
+    // interaction energies calculated: all should. intentionally small to
+    // (possibly) fit in constant cache
+    TView<Int, 3, D> pose_stack_min_bond_separation,
+
+    // dims: n-poses x max-n-blocks x max-n-blocks x
+    // max-n-interblock-connections x max-n-interblock-connections
+    TView<Int, 5, D> pose_stack_inter_block_bondsep,
+
+    //////////////////////
+    // Chemical properties
+    // how many atoms for a given block
+    // Dimsize n_block_types
+    TView<Int, 1, D> block_type_n_atoms,
+
+    TView<Real, 2, D> block_type_partial_charges,
+
+    // how many inter-block chemical bonds are there
+    // Dimsize: n_block_types
+    TView<Int, 1, D> block_type_n_interblock_bonds,
+
+    // what atoms form the inter-block chemical bonds
+    // Dimsize: n_block_types x max_n_interblock_bonds
+    TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+
+    // what is the path distance between pairs of atoms in the block
+    // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+    TView<Int, 3, D> block_type_representative_path_distance,
+    //////////////////////
+
+    // LJ parameters
+    TView<ElecGlobalParams<Real>, 1, D> global_params,
+    bool compute_derivs
+
+    ) -> std::tuple<TPack<Real, 1, D>, TPack<Vec<Real, 3>, 2, D>> {
+  using tmol::score::common::accumulate;
+  using Real3 = Vec<Real, 3>;
+
+  int const n_poses = coords.size(0);
+  int const max_n_pose_atoms = coords.size(1);
+  int const max_n_blocks = pose_stack_block_type.size(1);
+  int const max_n_block_atoms = block_type_atom_types.size(1);
+  int const n_block_types = block_type_n_atoms.size(0);
+  int const max_n_tiles = block_type_n_heavy_atoms_in_tile.size(2);
+  int const max_n_interblock_bonds =
+      block_type_atoms_forming_chemical_bonds.size(1);
+  int64_t const n_atom_types = type_params.size(0);
+
+  assert(max_n_interblock_bonds <= MAX_N_CONN);
+
+  assert(pose_stack_block_type.size(0) == n_poses);
+
+  assert(pose_stack_min_bond_separation.size(0) == n_poses);
+  assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
+  assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
+
+  assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
+  assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
+  assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
+
+  // assert(block_type_n_heavy_atoms_in_tile.size(0) == n_block_types);
+
+  // assert(block_type_heavy_atoms_in_tile.size(0) == n_block_types);
+  // assert(block_type_heavy_atoms_in_tile.size(1) == TILE_SIZE * max_n_tiles);
+
+  // assert(block_type_atom_types.size(0) == n_block_types);
+  // assert(block_type_atom_types.size(1) == max_n_block_atoms);
+
+  assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+
+  assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+
+  assert(block_type_representative_path_distance.size(0) == n_block_types);
+  assert(block_type_representative_path_distance.size(1) == max_n_block_atoms);
+  assert(block_type_representative_path_distance.size(2) == max_n_block_atoms);
+
+  auto output_t = TPack<Real, 1, D>::zeros({n_poses});
+  auto output = output_t.view;
+
+  auto dV_dcoords_t =
+      TPack<Vec<Real, 3>, 2, D>::zeros({n_poses, max_n_pose_atoms});
+  auto dV_dcoords = dV_dcoords_t.view;
+
+  auto scratch_block_spheres_t =
+      TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4});
+  auto scratch_block_spheres = scratch_block_spheres_t.view;
+
+  auto scratch_block_neighbors_t =
+      TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
+  auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+
+  // Optimal launch box on v100 and a100 is nt=32, vt=1
+  LAUNCH_BOX_32;
+  // Define nt and reduce_t
+  CTA_REAL_REDUCE_T_TYPEDEF;
+
+  auto eval_energies_and_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
+    auto elec_atom_energy_and_derivs =
+        ([=] TMOL_DEVICE_FUNC(
+             int atom_tile_ind1,
+             int atom_tile_ind2,
+             int start_atom1,
+             int start_atom2,
+             ElecScoringData<Real> const &score_dat,
+             int cp_separation) {
+          return elec_atom_energy_and_derivs_full(
+              atom_tile_ind1,
+              atom_tile_ind2,
+              start_atom1,
+              start_atom2,
+              score_dat,
+              cp_separation,
+              dV_dcoords  // pass in lambda-captured tensor
+          );
+        });
+
+    auto score_inter_elec_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int start_atom1,
+             int start_atom2,
+             int atom_tile_ind1,
+             int atom_tile_ind2,
+             ElecScoringData<Real> const &inter_dat) {
+          int separation = interres_count_pair_separation<TILE_SIZE>(
+              inter_dat, atom_tile_ind1, atom_tile_ind2);
+          return elec_atom_energy_and_derivs(
+              atom_tile_ind1,
+              atom_tile_ind2,
+              start_atom1,
+              start_atom2,
+              inter_dat,
+              separation);
+        });
+
+    auto score_intra_elec_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int start_atom1,
+             int start_atom2,
+             int atom_tile_ind1,
+             int atom_tile_ind2,
+             ElecScoringData<Real> const &intra_dat) {
+          int const atom_ind1 = start_atom1 + atom_tile_ind1;
+          int const atom_ind2 = start_atom2 + atom_tile_ind2;
+
+          int const separation =
+              block_type_representative_path_distance[intra_dat.r1.block_type]
+                                                     [atom_ind1][atom_ind2];
+          return elec_atom_energy_and_derivs(
+              atom_tile_ind1,
+              atom_tile_ind2,
+              start_atom1,
+              start_atom2,
+              intra_dat,
+              separation);
+        });
+
+    auto load_block_coords_and_params_into_shared =
+        ([=] TMOL_DEVICE_FUNC(
+             int pose_ind,
+             ElecSingleResData<Real> &r_dat,
+             int n_atoms_to_load,
+             int start_atom) {
+          elec_load_block_coords_and_charges_into_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              pose_ind,
+              r_dat,
+              n_atoms_to_load,
+              start_atom);
+        });
+
+    auto load_block_into_shared = ([=] TMOL_DEVICE_FUNC(
+                                       int pose_ind,
+                                       ElecSingleResData<Real> &r_dat,
+                                       int n_atoms_to_load,
+                                       int start_atom,
+                                       bool count_pair_striking_dist,
+                                       unsigned char *__restrict__ conn_ats) {
+      elec_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
+          coords,
+          block_type_partial_charges,
+          block_type_representative_path_distance,
+          pose_ind,
+          r_dat,
+          n_atoms_to_load,
+          start_atom,
+          count_pair_striking_dist,
+          conn_ats);
+    });
+
+    SHARED_MEMORY union shared_mem_union {
+      shared_mem_union() {}
+      ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> m;
+      CTA_REAL_REDUCE_T_VARIABLE;
+
+    } shared;
+
+    // Real total_lj = 0;
+    // Real total_lk = 0;
+
+    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+    int const block_ind1 = block_ind_pair / max_n_blocks;
+    int const block_ind2 = block_ind_pair % max_n_blocks;
+    if (block_ind1 > block_ind2) {
+      return;
+    }
+
+    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    int const max_important_bond_separation = 4;
+
+    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+
+    if (block_type1 < 0 || block_type2 < 0) {
+      return;
+    }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
+
+    auto load_tile_invariant_interres_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_ind2,
+             int block_type1,
+             int block_type2,
+             int n_atoms1,
+             int n_atoms2,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_tile_invariant_interres_data<DeviceDispatch, D, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_min_bond_separation,
+              block_type_n_interblock_bonds,
+              block_type_atoms_forming_chemical_bonds,
+              pose_stack_inter_block_bondsep,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_ind2,
+              block_type1,
+              block_type2,
+              n_atoms1,
+              n_atoms2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_interres1_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              block_type_representative_path_distance,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_interres2_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              block_type_representative_path_distance,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres_data_from_shared =
+        ([=](int, int, shared_mem_union &, ElecScoringData<Real> &) {
+          // elec_load_interres_data_from_shared(shared.m, inter_dat);
+        });
+
+    // Evaluate both the LJ and LK scores in separate dispatches
+    // over all atoms in the tile and the subset of heavy atoms in
+    // the tile
+    auto eval_interres_atom_pair_scores = ([=](ElecScoringData<Real> &inter_dat,
+                                               int start_atom1,
+                                               int start_atom2) {
+      auto eval_scores_for_atom_pairs = ([&](int tid) {
+        inter_dat.total_elec += tmol::score::common::InterResBlockEvaluation<
+            ElecScoringData,
+            AllAtomPairSelector,
+            D,
+            TILE_SIZE,
+            nt,
+            Real,
+            Int>::
+            eval_interres_atom_pair(
+                tid,
+                start_atom1,
+                start_atom2,
+                score_inter_elec_atom_pair,
+                inter_dat);
+      });
+
+      // The work: On GPU threads work independently, on CPU, this will be a
+      // for loop
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(
+          eval_scores_for_atom_pairs);
+    });
+
+    auto store_calculated_energies = ([=](ElecScoringData<Real> &score_dat,
+                                          shared_mem_union &shared) {
+      auto reduce_energies = ([&](int tid) {
+        Real const cta_total_elec =
+            DeviceDispatch<D>::template reduce_in_workgroup<nt>(
+                score_dat.total_elec, shared, mgpu::plus_t<Real>());
+
+        if (tid == 0) {
+          // printf("Storing energy %d %d %f %f\n", score_dat.block_ind1,
+          // score_dat.block_ind2, cta_total_lj, cta_total_lk);
+          accumulate<D, Real>::add(output[score_dat.pose_ind], cta_total_elec);
+        }
+      });
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
+    });
+
+    auto load_tile_invariant_intrares_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_type1,
+             int n_atoms1,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_tile_invariant_intrares_data<DeviceDispatch, D, nt>(
+              pose_stack_block_coord_offset,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_type1,
+              n_atoms1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_intrares1_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_intrares2_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares_data_from_shared =
+        ([=](int tile_ind1,
+             int tile_ind2,
+             shared_mem_union &shared,
+             ElecScoringData<Real> &intra_dat) {
+          elec_load_intrares_data_from_shared(
+              tile_ind1, tile_ind2, shared.m, intra_dat);
+        });
+
+    // Evaluate both the LJ and LK scores in separate dispatches
+    // over all atoms in the tile and the subset of heavy atoms in
+    // the tile
+    auto eval_intrares_atom_pair_scores = ([=](ElecScoringData<Real> &intra_dat,
+                                               int start_atom1,
+                                               int start_atom2) {
+      auto eval_scores_for_atom_pairs = ([&](int tid) {
+        intra_dat.total_elec += tmol::score::common::IntraResBlockEvaluation<
+            ElecScoringData,
+            AllAtomPairSelector,
+            D,
+            TILE_SIZE,
+            nt,
+            Real,
+            Int>::
+            eval_intrares_atom_pairs(
+                tid,
+                start_atom1,
+                start_atom2,
+                score_intra_elec_atom_pair,
+                intra_dat);
+      });
+
+      // The work: On GPU threads work independently, on CPU, this will be a
+      // for loop
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(
+          eval_scores_for_atom_pairs);
+    });
+
+    tmol::score::common::tile_evaluate_block_pair<
+        DeviceDispatch,
+        D,
+        ElecScoringData,
+        ElecScoringData,
+        Real,
+        TILE_SIZE>(
+        shared,
+        pose_ind,
+        block_ind1,
+        block_ind2,
+        block_type1,
+        block_type2,
+        n_atoms1,
+        n_atoms2,
+        load_tile_invariant_interres_data,
+        load_interres1_tile_data_to_shared,
+        load_interres2_tile_data_to_shared,
+        load_interres_data_from_shared,
+        eval_interres_atom_pair_scores,
+        store_calculated_energies,
+        load_tile_invariant_intrares_data,
+        load_intrares1_tile_data_to_shared,
+        load_intrares2_tile_data_to_shared,
+        load_intrares_data_from_shared,
+        eval_intrares_atom_pair_scores,
+        store_calculated_energies);
+  });
+
+  auto eval_energies_only = ([=] TMOL_DEVICE_FUNC(int cta) {
+    auto score_inter_elec_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int,
+             int,
+             int atom_tile_ind1,
+             int atom_tile_ind2,
+             ElecScoringData<Real> const &inter_dat) {
+          int separation = interres_count_pair_separation<TILE_SIZE>(
+              inter_dat, atom_tile_ind1, atom_tile_ind2);
+          return elec_atom_energy(
+              atom_tile_ind1, atom_tile_ind2, inter_dat, separation);
+        });
+
+    auto score_intra_elec_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int start_atom1,
+             int start_atom2,
+             int atom_tile_ind1,
+             int atom_tile_ind2,
+             ElecScoringData<Real> const &intra_dat) {
+          int const atom_ind1 = start_atom1 + atom_tile_ind1;
+          int const atom_ind2 = start_atom2 + atom_tile_ind2;
+
+          int const separation =
+
+              block_type_representative_path_distance[intra_dat.r1.block_type]
+                                                     [atom_ind1][atom_ind2];
+          return elec_atom_energy(
+              atom_tile_ind1, atom_tile_ind2, intra_dat, separation);
+        });
+
+    auto load_block_coords_and_params_into_shared =
+        ([=] TMOL_DEVICE_FUNC(
+             int pose_ind,
+             ElecSingleResData<Real> &r_dat,
+             int n_atoms_to_load,
+             int start_atom) {
+          elec_load_block_coords_and_charges_into_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              pose_ind,
+              r_dat,
+              n_atoms_to_load,
+              start_atom);
+        });
+
+    auto load_block_into_shared = ([=] TMOL_DEVICE_FUNC(
+                                       int pose_ind,
+                                       ElecSingleResData<Real> &r_dat,
+                                       int n_atoms_to_load,
+                                       int start_atom,
+                                       bool count_pair_striking_dist,
+                                       unsigned char *__restrict__ conn_ats) {
+      elec_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
+          coords,
+          block_type_partial_charges,
+          block_type_representative_path_distance,
+          pose_ind,
+          r_dat,
+          n_atoms_to_load,
+          start_atom,
+          count_pair_striking_dist,
+          conn_ats);
+    });
+
+    SHARED_MEMORY union shared_mem_union {
+      shared_mem_union() {}
+      ElecBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> m;
+      CTA_REAL_REDUCE_T_VARIABLE;
+
+    } shared;
+
+    Real total_lj = 0;
+    Real total_lk = 0;
+
+    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+    int const block_ind1 = block_ind_pair / max_n_blocks;
+    int const block_ind2 = block_ind_pair % max_n_blocks;
+    if (block_ind1 > block_ind2) {
+      return;
+    }
+
+    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    int const max_important_bond_separation = 4;
+
+    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+
+    if (block_type1 < 0 || block_type2 < 0) {
+      return;
+    }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
+
+    auto load_tile_invariant_interres_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_ind2,
+             int block_type1,
+             int block_type2,
+             int n_atoms1,
+             int n_atoms2,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_tile_invariant_interres_data<DeviceDispatch, D, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_min_bond_separation,
+              block_type_n_interblock_bonds,
+              block_type_atoms_forming_chemical_bonds,
+              pose_stack_inter_block_bondsep,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_ind2,
+              block_type1,
+              block_type2,
+              n_atoms1,
+              n_atoms2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_interres1_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              block_type_representative_path_distance,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             ElecScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          elec_load_interres2_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              block_type_representative_path_distance,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres_data_from_shared =
+        ([=](int, int, shared_mem_union &, ElecScoringData<Real> &) {
+          // elec_load_interres_data_from_shared(shared.m, inter_dat);
+        });
+
+    // Evaluate both the LJ and LK scores in separate dispatches
+    // over all atoms in the tile and the subset of heavy atoms in
+    // the tile
+    auto eval_interres_atom_pair_scores = ([=](ElecScoringData<Real> &inter_dat,
+                                               int start_atom1,
+                                               int start_atom2) {
+      auto eval_scores_for_atom_pairs = ([&](int tid) {
+        inter_dat.total_elec += tmol::score::common::InterResBlockEvaluation<
+            ElecScoringData,
+            AllAtomPairSelector,
+            D,
+            TILE_SIZE,
+            nt,
+            Real,
+            Int>::
+            eval_interres_atom_pair(
+                tid,
+                start_atom1,
+                start_atom2,
+                score_inter_elec_atom_pair,
+                inter_dat);
+      });
+
+      // The work: On GPU threads work independently, on CPU, this will be a
+      // for loop
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(
+          eval_scores_for_atom_pairs);
+    });
+
+    auto store_calculated_energies = ([=](ElecScoringData<Real> &score_dat,
+                                          shared_mem_union &shared) {
+      auto reduce_energies = ([&](int tid) {
+        Real const cta_total_elec =
+            DeviceDispatch<D>::template reduce_in_workgroup<nt>(
+                score_dat.total_elec, shared, mgpu::plus_t<Real>());
+
+        if (tid == 0) {
+          // printf("Storing energy %d %d %f %f\n", score_dat.block_ind1,
+          // score_dat.block_ind2, cta_total_lj, cta_total_lk);
+          accumulate<D, Real>::add(output[score_dat.pose_ind], cta_total_elec);
+        }
+      });
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
+    });
+
+    auto load_tile_invariant_intrares_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_type1,
+             int n_atoms1,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_tile_invariant_intrares_data<DeviceDispatch, D, nt>(
+              pose_stack_block_coord_offset,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_type1,
+              n_atoms1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_intrares1_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             ElecScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          elec_load_intrares2_tile_data_to_shared<DeviceDispatch, D, nt>(
+              coords,
+              block_type_partial_charges,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares_data_from_shared =
+        ([=](int tile_ind1,
+             int tile_ind2,
+             shared_mem_union &shared,
+             ElecScoringData<Real> &intra_dat) {
+          elec_load_intrares_data_from_shared(
+              tile_ind1, tile_ind2, shared.m, intra_dat);
+        });
+
+    // Evaluate both the LJ and LK scores in separate dispatches
+    // over all atoms in the tile and the subset of heavy atoms in
+    // the tile
+    auto eval_intrares_atom_pair_scores = ([=](ElecScoringData<Real> &intra_dat,
+                                               int start_atom1,
+                                               int start_atom2) {
+      auto eval_scores_for_atom_pairs = ([&](int tid) {
+        intra_dat.total_elec += tmol::score::common::IntraResBlockEvaluation<
+            ElecScoringData,
+            AllAtomPairSelector,
+            D,
+            TILE_SIZE,
+            nt,
+            Real,
+            Int>::
+            eval_intrares_atom_pairs(
+                tid,
+                start_atom1,
+                start_atom2,
+                score_intra_elec_atom_pair,
+                intra_dat);
+      });
+
+      // The work: On GPU threads work independently, on CPU, this will be a
+      // for loop
+      DeviceDispatch<D>::template for_each_in_workgroup<nt>(
+          eval_scores_for_atom_pairs);
+    });
+
+    tmol::score::common::tile_evaluate_block_pair<
+        DeviceDispatch,
+        D,
+        ElecScoringData,
+        ElecScoringData,
+        Real,
+        TILE_SIZE>(
+        shared,
+        pose_ind,
+        block_ind1,
+        block_ind2,
+        block_type1,
+        block_type2,
+        n_atoms1,
+        n_atoms2,
+        load_tile_invariant_interres_data,
+        load_interres1_tile_data_to_shared,
+        load_interres2_tile_data_to_shared,
+        load_interres_data_from_shared,
+        eval_interres_atom_pair_scores,
+        store_calculated_energies,
+        load_tile_invariant_intrares_data,
+        load_intrares1_tile_data_to_shared,
+        load_intrares2_tile_data_to_shared,
+        load_intrares_data_from_shared,
+        eval_intrares_atom_pair_scores,
+        store_calculated_energies);
+  });
+
+  ///////////////////////////////////////////////////////////////////////
+
+  // Three steps
+  // 0: setup
+  // 1: launch a kernel to find a small bounding sphere surrounding the blocks
+  // 2: launch a kernel to look for spheres that are within striking distance of
+  // each other
+  // 3: launch a kernel to evaluate lj/lk between pairs of blocks
+  // within striking distance
+
+  // 0
+  // TO DO: let DeviceDispatch hold a cuda stream (??)
+  // at::cuda::CUDAStream wrapped_stream = at::cuda::getDefaultCUDAStream();
+  // mgpu::standard_context_t context(wrapped_stream.stream());
+  int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
+
+  score::common::sphere_overlap::
+      compute_block_spheres<DeviceDispatch, D, Real, Int>::f(
+          coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          block_type_n_atoms,
+          scratch_block_spheres);
+
+  score::common::sphere_overlap::
+      detect_block_neighbors<DeviceDispatch, D, Real, Int>::f(
+          coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          block_type_n_atoms,
+          scratch_block_spheres,
+          scratch_block_neighbors,
+          Real(6.0));  // 6A hard coded here. Please fix! TEMP!
+
+  // 3
+  if (compute_derivs) {
+    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+        n_block_pairs, eval_energies_and_derivs);
+  } else {
+    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+        n_block_pairs, eval_energies_only);
+  }
+
+  return {output_t, dV_dcoords_t};
+}  // namespace potentials
+
+}  // namespace potentials
+}  // namespace elec
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -158,9 +158,6 @@ def elec(
     Real eps_elec = eps(low_poly_end, D, D0, S);
     Real deps_elec_d_dist = deps_ddist(low_poly_end, D, D0, S);
     Real dmax_elec = eiej * (C1 / (low_poly_end * eps_elec) - C2);
-    // Real dmax_elec_d_dist =
-    //     -C1 * eiej * (eps_elec + low_poly_end * deps_elec_d_dist)
-    //     / (low_poly_end * low_poly_end * eps_elec * eps_elec);
 
     elecE = interpolate<Real>(
         dist,
@@ -177,8 +174,6 @@ def elec(
     Real deps_elec_d_dist = deps_ddist(dist, D, D0, S);
 
     elecE = eiej * (C1 / (dist * eps_elec) - C2);
-    // delec_ddist = -C1 * eiej * (eps_elec + dist * deps_elec_d_dist)
-    //               / (dist * dist * eps_elec * eps_elec);
 
   } else if (dist < hi_poly_end) {
     // long range fade

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -124,6 +124,78 @@ def elec_delec_ddist(
   return {weight * elecE, weight * delec_ddist};
 }
 
+def elec(
+    Real dist,
+    Real e_i,
+    Real e_j,
+    Real bonded_path_length,
+    float D,
+    float D0,
+    float S,
+    float min_dis,
+    float max_dis)
+    ->Real {
+  Real low_poly_start = min_dis - 0.25;
+  Real low_poly_end = min_dis + 0.25;
+  Real hi_poly_start = max_dis - 1.0;
+  Real hi_poly_end = max_dis;
+
+  Real weight = connectivity_weight<Real>(bonded_path_length);
+
+  Real C1 = 322.0637;  // electrostatic energy constant
+  Real C2 = C1 / (max_dis * eps(max_dis, D, D0, S));
+
+  Real eiej = e_i * e_j;
+
+  Real elecE = 0;
+  if (dist < low_poly_start) {
+    // flat part
+    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
+    elecE = eiej * min_dis_score;
+  } else if (dist < low_poly_end) {
+    // short range fade
+    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
+    Real eps_elec = eps(low_poly_end, D, D0, S);
+    Real deps_elec_d_dist = deps_ddist(low_poly_end, D, D0, S);
+    Real dmax_elec = eiej * (C1 / (low_poly_end * eps_elec) - C2);
+    // Real dmax_elec_d_dist =
+    //     -C1 * eiej * (eps_elec + low_poly_end * deps_elec_d_dist)
+    //     / (low_poly_end * low_poly_end * eps_elec * eps_elec);
+
+    elecE = interpolate<Real>(
+        dist,
+        low_poly_start,
+        eiej * min_dis_score,
+        0.0,
+        low_poly_end,
+        dmax_elec,
+        deps_elec_d_dist);
+
+  } else if (dist < hi_poly_start) {
+    // Coulombic part
+    Real eps_elec = eps(dist, D, D0, S);
+    Real deps_elec_d_dist = deps_ddist(dist, D, D0, S);
+
+    elecE = eiej * (C1 / (dist * eps_elec) - C2);
+    // delec_ddist = -C1 * eiej * (eps_elec + dist * deps_elec_d_dist)
+    //               / (dist * dist * eps_elec * eps_elec);
+
+  } else if (dist < hi_poly_end) {
+    // long range fade
+    Real eps_elec = eps(hi_poly_start, D, D0, S);
+    Real deps_elec_d_dist = deps_ddist(hi_poly_start, D, D0, S);
+    Real dmin_elec = eiej * (C1 / (hi_poly_start * eps_elec) - C2);
+    Real dmin_elec_d_dist =
+        -C1 * eiej * (eps_elec + hi_poly_start * deps_elec_d_dist)
+        / (hi_poly_start * hi_poly_start * eps_elec * eps_elec);
+
+    elecE = interpolate_to_zero(
+        dist, hi_poly_start, dmin_elec, dmin_elec_d_dist, hi_poly_end);
+  }
+
+  return weight * elecE;
+}
+
 #undef Real3
 #undef def
 }  // namespace potentials

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -221,7 +221,7 @@ class LJLKPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "pose_score_op", ([&] {
+        coords.type(), "ljlk_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/score_function.py
+++ b/tmol/score/score_function.py
@@ -183,5 +183,5 @@ class WholePoseScoringModule:
         self.term_modules = term_modules
 
     def __call__(self, coords):
-        all_scores = torch.cat([term(coords) for term in self.term_modules])
+        all_scores = torch.cat([term(coords) for term in self.term_modules], dim=0)
         return torch.sum(self.weights * all_scores)

--- a/tmol/score/score_types.py
+++ b/tmol/score/score_types.py
@@ -12,5 +12,6 @@ class AutoNumber(Enum):
 class ScoreType(AutoNumber):
     fa_lj = ()
     fa_lk = ()
+    fa_elec = ()
     # keep this one last
     n_score_types = ()

--- a/tmol/score/terms/elec_creator.py
+++ b/tmol/score/terms/elec_creator.py
@@ -1,0 +1,19 @@
+from tmol.score.terms.term_creator import TermCreator, score_term_creator
+from tmol.score.score_types import ScoreType
+from tmol.database import ParameterDatabase
+import torch
+
+
+@score_term_creator
+class ElecTermCreator(TermCreator):
+    _score_types = [ScoreType.fa_elec]
+
+    @classmethod
+    def create_term(cls, param_db: ParameterDatabase, device: torch.device):
+        import tmol.score.elec.elec_energy_term
+
+        return tmol.score.elec.elec_energy_term.ElecEnergyTerm(param_db, device)
+
+    @classmethod
+    def score_types(cls):
+        return cls._score_types

--- a/tmol/tests/score/elec/test_elec_energy_term.py
+++ b/tmol/tests/score/elec/test_elec_energy_term.py
@@ -15,7 +15,6 @@ def test_smoke(default_database, torch_device):
 
     assert elec_energy.device == torch_device
     assert elec_energy.param_resolver.device == torch_device
-    # assert elec_energy.global_params.device == torch_device
 
 
 def test_annotate_restypes(ubq_res, default_database, torch_device):
@@ -40,306 +39,6 @@ def test_annotate_restypes(ubq_res, default_database, torch_device):
     assert pbt.elec_intra_repr_path_distance.device == torch_device
 
 
-# def test_create_neighbor_list(ubq_res, default_database, torch_device):
-#     #
-#     # torch_device = torch.device("cpu")
-#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
-#
-#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
-#         ubq_res[:4], torch_device
-#     )
-#     p2 = PoseStackBuilder.one_structure_from_polymeric_residues(
-#         ubq_res[:6], torch_device
-#     )
-#     poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
-#
-#     # for i, rt in enumerate(poses.packed_block_types.active_block_types):
-#     #     for j, atom in enumerate(rt.atoms):
-#     #         print(rt.name, j, atom.name)
-#     # return
-#
-#     # nab the ca coords for these residues
-#     bounding_spheres = numpy.full((2, 6, 4), numpy.nan, dtype=numpy.float32)
-#     for i in range(2):
-#         for j in range(4 if i == 0 else 6):
-#             bounding_spheres[i, j, :3] = ubq_res[j].coords[2, :]
-#     bounding_spheres[:, :, 3] = 3.0
-#     bounding_spheres = torch.tensor(
-#         bounding_spheres, dtype=torch.float32, device=torch_device
-#     )
-#
-#     neighbor_list = elec_energy.create_block_neighbor_lists(poses, bounding_spheres)
-#
-#     # check that the listed neighbors are in striking distance
-#     for i in range(neighbor_list.shape[0]):
-#         for j in range(neighbor_list.shape[1]):
-#             j_coord = bounding_spheres[i, j, 0:3]
-#             for k in range(neighbor_list.shape[2]):
-#                 ijk_neighbor = neighbor_list[i, j, k]
-#                 if ijk_neighbor == -1:
-#                     continue
-#                 k_coord = bounding_spheres[i, ijk_neighbor, 0:3]
-#                 dist = torch.norm(j_coord - k_coord)
-#                 assert dist < 6 + elec_energy.global_params.max_dis
-#
-#     # check that any pair of residues in striking distance is
-#     # listed as a neighbor
-#     for i in range(2):
-#         n_res = 4 if i == 0 else 6
-#         for j in range(n_res):
-#             j_count = 0
-#             j_coord = bounding_spheres[i, j, 0:3]
-#             for k in range(n_res):
-#                 k_coord = bounding_spheres[i, k, 0:3]
-#                 dis = torch.norm(j_coord - k_coord)
-#                 if dis < 6 + elec_energy.global_params.max_dis:
-#                     assert neighbor_list[i, j, j_count] == k
-#                     j_count += 1
-#             for k in range(j_count, 6):
-#                 assert neighbor_list[i, j, k] == -1
-#
-#
-# def test_render_inter_module(ubq_res, default_database, torch_device):
-#     #
-#     # torch_device = torch.device("cpu")
-#
-#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
-#
-#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
-#         ubq_res[:4], torch_device
-#     )
-#     p2 = PoseStackBuilder.one_structure_from_polymeric_residues(
-#         ubq_res[:6], torch_device
-#     )
-#     poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
-#
-#     # nab the ca coords for these residues
-#     bounding_spheres = numpy.full((2, 6, 4), numpy.nan, dtype=numpy.float32)
-#     for i in range(2):
-#         for j in range(4 if i == 0 else 6):
-#             bounding_spheres[i, j, :3] = ubq_res[j].coords[2, :]
-#     bounding_spheres[:, :, 3] = 3.0
-#     bounding_spheres = torch.tensor(
-#         bounding_spheres, dtype=torch.float32, device=torch_device
-#     )
-#
-#     # five trajectories for each system
-#     context_system_ids = torch.floor_divide(
-#         torch.arange(10, dtype=torch.int32, device=torch_device), 5
-#     )
-#
-#     weights = {"lj": 1.0, "lk": 1.0}
-#     for bt in poses.packed_block_types.active_block_types:
-#         elec_energy.setup_block_type(bt)
-#     elec_energy.setup_packed_block_types(poses.packed_block_types)
-#     elec_energy.setup_poses(poses)
-#     inter_module = elec_energy.render_inter_module(
-#         poses.packed_block_types, poses, context_system_ids, bounding_spheres, weights
-#     )
-#
-#     max_n_atoms_per_block = poses.packed_block_types.max_n_atoms
-#     # ok, let's create the contexts
-#     context_coords = torch.zeros(
-#         (10, 6, max_n_atoms_per_block, 3), dtype=torch.float32, device=torch_device
-#     )
-#     # this should be fine
-#     poses_expanded_coords, real_expanded_pose_ats = poses.expand_coords()
-#     context_coords[:5, :, :, :] = poses_expanded_coords[0:1]
-#     context_coords[5:, :, :, :] = poses_expanded_coords[1:2]
-#     context_coords = context_coords.view(10, -1, 3)
-#     context_coord_offsets = max_n_atoms_per_block * torch.remainder(
-#         torch.arange(60, dtype=torch.int32, device=torch_device).view(10, 6), 6
-#     )
-#
-#     context_block_type = torch.zeros((10, 6), dtype=torch.int32, device=torch_device)
-#     context_block_type[:5, :] = torch.tensor(
-#         poses.block_type_ind[0:1, :], device=torch_device
-#     )
-#     context_block_type[5:, :] = torch.tensor(
-#         poses.block_type_ind[1:2, :], device=torch_device
-#     )
-#
-#     alternate_coords = torch.zeros(
-#         (20, max_n_atoms_per_block, 3), dtype=torch.float32, device=torch_device
-#     )
-#     alternate_coords[:10, :, :] = poses_expanded_coords[0:1, 1:2, :]
-#     alternate_coords[10:, :, :] = poses_expanded_coords[1:2, 3:4, :]
-#     alternate_coords = alternate_coords.view(-1, 3)
-#     alternate_coord_offsets = max_n_atoms_per_block * torch.arange(
-#         20, dtype=torch.int32, device=torch_device
-#     )
-#
-#     alternate_ids = torch.zeros((20, 3), dtype=torch.int32, device=torch_device)
-#     alternate_ids[:, 0] = torch.floor_divide(torch.arange(20, dtype=torch.int32), 2)
-#     alternate_ids[:10, 1] = 1
-#     alternate_ids[10:, 1] = 3
-#     alternate_ids[:10, 2] = torch.tensor(
-#         poses.block_type_ind[0, 1], device=torch_device
-#     )
-#     alternate_ids[10:, 2] = torch.tensor(
-#         poses.block_type_ind[1, 3], device=torch_device
-#     )
-#
-#     # TEMP! Just score one residue
-#     # alternate_coords = alternate_coords[15:16]
-#     # alternate_ids = alternate_ids[15:16]
-#
-#     def run_once():
-#         rpes = inter_module.go(
-#             context_coords,
-#             context_coord_offsets,
-#             context_block_type,
-#             alternate_coords,
-#             alternate_coord_offsets,
-#             alternate_ids,
-#         )
-#         assert rpes is not None
-#         # print()
-#         # print(rpes)
-#
-#     run_once()
-#     run_once()
-#
-#     # rpes2 = inter_module.go(
-#     #     context_coords, context_block_type, alternate_coords, alternate_ids
-#     # )
-#     # assert rpes2 is not None
-#     # print(rpes2)
-#
-#
-# @pytest.mark.benchmark(group="time_rpe")
-# @pytest.mark.parametrize("n_alts", [2])
-# @pytest.mark.parametrize("n_traj", [1])
-# @pytest.mark.parametrize("n_poses", [10, 30, 100])
-# def test_inter_module_timing(
-#     benchmark, ubq_res, default_database, n_alts, n_traj, n_poses, torch_device
-# ):
-#     # n_traj = 100
-#     # n_poses = 100
-#     # n_alts = 10
-#
-#     # this is slow on CPU?
-#     # torch_device = torch.device("cuda")
-#
-#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
-#
-#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(ubq_res, torch_device)
-#     nres = p1.max_n_blocks
-#     poses = PoseStackBuilder.from_poses([p1] * n_poses, torch_device)
-#
-#     one_bounding_sphere_set = numpy.full((1, nres, 4), numpy.nan, dtype=numpy.float32)
-#     for i in range(nres):
-#         atnames = set([at.name for at in ubq_res[i].residue_type.atoms])
-#         cb = ubq_res[i].coords[5, :] if "CB" in atnames else ubq_res[i].coords[2, :]
-#         max_cb_dist = torch.max(
-#             torch.norm(
-#                 torch.tensor(
-#                     ubq_res[i].coords[2:3, :] - ubq_res[i].coords[:, :],
-#                     dtype=torch.float32,
-#                     device=torch_device,
-#                 ),
-#                 dim=1,
-#             )
-#         )
-#         one_bounding_sphere_set[0, i, :3] = cb
-#         one_bounding_sphere_set[0, i, 3] = max_cb_dist.item()
-#     # print("one bounding sphere set")
-#     # print(one_bounding_sphere_set)
-#
-#     # nab the ca coords for these residues
-#     bounding_spheres = numpy.repeat(one_bounding_sphere_set, n_poses, axis=0)
-#     bounding_spheres = torch.tensor(
-#         bounding_spheres, dtype=torch.float32, device=torch_device
-#     )
-#
-#     # n_traj trajectories for each system
-#     context_system_ids = torch.floor_divide(
-#         torch.arange(n_traj * n_poses, dtype=torch.int32, device=torch_device), n_traj
-#     )
-#
-#     weights = {"lj": 1.0, "lk": 1.0}
-#     for bt in poses.packed_block_types.active_block_types:
-#         elec_energy.setup_block_type(bt)
-#     elec_energy.setup_packed_block_types(poses.packed_block_types)
-#     elec_energy.setup_poses(poses)
-#     inter_module = elec_energy.render_inter_module(
-#         poses.packed_block_types, poses, context_system_ids, bounding_spheres, weights
-#     )
-#
-#     max_n_atoms_per_block = poses.packed_block_types.max_n_atoms
-#     # ok, let's create the contexts
-#     context_coords = torch.zeros(
-#         (n_traj * n_poses, nres, max_n_atoms_per_block, 3),
-#         dtype=torch.float32,
-#         device=torch_device,
-#     )
-#     poses_expanded_coords, real_expanded_pose_ats = poses.expand_coords()
-#     context_coords[:, :, :, :] = poses_expanded_coords[0:1, :, :, :]
-#     context_coords = context_coords.view(n_poses, -1, 3)
-#     context_coord_offsets = max_n_atoms_per_block * torch.remainder(
-#         torch.arange(nres * n_poses, dtype=torch.int32, device=torch_device).view(
-#             n_poses, nres
-#         ),
-#         nres,
-#     )
-#
-#     context_block_type = torch.zeros(
-#         (n_traj * n_poses, nres), dtype=torch.int32, device=torch_device
-#     )
-#     context_block_type[:, :] = torch.tensor(
-#         poses.block_type_ind[0:1, :], device=torch_device
-#     )
-#
-#     alternate_coords = torch.zeros(
-#         (n_alts * n_traj * n_poses, max_n_atoms_per_block, 3),
-#         dtype=torch.float32,
-#         device=torch_device,
-#     )
-#     which_block = torch.remainder(
-#         torch.floor_divide(
-#             torch.arange(
-#                 n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device
-#             ),
-#             n_alts,
-#         ),
-#         nres,
-#     )
-#     alternate_coords[:, :, :] = poses_expanded_coords[
-#         0:1, which_block.type(torch.int64), :, :
-#     ]
-#     alternate_coords = alternate_coords.view(-1, 3)
-#     alternate_coord_offsets = max_n_atoms_per_block * torch.arange(
-#         n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device
-#     )
-#
-#     alternate_ids = torch.zeros(
-#         (n_alts * n_traj * n_poses, 3), dtype=torch.int32, device=torch_device
-#     )
-#     alternate_ids[:, 0] = torch.floor_divide(
-#         torch.arange(n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device),
-#         n_alts,
-#     )
-#     alternate_ids[:, 1] = which_block
-#     alternate_ids[:, 2] = torch.tensor(
-#         poses.block_type_ind[0, which_block.cpu().numpy()], device=torch_device
-#     )
-#
-#     @benchmark
-#     def run():
-#         rpes = inter_module.go(
-#             context_coords,
-#             context_coord_offsets,
-#             context_block_type,
-#             alternate_coords,
-#             alternate_coord_offsets,
-#             alternate_ids,
-#         )
-#         return rpes
-#
-#     vals = run
-#     assert vals is not None
-
-
 def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_device):
     gold_vals = numpy.array([-0.164974], dtype=numpy.float32)
     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
@@ -352,19 +51,12 @@ def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_de
     elec_energy.setup_poses(p1)
 
     elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(p1)
-    # for ch in elec_pose_scorer.children():
-    #     print("child")
-    #     print(ch)
 
     coords = torch.nn.Parameter(p1.coords.clone())
     scores = elec_pose_scorer(coords)
 
     # make sure we're still good
     torch.arange(100, device=torch_device)
-
-    numpy.set_printoptions(precision=10)
-    # print(scores.cpu().detach().numpy())
-
     numpy.testing.assert_allclose(
         gold_vals, scores.cpu().detach().numpy(), atol=1e-5, rtol=1e-5
     )
@@ -373,8 +65,6 @@ def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_de
 def test_whole_pose_scoring_module_gradcheck(
     rts_ubq_res, default_database, torch_device
 ):
-    # gold_vals = numpy.array([[-7.691674], [3.6182203]], dtype=numpy.float32)
-
     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
         res=rts_ubq_res[0:4], device=torch_device
@@ -385,11 +75,6 @@ def test_whole_pose_scoring_module_gradcheck(
     elec_energy.setup_poses(p1)
 
     elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(p1)
-    # for ch in elec_pose_scorer.children():
-    #     print("child")
-    #     print(ch)
-
-    # coords = torch.nn.Parameter(p1.coords.clone())
 
     def score(coords):
         scores = elec_pose_scorer(coords)
@@ -413,20 +98,12 @@ def test_whole_pose_scoring_module_10(rts_ubq_res, default_database, torch_devic
     elec_energy.setup_poses(pn)
 
     elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(pn)
-    # for ch in elec_pose_scorer.children():
-    #     print("child")
-    #     print(ch)
 
     coords = torch.nn.Parameter(pn.coords.clone())
     scores = elec_pose_scorer(coords)
 
     # make sure we're still good
     torch.arange(100, device=torch_device)
-
-    numpy.set_printoptions(precision=10)
-    # print(scores.cpu().detach().numpy())
-
-    # print("scores!", scores.cpu().detach().numpy())
 
     numpy.testing.assert_allclose(
         gold_vals, scores.cpu().detach().numpy(), atol=1e-5, rtol=1e-5

--- a/tmol/tests/score/elec/test_elec_energy_term.py
+++ b/tmol/tests/score/elec/test_elec_energy_term.py
@@ -1,6 +1,5 @@
 import numpy
 import torch
-import pytest
 
 from tmol.score.elec.elec_energy_term import ElecEnergyTerm
 from tmol.pose.packed_block_types import residue_types_from_residues, PackedBlockTypes

--- a/tmol/tests/score/elec/test_elec_energy_term.py
+++ b/tmol/tests/score/elec/test_elec_energy_term.py
@@ -1,0 +1,433 @@
+import numpy
+import torch
+import pytest
+
+from tmol.score.elec.elec_energy_term import ElecEnergyTerm
+from tmol.pose.packed_block_types import residue_types_from_residues, PackedBlockTypes
+from tmol.pose.pose_stack_builder import PoseStackBuilder
+
+from tmol.tests.autograd import gradcheck
+
+
+def test_smoke(default_database, torch_device):
+
+    elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+
+    assert elec_energy.device == torch_device
+    assert elec_energy.param_resolver.device == torch_device
+    # assert elec_energy.global_params.device == torch_device
+
+
+def test_annotate_restypes(ubq_res, default_database, torch_device):
+
+    elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+
+    rt_list = residue_types_from_residues(ubq_res)
+    pbt = PackedBlockTypes.from_restype_list(rt_list, torch_device)
+
+    for rt in rt_list:
+        elec_energy.setup_block_type(rt)
+        assert hasattr(rt, "elec_partial_charge")
+        assert hasattr(rt, "elec_inter_repr_path_distance")
+        assert hasattr(rt, "elec_intra_repr_path_distance")
+    elec_energy.setup_packed_block_types(pbt)
+    assert hasattr(pbt, "elec_partial_charge")
+    assert hasattr(pbt, "elec_inter_repr_path_distance")
+    assert hasattr(pbt, "elec_intra_repr_path_distance")
+
+    assert pbt.elec_partial_charge.device == torch_device
+    assert pbt.elec_inter_repr_path_distance.device == torch_device
+    assert pbt.elec_intra_repr_path_distance.device == torch_device
+
+
+# def test_create_neighbor_list(ubq_res, default_database, torch_device):
+#     #
+#     # torch_device = torch.device("cpu")
+#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+#
+#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+#         ubq_res[:4], torch_device
+#     )
+#     p2 = PoseStackBuilder.one_structure_from_polymeric_residues(
+#         ubq_res[:6], torch_device
+#     )
+#     poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
+#
+#     # for i, rt in enumerate(poses.packed_block_types.active_block_types):
+#     #     for j, atom in enumerate(rt.atoms):
+#     #         print(rt.name, j, atom.name)
+#     # return
+#
+#     # nab the ca coords for these residues
+#     bounding_spheres = numpy.full((2, 6, 4), numpy.nan, dtype=numpy.float32)
+#     for i in range(2):
+#         for j in range(4 if i == 0 else 6):
+#             bounding_spheres[i, j, :3] = ubq_res[j].coords[2, :]
+#     bounding_spheres[:, :, 3] = 3.0
+#     bounding_spheres = torch.tensor(
+#         bounding_spheres, dtype=torch.float32, device=torch_device
+#     )
+#
+#     neighbor_list = elec_energy.create_block_neighbor_lists(poses, bounding_spheres)
+#
+#     # check that the listed neighbors are in striking distance
+#     for i in range(neighbor_list.shape[0]):
+#         for j in range(neighbor_list.shape[1]):
+#             j_coord = bounding_spheres[i, j, 0:3]
+#             for k in range(neighbor_list.shape[2]):
+#                 ijk_neighbor = neighbor_list[i, j, k]
+#                 if ijk_neighbor == -1:
+#                     continue
+#                 k_coord = bounding_spheres[i, ijk_neighbor, 0:3]
+#                 dist = torch.norm(j_coord - k_coord)
+#                 assert dist < 6 + elec_energy.global_params.max_dis
+#
+#     # check that any pair of residues in striking distance is
+#     # listed as a neighbor
+#     for i in range(2):
+#         n_res = 4 if i == 0 else 6
+#         for j in range(n_res):
+#             j_count = 0
+#             j_coord = bounding_spheres[i, j, 0:3]
+#             for k in range(n_res):
+#                 k_coord = bounding_spheres[i, k, 0:3]
+#                 dis = torch.norm(j_coord - k_coord)
+#                 if dis < 6 + elec_energy.global_params.max_dis:
+#                     assert neighbor_list[i, j, j_count] == k
+#                     j_count += 1
+#             for k in range(j_count, 6):
+#                 assert neighbor_list[i, j, k] == -1
+#
+#
+# def test_render_inter_module(ubq_res, default_database, torch_device):
+#     #
+#     # torch_device = torch.device("cpu")
+#
+#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+#
+#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+#         ubq_res[:4], torch_device
+#     )
+#     p2 = PoseStackBuilder.one_structure_from_polymeric_residues(
+#         ubq_res[:6], torch_device
+#     )
+#     poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
+#
+#     # nab the ca coords for these residues
+#     bounding_spheres = numpy.full((2, 6, 4), numpy.nan, dtype=numpy.float32)
+#     for i in range(2):
+#         for j in range(4 if i == 0 else 6):
+#             bounding_spheres[i, j, :3] = ubq_res[j].coords[2, :]
+#     bounding_spheres[:, :, 3] = 3.0
+#     bounding_spheres = torch.tensor(
+#         bounding_spheres, dtype=torch.float32, device=torch_device
+#     )
+#
+#     # five trajectories for each system
+#     context_system_ids = torch.floor_divide(
+#         torch.arange(10, dtype=torch.int32, device=torch_device), 5
+#     )
+#
+#     weights = {"lj": 1.0, "lk": 1.0}
+#     for bt in poses.packed_block_types.active_block_types:
+#         elec_energy.setup_block_type(bt)
+#     elec_energy.setup_packed_block_types(poses.packed_block_types)
+#     elec_energy.setup_poses(poses)
+#     inter_module = elec_energy.render_inter_module(
+#         poses.packed_block_types, poses, context_system_ids, bounding_spheres, weights
+#     )
+#
+#     max_n_atoms_per_block = poses.packed_block_types.max_n_atoms
+#     # ok, let's create the contexts
+#     context_coords = torch.zeros(
+#         (10, 6, max_n_atoms_per_block, 3), dtype=torch.float32, device=torch_device
+#     )
+#     # this should be fine
+#     poses_expanded_coords, real_expanded_pose_ats = poses.expand_coords()
+#     context_coords[:5, :, :, :] = poses_expanded_coords[0:1]
+#     context_coords[5:, :, :, :] = poses_expanded_coords[1:2]
+#     context_coords = context_coords.view(10, -1, 3)
+#     context_coord_offsets = max_n_atoms_per_block * torch.remainder(
+#         torch.arange(60, dtype=torch.int32, device=torch_device).view(10, 6), 6
+#     )
+#
+#     context_block_type = torch.zeros((10, 6), dtype=torch.int32, device=torch_device)
+#     context_block_type[:5, :] = torch.tensor(
+#         poses.block_type_ind[0:1, :], device=torch_device
+#     )
+#     context_block_type[5:, :] = torch.tensor(
+#         poses.block_type_ind[1:2, :], device=torch_device
+#     )
+#
+#     alternate_coords = torch.zeros(
+#         (20, max_n_atoms_per_block, 3), dtype=torch.float32, device=torch_device
+#     )
+#     alternate_coords[:10, :, :] = poses_expanded_coords[0:1, 1:2, :]
+#     alternate_coords[10:, :, :] = poses_expanded_coords[1:2, 3:4, :]
+#     alternate_coords = alternate_coords.view(-1, 3)
+#     alternate_coord_offsets = max_n_atoms_per_block * torch.arange(
+#         20, dtype=torch.int32, device=torch_device
+#     )
+#
+#     alternate_ids = torch.zeros((20, 3), dtype=torch.int32, device=torch_device)
+#     alternate_ids[:, 0] = torch.floor_divide(torch.arange(20, dtype=torch.int32), 2)
+#     alternate_ids[:10, 1] = 1
+#     alternate_ids[10:, 1] = 3
+#     alternate_ids[:10, 2] = torch.tensor(
+#         poses.block_type_ind[0, 1], device=torch_device
+#     )
+#     alternate_ids[10:, 2] = torch.tensor(
+#         poses.block_type_ind[1, 3], device=torch_device
+#     )
+#
+#     # TEMP! Just score one residue
+#     # alternate_coords = alternate_coords[15:16]
+#     # alternate_ids = alternate_ids[15:16]
+#
+#     def run_once():
+#         rpes = inter_module.go(
+#             context_coords,
+#             context_coord_offsets,
+#             context_block_type,
+#             alternate_coords,
+#             alternate_coord_offsets,
+#             alternate_ids,
+#         )
+#         assert rpes is not None
+#         # print()
+#         # print(rpes)
+#
+#     run_once()
+#     run_once()
+#
+#     # rpes2 = inter_module.go(
+#     #     context_coords, context_block_type, alternate_coords, alternate_ids
+#     # )
+#     # assert rpes2 is not None
+#     # print(rpes2)
+#
+#
+# @pytest.mark.benchmark(group="time_rpe")
+# @pytest.mark.parametrize("n_alts", [2])
+# @pytest.mark.parametrize("n_traj", [1])
+# @pytest.mark.parametrize("n_poses", [10, 30, 100])
+# def test_inter_module_timing(
+#     benchmark, ubq_res, default_database, n_alts, n_traj, n_poses, torch_device
+# ):
+#     # n_traj = 100
+#     # n_poses = 100
+#     # n_alts = 10
+#
+#     # this is slow on CPU?
+#     # torch_device = torch.device("cuda")
+#
+#     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+#
+#     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(ubq_res, torch_device)
+#     nres = p1.max_n_blocks
+#     poses = PoseStackBuilder.from_poses([p1] * n_poses, torch_device)
+#
+#     one_bounding_sphere_set = numpy.full((1, nres, 4), numpy.nan, dtype=numpy.float32)
+#     for i in range(nres):
+#         atnames = set([at.name for at in ubq_res[i].residue_type.atoms])
+#         cb = ubq_res[i].coords[5, :] if "CB" in atnames else ubq_res[i].coords[2, :]
+#         max_cb_dist = torch.max(
+#             torch.norm(
+#                 torch.tensor(
+#                     ubq_res[i].coords[2:3, :] - ubq_res[i].coords[:, :],
+#                     dtype=torch.float32,
+#                     device=torch_device,
+#                 ),
+#                 dim=1,
+#             )
+#         )
+#         one_bounding_sphere_set[0, i, :3] = cb
+#         one_bounding_sphere_set[0, i, 3] = max_cb_dist.item()
+#     # print("one bounding sphere set")
+#     # print(one_bounding_sphere_set)
+#
+#     # nab the ca coords for these residues
+#     bounding_spheres = numpy.repeat(one_bounding_sphere_set, n_poses, axis=0)
+#     bounding_spheres = torch.tensor(
+#         bounding_spheres, dtype=torch.float32, device=torch_device
+#     )
+#
+#     # n_traj trajectories for each system
+#     context_system_ids = torch.floor_divide(
+#         torch.arange(n_traj * n_poses, dtype=torch.int32, device=torch_device), n_traj
+#     )
+#
+#     weights = {"lj": 1.0, "lk": 1.0}
+#     for bt in poses.packed_block_types.active_block_types:
+#         elec_energy.setup_block_type(bt)
+#     elec_energy.setup_packed_block_types(poses.packed_block_types)
+#     elec_energy.setup_poses(poses)
+#     inter_module = elec_energy.render_inter_module(
+#         poses.packed_block_types, poses, context_system_ids, bounding_spheres, weights
+#     )
+#
+#     max_n_atoms_per_block = poses.packed_block_types.max_n_atoms
+#     # ok, let's create the contexts
+#     context_coords = torch.zeros(
+#         (n_traj * n_poses, nres, max_n_atoms_per_block, 3),
+#         dtype=torch.float32,
+#         device=torch_device,
+#     )
+#     poses_expanded_coords, real_expanded_pose_ats = poses.expand_coords()
+#     context_coords[:, :, :, :] = poses_expanded_coords[0:1, :, :, :]
+#     context_coords = context_coords.view(n_poses, -1, 3)
+#     context_coord_offsets = max_n_atoms_per_block * torch.remainder(
+#         torch.arange(nres * n_poses, dtype=torch.int32, device=torch_device).view(
+#             n_poses, nres
+#         ),
+#         nres,
+#     )
+#
+#     context_block_type = torch.zeros(
+#         (n_traj * n_poses, nres), dtype=torch.int32, device=torch_device
+#     )
+#     context_block_type[:, :] = torch.tensor(
+#         poses.block_type_ind[0:1, :], device=torch_device
+#     )
+#
+#     alternate_coords = torch.zeros(
+#         (n_alts * n_traj * n_poses, max_n_atoms_per_block, 3),
+#         dtype=torch.float32,
+#         device=torch_device,
+#     )
+#     which_block = torch.remainder(
+#         torch.floor_divide(
+#             torch.arange(
+#                 n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device
+#             ),
+#             n_alts,
+#         ),
+#         nres,
+#     )
+#     alternate_coords[:, :, :] = poses_expanded_coords[
+#         0:1, which_block.type(torch.int64), :, :
+#     ]
+#     alternate_coords = alternate_coords.view(-1, 3)
+#     alternate_coord_offsets = max_n_atoms_per_block * torch.arange(
+#         n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device
+#     )
+#
+#     alternate_ids = torch.zeros(
+#         (n_alts * n_traj * n_poses, 3), dtype=torch.int32, device=torch_device
+#     )
+#     alternate_ids[:, 0] = torch.floor_divide(
+#         torch.arange(n_alts * n_traj * n_poses, dtype=torch.int32, device=torch_device),
+#         n_alts,
+#     )
+#     alternate_ids[:, 1] = which_block
+#     alternate_ids[:, 2] = torch.tensor(
+#         poses.block_type_ind[0, which_block.cpu().numpy()], device=torch_device
+#     )
+#
+#     @benchmark
+#     def run():
+#         rpes = inter_module.go(
+#             context_coords,
+#             context_coord_offsets,
+#             context_block_type,
+#             alternate_coords,
+#             alternate_coord_offsets,
+#             alternate_ids,
+#         )
+#         return rpes
+#
+#     vals = run
+#     assert vals is not None
+
+
+def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_device):
+    gold_vals = numpy.array([-0.164974], dtype=numpy.float32)
+    elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[0:4], device=torch_device
+    )
+    for bt in p1.packed_block_types.active_block_types:
+        elec_energy.setup_block_type(bt)
+    elec_energy.setup_packed_block_types(p1.packed_block_types)
+    elec_energy.setup_poses(p1)
+
+    elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(p1)
+    # for ch in elec_pose_scorer.children():
+    #     print("child")
+    #     print(ch)
+
+    coords = torch.nn.Parameter(p1.coords.clone())
+    scores = elec_pose_scorer(coords)
+
+    # make sure we're still good
+    torch.arange(100, device=torch_device)
+
+    numpy.set_printoptions(precision=10)
+    # print(scores.cpu().detach().numpy())
+
+    numpy.testing.assert_allclose(
+        gold_vals, scores.cpu().detach().numpy(), atol=1e-5, rtol=1e-5
+    )
+
+
+def test_whole_pose_scoring_module_gradcheck(
+    rts_ubq_res, default_database, torch_device
+):
+    # gold_vals = numpy.array([[-7.691674], [3.6182203]], dtype=numpy.float32)
+
+    elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[0:4], device=torch_device
+    )
+    for bt in p1.packed_block_types.active_block_types:
+        elec_energy.setup_block_type(bt)
+    elec_energy.setup_packed_block_types(p1.packed_block_types)
+    elec_energy.setup_poses(p1)
+
+    elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(p1)
+    # for ch in elec_pose_scorer.children():
+    #     print("child")
+    #     print(ch)
+
+    # coords = torch.nn.Parameter(p1.coords.clone())
+
+    def score(coords):
+        scores = elec_pose_scorer(coords)
+        return torch.sum(scores)
+
+    gradcheck(score, (p1.coords.requires_grad_(True),), eps=1e-3, atol=5e-3, rtol=5e-3)
+
+
+def test_whole_pose_scoring_module_10(rts_ubq_res, default_database, torch_device):
+    n_poses = 10
+    gold_vals = numpy.tile(numpy.array([-131.9225], dtype=numpy.float32), (n_poses))
+    elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res, device=torch_device
+    )
+    pn = PoseStackBuilder.from_poses([p1] * n_poses, device=torch_device)
+
+    for bt in pn.packed_block_types.active_block_types:
+        elec_energy.setup_block_type(bt)
+    elec_energy.setup_packed_block_types(pn.packed_block_types)
+    elec_energy.setup_poses(pn)
+
+    elec_pose_scorer = elec_energy.render_whole_pose_scoring_module(pn)
+    # for ch in elec_pose_scorer.children():
+    #     print("child")
+    #     print(ch)
+
+    coords = torch.nn.Parameter(pn.coords.clone())
+    scores = elec_pose_scorer(coords)
+
+    # make sure we're still good
+    torch.arange(100, device=torch_device)
+
+    numpy.set_printoptions(precision=10)
+    # print(scores.cpu().detach().numpy())
+
+    # print("scores!", scores.cpu().detach().numpy())
+
+    numpy.testing.assert_allclose(
+        gold_vals, scores.cpu().detach().numpy(), atol=1e-5, rtol=1e-5
+    )

--- a/tmol/tests/score/elec/test_elec_energy_term.py
+++ b/tmol/tests/score/elec/test_elec_energy_term.py
@@ -39,7 +39,7 @@ def test_annotate_restypes(ubq_res, default_database, torch_device):
 
 
 def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_device):
-    gold_vals = numpy.array([-0.164974], dtype=numpy.float32)
+    gold_vals = numpy.array([[-0.164974]], dtype=numpy.float32)
     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
         res=rts_ubq_res[0:4], device=torch_device
@@ -84,7 +84,7 @@ def test_whole_pose_scoring_module_gradcheck(
 
 def test_whole_pose_scoring_module_10(rts_ubq_res, default_database, torch_device):
     n_poses = 10
-    gold_vals = numpy.tile(numpy.array([-131.9225], dtype=numpy.float32), (n_poses))
+    gold_vals = numpy.tile(numpy.array([[-131.9225]], dtype=numpy.float32), (n_poses))
     elec_energy = ElecEnergyTerm(param_db=default_database, device=torch_device)
     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
         res=rts_ubq_res, device=torch_device

--- a/tmol/tests/score/elec/test_script_modules.py
+++ b/tmol/tests/score/elec/test_script_modules.py
@@ -146,6 +146,24 @@ def test_elec_intra(default_database, ubq_system, torch_device):
     )
 
 
+# torch intra op
+def test_elec_intra4(default_database, ubq_res, torch_device):
+    from tmol.system.packed import PackedResidueSystem
+
+    ubq_system = PackedResidueSystem.from_residues(ubq_res[:1])
+    s = ScoreSetup.from_fixture(default_database, ubq_system, torch_device)
+    op = ElecIntraModule(s.param_resolver)
+
+    print("s.tcoords, s.tpcs, s.trbpl")
+    print(s.tcoords, s.tpcs, s.trbpl)
+    val = op(s.tcoords, s.tpcs, s.trbpl)
+    print("val", val)
+
+    torch.testing.assert_allclose(
+        val.cpu(), torch.tensor((-0.1650,), dtype=torch.float64), atol=1e-4, rtol=1e-2
+    )
+
+
 # torch intra gradcheck
 def test_elec_intra_gradcheck(default_database, ubq_system, torch_device):
     s = ScoreSetup.from_fixture(default_database, ubq_system, torch_device)

--- a/tmol/tests/score/elec/test_script_modules.py
+++ b/tmol/tests/score/elec/test_script_modules.py
@@ -150,17 +150,14 @@ def test_elec_intra(default_database, ubq_system, torch_device):
 def test_elec_intra4(default_database, ubq_res, torch_device):
     from tmol.system.packed import PackedResidueSystem
 
-    ubq_system = PackedResidueSystem.from_residues(ubq_res[:1])
+    ubq_system = PackedResidueSystem.from_residues(ubq_res[:4])
     s = ScoreSetup.from_fixture(default_database, ubq_system, torch_device)
     op = ElecIntraModule(s.param_resolver)
 
-    print("s.tcoords, s.tpcs, s.trbpl")
-    print(s.tcoords, s.tpcs, s.trbpl)
     val = op(s.tcoords, s.tpcs, s.trbpl)
-    print("val", val)
 
     torch.testing.assert_allclose(
-        val.cpu(), torch.tensor((-0.1650,), dtype=torch.float64), atol=1e-4, rtol=1e-2
+        val.cpu(), torch.tensor((-0.164974,), dtype=torch.float64), atol=1e-4, rtol=1e-2
     )
 
 

--- a/tmol/tests/score/test_score_function_benchmarks.py
+++ b/tmol/tests/score/test_score_function_benchmarks.py
@@ -8,6 +8,7 @@ from tmol.score.score_function import ScoreFunction
 from tmol.pose.pose_stack_builder import PoseStackBuilder
 
 from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
+from tmol.score.elec.elec_energy_term import ElecEnergyTerm
 
 
 @pytest.mark.parametrize("energy_term", [LJLKEnergyTerm], ids=["ljlk"])
@@ -37,7 +38,9 @@ def dont_test_res_centric_score_benchmark_setup(
 
 @pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10, 30, 100]))
 @pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
-@pytest.mark.parametrize("energy_term", [LJLKEnergyTerm], ids=["ljlk"])
+@pytest.mark.parametrize(
+    "energy_term", [LJLKEnergyTerm, ElecEnergyTerm], ids=["ljlk", "elec"]
+)
 @pytest.mark.benchmark(group="res_centric_score_components")
 def test_res_centric_score_benchmark(
     benchmark,

--- a/tmol/tests/score/test_score_function_benchmarks.py
+++ b/tmol/tests/score/test_score_function_benchmarks.py
@@ -96,3 +96,66 @@ def test_res_centric_score_benchmark(
     # print("scores")
     # print(scores[:,:3])
     # print(scores.shape)
+
+
+@pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10, 30, 100]))
+@pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
+@pytest.mark.parametrize(
+    "energy_terms", [[LJLKEnergyTerm, ElecEnergyTerm]], ids=["ljlk_and_elec"]
+)
+@pytest.mark.benchmark(group="res_centric_combined_score_components")
+def test_combined_res_centric_score_benchmark(
+    benchmark,
+    benchmark_pass,
+    energy_terms,
+    n_poses,
+    rts_ubq_res,
+    default_database,
+    torch_device,
+):
+    n_poses = int(n_poses)
+    pose_stack1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        rts_ubq_res, torch_device
+    )
+    pose_stack_n = PoseStackBuilder.from_poses([pose_stack1] * n_poses, torch_device)
+
+    sfxn = ScoreFunction(default_database, torch_device)
+
+    for energy_term in energy_terms:
+        for st in energy_term.score_types():
+            sfxn.set_weight(st, 1.0)
+
+    scorer = sfxn.render_whole_pose_scoring_module(pose_stack_n)
+
+    if benchmark_pass == "full":
+        pose_stack_n.coords.requires_grad_(True)
+
+        @benchmark
+        def score_pass():
+            scores = torch.sum(scorer(pose_stack_n.coords))
+            scores.backward(retain_graph=True)
+            return scores.cpu()
+
+    elif benchmark_pass == "forward":
+
+        @benchmark
+        def score_pass():
+            scores = torch.sum(scorer(pose_stack_n.coords))
+            scores.cpu()
+            return scores
+
+    elif benchmark_pass == "backward":
+        pose_stack_n.coords.requires_grad_(True)
+        scores = torch.sum(scorer(pose_stack_n.coords))
+
+        @benchmark
+        def score_pass():
+            scores.backward(retain_graph=True)
+            return scores.cpu()
+
+    else:
+        raise NotImplementedError
+
+    # print("scores")
+    # print(scores[:,:3])
+    # print(scores.shape)


### PR DESCRIPTION
Create residue centric, whole-pose term for the electrostatics potential.

Note: both ref2015 and beta_nov16 use the "branch atom is dipole representative" behavior in Rosetta3 and this branch dutifully replicates that decision, even if it seems that the results from energy function parameterization showed that "base atom is dipole representative" behavior to have an edge.