### PR TITLE
Aleaverfay/res centric lkball

### DIFF
--- a/tmol/score/hbond/hbond_dependent_term.py
+++ b/tmol/score/hbond/hbond_dependent_term.py
@@ -54,6 +54,10 @@ def attached_H_for_don(atom_is_hydrogen, D_idx, bonds, bond_spans):
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class HBondBlockTypeParams(ValidateAttrs):
+    donH_inds: NDArray[numpy.int32][:]
+    don_hvy_inds: NDArray[numpy.int32][:]
+    acc_inds: NDArray[numpy.int32][:]
+
     tile_n_donH: NDArray[numpy.int32][:]
     tile_n_don_hvy: NDArray[numpy.int32][:]
     tile_n_acc: NDArray[numpy.int32][:]
@@ -221,6 +225,9 @@ class HBondDependentTerm(BondDependentTerm):
         tile_which_donH_of_donH_hvy[is_tiled_donH] = which_H_for_Hs_D
 
         hbbt_params = HBondBlockTypeParams(
+            donH_inds=H_idx,
+            don_hvy_inds=D_idx,
+            acc_inds=A_idx,
             tile_n_donH=tile_n_donH,
             tile_n_don_hvy=tile_n_don_hvy,
             tile_n_acc=tile_n_acc,

--- a/tmol/score/hbond/hbond_dependent_term.py
+++ b/tmol/score/hbond/hbond_dependent_term.py
@@ -24,40 +24,72 @@ from tmol.types.torch import Tensor
 def attached_H_for_don(atom_is_hydrogen, D_idx, bonds, bond_spans):
     donH = numpy.full(atom_is_hydrogen.shape, -1, dtype=numpy.int32)
     heavy_at_don_for_H = numpy.full(atom_is_hydrogen.shape, -1, dtype=numpy.int32)
+    which_H_for_hvy = numpy.full(atom_is_hydrogen.shape, -1, dtype=numpy.int32)
+    n_attached_H_for_D = numpy.full(D_idx.shape, 0, dtype=numpy.int32)
+
     n_donH = 0
-    for d in D_idx:
+    for i, d in enumerate(D_idx):
+        count_H_for_d = 0
         for b_ind in range(bond_spans[d, 0], bond_spans[d, 1]):
             neighb = bonds[b_ind, 1]
             if atom_is_hydrogen[neighb]:
                 donH[n_donH] = neighb
                 heavy_at_don_for_H[n_donH] = d
+                which_H_for_hvy[n_donH] = count_H_for_d
+                count_H_for_d += 1
                 n_donH += 1
+        n_attached_H_for_D[i] = count_H_for_d
     donH = donH[:n_donH]
+    heavy_at_don_for_H = heavy_at_don_for_H[:n_donH]
+    which_H_for_hvy = which_H_for_hvy[:n_donH]
+
     sort_inds = numpy.argsort(donH)
-    return donH[sort_inds], heavy_at_don_for_H[sort_inds]
+    return (
+        donH[sort_inds],
+        heavy_at_don_for_H[sort_inds],
+        which_H_for_hvy[sort_inds],
+        n_attached_H_for_D,
+    )
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class HBondBlockTypeParams(ValidateAttrs):
     tile_n_donH: NDArray[numpy.int32][:]
+    tile_n_don_hvy: NDArray[numpy.int32][:]
     tile_n_acc: NDArray[numpy.int32][:]
-    tile_donH_inds: NDArray[numpy.int32][:, :]
-    tile_acc_inds: NDArray[numpy.int32][:, :]
+    tile_donH_inds: NDArray[numpy.int32][:, :]  # the tile-ind of a particular donH
+    tile_donH_hvy_inds: NDArray[numpy.int32][
+        :, :
+    ]  # the res-ind of hvy for a particular donH
+    tile_don_hvy_inds: NDArray[numpy.int32][
+        :, :
+    ]  # the tile-ind of a particular donor hvy
+    tile_which_donH_of_donH_hvy: NDArray[numpy.int32][
+        :, :
+    ]  # ind [0..nattachedH) for donH for corr hvy
+    tile_acc_inds: NDArray[numpy.int32][:, :]  # the tile-ind of a particular acc
     tile_donorH_type: NDArray[numpy.int32][:, :]
     tile_acceptor_type: NDArray[numpy.int32][:, :]
     tile_acceptor_hybridization: NDArray[numpy.int32][:, :]
+    tile_acceptor_n_attached_H: NDArray[numpy.int32][:, :]
     is_hydrogen: NDArray[numpy.int32][:]
+    # possible additions? tile_don_hvy_n_attached_H, tile_don_hvy_type
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class HBondPackedBlockTypesParams(ValidateAttrs):
     tile_n_donH: Tensor[torch.int32][:, :]
+    tile_n_don_hvy: Tensor[torch.int32][:, :]
     tile_n_acc: Tensor[torch.int32][:, :]
     tile_donH_inds: Tensor[torch.int32][:, :, :]
+    tile_donH_hvy_inds: Tensor[torch.int32][:, :, :]
+    tile_don_hvy_inds: Tensor[torch.int32][:, :, :]
+    tile_which_donH_of_donH_hvy: Tensor[torch.int32][:, :, :]
     tile_acc_inds: Tensor[torch.int32][:, :, :]
     tile_donorH_type: Tensor[torch.int32][:, :, :]
     tile_acceptor_type: Tensor[torch.int32][:, :, :]
     tile_acceptor_hybridization: Tensor[torch.int32][:, :, :]
+    tile_acceptor_n_attached_H: Tensor[torch.int32][:, :, :]
     is_hydrogen: Tensor[torch.int32][:, :]
 
 
@@ -146,36 +178,61 @@ class HBondDependentTerm(BondDependentTerm):
         # now lets get the list of attached hydrogen atoms:
         D_idx = numpy.nonzero(is_don)[0].astype(dtype=numpy.int32)
         indexed_bonds = block_type.intrares_indexed_bonds
-        H_idx, D_for_H = attached_H_for_don(
+        H_idx, D_for_H, which_H_for_Hs_D, n_H_for_D = attached_H_for_don(
             is_hydrogen,
             D_idx,
             indexed_bonds.bonds.cpu().numpy()[0],
             indexed_bonds.bond_spans.cpu().numpy()[0],
         )
         donH_type = don_type[D_for_H]
+        n_H_for_at = numpy.zeros(block_type.n_atoms, dtype=numpy.int32)
+        n_H_for_at[D_idx] = n_H_for_D
+        tile_acceptor_n_attached_H = numpy.full(
+            (n_tiles, tile_size), -1, dtype=numpy.int32
+        )
+        tile_acceptor_n_attached_H[is_tiled_acc] = n_H_for_at[A_idx]
 
         tiled_donH_orig_inds, tile_n_donH = arg_tile_subset_indices(
             H_idx, tile_size, block_type.n_atoms
         )
+        tiled_don_hvy_orig_inds, tile_n_don_hvy = arg_tile_subset_indices(
+            D_idx, tile_size, block_type.n_atoms
+        )
 
-        assert n_tiles == tile_n_donH.shape[0]
+        assert tile_n_donH.shape[0] == n_tiles
+        assert tile_n_don_hvy.shape[0] == n_tiles
         tiled_donH_orig_inds = tiled_donH_orig_inds.reshape((n_tiles, tile_size))
         is_tiled_donH = tiled_donH_orig_inds != -1
+        tiled_don_hvy_orig_inds = tiled_don_hvy_orig_inds.reshape((n_tiles, tile_size))
+        is_tiled_don_hvy = tiled_don_hvy_orig_inds != -1
+        # print("is_tiled_don_hvy", is_tiled_don_hvy)
+        # print("D_idx", D_idx)
 
         tile_donH_inds = numpy.full((n_tiles, tile_size), -1, dtype=numpy.int32)
+        tile_don_hvy_inds = numpy.copy(tile_donH_inds)
+        tile_donH_hvy_inds = numpy.copy(tile_donH_inds)
         tile_donorH_type = numpy.copy(tile_donH_inds)
+        tile_which_donH_of_donH_hvy = numpy.copy(tile_donH_inds)
 
         tile_donH_inds[is_tiled_donH] = H_idx
+        tile_don_hvy_inds[is_tiled_don_hvy] = D_idx
+        tile_donH_hvy_inds[is_tiled_donH] = D_for_H
         tile_donorH_type[is_tiled_donH] = donH_type
+        tile_which_donH_of_donH_hvy[is_tiled_donH] = which_H_for_Hs_D
 
         hbbt_params = HBondBlockTypeParams(
             tile_n_donH=tile_n_donH,
+            tile_n_don_hvy=tile_n_don_hvy,
             tile_n_acc=tile_n_acc,
             tile_donH_inds=tile_donH_inds,
+            tile_donH_hvy_inds=tile_donH_hvy_inds,
+            tile_don_hvy_inds=tile_don_hvy_inds,
+            tile_which_donH_of_donH_hvy=tile_which_donH_of_donH_hvy,
             tile_acc_inds=tile_acc_inds,
             tile_donorH_type=tile_donorH_type,
             tile_acceptor_type=tile_acceptor_type,
             tile_acceptor_hybridization=tile_acceptor_hybridization,
+            tile_acceptor_n_attached_H=tile_acceptor_n_attached_H,
             is_hydrogen=is_hydrogen,
         )
         setattr(block_type, "hbbt_params", hbbt_params)
@@ -195,8 +252,18 @@ class HBondDependentTerm(BondDependentTerm):
             assert bt.hbbt_params.tile_n_acc.shape[0] <= max_n_tiles
 
         tile_n_donH = numpy.zeros((pbt.n_types, max_n_tiles), dtype=numpy.int32)
+        tile_n_don_hvy = numpy.zeros((pbt.n_types, max_n_tiles), dtype=numpy.int32)
         tile_n_acc = numpy.zeros((pbt.n_types, max_n_tiles), dtype=numpy.int32)
         tile_donH_inds = numpy.full(
+            (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
+        )
+        tile_donH_hvy_inds = numpy.full(
+            (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
+        )
+        tile_don_hvy_inds = numpy.full(
+            (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
+        )
+        tile_which_donH_of_donH_hvy = numpy.full(
             (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
         )
         tile_acc_inds = numpy.full(
@@ -211,6 +278,9 @@ class HBondDependentTerm(BondDependentTerm):
         tile_acceptor_hybridization = numpy.full(
             (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
         )
+        tile_acceptor_n_attached_H = numpy.full(
+            (pbt.n_types, max_n_tiles, tile_size), -1, dtype=numpy.int32
+        )
         is_hydrogen = numpy.full(
             (pbt.n_types, pbt.max_n_atoms), False, dtype=numpy.int32
         )
@@ -221,15 +291,23 @@ class HBondDependentTerm(BondDependentTerm):
             i_n_ats = block_type.n_atoms
 
             tile_n_donH[i, :i_n_tiles] = i_hb_params.tile_n_donH
-            tile_n_donH[i, :i_n_tiles] = i_hb_params.tile_n_donH
+            tile_n_don_hvy[i, :i_n_tiles] = i_hb_params.tile_n_don_hvy
             tile_n_acc[i, :i_n_tiles] = i_hb_params.tile_n_acc
             tile_donH_inds[i, :i_n_tiles] = i_hb_params.tile_donH_inds
+            tile_donH_hvy_inds[i, :i_n_tiles] = i_hb_params.tile_donH_hvy_inds
+            tile_don_hvy_inds[i, :i_n_tiles] = i_hb_params.tile_don_hvy_inds
+            tile_which_donH_of_donH_hvy[
+                i, :i_n_tiles
+            ] = i_hb_params.tile_which_donH_of_donH_hvy
             tile_acc_inds[i, :i_n_tiles] = i_hb_params.tile_acc_inds
             tile_donorH_type[i, :i_n_tiles] = i_hb_params.tile_donorH_type
             tile_acceptor_type[i, :i_n_tiles] = i_hb_params.tile_acceptor_type
             tile_acceptor_hybridization[
                 i, :i_n_tiles
             ] = i_hb_params.tile_acceptor_hybridization
+            tile_acceptor_n_attached_H[
+                i, :i_n_tiles
+            ] = i_hb_params.tile_acceptor_n_attached_H
             is_hydrogen[i, :i_n_ats] = i_hb_params.is_hydrogen
 
         def _tint32(arr):
@@ -237,12 +315,17 @@ class HBondDependentTerm(BondDependentTerm):
 
         params = HBondPackedBlockTypesParams(
             tile_n_donH=_tint32(tile_n_donH),
+            tile_n_don_hvy=_tint32(tile_n_don_hvy),
             tile_n_acc=_tint32(tile_n_acc),
             tile_donH_inds=_tint32(tile_donH_inds),
+            tile_donH_hvy_inds=_tint32(tile_donH_hvy_inds),
+            tile_don_hvy_inds=_tint32(tile_don_hvy_inds),
+            tile_which_donH_of_donH_hvy=_tint32(tile_which_donH_of_donH_hvy),
             tile_acc_inds=_tint32(tile_acc_inds),
             tile_donorH_type=_tint32(tile_donorH_type),
             tile_acceptor_type=_tint32(tile_acceptor_type),
             tile_acceptor_hybridization=_tint32(tile_acceptor_hybridization),
+            tile_acceptor_n_attached_H=_tint32(tile_acceptor_n_attached_H),
             is_hydrogen=_tint32(is_hydrogen),
         )
 

--- a/tmol/score/hbond/identification.hh
+++ b/tmol/score/hbond/identification.hh
@@ -10,10 +10,6 @@ namespace tmol {
 namespace score {
 namespace hbond {
 
-// using tmol::score::bonded_atom::BlockCentricAtom;
-// using tmol::score::bonded_atom::BlockCentricIndexedBonds;
-// using tmol::score::bonded_atom::IndexedBonds;
-
 #define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 
 struct AcceptorHybridization {

--- a/tmol/score/hbond/identification.hh
+++ b/tmol/score/hbond/identification.hh
@@ -10,9 +10,9 @@ namespace tmol {
 namespace score {
 namespace hbond {
 
-using tmol::score::bonded_atom::BlockCentricAtom;
-using tmol::score::bonded_atom::BlockCentricIndexedBonds;
-using tmol::score::bonded_atom::IndexedBonds;
+// using tmol::score::bonded_atom::BlockCentricAtom;
+// using tmol::score::bonded_atom::BlockCentricIndexedBonds;
+// using tmol::score::bonded_atom::IndexedBonds;
 
 #define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 
@@ -37,7 +37,7 @@ struct AcceptorBases {
       Int stack,
       Int A,
       Int hybridization,
-      IndexedBonds<Int, Dev> bonds,
+      bonded_atom::IndexedBonds<Int, Dev> bonds,
       func_t atom_is_hydrogen)
       ->AcceptorBases {
     Int B = -1, B0 = -1;
@@ -72,7 +72,7 @@ struct AcceptorBases {
       Int stack,
       Int A,
       Int hybridization,
-      IndexedBonds<Int, Dev> bonds,
+      bonded_atom::IndexedBonds<Int, Dev> bonds,
       func_t atom_is_hydrogen)
       ->AcceptorBases {
     Int B = -1;
@@ -108,7 +108,7 @@ struct AcceptorBases {
       Int stack,
       Int A,
       Int hybridization,
-      IndexedBonds<Int, Dev> bonds,
+      bonded_atom::IndexedBonds<Int, Dev> bonds,
       func_t atom_is_hydrogen)
       ->AcceptorBases {
     Int B = -1;
@@ -144,7 +144,7 @@ struct AcceptorBases {
       Int stack,
       Int A,
       Int hybridization,
-      IndexedBonds<Int, Dev> bonds,
+      bonded_atom::IndexedBonds<Int, Dev> bonds,
       func_t atom_is_hydrogen)
       ->AcceptorBases {
     if (hybridization == AcceptorHybridization::sp2) {
@@ -164,16 +164,17 @@ struct AcceptorBases {
 
 template <typename Int>
 struct BlockCentricAcceptorBases {
-  BlockCentricAtom<Int> A;
-  BlockCentricAtom<Int> B;
-  BlockCentricAtom<Int> B0;
+  bonded_atom::BlockCentricAtom<Int> A;
+  bonded_atom::BlockCentricAtom<Int> B;
+  bonded_atom::BlockCentricAtom<Int> B0;
 
   template <tmol::Device Dev>
   static def sp2_acceptor_base(
-      BlockCentricAtom<Int> A,
-      BlockCentricIndexedBonds<Int, Dev> bonds,
+      bonded_atom::BlockCentricAtom<Int> A,
+      bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds,
       TView<Int, 2, Dev> bt_atom_is_hydrogen)
       ->BlockCentricAcceptorBases {
+    using bonded_atom::BlockCentricAtom;
     BlockCentricAtom<Int> B({-1, -1, -1});
     BlockCentricAtom<Int> B0({-1, -1, -1});
 
@@ -214,12 +215,13 @@ struct BlockCentricAcceptorBases {
 
   template <tmol::Device Dev>
   static def sp3_acceptor_base(
-      BlockCentricAtom<Int> A,
-      BlockCentricIndexedBonds<Int, Dev> bonds,
+      bonded_atom::BlockCentricAtom<Int> A,
+      bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds,
       TView<Int, 2, Dev> bt_atom_is_hydrogen)
       ->BlockCentricAcceptorBases {
-    BlockCentricAtom<Int> B({-1, -1, -1});
-    BlockCentricAtom<Int> B0({-1, -1, -1});
+    using bonded_atom::BlockCentricAtom;
+    BlockCentricAtom<Int> B{-1, -1, -1};
+    BlockCentricAtom<Int> B0{-1, -1, -1};
 
     for (BlockCentricAtom<Int> other_atom : bonds.bound_to(A)) {
       if (bt_atom_is_hydrogen[other_atom.block_type][other_atom.atom]) {
@@ -248,12 +250,13 @@ struct BlockCentricAcceptorBases {
 
   template <tmol::Device Dev>
   static def ring_acceptor_base(
-      BlockCentricAtom<Int> A,
-      BlockCentricIndexedBonds<Int, Dev> bonds,
+      bonded_atom::BlockCentricAtom<Int> A,
+      bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds,
       TView<Int, 2, Dev> bt_atom_is_hydrogen)
       ->BlockCentricAcceptorBases {
-    BlockCentricAtom<Int> B({-1, -1, -1});
-    BlockCentricAtom<Int> B0({-1, -1, -1});
+    using bonded_atom::BlockCentricAtom;
+    BlockCentricAtom<Int> B{-1, -1, -1};
+    BlockCentricAtom<Int> B0{-1, -1, -1};
 
     for (BlockCentricAtom<Int> other_atom : bonds.bound_to(A)) {
       if (!bt_atom_is_hydrogen[other_atom.block_type][other_atom.atom]) {
@@ -283,9 +286,9 @@ struct BlockCentricAcceptorBases {
 
   template <tmol::Device Dev>
   static def for_acceptor(
-      BlockCentricAtom<Int> A,
+      bonded_atom::BlockCentricAtom<Int> A,
       Int hybridization,
-      BlockCentricIndexedBonds<Int, Dev> bonds,
+      bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds,
       TView<Int, 2, Dev> bt_atom_is_hydrogen)
       ->BlockCentricAcceptorBases {
     if (hybridization == AcceptorHybridization::sp2) {
@@ -302,15 +305,17 @@ struct BlockCentricAcceptorBases {
 
 template <typename Int>
 struct BlockCentricDonorBase {
-  BlockCentricAtom<Int> H;
-  BlockCentricAtom<Int> D;
+  bonded_atom::BlockCentricAtom<Int> H;
+  bonded_atom::BlockCentricAtom<Int> D;
 
   template <tmol::Device Dev>
   static def for_polar_H(
-      BlockCentricAtom<Int> H,
-      BlockCentricIndexedBonds<Int, Dev> bonds,
+      bonded_atom::BlockCentricAtom<Int> H,
+      bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds,
       TView<Int, 2, Dev> bt_atom_is_hydrogen)
       ->BlockCentricDonorBase<Int> {
+    using bonded_atom::BlockCentricAtom;
+
     BlockCentricAtom<Int> D{-1, -1, -1};
     for (BlockCentricAtom<Int> other_atom : bonds.bound_to(H)) {
       if (!bt_atom_is_hydrogen[other_atom.block_type][other_atom.atom]) {

--- a/tmol/score/hbond/identification.pybind.cc
+++ b/tmol/score/hbond/identification.pybind.cc
@@ -28,7 +28,8 @@ void id_acceptor_bases(
   });
 
   for (int stack : iter::range(A_idx.size(0))) {
-    IndexedBonds<Int, D> indexed_bonds({bonds[stack], bond_spans[stack]});
+    bonded_atom::IndexedBonds<Int, D> indexed_bonds(
+        {bonds[stack], bond_spans[stack]});
     for (int ai : iter::range(A_idx.size(1))) {
       // atoms with negative indices are not real
       // the negative index is a sentinel value that
@@ -68,7 +69,8 @@ void id_donor_attached_hydrogens(
   int const max_n_hydrogens = H_idx.size(2);
 
   for (int stack : iter::range(D_idx.size(0))) {
-    IndexedBonds<Int, D> indexed_bonds({bonds[stack], bond_spans[stack]});
+    bonded_atom::IndexedBonds<Int, D> indexed_bonds(
+        {bonds[stack], bond_spans[stack]});
     for (int di : iter::range(D_idx.size(1))) {
       // atoms with negative indices are not real
       // the negative index is a sentinel value that

--- a/tmol/score/hbond/potentials/hbond.hh
+++ b/tmol/score/hbond/potentials/hbond.hh
@@ -793,6 +793,8 @@ TMOL_DEVICE_FUNC Real hbond_atom_energy_and_derivs_full(
     int cp_separation,
     TView<Eigen::Matrix<Real, 3, 1>, 3, Dev> dV_dcoords) {
   using Real3 = Eigen::Matrix<Real, 3, 1>;
+  using bonded_atom::BlockCentricAtom;
+  using bonded_atom::BlockCentricIndexedBonds;
 
   Real3 Hxyz = coord_from_shared(don_dat.coords, don_h_atom_tile_ind);
   Real3 Axyz = coord_from_shared(acc_dat.coords, acc_atom_tile_ind);
@@ -878,7 +880,8 @@ TMOL_DEVICE_FUNC Real hbond_atom_energy_and_derivs_full(
     // code duplication
 
     auto accum_for_acc_atom = ([&] TMOL_DEVICE_FUNC(
-                                   BlockCentricAtom<Int> const &bcat,
+                                   bonded_atom::BlockCentricAtom<Int> const
+                                       &bcat,
                                    Real3 dV_dat) {
       bool any_nonzero = false;
       for (int j = 0; j < 3; ++j) {

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -83,19 +83,17 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::f(
     // logic for deciding whether two atoms in those blocks should have their
     // interaction energies calculated: all should. intentionally small to
     // (possibly) fit in constant cache
-    TView<Int, 3, Dev>
-        pose_stack_min_bond_separation,  // ?? needed ?? I think so
+    TView<Int, 3, Dev> pose_stack_min_bond_separation,
 
     // dims: n-poses x max-n-blocks x max-n-blocks x
     // max-n-interblock-connections x max-n-interblock-connections
-    TView<Int, 5, Dev>
-        pose_stack_inter_block_bondsep,  // ?? needed ?? I think so
+    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
 
     //////////////////////
     // Chemical properties
     // how many atoms for a given block
     // Dimsize n_block_types
-    TView<Int, 1, Dev> block_type_n_atoms,  // ?? needed ?? I think so
+    TView<Int, 1, Dev> block_type_n_atoms,
 
     // how many inter-block chemical bonds are there
     // Dimsize: n_block_types

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -69,7 +69,7 @@ template <
     tmol::Device D,
     typename Real,
     typename Int>
-auto LJLKPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
+auto LJLKPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
     TView<Vec<Real, 3>, 2, D> coords,
     TView<Int, 2, D> pose_stack_block_coord_offset,
     TView<Int, 2, D> pose_stack_block_type,

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -69,7 +69,7 @@ template <
     tmol::Device D,
     typename Real,
     typename Int>
-auto LJLKPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
+auto LJLKPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     TView<Vec<Real, 3>, 2, D> coords,
     TView<Int, 2, D> pose_stack_block_coord_offset,
     TView<Int, 2, D> pose_stack_block_type,

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -1,8 +1,9 @@
+import numpy
 import torch
 
+from .params import LKBallBlockTypeParams, LKBallPackedBlockTypeParams
 from .lk_ball_whole_pose_module import LKBallWholePoseScoringModule
 from ..atom_type_dependent_term import AtomTypeDependentTerm
-from ..bond_dependent_term import BondDependentTerm
 from ..hbond.hbond_dependent_term import HBondDependentTerm
 from ..ljlk.params import LJLKGlobalParams, LJLKParamResolver
 from tmol.database import ParameterDatabase
@@ -10,12 +11,11 @@ from tmol.database import ParameterDatabase
 from tmol.chemical.restypes import RefinedResidueType
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.pose.pose_stack import PoseStack
-
-# from tmol.types.torch import Tensor
+from tmol.score.common.stack_condense import arg_tile_subset_indices
 
 
 class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
-    tile_size: int = 32
+    tile_size: int = HBondDependentTerm.tile_size
     ljlk_global_params: LJLKGlobalParams
     ljlk_param_resolver: LJLKParamResolver
 
@@ -41,17 +41,158 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
     def setup_block_type(self, block_type: RefinedResidueType):
         super(LKBallEnergyTerm, self).setup_block_type(block_type)
         if hasattr(block_type, "lk_ball_params"):
+            print("early return")
             return
-        # TO DO!
+        # ok, let's collect two things:
+        # the combined set of donors and acceptors
+        # the set of heavy atoms
+        hbbt_params = block_type.hbbt_params
+        n_tiles = hbbt_params.tile_donH_inds.shape[0]
+
+        atom_is_polar = numpy.full((block_type.n_atoms,), False, dtype=numpy.bool)
+        atom_is_polar[hbbt_params.don_hvy_inds] = True
+        atom_is_polar[hbbt_params.acc_inds] = True
+        polar_inds = numpy.nonzero(atom_is_polar)[0].astype(numpy.int32)
+        # print("polar_inds", block_type.name)
+        # print(polar_inds)
+
+        tile_size = LKBallEnergyTerm.tile_size
+        tiled_polar_orig_inds, tile_n_polar = arg_tile_subset_indices(
+            polar_inds, tile_size, block_type.n_atoms
+        )
+        tiled_polar_orig_inds = tiled_polar_orig_inds.reshape(n_tiles, tile_size)
+        # print("tile_n_polar")
+        # print(tile_n_polar)
+
+        is_tiled_polar = tiled_polar_orig_inds != -1
+        tiled_polars = numpy.full((n_tiles, tile_size), -1, dtype=numpy.int32)
+        tiled_polars[is_tiled_polar] = polar_inds
+        # print("tiled_polars")
+        # print(tiled_polars)
+
+        # ASSUMPTION! either h or hvy; change when VRTS are added!
+        # Grace: lk parameters for VRTs should not affect score even if included
+        atom_is_heavy = numpy.invert(hbbt_params.is_hydrogen == 1)
+
+        atom_is_heavy_apolar = numpy.logical_and(
+            atom_is_heavy, numpy.invert(atom_is_polar)
+        )
+        heavy_apolar_inds = numpy.nonzero(atom_is_heavy_apolar)[0].astype(numpy.int32)
+        # print("heavy_apolar_inds")
+        # print(heavy_apolar_inds)
+
+        tiled_heavy_apolar_orig_inds, tile_n_apolar = arg_tile_subset_indices(
+            heavy_apolar_inds, tile_size, block_type.n_atoms
+        )
+        tiled_heavy_apolar_orig_inds = tiled_heavy_apolar_orig_inds.reshape(
+            n_tiles, tile_size
+        )
+        is_tiled_heavy_apolar = tiled_heavy_apolar_orig_inds != -1
+        tiled_heavy_apolar = numpy.full((n_tiles, tile_size), -1, dtype=numpy.int32)
+        tiled_heavy_apolar[is_tiled_heavy_apolar] = heavy_apolar_inds
+        # print("tiled_heavy_apolar", block_type.name)
+        # print(tiled_heavy_apolar)
+
+        # now lets combine the heavy polar indices and the heavy non-polar indices
+        tiled_pols_and_occs = numpy.copy(tiled_polars)
+        tile_n_occ = numpy.copy(tile_n_polar)
+        for i in range(n_tiles):
+            tile_n_occ[i] = tile_n_polar[i] + tile_n_apolar[i]
+            r = slice(tile_n_polar[i], tile_n_occ[i])
+            tiled_pols_and_occs[i, r] = tiled_heavy_apolar[i, : tile_n_apolar[i]]
+        # print("tiled_pols_and_occs")
+        # print(tiled_pols_and_occs)
+        is_pol_or_occ = tiled_pols_and_occs != -1
+
+        # ok, now let's collect the properties of the atoms in this block
+        # needed for LKBallTypeParams (see properties/params.hh)
+        assert hasattr(block_type, "atom_types")
+        at = block_type.atom_types
+        type_params = self.ljlk_param_resolver.type_params.to(torch.device("cpu"))
+        bt_lj_radius = type_params.lj_radius[at].numpy()
+        bt_lk_dgfree = type_params.lk_dgfree[at].numpy()
+        bt_lk_lambda = type_params.lk_lambda[at].numpy()
+        bt_lk_volume = type_params.lk_volume[at].numpy()
+        bt_is_donor = type_params.is_donor[at].numpy()
+        bt_is_hydroxyl = type_params.is_hydroxyl[at].numpy()
+        bt_is_polarh = type_params.is_polarh[at].numpy()
+        bt_is_acceptor = type_params.is_acceptor[at].numpy()
+
+        bt_lk_ball_at_params = numpy.stack(
+            (
+                bt_lj_radius,
+                bt_lk_dgfree,
+                bt_lk_lambda,
+                bt_lk_volume,
+                bt_is_donor,
+                bt_is_hydroxyl,
+                bt_is_polarh,
+                bt_is_acceptor,
+            ),
+            axis=1,
+        )
+        tiled_bt_lk_ball_at_params = numpy.zeros(
+            (n_tiles, tile_size, 8), dtype=numpy.float32
+        )
+        tiled_bt_lk_ball_at_params[is_pol_or_occ] = bt_lk_ball_at_params[
+            tiled_pols_and_occs[is_pol_or_occ]
+        ]
+
+        bt_lk_ball_params = LKBallBlockTypeParams(
+            tile_n_polar_atoms=tile_n_polar,
+            tile_n_occluder_atoms=tile_n_occ,
+            tile_pol_occ_inds=tiled_pols_and_occs,
+            tile_lk_ball_params=tiled_bt_lk_ball_at_params,
+        )
+        setattr(block_type, "lk_ball_params", bt_lk_ball_params)
 
     def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
         super(LKBallEnergyTerm, self).setup_packed_block_types(packed_block_types)
+        if hasattr(packed_block_types, "lk_ball_params"):
+            return
+        n_types = packed_block_types.n_types
+        n_tiles = packed_block_types.hbpbt_params.tile_donH_inds.shape[1]
+        tile_size = LKBallEnergyTerm.tile_size
+
+        tile_n_polar_atoms = numpy.full((n_types, n_tiles), 0, dtype=numpy.int32)
+        tile_n_occluder_atoms = numpy.full((n_types, n_tiles), 0, dtype=numpy.int32)
+        tile_pol_occ_inds = numpy.full(
+            (n_types, n_tiles, tile_size), -1, dtype=numpy.int32
+        )
+        tile_lk_ball_params = numpy.full(
+            (n_types, n_tiles, tile_size, 8), 0, dtype=numpy.float32
+        )
+
+        for i, bt in enumerate(packed_block_types.active_block_types):
+            i_lkbp = bt.lk_ball_params
+            i_n_tiles = i_lkbp.tile_n_polar_atoms.shape[0]
+
+            tile_n_polar_atoms[i, :i_n_tiles] = i_lkbp.tile_n_polar_atoms
+            tile_n_occluder_atoms[i, :i_n_tiles] = i_lkbp.tile_n_occluder_atoms
+            tile_pol_occ_inds[i, :i_n_tiles] = i_lkbp.tile_pol_occ_inds
+            tile_lk_ball_params[i, :i_n_tiles] = i_lkbp.tile_lk_ball_params
+
+        def _t(t):
+            return torch.tensor(t, device=packed_block_types.device)
+
+        tile_n_polar_atoms = _t(tile_n_polar_atoms)
+        tile_n_occluder_atoms = _t(tile_n_occluder_atoms)
+        tile_pol_occ_inds = _t(tile_pol_occ_inds)
+        tile_lk_ball_params = _t(tile_lk_ball_params)
+
+        lk_ball_params = LKBallPackedBlockTypeParams(
+            tile_n_polar_atoms=tile_n_polar_atoms,
+            tile_n_occluder_atoms=tile_n_occluder_atoms,
+            tile_pol_occ_inds=tile_pol_occ_inds,
+            tile_lk_ball_params=tile_lk_ball_params,
+        )
+        setattr(packed_block_types, "lk_ball_params", lk_ball_params)
 
     def setup_poses(self, pose_stack: PoseStack):
         super(LKBallEnergyTerm, self).setup_poses(pose_stack)
 
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
-        pbt = pose_stack.packed_block_types
+        pbt,
         ljlk_global_params = self.ljlk_param_resolver.global_params
 
         return LKBallWholePoseScoringModule(
@@ -69,11 +210,11 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             bt_tile_n_donH=pbt.hbpbt_params.tile_n_donH,
             bt_tile_n_acc=pbt.hbpbt_params.tile_n_acc,
             bt_tile_donH_inds=pbt.hbpbt_params.tile_donH_inds,
-            bt_tile_don_hvy_inds=None,  # TO DO!!!
-            bt_tile_which_donH_for_hvy=None,  # TO DO!!
+            bt_tile_don_hvy_inds=pbt.hbpbt_params.tile_donH_hvy_inds,
+            bt_tile_which_donH_for_hvy=pbt.hbpbt_params.tile_which_donH_of_donH_hvy,
             bt_tile_acc_inds=pbt.hbpbt_params.tile_acc_inds,
             bt_tile_acceptor_hybridization=pbt.hbpbt_params.tile_acceptor_hybridization,
-            bt_tile_acc_n_attached_H=None,  # TO DO!!
+            bt_tile_acc_n_attached_H=pbt.hbpbt_params.tile_acceptor_n_attached_H,
             bt_atom_is_hydrogen=pbt.hbpbt_params.is_hydrogen,
             bt_tile_n_polar_atoms=None,  # TO DO!!
             bt_tile_n_occluder_atoms=None,  # TO DO!!

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -14,7 +14,7 @@ from tmol.types.torch import Tensor
 
 
 @attr.s(auto_attribs=True)
-class LKBallEnergyTerm(HBondDependentTerm, AtomTypeDependentTerm, BondDependentTerm):
+class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     ljlk_global_params: LJLKGlobalParams
     ljlk_param_resolver: LJLKParamResolver

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -39,7 +39,6 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
     def setup_block_type(self, block_type: RefinedResidueType):
         super(LKBallEnergyTerm, self).setup_block_type(block_type)
         if hasattr(block_type, "lk_ball_params"):
-            print("early return")
             return
 
         # we are going to order the data needed for score evaluation around the
@@ -76,7 +75,8 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         tiled_polars[is_tiled_polar] = polar_inds
 
         # ASSUMPTION! either h or hvy; change when VRTS are added!
-        # Grace: lk parameters for VRTs should not affect score even if included
+        # Grace: lk parameters for VRTs should not affect score even if included,
+        # it would just be slightly inefficient
         atom_is_heavy = numpy.invert(hbbt_params.is_hydrogen == 1)
 
         # "apolar" here means "does not build waters"; e.g. proline's N would be

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -192,7 +192,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         super(LKBallEnergyTerm, self).setup_poses(pose_stack)
 
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
-        pbt,
+        pbt = pose_stack.packed_block_types
         ljlk_global_params = self.ljlk_param_resolver.global_params
 
         return LKBallWholePoseScoringModule(
@@ -213,16 +213,16 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             bt_tile_don_hvy_inds=pbt.hbpbt_params.tile_donH_hvy_inds,
             bt_tile_which_donH_for_hvy=pbt.hbpbt_params.tile_which_donH_of_donH_hvy,
             bt_tile_acc_inds=pbt.hbpbt_params.tile_acc_inds,
-            bt_tile_acceptor_hybridization=pbt.hbpbt_params.tile_acceptor_hybridization,
+            bt_tile_hybridization=pbt.hbpbt_params.tile_acceptor_hybridization,
             bt_tile_acc_n_attached_H=pbt.hbpbt_params.tile_acceptor_n_attached_H,
             bt_atom_is_hydrogen=pbt.hbpbt_params.is_hydrogen,
-            bt_tile_n_polar_atoms=None,  # TO DO!!
-            bt_tile_n_occluder_atoms=None,  # TO DO!!
-            bt_tile_pol_occ_inds=None,  # TO DO!!
-            bt_tile_lk_ball_params=None,  # TO DO!!
+            bt_tile_n_polar_atoms=pbt.lk_ball_params.tile_n_polar_atoms,
+            bt_tile_n_occluder_atoms=pbt.lk_ball_params.tile_n_occluder_atoms,
+            bt_tile_pol_occ_inds=pbt.lk_ball_params.tile_pol_occ_inds,
+            bt_tile_lk_ball_params=pbt.lk_ball_params.tile_lk_ball_params,
             bt_path_distance=pbt.bond_separation,
             lk_ball_global_params=self.stack_lk_ball_global_params(),
-            water_gen_global_params=self.stack_water_gen_global_params(),
+            water_gen_global_params=self.stack_lk_ball_water_gen_global_params(),
             sp2_water_tors=ljlk_global_params.lkb_water_tors_sp2,
             sp3_water_tors=ljlk_global_params.lkb_water_tors_sp3,
             ring_water_tors=ljlk_global_params.lkb_water_tors_ring,
@@ -245,7 +245,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             dim=1,
         )
 
-    def stack_lkball_water_gen_global_params(self):
+    def stack_lk_ball_water_gen_global_params(self):
         return torch.stack(
             self._tfloat(
                 [

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -1,6 +1,6 @@
-import attr
 import torch
 
+from .lk_ball_whole_pose_module import LKBallWholePoseScoringModule
 from ..atom_type_dependent_term import AtomTypeDependentTerm
 from ..bond_dependent_term import BondDependentTerm
 from ..hbond.hbond_dependent_term import HBondDependentTerm
@@ -10,26 +10,39 @@ from tmol.database import ParameterDatabase
 from tmol.chemical.restypes import RefinedResidueType
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.pose.pose_stack import PoseStack
-from tmol.types.torch import Tensor
+
+# from tmol.types.torch import Tensor
 
 
-@attr.s(auto_attribs=True)
 class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
-
+    tile_size: int = 32
     ljlk_global_params: LJLKGlobalParams
     ljlk_param_resolver: LJLKParamResolver
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
-        ljlk_param_resolver = LJLKParamResolver.from_database(
+        super(LKBallEnergyTerm, self).__init__(param_db=param_db, device=device)
+
+        self.ljlk_param_resolver = LJLKParamResolver.from_database(
             param_db.chemical, param_db.scoring.ljlk, device=device
         )
-        super(LKBallEnergyTerm, self).__init__(param_db=param_db, device=device)
-        self.type_params = ljlk_param_resolver.type_params
-        self.global_params = ljlk_param_resolver.global_params
+        # self.type_params = ljlk_param_resolver.type_params
+        # self.global_params = ljlk_param_resolver.global_params
         self.tile_size = LKBallEnergyTerm.tile_size
+
+    @classmethod
+    def score_types(cls):
+        import tmol.score.terms.lk_ball_creator
+
+        return tmol.score.terms.lk_ball_creator.LKBallTermCreator.score_types()
+
+    def n_bodies(self):
+        return 2
 
     def setup_block_type(self, block_type: RefinedResidueType):
         super(LKBallEnergyTerm, self).setup_block_type(block_type)
+        if hasattr(block_type, "lk_ball_params"):
+            return
+        # TO DO!
 
     def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
         super(LKBallEnergyTerm, self).setup_packed_block_types(packed_block_types)
@@ -37,261 +50,69 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
     def setup_poses(self, pose_stack: PoseStack):
         super(LKBallEnergyTerm, self).setup_poses(pose_stack)
 
-    def inter_module(
-        self,
-        packed_block_types: PackedBlockTypes,
-        pose_stack: PoseStack,
-        context_system_ids: Tensor[int][:, :],
-        system_bounding_spheres: Tensor[float][:, :, 4],
-        weights,  # map string->Real
-    ):
-        system_neighbor_list = self.create_block_neighbor_lists(system_bounding_spheres)
-        lkb_weight = torch.zeros((1,), dtype=torch.float32, device=self.device)
-        lkb_weight[0] = weights["lk_ball"] if "lk_ball" in weights else 0
+    def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
+        pbt = pose_stack.packed_block_types
+        ljlk_global_params = self.ljlk_param_resolver.global_params
 
-        pbt = packed_block_types
-        return LKBallInterSystemModule(
-            context_system_ids=context_system_ids,
-            system_min_block_bondsep=pose_stack.min_block_bondsep,
-            system_inter_block_bondsep=pose_stack.inter_block_bondsep,
-            system_neighbor_list=system_neighbor_list,
-            bt_n_heavy_atoms=pbt.n_heavy_atoms,
-            bt_atom_types=pbt.atom_types,
-            bt_heavy_atom_inds=pbt.heavy_atom_inds,
+        return LKBallWholePoseScoringModule(
+            pose_stack_block_coord_offset=pose_stack.block_coord_offset,
+            pose_stack_block_type=pose_stack.block_type_ind,
+            pose_stack_inter_residue_connections=pose_stack.inter_residue_connections,
+            pose_stack_min_bond_separation=pose_stack.min_block_bondsep,
+            pose_stack_inter_block_bondsep=pose_stack.inter_block_bondsep,
+            bt_n_atoms=pbt.n_atoms,
             bt_n_interblock_bonds=pbt.n_conn,
             bt_atoms_forming_chemical_bonds=pbt.conn_atom,
+            bt_n_all_bonds=pbt.n_all_bonds,
+            bt_all_bonds=pbt.all_bonds,
+            bt_atom_all_bond_ranges=pbt.atom_all_bond_ranges,
+            bt_tile_n_donH=pbt.hbpbt_params.tile_n_donH,
+            bt_tile_n_acc=pbt.hbpbt_params.tile_n_acc,
+            bt_tile_donH_inds=pbt.hbpbt_params.tile_donH_inds,
+            bt_tile_don_hvy_inds=None,  # TO DO!!!
+            bt_tile_which_donH_for_hvy=None,  # TO DO!!
+            bt_tile_acc_inds=pbt.hbpbt_params.tile_acc_inds,
+            bt_tile_acceptor_hybridization=pbt.hbpbt_params.tile_acceptor_hybridization,
+            bt_tile_acc_n_attached_H=None,  # TO DO!!
+            bt_atom_is_hydrogen=pbt.hbpbt_params.is_hydrogen,
+            bt_tile_n_polar_atoms=None,  # TO DO!!
+            bt_tile_n_occluder_atoms=None,  # TO DO!!
+            bt_tile_pol_occ_inds=None,  # TO DO!!
+            bt_tile_lk_ball_params=None,  # TO DO!!
             bt_path_distance=pbt.bond_separation,
-            bt_is_acceptor=pbt.hbpbt_params.is_acceptor,
-            bt_acceptor_type=pbt.hbpbt_params.acceptor_type,
-            bt_acceptor_hybridization=pbt.hbpbt_params.acceptor_hybridization,
-            bt_acceptor_base_inds=pbt.hbpbt_params.acceptor_base_inds,
-            bt_is_donor=pbt.hbpbt_params.is_donor,
-            bt_donor_type=pbt.hbpbt_params.donor_type,
-            bt_donor_attached_hydrogens=pbt.hbpbt_params.donor_attached_hydrogens,
-            param_resolver=self.ljlk_param_resolver,
-            lkb_weight=lkb_weight,
+            lk_ball_global_params=self.stack_lk_ball_global_params(),
+            water_gen_global_params=self.stack_water_gen_global_params(),
+            sp2_water_tors=ljlk_global_params.lkb_water_tors_sp2,
+            sp3_water_tors=ljlk_global_params.lkb_water_tors_sp3,
+            ring_water_tors=ljlk_global_params.lkb_water_tors_ring,
         )
 
-    def create_block_neighbor_lists(
-        self, system_bounding_spheres: Tensor[float][:, :, 4]
-    ):
-        # we need to make lists of all block pairs within
-        # striking distances of each other that we will use to
-        # decide which atom-pair calculations to perform during
-        # rotamer substititions
-        sphere_centers = system_bounding_spheres[:, :, :3].clone().detach()
-        n_sys = system_bounding_spheres.shape[0]
-        max_n_blocks = system_bounding_spheres.shape[1]
-        sphere_centers_1 = sphere_centers.view((n_sys, -1, max_n_blocks, 3))
-        sphere_centers_2 = sphere_centers.view((n_sys, max_n_blocks, -1, 3))
-        sphere_dists = torch.norm(sphere_centers_1 - sphere_centers_2, dim=3)
-        expanded_radii = (
-            system_bounding_spheres[:, :, 3] + self.ljlk_global_params.max_dis / 2
-        )
-        expanded_radii_1 = expanded_radii.view(n_sys, -1, max_n_blocks)
-        expanded_radii_2 = expanded_radii.view(n_sys, max_n_blocks, -1)
-        radii_sum = expanded_radii_1 + expanded_radii_2
-        spheres_overlap = sphere_dists < radii_sum
+    def _tfloat(self, ts):
+        return tuple(map(lambda t: t.to(torch.float), ts))
 
-        # great -- now how tf are we going to condense this into the lists
-        # of neighbors for each block?
-
-        neighbor_counts = torch.sum(spheres_overlap, dim=2)
-        max_n_neighbors = torch.max(neighbor_counts)
-
-        neighbor_list = torch.full(
-            (n_sys, max_n_blocks, max_n_neighbors),
-            -1,
-            dtype=torch.int32,
-            device=self.device,
-        )
-        nz_spheres_overlap = torch.nonzero(spheres_overlap)
-        inc_inds = (
-            torch.arange(max_n_neighbors, device=self.device)
-            .repeat(n_sys * max_n_blocks)
-            .view(n_sys, max_n_blocks, max_n_neighbors)
-        )
-        store_neighbor = inc_inds < neighbor_counts.view(n_sys, max_n_blocks, 1)
-
-        neighbor_list[
-            nz_spheres_overlap[:, 0],
-            nz_spheres_overlap[:, 1],
-            inc_inds[store_neighbor].view(-1),
-        ] = nz_spheres_overlap[:, 2].type(torch.int32)
-
-        return neighbor_list
-
-
-class LKBallInterSystemModule(torch.jit.ScriptModule):
-    def __init__(
-        self,
-        context_system_ids,
-        system_min_block_bondsep,
-        system_inter_block_bondsep,
-        system_neighbor_list,
-        bt_n_heavy_atoms,
-        bt_atom_types,
-        bt_heavy_atom_inds,
-        bt_n_interblock_bonds,
-        bt_atoms_forming_chemical_bonds,
-        bt_path_distance,
-        bt_is_acceptor,
-        bt_acceptor_type,
-        bt_acceptor_hybridization,
-        bt_acceptor_base_inds,
-        bt_is_donor,
-        bt_donor_type,
-        bt_donor_attached_hydrogens,
-        param_resolver: LJLKParamResolver,
-        lkb_weight,
-    ):
-        super().__init__()
-
-        def _p(t):
-            return torch.nn.Parameter(t, requires_grad=False)
-
-        def _t(ts):
-            return tuple(map(lambda t: t.to(torch.float), ts))
-
-        # TEMP!
-        self.context_water_coords = _p(
-            torch.zeros(
-                (1, 1, 1, 4, 3), dtype=torch.float32, device=context_system_ids.device
-            )
+    def stack_lk_ball_global_params(self):
+        return torch.stack(
+            self._tfloat(
+                [
+                    self.ljlk_param_resolver.global_params.lj_hbond_dis,
+                    self.ljlk_param_resolver.global_params.lj_hbond_OH_donor_dis,
+                    self.ljlk_param_resolver.global_params.lj_hbond_hdis,
+                    self.ljlk_param_resolver.global_params.lkb_water_dist,
+                    self.ljlk_param_resolver.global_params.max_dis,
+                ]
+            ),
+            dim=1,
         )
 
-        self.context_system_ids = _p(context_system_ids)
-        self.system_min_block_bondsep = _p(system_min_block_bondsep)
-        self.system_inter_block_bondsep = _p(system_inter_block_bondsep)
-        self.system_neighbor_list = _p(system_neighbor_list)
-
-        # self.bt_n_atoms = _p(bt_n_atoms)
-        self.bt_n_heavy_atoms = _p(bt_n_heavy_atoms)
-        self.bt_atom_types = _p(bt_atom_types)
-        self.bt_heavy_atom_inds = _p(bt_heavy_atom_inds)
-        self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
-        self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
-        self.bt_path_distance = _p(bt_path_distance)
-
-        self.bt_is_acceptor = _p(bt_is_acceptor)
-        self.bt_acceptor_type = _p(bt_acceptor_type)
-        self.bt_acceptor_hybridization = _p(bt_acceptor_hybridization)
-        self.bt_acceptor_base_inds = _p(bt_acceptor_base_inds)
-        self.bt_is_donor = _p(bt_is_donor)
-        self.bt_donor_type = _p(bt_donor_type)
-        self.bt_donor_attached_hydrogens = _p(bt_donor_attached_hydrogens)
-
-        self.lkball_global_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        param_resolver.global_params.lj_hbond_dis,
-                        param_resolver.global_params.lj_hbond_OH_donor_dis,
-                        param_resolver.global_params.lj_hbond_hdis,
-                        param_resolver.global_params.lkb_water_dist,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        # Pack parameters into dense tensor. Parameter ordering must match
-        # struct layout declared in `potentials/params.hh`.
-        self.lj_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        param_resolver.type_params.lj_radius,
-                        param_resolver.type_params.lj_wdepth,
-                        param_resolver.type_params.is_donor,
-                        param_resolver.type_params.is_hydroxyl,
-                        param_resolver.type_params.is_polarh,
-                        param_resolver.type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        # Pack parameters into dense tensor. Parameter ordering must match
-        # struct layout declared in `potentials/params.hh`.
-        self.lk_type_params = _p(
-            torch.stack(
-                _t(
-                    [
-                        param_resolver.type_params.lj_radius,
-                        param_resolver.type_params.lk_dgfree,
-                        param_resolver.type_params.lk_lambda,
-                        param_resolver.type_params.lk_volume,
-                        param_resolver.type_params.is_donor,
-                        param_resolver.type_params.is_hydroxyl,
-                        param_resolver.type_params.is_polarh,
-                        param_resolver.type_params.is_acceptor,
-                    ]
-                ),
-                dim=1,
-            )
-        )
-
-        self.watergen_water_tors_sp2 = torch.nn.Parameter(
-            param_resolver.global_params.lkb_water_tors_sp2, requires_grad=False
-        )
-        self.watergen_water_tors_sp3 = torch.nn.Parameter(
-            param_resolver.global_params.lkb_water_tors_sp3, requires_grad=False
-        )
-        self.watergen_water_tors_ring = torch.nn.Parameter(
-            param_resolver.global_params.lkb_water_tors_ring, requires_grad=False
-        )
-
-        # self.global_params = _p(
-        #     torch.stack(
-        #         _t(
-        #             [
-        #                 global_params.lj_hbond_dis,
-        #                 global_params.lj_hbond_OH_donor_dis,
-        #                 global_params.lj_hbond_hdis,
-        #             ]
-        #         ),
-        #         dim=1,
-        #     )
-        # )
-
-        self.lkb_weight = _p(lkb_weight)
-
-    @torch.jit.script_method
-    def forward(
-        self, context_coords, context_block_type, alternate_coords, alternate_ids
-    ):
-        return torch.ops.tmol.score_lkball_inter_system_scores(
-            context_coords,
-            context_block_type,
-            alternate_coords,
-            alternate_ids,
-            self.context_water_coords,
-            self.context_system_ids,
-            self.system_min_block_bondsep,
-            self.system_inter_block_bondsep,
-            self.system_neighbor_list,
-            # self.bt_n_atoms,
-            # self.bt_n_heavy_atoms,
-            # self.bt_atom_types,
-            # self.bt_heavy_atom_inds,
-            # self.bt_n_interblock_bonds,
-            # self.bt_atoms_forming_chemical_bonds,
-            # self.bt_path_distance,
-            self.bt_is_acceptor,
-            self.bt_acceptor_type,
-            self.bt_acceptor_hybridization,
-            self.bt_acceptor_base_inds,
-            self.bt_is_donor,
-            self.bt_donor_type,
-            self.bt_donor_attached_hydrogens,
-            # self.lj_type_params,
-            # self.lk_type_params,
-            # self.global_params,
-            self.lkball_global_params,
-            self.watergen_water_tors_sp2,
-            self.watergen_water_tors_sp3,
-            self.watergen_water_tors_ring,
-            self.lkb_weight,
+    def stack_lkball_water_gen_global_params(self):
+        return torch.stack(
+            self._tfloat(
+                [
+                    self.ljlk_param_resolver.global_params.lkb_water_dist,
+                    self.ljlk_param_resolver.global_params.lkb_water_angle_sp2,
+                    self.ljlk_param_resolver.global_params.lkb_water_angle_sp3,
+                    self.ljlk_param_resolver.global_params.lkb_water_angle_ring,
+                ]
+            ),
+            dim=1,
         )

--- a/tmol/score/lk_ball/lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/lk_ball_energy_term.py
@@ -176,11 +176,6 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         def _t(t):
             return torch.tensor(t, device=packed_block_types.device)
 
-        tile_n_polar_atoms = _t(tile_n_polar_atoms)
-        tile_n_occluder_atoms = _t(tile_n_occluder_atoms)
-        tile_pol_occ_inds = _t(tile_pol_occ_inds)
-        tile_lk_ball_params = _t(tile_lk_ball_params)
-
         lk_ball_params = LKBallPackedBlockTypeParams(
             tile_n_polar_atoms=_t(tile_n_polar_atoms),
             tile_n_occluder_atoms=_t(tile_n_occluder_atoms),

--- a/tmol/score/lk_ball/lk_ball_whole_pose_module.py
+++ b/tmol/score/lk_ball/lk_ball_whole_pose_module.py
@@ -1,0 +1,135 @@
+import torch
+
+from tmol.score.lk_ball.potentials.compiled import gen_pose_waters, pose_score_lk_ball
+
+
+class LKBallWholePoseScoringModule(torch.nn.Module):
+    def __init__(
+        self,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_residue_connections,
+        pose_stack_min_bond_separation,
+        pose_stack_inter_block_bondsep,
+        bt_n_atoms,
+        bt_n_interblock_bonds,
+        bt_atoms_forming_chemical_bonds,
+        bt_n_all_bonds,
+        bt_all_bonds,
+        bt_atom_all_bond_ranges,
+        bt_tile_n_donH,
+        bt_tile_n_acc,
+        bt_tile_donH_inds,
+        bt_tile_don_hvy_inds,
+        bt_tile_which_donH_for_hvy,
+        bt_tile_acc_inds,
+        bt_tile_hybridization,
+        bt_tile_acc_n_attached_H,
+        bt_atom_is_hydrogen,
+        bt_tile_n_polar_atoms,
+        bt_tile_n_occluder_atoms,
+        bt_tile_pol_occ_inds,
+        bt_tile_lk_ball_params,
+        bt_path_distance,
+        lk_ball_global_params,
+        water_gen_global_params,
+        sp2_water_tors,
+        sp3_water_tors,
+        ring_water_tors,
+    ):
+        super(LKBallWholePoseScoringModule, self).__init__()
+
+        def _p(t):
+            return torch.nn.Parameter(t, requires_grad=False)
+
+        def _t(ts):
+            return tuple(map(lambda t: t.to(torch.float), ts))
+
+        self.pose_stack_block_coord_offset = _p(pose_stack_block_coord_offset)
+        self.pose_stack_block_type = _p(pose_stack_block_type)
+        self.pose_stack_inter_residue_connections = _p(
+            pose_stack_inter_residue_connections
+        )
+        self.pose_stack_min_bond_separation = _p(pose_stack_min_bond_separation)
+        self.pose_stack_inter_block_bondsep = _p(pose_stack_inter_block_bondsep)
+
+        self.bt_n_atoms = _p(bt_n_atoms)
+        self.bt_n_interblock_bonds = _p(bt_n_interblock_bonds)
+        self.bt_atoms_forming_chemical_bonds = _p(bt_atoms_forming_chemical_bonds)
+        self.bt_n_all_bonds = _p(bt_n_all_bonds)
+        self.bt_all_bonds = _p(bt_all_bonds)
+
+        self.bt_atom_all_bond_ranges = _p(bt_atom_all_bond_ranges)
+        self.bt_tile_n_donH = _p(bt_tile_n_donH)
+        self.bt_tile_n_acc = _p(bt_tile_n_acc)
+        self.bt_tile_donH_inds = _p(bt_tile_donH_inds)
+        self.bt_tile_don_hvy_inds = _p(bt_tile_don_hvy_inds)
+
+        self.bt_tile_which_donH_for_hvy = _p(bt_tile_which_donH_for_hvy)
+        self.bt_tile_acc_inds = _p(bt_tile_acc_inds)
+        self.bt_tile_hybridization = _p(bt_tile_hybridization)
+        self.bt_tile_acc_n_attached_H = _p(bt_tile_acc_n_attached_H)
+        self.bt_atom_is_hydrogen = _p(bt_atom_is_hydrogen)
+
+        self.bt_tile_n_polar_atoms = _p(bt_tile_n_polar_atoms)
+        self.bt_tile_n_occluder_atoms = _p(bt_tile_n_occluder_atoms)
+        self.bt_tile_pol_occ_inds = _p(bt_tile_pol_occ_inds)
+        self.bt_tile_lk_ball_params = _p(bt_tile_lk_ball_params)
+        self.bt_path_distance = _p(bt_path_distance)
+
+        self.lk_ball_global_params = _p(lk_ball_global_params)
+        self.water_gen_global_params = _p(water_gen_global_params)
+        self.sp2_water_tors = _p(sp2_water_tors)
+        self.sp3_water_tors = _p(sp3_water_tors)
+        self.ring_water_tors = _p(ring_water_tors)
+
+    def forward(self, pose_coords):
+        """Two step scoring: first build the waters and then score;
+        derivatives are calculated backwards through the water
+        building step by torch's autograd machinery
+        """
+
+        water_coords = gen_pose_waters(
+            pose_coords,
+            self.pose_stack_block_coord_offset,
+            self.pose_stack_block_type,
+            self.pose_stack_inter_residue_connections,
+            self.bt_n_atoms,
+            self.bt_n_interblock_bonds,
+            self.bt_atoms_forming_chemical_bonds,
+            self.bt_n_all_bonds,
+            self.bt_all_bonds,
+            self.bt_atom_all_bond_ranges,
+            self.bt_tile_n_donH,
+            self.bt_tile_n_acc,
+            self.bt_tile_donH_inds,
+            self.bt_tile_don_hvy_inds,
+            self.bt_tile_which_donH_for_hvy,
+            self.bt_tile_acc_inds,
+            self.bt_tile_hybridization,
+            self.bt_tile_acc_n_attached_H,
+            self.bt_atom_is_hydrogen,
+            self.water_gen_global_params,
+            self.sp2_water_tors,
+            self.sp3_water_tors,
+            self.ring_water_tors,
+        )
+
+        return pose_score_lk_bal(
+            pose_coords,
+            water_coords,
+            self.pose_stack_block_coord_offset,
+            self.pose_stack_block_type,
+            self.pose_stack_inter_residue_connections,
+            self.pose_stack_min_bond_separation,
+            self.pose_stack_inter_block_bondsep,
+            self.bt_n_atoms,
+            self.bt_n_interblock_bonds,
+            self.bt_atoms_forming_chemical_bonds,
+            self.bt_tile_n_polar_atoms,
+            self.bt_tile_n_occluder_atoms,
+            self.bt_tile_pol_occ_inds,
+            self.bt_tile_lk_ball_params,
+            self.bt_path_distance,
+            self.lk_ball_global_params,
+        )

--- a/tmol/score/lk_ball/lk_ball_whole_pose_module.py
+++ b/tmol/score/lk_ball/lk_ball_whole_pose_module.py
@@ -89,6 +89,30 @@ class LKBallWholePoseScoringModule(torch.nn.Module):
         building step by torch's autograd machinery
         """
 
+        # print("pose_coords"); print(pose_coords.cpu()[0,:5])
+        # print("self.pose_stack_block_coord_offset"); print(self.pose_stack_block_coord_offset.cpu()[0,:5])
+        # print("self.pose_stack_block_type"); print(self.pose_stack_block_type.cpu()[0,:5])
+        # print("self.pose_stack_inter_residue_connections"); print(self.pose_stack_inter_residue_connections.cpu()[0,:5])
+        # print("self.bt_n_atoms"); print(self.bt_n_atoms.cpu()[:])
+        # print("self.bt_n_interblock_bonds"); print(self.bt_n_interblock_bonds.cpu()[:])
+        # print("self.bt_atoms_forming_chemical_bonds"); print(self.bt_atoms_forming_chemical_bonds.cpu()[0])
+        # print("self.bt_n_all_bonds"); print(self.bt_n_all_bonds.cpu()[0])
+        # print("self.bt_all_bonds"); print(self.bt_all_bonds.cpu()[0,:5])
+        # print("self.bt_atom_all_bond_ranges"); print(self.bt_atom_all_bond_ranges.cpu()[0,:5])
+        # print("self.bt_tile_n_donH"); print(self.bt_tile_n_donH.cpu()[0])
+        # print("self.bt_tile_n_acc"); print(self.bt_tile_n_acc.cpu()[0])
+        # print("self.bt_tile_donH_inds"); print(self.bt_tile_donH_inds.cpu()[0,0,:5])
+        # print("self.bt_tile_don_hvy_inds"); print(self.bt_tile_don_hvy_inds.cpu()[0,0,:5])
+        # print("self.bt_tile_which_donH_for_hvy"); print(self.bt_tile_which_donH_for_hvy.cpu()[0,0,:5])
+        # print("self.bt_tile_acc_inds"); print(self.bt_tile_acc_inds.cpu()[0,0,:5])
+        # print("self.bt_tile_hybridization"); print(self.bt_tile_hybridization.cpu()[0,0,:5])
+        # print("self.bt_tile_acc_n_attached_H"); print(self.bt_tile_acc_n_attached_H.cpu()[0,0,:5])
+        # print("self.bt_atom_is_hydrogen"); print(self.bt_atom_is_hydrogen.cpu()[0,:5])
+        # print("self.water_gen_global_params"); print(self.water_gen_global_params.cpu()[:])
+        # print("self.sp2_water_tors"); print(self.sp2_water_tors.cpu()[:])
+        # print("self.sp3_water_tors"); print(self.sp3_water_tors.cpu()[:])
+        # print("self.ring_water_tors"); print(self.ring_water_tors.cpu()[:])
+
         water_coords = gen_pose_waters(
             pose_coords,
             self.pose_stack_block_coord_offset,
@@ -115,7 +139,10 @@ class LKBallWholePoseScoringModule(torch.nn.Module):
             self.ring_water_tors,
         )
 
-        return pose_score_lk_bal(
+        # print("water coords")
+        # print(water_coords.cpu()[0,0:5])
+
+        return pose_score_lk_ball(
             pose_coords,
             water_coords,
             self.pose_stack_block_coord_offset,

--- a/tmol/score/lk_ball/lk_ball_whole_pose_module.py
+++ b/tmol/score/lk_ball/lk_ball_whole_pose_module.py
@@ -89,30 +89,6 @@ class LKBallWholePoseScoringModule(torch.nn.Module):
         building step by torch's autograd machinery
         """
 
-        # print("pose_coords"); print(pose_coords.cpu()[0,:5])
-        # print("self.pose_stack_block_coord_offset"); print(self.pose_stack_block_coord_offset.cpu()[0,:5])
-        # print("self.pose_stack_block_type"); print(self.pose_stack_block_type.cpu()[0,:5])
-        # print("self.pose_stack_inter_residue_connections"); print(self.pose_stack_inter_residue_connections.cpu()[0,:5])
-        # print("self.bt_n_atoms"); print(self.bt_n_atoms.cpu()[:])
-        # print("self.bt_n_interblock_bonds"); print(self.bt_n_interblock_bonds.cpu()[:])
-        # print("self.bt_atoms_forming_chemical_bonds"); print(self.bt_atoms_forming_chemical_bonds.cpu()[0])
-        # print("self.bt_n_all_bonds"); print(self.bt_n_all_bonds.cpu()[0])
-        # print("self.bt_all_bonds"); print(self.bt_all_bonds.cpu()[0,:5])
-        # print("self.bt_atom_all_bond_ranges"); print(self.bt_atom_all_bond_ranges.cpu()[0,:5])
-        # print("self.bt_tile_n_donH"); print(self.bt_tile_n_donH.cpu()[0])
-        # print("self.bt_tile_n_acc"); print(self.bt_tile_n_acc.cpu()[0])
-        # print("self.bt_tile_donH_inds"); print(self.bt_tile_donH_inds.cpu()[0,0,:5])
-        # print("self.bt_tile_don_hvy_inds"); print(self.bt_tile_don_hvy_inds.cpu()[0,0,:5])
-        # print("self.bt_tile_which_donH_for_hvy"); print(self.bt_tile_which_donH_for_hvy.cpu()[0,0,:5])
-        # print("self.bt_tile_acc_inds"); print(self.bt_tile_acc_inds.cpu()[0,0,:5])
-        # print("self.bt_tile_hybridization"); print(self.bt_tile_hybridization.cpu()[0,0,:5])
-        # print("self.bt_tile_acc_n_attached_H"); print(self.bt_tile_acc_n_attached_H.cpu()[0,0,:5])
-        # print("self.bt_atom_is_hydrogen"); print(self.bt_atom_is_hydrogen.cpu()[0,:5])
-        # print("self.water_gen_global_params"); print(self.water_gen_global_params.cpu()[:])
-        # print("self.sp2_water_tors"); print(self.sp2_water_tors.cpu()[:])
-        # print("self.sp3_water_tors"); print(self.sp3_water_tors.cpu()[:])
-        # print("self.ring_water_tors"); print(self.ring_water_tors.cpu()[:])
-
         water_coords = gen_pose_waters(
             pose_coords,
             self.pose_stack_block_coord_offset,
@@ -138,9 +114,6 @@ class LKBallWholePoseScoringModule(torch.nn.Module):
             self.sp3_water_tors,
             self.ring_water_tors,
         )
-
-        # print("water coords")
-        # print(water_coords.cpu()[0,0:5])
 
         return pose_score_lk_ball(
             pose_coords,

--- a/tmol/score/lk_ball/lk_ball_whole_pose_module.py
+++ b/tmol/score/lk_ball/lk_ball_whole_pose_module.py
@@ -42,9 +42,6 @@ class LKBallWholePoseScoringModule(torch.nn.Module):
         def _p(t):
             return torch.nn.Parameter(t, requires_grad=False)
 
-        def _t(ts):
-            return tuple(map(lambda t: t.to(torch.float), ts))
-
         self.pose_stack_block_coord_offset = _p(pose_stack_block_coord_offset)
         self.pose_stack_block_type = _p(pose_stack_block_type)
         self.pose_stack_inter_residue_connections = _p(

--- a/tmol/score/lk_ball/params.py
+++ b/tmol/score/lk_ball/params.py
@@ -1,23 +1,25 @@
 import attr
+import numpy
+import torch
 
 from tmol.types.attrs import ValidateAttrs
 from tmol.types.array import NDArray
 from tmol.types.torch import Tensor
 
 
-@attr.s(auto_attribs=True, froze=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class LKBallBlockTypeParams(ValidateAttrs):
     tile_n_polar_atoms: NDArray[numpy.int32][:]
     tile_n_occluder_atoms: NDArray[numpy.int32][:]
     tile_pol_occ_inds: NDArray[numpy.int32][:, :]
-    tile_n_occluder_atoms: NDArray[numpy.int32][:]
-    tile_lk_ball_params: NDArray[numpy.float32][:, :, :]
+    # tile_n_occluder_atoms: NDArray[numpy.int32][:]
+    tile_lk_ball_params: NDArray[numpy.float32][:, :, 8]
 
 
-@attr.s(auto_attribs=True, froze=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class LKBallPackedBlockTypeParams(ValidateAttrs):
-    tile_n_polar_atoms: Tensor[torch.int32][:]
-    tile_n_occluder_atoms: Tensor[torch.int32][:]
-    tile_pol_occ_inds: Tensor[torch.int32][:, :]
-    tile_n_occluder_atoms: Tensor[torch.int32][:]
-    tile_lk_ball_params: Tensor[torch.float32][:, :, :]
+    tile_n_polar_atoms: Tensor[torch.int32][:, :]
+    tile_n_occluder_atoms: Tensor[torch.int32][:, :]
+    tile_pol_occ_inds: Tensor[torch.int32][:, :, :]
+    # tile_n_occluder_atoms: Tensor[torch.int32][:]
+    tile_lk_ball_params: Tensor[torch.float32][:, :, :, 8]

--- a/tmol/score/lk_ball/params.py
+++ b/tmol/score/lk_ball/params.py
@@ -1,0 +1,23 @@
+import attr
+
+from tmol.types.attrs import ValidateAttrs
+from tmol.types.array import NDArray
+from tmol.types.torch import Tensor
+
+
+@attr.s(auto_attribs=True, froze=True, slots=True)
+class LKBallBlockTypeParams(ValidateAttrs):
+    tile_n_polar_atoms: NDArray[numpy.int32][:]
+    tile_n_occluder_atoms: NDArray[numpy.int32][:]
+    tile_pol_occ_inds: NDArray[numpy.int32][:, :]
+    tile_n_occluder_atoms: NDArray[numpy.int32][:]
+    tile_lk_ball_params: NDArray[numpy.float32][:, :, :]
+
+
+@attr.s(auto_attribs=True, froze=True, slots=True)
+class LKBallPackedBlockTypeParams(ValidateAttrs):
+    tile_n_polar_atoms: Tensor[torch.int32][:]
+    tile_n_occluder_atoms: Tensor[torch.int32][:]
+    tile_pol_occ_inds: Tensor[torch.int32][:, :]
+    tile_n_occluder_atoms: Tensor[torch.int32][:]
+    tile_lk_ball_params: Tensor[torch.float32][:, :, :]

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -417,25 +417,23 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
       AutogradContext* ctx,
 
       Tensor pose_coords,
-      Tensor pose_coords,
       Tensor water_coords,
       Tensor pose_stack_block_coord_offset,
       Tensor pose_stack_block_type,
-
       Tensor pose_stack_inter_residue_connections,
+
       Tensor pose_stack_min_bond_separation,
       Tensor pose_stack_inter_block_bondsep,
       Tensor block_type_n_atoms,
       Tensor block_type_n_interblock_bonds,
-
       Tensor block_type_atoms_forming_chemical_bonds,
+
       Tensor block_type_tile_n_polar_atoms,
       Tensor block_type_tile_n_occluder_atoms,
-      Tensor block_type_tile_polar_inds,
-      Tensor block_type_tile_occluder_inds,
-
+      Tensor block_type_tile_pol_occ_inds,
       Tensor block_type_tile_lk_ball_params,
       Tensor block_type_path_distance,
+
       Tensor global_params) {
     at::Tensor score;
     at::Tensor block_neighbors;
@@ -463,11 +461,10 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 
                   TCAST(block_type_tile_n_polar_atoms),
                   TCAST(block_type_tile_n_occluder_atoms),
-                  TCAST(block_type_tile_polar_inds),
-                  TCAST(block_type_tile_occluder_inds),
+                  TCAST(block_type_tile_pol_occ_inds),
                   TCAST(block_type_tile_lk_ball_params),
-
                   TCAST(block_type_path_distance),
+
                   TCAST(global_params));
 
           score = std::get < 0(result).tensor;
@@ -475,22 +472,23 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
         }));
 
     ctx->save_for_backward({pose_coords,
-                            pose_coords,
                             water_coords,
                             pose_stack_block_coord_offset,
                             pose_stack_block_type,
                             pose_stack_inter_residue_connections,
+
                             pose_stack_min_bond_separation,
                             pose_stack_inter_block_bondsep,
                             block_type_n_atoms,
                             block_type_n_interblock_bonds,
                             block_type_atoms_forming_chemical_bonds,
+
                             block_type_tile_n_polar_atoms,
                             block_type_tile_n_occluder_atoms,
-                            block_type_tile_polar_inds,
-                            block_type_tile_occluder_inds,
+                            block_type_tile_pol_occ_inds,
                             block_type_tile_lk_ball_params,
                             block_type_path_distance,
+
                             global_params,
                             block_neighbors});
 
@@ -503,22 +501,23 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     int i = 0;
 
     auto pose_coords = saved[i++];
-    auto pose_coords = saved[i++];
     auto water_coords = saved[i++];
     auto pose_stack_block_coord_offset = saved[i++];
     auto pose_stack_block_type = saved[i++];
     auto pose_stack_inter_residue_connections = saved[i++];
+
     auto pose_stack_min_bond_separation = saved[i++];
     auto pose_stack_inter_block_bondsep = saved[i++];
     auto block_type_n_atoms = saved[i++];
     auto block_type_n_interblock_bonds = saved[i++];
     auto block_type_atoms_forming_chemical_bonds = saved[i++];
+
     auto block_type_tile_n_polar_atoms = saved[i++];
     auto block_type_tile_n_occluder_atoms = saved[i++];
-    auto block_type_tile_polar_inds = saved[i++];
-    auto block_type_tile_occluder_inds = saved[i++];
+    auto block_type_tile_pol_occ_inds = saved[i++];
     auto block_type_tile_lk_ball_params = saved[i++];
     auto block_type_path_distance = saved[i++];
+
     auto global_params = saved[i++];
     auto block_neighbors = saved[i++];
 
@@ -548,11 +547,10 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 
                   TCAST(block_type_tile_n_polar_atoms),
                   TCAST(block_type_tile_n_occluder_atoms),
-                  TCAST(block_type_tile_polar_inds),
-                  TCAST(block_type_tile_occluder_inds),
+                  TCAST(block_type_tile_pol_occ_inds),
                   TCAST(block_type_tile_lk_ball_params),
-
                   TCAST(block_type_path_distance),
+
                   TCAST(global_params),
                   TCAST(block_neighbors),
                   TCAST(dTdV));
@@ -579,8 +577,6 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
             torch::Tensor(),
             torch::Tensor(),
 
-            torch::Tensor(),
-            torch::Tensor(),
             torch::Tensor()};
   }
 };
@@ -588,47 +584,43 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 template <template <tmol::Device> class Dispatch>
 Tensor lkball_pose_score(
     Tensor pose_coords,
-    Tensor pose_coords,
     Tensor water_coords,
     Tensor pose_stack_block_coord_offset,
     Tensor pose_stack_block_type,
-
     Tensor pose_stack_inter_residue_connections,
+
     Tensor pose_stack_min_bond_separation,
     Tensor pose_stack_inter_block_bondsep,
     Tensor block_type_n_atoms,
     Tensor block_type_n_interblock_bonds,
-
     Tensor block_type_atoms_forming_chemical_bonds,
+
     Tensor block_type_tile_n_polar_atoms,
     Tensor block_type_tile_n_occluder_atoms,
-    Tensor block_type_tile_polar_inds,
-    Tensor block_type_tile_occluder_inds,
-
+    Tensor block_type_tile_pol_occ_inds,
     Tensor block_type_tile_lk_ball_params,
     Tensor block_type_path_distance,
+
     Tensor global_params) {
   return LKBallPoseScoreOp::apply(
-      pose_coords,
       pose_coords,
       water_coords,
       pose_stack_block_coord_offset,
       pose_stack_block_type,
-
       pose_stack_inter_residue_connections,
+
       pose_stack_min_bond_separation,
       pose_stack_inter_block_bondsep,
       block_type_n_atoms,
       block_type_n_interblock_bonds,
-
       block_type_atoms_forming_chemical_bonds,
+
       block_type_tile_n_polar_atoms,
       block_type_tile_n_occluder_atoms,
-      block_type_tile_polar_inds,
-      block_type_tile_occluder_inds,
-
+      block_type_tile_pol_occ_inds,
       block_type_tile_lk_ball_params,
       block_type_path_distance,
+
       global_params);
 }
 

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -289,14 +289,16 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
       Tensor block_type_tile_n_acc,
       Tensor block_type_tile_donH_inds,
       Tensor block_type_tile_don_hvy_inds,
-      Tensor block_type_tile_acc_inds,
+      Tensor block_type_tile_which_donH_for_hvy,
 
+      Tensor block_type_tile_acc_inds,
       Tensor block_type_tile_hybridization,
+      Tensor block_type_tile_acc_n_attached_H,
       Tensor block_type_atom_is_hydrogen,
       Tensor global_params,
+
       Tensor sp2_water_tors,
       Tensor sp3_water_tors,
-
       Tensor ring_water_tors) {
     at::Tensor waters;
 
@@ -315,19 +317,25 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
                       TCAST(pose_stack_block_type),
                       TCAST(pose_stack_inter_residue_connections),
                       TCAST(block_type_n_atoms),
+
                       TCAST(block_type_n_interblock_bonds),
                       TCAST(block_type_atoms_forming_chemical_bonds),
                       TCAST(block_type_n_all_bonds),
                       TCAST(block_type_all_bonds),
                       TCAST(block_type_atom_all_bond_ranges),
+
                       TCAST(block_type_tile_n_donH),
                       TCAST(block_type_tile_n_acc),
                       TCAST(block_type_tile_donH_inds),
                       TCAST(block_type_tile_don_hvy_inds),
+                      TCAST(block_type_tile_which_donH_for_hvy),
+
                       TCAST(block_type_tile_acc_inds),
                       TCAST(block_type_tile_hybridization),
+                      TCAST(block_type_tile_acc_n_attached_H),
                       TCAST(block_type_atom_is_hydrogen),
                       TCAST(global_params),
+
                       TCAST(sp2_water_tors),
                       TCAST(sp3_water_tors),
                       TCAST(ring_water_tors));
@@ -351,14 +359,16 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
                             block_type_tile_n_acc,
                             block_type_tile_donH_inds,
                             block_type_tile_don_hvy_inds,
-                            block_type_tile_acc_inds,
+                            block_type_tile_which_donH_for_hvy,
 
+                            block_type_tile_acc_inds,
                             block_type_tile_hybridization,
+                            block_type_tile_acc_n_attached_H,
                             block_type_atom_is_hydrogen,
                             global_params,
+
                             sp2_water_tors,
                             sp3_water_tors,
-
                             ring_water_tors});
 
     return waters;
@@ -385,19 +395,22 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
     auto block_type_tile_n_acc = saved[i++];
     auto block_type_tile_donH_inds = saved[i++];
     auto block_type_tile_don_hvy_inds = saved[i++];
-    auto block_type_tile_acc_inds = saved[i++];
+    auto block_type_tile_which_donH_for_hvy = saved[i++];
 
+    auto block_type_tile_acc_inds = saved[i++];
     auto block_type_tile_hybridization = saved[i++];
+    auto block_type_tile_acc_n_attached_H = saved[i++];
     auto block_type_atom_is_hydrogen = saved[i++];
     auto global_params = saved[i++];
+
     auto sp2_water_tors = saved[i++];
     auto sp3_water_tors = saved[i++];
     auto ring_water_tors = saved[i++];
 
     at::Tensor dT_d_pose_coords;
-    using Int = int64_t;
 
-    constexpr int MAX_WATER = 4;
+    using Int = int32_t;
+
     auto dE_dWxyz = grad_outputs[0];
 
     TMOL_DISPATCH_FLOATING_DEVICE(
@@ -423,8 +436,10 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
                       TCAST(block_type_tile_n_acc),
                       TCAST(block_type_tile_donH_inds),
                       TCAST(block_type_tile_don_hvy_inds),
+                      TCAST(block_type_tile_which_donH_for_hvy),
                       TCAST(block_type_tile_acc_inds),
                       TCAST(block_type_tile_hybridization),
+                      TCAST(block_type_tile_acc_n_attached_H),
                       TCAST(block_type_atom_is_hydrogen),
                       TCAST(global_params),
                       TCAST(sp2_water_tors),
@@ -445,7 +460,7 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
             torch::Tensor(),  torch::Tensor(), torch::Tensor(),
             torch::Tensor(),  torch::Tensor(),
 
-            torch::Tensor()};
+            torch::Tensor(),  torch::Tensor(), torch::Tensor()};
   };
 };
 
@@ -535,11 +550,14 @@ Tensor pose_watergen_op(
     Tensor block_type_tile_n_acc,
     Tensor block_type_tile_donH_inds,
     Tensor block_type_tile_don_hvy_inds,
-    Tensor block_type_tile_acc_inds,
+    Tensor block_type_tile_which_donH_for_hvy,
 
+    Tensor block_type_tile_acc_inds,
     Tensor block_type_tile_hybridization,
+    Tensor block_type_tile_acc_n_attached_H,
     Tensor block_type_atom_is_hydrogen,
     Tensor global_params,
+
     Tensor sp2_water_tors,
     Tensor sp3_water_tors,
     Tensor ring_water_tors) {
@@ -558,8 +576,10 @@ Tensor pose_watergen_op(
       block_type_tile_n_acc,
       block_type_tile_donH_inds,
       block_type_tile_don_hvy_inds,
+      block_type_tile_which_donH_for_hvy,
       block_type_tile_acc_inds,
       block_type_tile_hybridization,
+      block_type_tile_acc_n_attached_H,
       block_type_atom_is_hydrogen,
       global_params,
       sp2_water_tors,

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -6,10 +6,12 @@
 
 #include <tmol/score/common/simple_dispatch.hh>
 #include <tmol/score/common/forall_dispatch.hh>
+#include <tmol/score/common/device_operations.hh>
 
 #include "dispatch.hh"
 #include "gen_waters.hh"
 #include "rotamer_pair_energy_lkball.hh"
+#include "lk_ball_pose_score.hh"
 
 namespace tmol {
 namespace score {
@@ -409,6 +411,227 @@ Tensor rotamer_pair_energies(
   return rpes;
 }
 
+class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
+ public:
+  static Tensor forward(
+      AutogradContext* ctx,
+
+      Tensor pose_coords,
+      Tensor pose_coords,
+      Tensor water_coords,
+      Tensor pose_stack_block_coord_offset,
+      Tensor pose_stack_block_type,
+
+      Tensor pose_stack_inter_residue_connections,
+      Tensor pose_stack_min_bond_separation,
+      Tensor pose_stack_inter_block_bondsep,
+      Tensor block_type_n_atoms,
+      Tensor block_type_n_interblock_bonds,
+
+      Tensor block_type_atoms_forming_chemical_bonds,
+      Tensor block_type_tile_n_polar_atoms,
+      Tensor block_type_tile_n_occluder_atoms,
+      Tensor block_type_tile_polar_inds,
+      Tensor block_type_tile_occluder_inds,
+
+      Tensor block_type_tile_lk_ball_params,
+      Tensor block_type_path_distance,
+      Tensor global_params) {
+    at::Tensor score;
+    at::Tensor block_neighbors;
+
+    using Int = int32_t;
+
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        I.type(), "lk_ball_pose_score_op", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+
+          auto result =
+              LKBallPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::forward(
+                  TCAST(pose_coords),
+                  TCAST(water_coords),
+                  TCAST(pose_stack_block_coord_offset),
+                  TCAST(pose_stack_block_type),
+                  TCAST(pose_stack_inter_residue_connections),
+
+                  TCAST(pose_stack_min_bond_separation),
+                  TCAST(pose_stack_inter_block_bondsep),
+                  TCAST(block_type_n_atoms),
+                  TCAST(block_type_n_interblock_bonds),
+                  TCAST(block_type_atoms_forming_chemical_bonds),
+
+                  TCAST(block_type_tile_n_polar_atoms),
+                  TCAST(block_type_tile_n_occluder_atoms),
+                  TCAST(block_type_tile_polar_inds),
+                  TCAST(block_type_tile_occluder_inds),
+                  TCAST(block_type_tile_lk_ball_params),
+
+                  TCAST(block_type_path_distance),
+                  TCAST(global_params));
+
+          score = std::get < 0(result).tensor;
+          block_neighbors = std::get<1>(result).tensor;
+        }));
+
+    ctx->save_for_backward({pose_coords,
+                            pose_coords,
+                            water_coords,
+                            pose_stack_block_coord_offset,
+                            pose_stack_block_type,
+                            pose_stack_inter_residue_connections,
+                            pose_stack_min_bond_separation,
+                            pose_stack_inter_block_bondsep,
+                            block_type_n_atoms,
+                            block_type_n_interblock_bonds,
+                            block_type_atoms_forming_chemical_bonds,
+                            block_type_tile_n_polar_atoms,
+                            block_type_tile_n_occluder_atoms,
+                            block_type_tile_polar_inds,
+                            block_type_tile_occluder_inds,
+                            block_type_tile_lk_ball_params,
+                            block_type_path_distance,
+                            global_params,
+                            block_neighbors});
+
+    return score;
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    auto saved = ctx->get_saved_variables();
+
+    int i = 0;
+
+    auto pose_coords = saved[i++];
+    auto pose_coords = saved[i++];
+    auto water_coords = saved[i++];
+    auto pose_stack_block_coord_offset = saved[i++];
+    auto pose_stack_block_type = saved[i++];
+    auto pose_stack_inter_residue_connections = saved[i++];
+    auto pose_stack_min_bond_separation = saved[i++];
+    auto pose_stack_inter_block_bondsep = saved[i++];
+    auto block_type_n_atoms = saved[i++];
+    auto block_type_n_interblock_bonds = saved[i++];
+    auto block_type_atoms_forming_chemical_bonds = saved[i++];
+    auto block_type_tile_n_polar_atoms = saved[i++];
+    auto block_type_tile_n_occluder_atoms = saved[i++];
+    auto block_type_tile_polar_inds = saved[i++];
+    auto block_type_tile_occluder_inds = saved[i++];
+    auto block_type_tile_lk_ball_params = saved[i++];
+    auto block_type_path_distance = saved[i++];
+    auto global_params = saved[i++];
+    auto block_neighbors = saved[i++];
+
+    at::Tensor dV_d_pose_coords, dV_d_water_coords;
+    using Int = int32_t;
+
+    auto dTdV = grad_outputs[0];
+
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        I.type(), "ScoreOpBackward", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+
+          auto result =
+              LKBallPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::backward(
+                  TCAST(pose_coords),
+                  TCAST(water_coords),
+                  TCAST(pose_stack_block_coord_offset),
+                  TCAST(pose_stack_block_type),
+                  TCAST(pose_stack_inter_residue_connections),
+
+                  TCAST(pose_stack_min_bond_separation),
+                  TCAST(pose_stack_inter_block_bondsep),
+                  TCAST(block_type_n_atoms),
+                  TCAST(block_type_n_interblock_bonds),
+                  TCAST(block_type_atoms_forming_chemical_bonds),
+
+                  TCAST(block_type_tile_n_polar_atoms),
+                  TCAST(block_type_tile_n_occluder_atoms),
+                  TCAST(block_type_tile_polar_inds),
+                  TCAST(block_type_tile_occluder_inds),
+                  TCAST(block_type_tile_lk_ball_params),
+
+                  TCAST(block_type_path_distance),
+                  TCAST(global_params),
+                  TCAST(block_neighbors),
+                  TCAST(dTdV));
+
+          dV_d_pose_coords = std::get<0>(result).tensor;
+          dV_d_water_coords = std::get<1>(result).tensor;
+        }));
+
+    return {dV_d_pose_coords,
+            dV_d_water_coords,
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor()};
+  }
+};
+
+template <template <tmol::Device> class Dispatch>
+Tensor lkball_pose_score(
+    Tensor pose_coords,
+    Tensor pose_coords,
+    Tensor water_coords,
+    Tensor pose_stack_block_coord_offset,
+    Tensor pose_stack_block_type,
+
+    Tensor pose_stack_inter_residue_connections,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_n_interblock_bonds,
+
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_tile_n_polar_atoms,
+    Tensor block_type_tile_n_occluder_atoms,
+    Tensor block_type_tile_polar_inds,
+    Tensor block_type_tile_occluder_inds,
+
+    Tensor block_type_tile_lk_ball_params,
+    Tensor block_type_path_distance,
+    Tensor global_params) {
+  return LKBallPoseScoreOp::apply(
+      pose_coords,
+      pose_coords,
+      water_coords,
+      pose_stack_block_coord_offset,
+      pose_stack_block_type,
+
+      pose_stack_inter_residue_connections,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_n_interblock_bonds,
+
+      block_type_atoms_forming_chemical_bonds,
+      block_type_tile_n_polar_atoms,
+      block_type_tile_n_occluder_atoms,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+
+      block_type_tile_lk_ball_params,
+      block_type_path_distance,
+      global_params);
+}
+
 // Macro indirection to force TORCH_EXTENSION_NAME macro expansion
 // See https://stackoverflow.com/a/3221914
 #define TORCH_LIBRARY_(ns, m) TORCH_LIBRARY(ns, m)
@@ -419,6 +642,7 @@ TORCH_LIBRARY_(TORCH_EXTENSION_NAME, m) {
   m.def(
       "score_lkball_inter_system_scores",
       &rotamer_pair_energies<common::ForallDispatch>);
+  m.def("lkball_pose_score", &lkball_pose_score<common::DeviceOperations>);
 }
 
 }  // namespace potentials

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -441,12 +441,16 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        I.type(), "lk_ball_pose_score_op", ([&] {
+        pose_coords.type(), "lk_ball_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
-          auto result =
-              LKBallPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::forward(
+          auto result = LKBallPoseScoreDispatch<
+              common::DeviceOperations,
+              Dev,
+              Real,
+              Int>::
+              forward(
                   TCAST(pose_coords),
                   TCAST(water_coords),
                   TCAST(pose_stack_block_coord_offset),
@@ -467,7 +471,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 
                   TCAST(global_params));
 
-          score = std::get < 0(result).tensor;
+          score = std::get<0>(result).tensor;
           block_neighbors = std::get<1>(result).tensor;
         }));
 
@@ -527,12 +531,16 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     auto dTdV = grad_outputs[0];
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        I.type(), "ScoreOpBackward", ([&] {
+        pose_coords.type(), "lk_ball_pose_score_backward", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
-          auto result =
-              LKBallPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::backward(
+          auto result = LKBallPoseScoreDispatch<
+              common::DeviceOperations,
+              Dev,
+              Real,
+              Int>::
+              backward(
                   TCAST(pose_coords),
                   TCAST(water_coords),
                   TCAST(pose_stack_block_coord_offset),

--- a/tmol/score/lk_ball/potentials/compiled.py
+++ b/tmol/score/lk_ball/potentials/compiled.py
@@ -14,6 +14,8 @@ load(
                 "lk_ball_pose_score.cuda.cu",
                 "rotamer_pair_energy_lkball.cpu.cpp",
                 "rotamer_pair_energy_lkball.cuda.cu",
+                "gen_pose_waters.cpu.cpp",
+                "gen_pose_waters.cuda.cu",
             ],
         )
     ),
@@ -23,3 +25,5 @@ load(
 _ops = getattr(torch.ops, modulename(__name__))
 score_lkball = _ops.score_lkball
 watergen_lkball = _ops.watergen_lkball
+gen_pose_waters = _ops.gen_pose_waters
+pose_score_lk_ball = _ops.lk_ball_pose_score

--- a/tmol/score/lk_ball/potentials/compiled.py
+++ b/tmol/score/lk_ball/potentials/compiled.py
@@ -10,6 +10,8 @@ load(
                 "compiled.ops.cpp",
                 "compiled.cpu.cpp",
                 "compiled.cuda.cu",
+                "lk_ball_pose_score.cpu.cpp",
+                "lk_ball_pose_score.cuda.cu",
                 "rotamer_pair_energy_lkball.cpu.cpp",
                 "rotamer_pair_energy_lkball.cuda.cu",
             ],

--- a/tmol/score/lk_ball/potentials/constants.hh
+++ b/tmol/score/lk_ball/potentials/constants.hh
@@ -1,0 +1,5 @@
+#pragma once
+
+#define TILE_SIZE 32
+#define MAX_N_WATER 4
+#define MAX_N_CONN 4

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.cpu.cpp
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.cpu.cpp
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cpu.impl.hh>
+#include <tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+template struct GeneratePoseWaters<
+    common::DeviceOperations,
+    tmol::Device::CPU,
+    float,
+    int>;
+template struct GeneratePoseWaters<
+    common::DeviceOperations,
+    tmol::Device::CPU,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.cuda.cu
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.cuda.cu
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cuda.impl.cuh>
+#include <tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+template struct GeneratePoseWaters<
+    common::DeviceOperations,
+    tmol::Device::CUDA,
+    float,
+    int>;
+template struct GeneratePoseWaters<
+    common::DeviceOperations,
+    tmol::Device::CUDA,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.hh
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.hh
@@ -1,5 +1,6 @@
-#include <tmol/score/common/dispatch.cpu.impl.hh>
-#include <tmol/score/hbond/identification.hh>
+#pragma once
+
+#include <tmol/score/lk_ball/potentials/params.hh>
 
 namespace tmol {
 namespace score {
@@ -47,8 +48,10 @@ struct GeneratePoseWaters {
       TView<Int, 2, Dev> block_type_tile_n_acc,
       TView<Int, 3, Dev> block_type_tile_donH_inds,
       TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_which_donH_for_hvy,
       TView<Int, 3, Dev> block_type_tile_acc_inds,
       TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 3, Dev> block_type_tile_acc_n_attached_H,
       TView<Int, 2, Dev> block_type_atom_is_hydrogen,
 
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
@@ -90,8 +93,10 @@ struct GeneratePoseWaters {
       TView<Int, 2, Dev> block_type_tile_n_acc,
       TView<Int, 3, Dev> block_type_tile_donH_inds,
       TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_which_donH_for_hvy,
       TView<Int, 3, Dev> block_type_tile_acc_inds,
       TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 3, Dev> block_type_tile_acc_n_attached_H,
       TView<Int, 2, Dev> block_type_atom_is_hydrogen,
 
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.hh
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.hh
@@ -7,7 +7,7 @@ namespace score {
 namespace lk_ball {
 namespace potentials {
 
-#define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+// #define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 
 template <
     template <tmol::Device>
@@ -16,7 +16,7 @@ template <
     typename Real,
     typename Int>
 struct GeneratePoseWaters {
-  static def forward(
+  static auto forward(
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
       TView<Int, 2, Dev> pose_stack_block_type,
@@ -57,10 +57,9 @@ struct GeneratePoseWaters {
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
       TView<Real, 1, Dev> sp2_water_tors,
       TView<Real, 1, Dev> sp3_water_tors,
-      TView<Real, 1, Dev> ring_water_tors)
-      ->TPack<Vec<Real, 3>, 3, Dev>;
+      TView<Real, 1, Dev> ring_water_tors) -> TPack<Vec<Real, 3>, 3, Dev>;
 
-  static def backward(
+  static auto backward(
       TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
@@ -102,8 +101,7 @@ struct GeneratePoseWaters {
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
       TView<Real, 1, Dev> sp2_water_tors,
       TView<Real, 1, Dev> sp3_water_tors,
-      TView<Real, 1, Dev> ring_water_tors)
-      ->TPack<Vec<Real, 3>, 2, Dev>;
+      TView<Real, 1, Dev> ring_water_tors) -> TPack<Vec<Real, 3>, 2, Dev>;
 };
 
 #undef def

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.hh
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.hh
@@ -1,0 +1,109 @@
+#include <tmol/score/common/dispatch.cpu.impl.hh>
+#include <tmol/score/hbond/identification.hh>
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+#define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+
+template <
+    template <tmol::Device>
+    class Dispatch,
+    tmol::Device Dev,
+    typename Real,
+    typename Int>
+struct GeneratePoseWaters {
+  static def forward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 1, Dev> block_type_n_all_bonds,
+      TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds,
+      TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges,
+
+      TView<Int, 2, Dev> block_type_tile_n_donH,
+      TView<Int, 2, Dev> block_type_tile_n_acc,
+      TView<Int, 3, Dev> block_type_tile_donH_inds,
+      TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_acc_inds,
+      TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+
+      TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
+      TView<Real, 1, Dev> sp2_water_tors,
+      TView<Real, 1, Dev> sp3_water_tors,
+      TView<Real, 1, Dev> ring_water_tors)
+      ->TPack<Vec<Real, 3>, 3, Dev>;
+
+  static def backward(
+      TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 1, Dev> block_type_n_all_bonds,
+      TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds,
+      TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges,
+
+      TView<Int, 2, Dev> block_type_tile_n_donH,
+      TView<Int, 2, Dev> block_type_tile_n_acc,
+      TView<Int, 3, Dev> block_type_tile_donH_inds,
+      TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_acc_inds,
+      TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+
+      TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
+      TView<Real, 1, Dev> sp2_water_tors,
+      TView<Real, 1, Dev> sp3_water_tors,
+      TView<Real, 1, Dev> ring_water_tors)
+      ->TPack<Vec<Real, 3>, 2, Dev>;
+};
+
+#undef def
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh
@@ -18,6 +18,8 @@
 #include "water.hh"
 #include <tmol/score/lk_ball/potentials/constants.hh>
 
+#include <iostream>  // TEMP!
+
 namespace tmol {
 namespace score {
 namespace lk_ball {
@@ -32,7 +34,7 @@ template <
     typename Real,
     typename Int>
 struct GeneratePoseWaters {
-  static def forward(
+  static auto forward(
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
       TView<Int, 2, Dev> pose_stack_block_type,
@@ -73,8 +75,7 @@ struct GeneratePoseWaters {
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
       TView<Real, 1, Dev> sp2_water_tors,
       TView<Real, 1, Dev> sp3_water_tors,
-      TView<Real, 1, Dev> ring_water_tors)
-      ->TPack<Vec<Real, 3>, 3, Dev> {
+      TView<Real, 1, Dev> ring_water_tors) -> TPack<Vec<Real, 3>, 3, Dev> {
     int const n_poses = pose_coords.size(0);
     int const max_n_pose_atoms = pose_coords.size(1);
     int const max_n_blocks = pose_stack_block_type.size(1);
@@ -161,6 +162,7 @@ struct GeneratePoseWaters {
           block_type_n_interblock_bonds,
           block_type_atoms_forming_chemical_bonds,
           block_type_atom_is_hydrogen,
+          global_params,
 
           pose_ind,
           block_ind,
@@ -245,7 +247,7 @@ struct GeneratePoseWaters {
     return water_coords_t;
   };
 
-  static def backward(
+  static auto backward(
       TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
@@ -287,8 +289,7 @@ struct GeneratePoseWaters {
       TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
       TView<Real, 1, Dev> sp2_water_tors,
       TView<Real, 1, Dev> sp3_water_tors,
-      TView<Real, 1, Dev> ring_water_tors)
-      ->TPack<Vec<Real, 3>, 2, Dev> {
+      TView<Real, 1, Dev> ring_water_tors) -> TPack<Vec<Real, 3>, 2, Dev> {
     int const n_poses = pose_coords.size(0);
     int const max_n_pose_atoms = pose_coords.size(1);
     int const max_n_blocks = pose_stack_block_type.size(1);
@@ -378,6 +379,7 @@ struct GeneratePoseWaters {
           block_type_n_interblock_bonds,
           block_type_atoms_forming_chemical_bonds,
           block_type_atom_is_hydrogen,
+          global_params,
 
           pose_ind,
           block_ind,

--- a/tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh
+++ b/tmol/score/lk_ball/potentials/gen_pose_waters.impl.hh
@@ -1,0 +1,455 @@
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/TensorStruct.h>
+#include <tmol/utility/tensor/TensorUtil.h>
+#include <tmol/utility/nvtx.hh>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/dispatch.hh>
+#include <tmol/score/common/geom.hh>
+
+#include <tmol/score/hbond/identification.hh>
+#include <tmol/score/ljlk/potentials/params.hh>
+
+#include "water.hh"
+
+#define MAX_N_WATER 4
+#define TILE_SIZE 32
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+#define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+
+template <
+    template <tmol::Device>
+    class Dispatch,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+struct GeneratePoseWaters {
+  static def forward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 1, Dev> block_type_n_all_bonds,
+      TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds,
+      TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges,
+
+      TView<Int, 2, Dev> block_type_tile_n_donH,
+      TView<Int, 2, Dev> block_type_tile_n_acc,
+      TView<Int, 3, Dev> block_type_tile_donH_inds,
+      TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_acc_inds,
+      TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+
+      TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
+      TView<Real, 1, Dev> sp2_water_tors,
+      TView<Real, 1, Dev> sp3_water_tors,
+      TView<Real, 1, Dev> ring_water_tors)
+      ->TPack<Vec<Real, 3>, 3, Dev> {
+    int const n_poses = pose_coords.size(0);
+    int const max_n_pose_atoms = pose_coords.size(1);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+    int const n_block_types = block_type_n_atoms.size(0);
+    int const max_n_block_atoms = block_type_atom_all_bond_ranges.size(1);
+    int const max_n_tiles = block_type_tile_n_donH.size(1);
+
+    assert(pose_stack_block_coord_offset.size(0) == n_poses);
+    assert(pose_stack_block_type.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+    assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+    assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+    assert(block_type_atoms_forming_chemical_bonds.size(1) == max_n_conn);
+    assert(block_type_n_all_bonds.size(0) == n_block_types);
+    assert(block_type_atom_all_bond_ranges.size(0) == n_block_types);
+    assert(block_type_tile_n_donH.size(0) == n_block_types);
+    assert(block_type_tile_n_acc.size(0) == n_block_types);
+    assert(block_type_tile_n_acc.size(1) == max_n_tiles);
+    assert(block_type_tile_donH_inds.size(0) == n_block_types);
+    assert(block_type_tile_donH_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_donH_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_acc_inds.size(0) == n_block_types);
+    assert(block_type_tile_acc_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_acc_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_hybridization.size(0) == n_block_types);
+    assert(block_type_tile_hybridization.size(1) == max_n_tiles);
+    assert(block_type_tile_hybridization.size(2) == TILE_SIZE);
+    assert(block_type_atom_is_hydrogen.size(0) == n_block_types);
+    assert(block_type_atom_is_hydrogen.size(1) == max_n_block_atoms);
+
+    NVTXRange _function(__FUNCTION__);
+
+    using tmol::score::hbond::AcceptorBases;
+    using tmol::score::hbond::AcceptorHybridization;
+
+    nvtx_range_push("watergen::setup");
+    auto water_coords_t = TPack<Vec<Real, 3>, 3, Dev>::full(
+        {n_poses, max_n_pose_atoms, MAX_N_WATER}, NAN);
+    auto water_coords = water_coords_t.view;
+
+    nvtx_range_pop();
+
+    nvtx_range_push("watergen::gen");
+
+    auto f_watergen = ([=] EIGEN_DEVICE_FUNC(int ind) {
+      int const pose_ind = ind / max_n_blocks;
+      int const block_ind = ind % max_n_blocks;
+      int const block_type = pose_stack_block_type[pose_ind][block_ind];
+
+      if (block_type < 0) return;
+
+      int const n_atoms = block_type_n_atoms[block_type];
+
+      // Allocate shared mem
+      SHARED_MEMORY WaterGenSharedData<Real, TILE_SIZE, MAX_N_CONN> shared_m;
+
+      // Allocate stack mem
+      WaterGenData<Dev, Real, Int> water_gen_dat;
+
+      // TO DO: make this "1 body" tile action templated
+      // Step 1: load in tile-invariant data for this block
+      water_gen_load_tile_invariant_data(
+          pose_coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          pose_stack_inter_residue_connections,
+
+          block_type_n_all_bonds,
+          block_type_all_bonds,
+          block_type_atom_all_bond_ranges,
+          block_type_n_interblock_bonds,
+          block_type_atoms_forming_chemical_bonds,
+          block_type_atom_is_hydrogen,
+
+          pose_ind,
+          block_ind,
+          block_type,
+          n_atoms,
+
+          water_gen_dat,
+          shared_m);
+
+      // Step 2: iterate accross tiles of atoms for this block
+      int const n_iterations = (n_atoms - 1) / TILE_SIZE + 1;
+      for (int tile_ind = 0; tile_ind < n_iterations; ++tile_ind) {
+        int const n_atoms_to_load =
+            min(TILE_SIZE, n_atoms - TILE_SIZE * tile_ind);
+
+        if (tile_ind != 0) {
+          DeviceDispatch<Dev>::synchronize();
+        }
+
+        // Step 3: and load data for each tile into shared memory
+        water_gen_load_block_coords_and_params_into_shared(
+            pose_coords,
+            block_type_tile_n_donH,
+            block_type_tile_n_acc,
+            block_type_tile_donH_inds,
+            block_type_tile_don_hvy_inds,
+            block_type_tile_which_donH_for_hhvy,
+            block_type_tile_acc_inds,
+            block_type_tile_donor_type,
+            block_type_tile_acceptor_type,
+            block_type_tile_hybridization,
+            block_type_tile_acc_n_attached_H,
+            pose_ind,
+            tile_ind,
+            wat_gen_dat.r_dat,
+            n_atoms_to_load,
+            start_atom);
+        DeviceDispatch<Dev>::synchronize();
+
+        auto gen_tile_waters = ([&] TMOL_DEVICE_FUNC(int tid) {
+          // Each iteration will build one water
+          // Donor hydrogens build for their parent heavy atom and have to
+          // know which hydrogen child they represent for their heavy atom
+          // so they can write their computed coordinates to different
+          // locations; the number of donor hydrogens must also be accounted
+          // for when building waters for acceptors because some acceptors
+          // are also donors
+          int const n_waters = water_gen_dat.r_dat.n_donH
+                               + water_gen_dat.r_dat.n_acc * MAX_N_WATER;
+          for (int i = tid; i < n_waters; i += nt) {
+            bool building_donor_water = i < water_gen_dat.r_dat.n_donH;
+            if (building_donor_water) {
+              build_water_for_don<TILE_SIZE>(
+                  water_coords,
+                  wat_gen_dat,
+                  tile_ind * TILE_SIZE,
+                  i  // i is the index of the polar H within this tile
+              );
+            } else {
+              int const acc_ind =
+                  (i - water_gen_dat.r_dat.n_donH) / MAX_N_WATER;
+              int const water_ind =
+                  (i - water_gen_dat.r_dat.n_donH) % MAX_N_WATER;
+              build_water_for_acc<TILE_SIZE>(
+                  sp2_water_tors,
+                  sp3_water_tors,
+                  ring_water_tors,
+                  water_coords,
+                  wat_gen_dat,
+                  tile_ind * TILE_SIZE,
+                  acc_ind,
+                  water_ind);
+            }
+          }
+        });
+        // Step 4: ...before performing the work for each tile
+        DeviceOps<Dev>::template foreach_in_workgroup<nt>(gen_tile_waters);
+      }
+    });
+
+    int const n_blocks = n_poses * max_n_blocks;
+    DeviceOps<Dev>::template foreach_workgroup<launch_t>(n_blocks, f_watergen);
+
+    return water_coords_t;
+  };
+
+  static def backward(
+      TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 1, Dev> block_type_n_all_bonds,
+      TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds,
+      TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges,
+
+      TView<Int, 2, Dev> block_type_tile_n_donH,
+      TView<Int, 2, Dev> block_type_tile_n_acc,
+      TView<Int, 3, Dev> block_type_tile_donH_inds,
+      TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+      TView<Int, 3, Dev> block_type_tile_acc_inds,
+      TView<Int, 3, Dev> block_type_tile_hybridization,
+      TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+
+      TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
+      TView<Real, 1, Dev> sp2_water_tors,
+      TView<Real, 1, Dev> sp3_water_tors,
+      TView<Real, 1, Dev> ring_water_tors)
+      ->TPack<Vec<Real, 3>, 2, Dev> {
+    int const n_poses = pose_coords.size(0);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+    int const n_block_types = block_type_n_atoms.size(0);
+    int const max_n_block_atoms = block_type_atom_all_bond_ranges.size(1);
+    int const max_n_tiles = block_type_tile_n_donH.size(1);
+
+    assert(pose_stack_block_coord_offset.size(0) == n_poses);
+    assert(pose_stack_block_type.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+    assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+    assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+    assert(block_type_atoms_forming_chemical_bonds.size(1) == max_n_conn);
+    assert(block_type_n_all_bonds.size(0) == n_block_types);
+    assert(block_type_atom_all_bond_ranges.size(0) == n_block_types);
+    assert(block_type_tile_n_donH.size(0) == n_block_types);
+    assert(block_type_tile_n_acc.size(0) == n_block_types);
+    assert(block_type_tile_n_acc.size(1) == max_n_tiles);
+    assert(block_type_tile_donH_inds.size(0) == n_block_types);
+    assert(block_type_tile_donH_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_donH_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_acc_inds.size(0) == n_block_types);
+    assert(block_type_tile_acc_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_acc_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_hybridization.size(0) == n_block_types);
+    assert(block_type_tile_hybridization.size(1) == max_n_tiles);
+    assert(block_type_tile_hybridization.size(2) == TILE_SIZE);
+    assert(block_type_atom_is_hydrogen.size(0) == n_block_types);
+    assert(block_type_atom_is_hydrogen.size(1) == max_n_block_atoms);
+
+    NVTXRange _function(__FUNCTION__);
+
+    nvtx_range_push("watergen::dsetup");
+
+    using tmol::score::hbond::AcceptorBases;
+    using tmol::score::hbond::AcceptorHybridization;
+
+    int nstacks = coords.size(0);
+    int num_Vs = coords.size(1);
+
+    auto dE_d_pose_coords_t =
+        TPack<Vec<Real, 3>, 2, Dev>::zeros({n_poses, max_n_atoms, MAX_N_WATER});
+    auto dE_d_pose_coords = dE_d_pose_coords_t.view;
+
+    int nsp2wats = sp2_water_tors.size(0);
+    int nsp3wats = sp3_water_tors.size(0);
+    int nringwats = ring_water_tors.size(0);
+    nvtx_range_pop();
+
+    auto f_watergen = ([=] EIGEN_DEVICE_FUNC(int ind) {
+      int const pose_ind = ind / max_n_blocks;
+      int const block_ind = ind % max_n_blocks;
+      int const block_type = pose_stack_block_type[pose_ind][block_ind];
+
+      if (block_type < 0) return;
+
+      int const n_atoms = block_type_n_atoms[block_type];
+
+      // Allocate shared mem
+      SHARED_MEMORY WaterGenSharedData<Real, TILE_SIZE, MAX_N_CONN> shared_m;
+
+      // Allocate stack mem
+      WaterGenData<Dev, Real, Int> water_gen_dat;
+
+      // TO DO: make this "1 body" tile action templated
+      // Step 1: load in tile-invariant data for this block
+      water_gen_load_tile_invariant_data(
+          pose_coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          pose_stack_inter_residue_connections,
+
+          block_type_n_all_bonds,
+          block_type_all_bonds,
+          block_type_atom_all_bond_ranges,
+          block_type_n_interblock_bonds,
+          block_type_atoms_forming_chemical_bonds,
+          block_type_atom_is_hydrogen,
+
+          pose_ind,
+          block_ind,
+          block_type,
+          n_atoms,
+
+          water_gen_dat,
+          shared_m);
+
+      // Step 2: iterate accross tiles of atoms for this block
+      int const n_iterations = (n_atoms - 1) / TILE_SIZE + 1;
+      for (int tile_ind = 0; tile_ind < n_iterations; ++tile_ind) {
+        int const n_atoms_to_load =
+            min(TILE_SIZE, n_atoms - TILE_SIZE * tile_ind);
+
+        if (tile_ind != 0) {
+          DeviceDispatch<Dev>::synchronize();
+        }
+
+        // Step 3: and load data for each tile into shared memory
+        water_gen_load_block_coords_and_params_into_shared(
+            pose_coords,
+            block_type_tile_n_donH,
+            block_type_tile_n_acc,
+            block_type_tile_donH_inds,
+            block_type_tile_don_hvy_inds,
+            block_type_tile_which_donH_for_hhvy,
+            block_type_tile_acc_inds,
+            block_type_tile_donor_type,
+            block_type_tile_acceptor_type,
+            block_type_tile_hybridization,
+            block_type_tile_acc_n_attached_H,
+            pose_ind,
+            tile_ind,
+            wat_gen_dat.r_dat,
+            n_atoms_to_load,
+            start_atom);
+        DeviceDispatch<Dev>::synchronize();
+
+        auto gen_tile_waters = ([&] TMOL_DEVICE_FUNC(int tid) {
+          // Each iteration will build one water
+          // Donor hydrogens build for their parent heavy atom and have to
+          // know which hydrogen child they represent for their heavy atom
+          // so they can write their computed coordinates to different
+          // locations; the number of donor hydrogens must also be accounted
+          // for when building waters for acceptors because some acceptors
+          // are also donors
+          int const n_waters = water_gen_dat.r_dat.n_donH
+                               + water_gen_dat.r_dat.n_acc * MAX_N_WATER;
+          for (int i = tid; i < n_waters; i += nt) {
+            bool building_donor_water = i < water_gen_dat.r_dat.n_donH;
+            if (building_donor_water) {
+              d_build_water_for_don<TILE_SIZE>(
+                  dE_dW,
+                  dE_d_pose_coords,
+                  wat_gen_dat,
+                  tile_ind * TILE_SIZE,
+                  i  // i is the index of the polar H within this tile
+              );
+            } else {
+              int const acc_ind =
+                  (i - water_gen_dat.r_dat.n_donH) / MAX_N_WATER;
+              int const water_ind =
+                  (i - water_gen_dat.r_dat.n_donH) % MAX_N_WATER;
+              d_build_water_for_acc<TILE_SIZE>(
+                  sp2_water_tors,
+                  sp3_water_tors,
+                  ring_water_tors,
+                  dE_dW,
+                  dE_d_pose_coord,
+                  wat_gen_dat,
+                  tile_ind * TILE_SIZE,
+                  acc_ind,
+                  water_ind);
+            }
+          }
+        });
+        // Step 4: ...before performing the work for each tile
+        DeviceOps<Dev>::template foreach_in_workgroup<nt>(gen_tile_waters);
+      }
+    });
+
+    int const n_blocks = n_poses * max_n_blocks;
+    nvtx_range_push("watergen::dgen");
+    DeviceOps<Dev>::template foreach_workgroup<launch_t>(n_blocks, f_watergen);
+    nvtx_range_pop();
+
+    return dE_dpose_coords_t;
+  };
+};
+
+#undef def
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1111,7 +1111,6 @@ TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
 
   if (dist >= block_pair_dat.global_params.distance_threshold) {
     return {0, 0, 0, 0};
-    ;
   }
 
   Eigen::Matrix<Real, 4, 3> wmat_polar;

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -6,6 +6,8 @@
 
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/diamond_macros.hh>
+#include <tmol/score/common/data_loading.hh>
 #include <tmol/score/ljlk/potentials/lk_isotropic.hh>
 
 #include "params.hh"

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -14,6 +14,11 @@ namespace score {
 namespace lk_ball {
 namespace potentials {
 
+enum lk_ball_score_type {
+  w_lk_ball_iso = 0; w_lk_ball; w_lk_bridge; w_lk_bridge_uncpl;
+  n_lk_ball_score_types;  // keep this last
+};
+
 #define def auto EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
 
 // fd  these could be exposed as global parameters
@@ -487,25 +492,24 @@ class LKBallSingleResData {
   int water_coord_offset;
   int n_atoms;
   int n_conn;
-  Real* atom_coords;
-  Real* water_coords;
+  Real *pose_coords;
+  Real *water_coords;
   unsigned char n_polars;
   unsigned char n_occluders;
-  unsigned char* polar_tile_inds;
-  unsigned char* n_attached_waters;
-  unsgiend char* occulder_tile_inds;
-  LKBallTypeParams* lk_ball_params;
-  unsigned char* path_dist;
+  unsigned char *polar_tile_inds;
+  unsgiend char *occluder_tile_inds;
+  LKBallTypeParams<Real> *lk_ball_params;
+  unsigned char *path_dist;
 };
 
-template <tmol::Device Dev, typename Real, typename Int>
+template <typename Real>
 class LKBallResPairData {
  public:
   int pose_ind;
   int max_important_bond_separation;
   int min_separation;
   bool in_count_pair_striking_dist;
-  unsigned char* conn_seps;
+  unsigned char *conn_seps;
 
   // load global params once; store totalE's
   LKBallGlobalParams<Real> global_params;
@@ -513,40 +517,21 @@ class LKBallResPairData {
   Real total_lk_ball;
   Real total_lk_bridge;
   Real total_lk_bridge_uncpl;
-
-  // If the hbond involves atoms from other residues, we need
-  // to be able to retrieve their coordinates
-  TView<Vec<Real, 3>, 2, Dev> coords;
-  TView<Int, 2, Dev> pose_stack_block_coord_offset;
-  TView<Int, 2, Dev> pose_stack_block_type;
-
-  // For determining which atoms to retrieve from neighboring
-  // residues we have to know how the blocks in the Pose
-  // are connected
-  TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections;
-
-  // And we need to know the properties of the block types
-  // that we are working with to iterate across chemical bonds
-  TView<Int, 1, Dev> block_type_n_all_bonds;
-  TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds;
-  TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges;
-  TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds;
-  TView<Int, 2, Dev> block_type_atom_is_hydrogen;
 };
 
-template <tmol::Device Dev, typename Real, typename Int>
+template <typename Real>
 class LKBallScoringData {
  public:
   LKBallSingleResData<Real> r1;
   LKBallSingleResData<Real> r2;
-  LKBallResPairData<Dev, Real, Int> pair_data;
+  LKBallResPairData<Real> pair_data;
 };
 
 template <typename Real, int TILE_SIZE, int MAX_N_WATER, int MAX_N_CONN>
-struct HBondBlockPairSharedData {
+struct LKBallBlockPairSharedData {
   Real atom_coords1[TILE_SIZE * 3];  // 768 bytes for coords
   Real atom_coords2[TILE_SIZE * 3];
-  Real water_coords1[TILE_SIZE * MAX_N_WATER * 3];  // 768 bytes for coords
+  Real water_coords1[TILE_SIZE * MAX_N_WATER * 3];  // 3072 bytes for coords
   Real water_coords2[TILE_SIZE * MAX_N_WATER * 3];
 
   unsigned char n_polars1;  // 4 bytes for counts
@@ -555,12 +540,10 @@ struct HBondBlockPairSharedData {
   unsigned char n_occluders2;
   unsigned char polar_tile_inds1[TILE_SIZE];  // 320 bytes for indices
   unsigned char polar_tile_inds2[TILE_SIZE];
-  unsigned char n_attached_waters1[TILE_SIZE];
-  unsigned char n_attached_waters2[TILE_SIZE];
   unsigned char occluder_tile_inds1[TILE_SIZE];
   unsigned char occluder_tile_inds2[TILE_SIZE];
-  LKBallTypeParams lk_ball_params1[TILE_SIZE];
-  LKBallTypeParams lk_ball_params2[TILE_SIZE];
+  LKBallTypeParams<Real> lk_ball_params1[TILE_SIZE];
+  LKBallTypeParams<Real> lk_ball_params2[TILE_SIZE];
 
   unsigned char conn_ats1[MAX_N_CONN];  // 8 bytes
   unsigned char conn_ats2[MAX_N_CONN];
@@ -570,6 +553,828 @@ struct HBondBlockPairSharedData {
 };
 
 #undef def
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int MAX_N_WATER,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_block_coords_and_params_into_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<LKBallTypeParams, 3, Dev> block_type_tile_lk_ball_params,
+    int pose_ind,
+    int tile_ind,
+    LKBallSingleResData<Real> &r_dat,
+    int n_atoms_to_load,
+    int start_atom) {
+  // pre-condition: n_atoms_to_load < TILE_SIZE
+  // Note that TILE_SIZE is not explicitly passed in, but is "present"
+  // in r_dat.coords allocation
+
+  DeviceDispatch<Dev>::template copy_contiguous_data<nt, 3>(
+      r_dat.pose_coords,
+      reinterpret_cast<Real *>(
+          &pose_coords[pose_ind][r_dat.block_coord_offset + start_atom]),
+      n_atoms_to_load * 3);
+  DeviceDispatch<Dev>::template copy_contiguous_data<nt, MAX_N_WATER * 3>(
+      r_dat.water_coords,
+      reinterpret_cast<Real *>(
+          &water_coords[pose_ind][r_dat.block_coord_offset + start_atom][0]),
+      n_atoms_to_load * MAX_N_WATER * 3);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.polar_tile_inds,
+      &block_type_tile_polar_inds[r_dat.block_type][tile_ind][0],
+      r_dat.n_polars);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.occluder_tile_inds,
+      &block_type_tile_occluder_inds[r_dat.block_type][tile_ind][0],
+      r_dat.n_occluders);
+  int const N_PARAMS = sizeof(LKBallTypeParams<Real>) / sizeof(Real);
+  DeviceDispatch<Dev>::template copy_contiguous_data<nt, N_PARAMS>(
+      reinterpret_cast<Real *>(r_dat.lk_ball_params),
+      reinterpret_cast<Real *>(
+          &block_type_tile_lk_ball_params[r_dat.block_type][tile_ind][0]),
+      r_dat.n_occluders * N_PARAMS);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_block_into_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+    TView<Int, 3, Dev> block_type_path_distance,
+    int pose_ind,
+    int tile_ind,
+    LKBallSingleResData<Real> &r_dat,
+    int n_atoms_to_load,
+    int start_atom,
+    bool count_pair_striking_dist,
+    unsigned char *__restrict__ conn_ats) {
+  lk_ball_load_block_coords_and_params_into_shared<
+      DeviceDispatch,
+      Dev,
+      nt,
+      MAX_N_WATER>(
+      pose_coords,
+      water_coords,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+      block_type_tile_lk_ball_params,
+      pose_ind,
+      tile_ind,
+      r_dat,
+      n_atoms_to_load,
+      start_atom);
+
+  auto copy_path_dists = ([=](int tid) {
+    for (int count = tid; count < n_atoms_to_load; count += nt) {
+      int const atid = start_atom + count;
+      for (int j = 0; j < r_dat.n_conn; ++j) {
+        unsigned char ij_path_dist =
+            block_type_path_distance[r_dat.block_type][conn_ats[j]][atid];
+        r_dat.path_dist[j * TILE_SIZE + count] = ij_path_dist;
+      }
+    }
+  });
+  if (count_pair_striking_dist) {
+    DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(copy_path_dists);
+  }
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Int,
+    typename Real,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN>
+void TMOL_DEVICE_FUNC lk_ball_load_tile_invariant_interres_data(
+    TView<Int, 2, Dev> pose_stack_block_coord_offset,
+    TView<Int, 2, Dev> pose_stack_block_type,
+    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+    TView<Int, 3, Dev> pose_stack_min_bond_separation,
+    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
+    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+    TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
+    int const max_important_bond_separation,
+    int pose_ind,
+    int block_ind1,
+    int block_ind2,
+    int block_type1,
+    int block_type2,
+    int n_atoms1,
+    int n_atoms2,
+    LKBallScoringData<Real> &inter_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN>
+        &shared_m) {
+  inter_dat.pair_data.pose_ind = pose_ind;
+  inter_dat.r1.block_ind = block_ind1;
+  inter_dat.r2.block_ind = block_ind2;
+  inter_dat.r1.block_type = block_type1;
+  inter_dat.r2.block_type = block_type2;
+  inter_dat.r1.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind1];
+  inter_dat.r2.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind2];
+  inter_dat.pair_data.max_important_bond_separation =
+      max_important_bond_separation;
+  inter_dat.pair_data.min_separation =
+      pose_stack_min_bond_separation[pose_ind][block_ind1][block_ind2];
+  inter_dat.pair_data.in_count_pair_striking_dist =
+      inter_dat.pair_data.min_separation <= max_important_bond_separation;
+  inter_dat.r1.n_atoms = n_atoms1;
+  inter_dat.r2.n_atoms = n_atoms2;
+  inter_dat.r1.n_conn = block_type_n_interblock_bonds[block_type1];
+  inter_dat.r2.n_conn = block_type_n_interblock_bonds[block_type2];
+
+  // set the pointers in inter_dat to point at the shared-memory arrays
+  inter_dat.r1.pose_coords = shared_m.pose_coords1;
+  inter_dat.r2.pose_coords = shared_m.pose_coords2;
+  inter_dat.r1.water_coords = shared_m.water_coords1;
+  inter_dat.r2.water_coords = shared_m.water_coords2;
+  inter_dat.r1.polar_tile_inds = shared_m.polar_tile_inds1;
+  inter_dat.r2.polar_tile_inds = shared_m.polar_tile_inds2;
+  inter_dat.r1.occluder_tile_inds = shared_m.occluder_tile_inds1;
+  inter_dat.r2.occluder_tile_inds = shared_m.occluder_tile_inds2;
+  inter_dat.r1.lk_ball_params = shared_m.lk_ball_params1;
+  inter_dat.r2.lk_ball_params = shared_m.lk_ball_params2;
+
+  inter_dat.r1.path_dist = shared_m.path_dist1;
+  inter_dat.r2.path_dist = shared_m.path_dist2;
+  inter_dat.pair_data.conn_seps = shared_m.conn_seps;
+
+  // Count pair setup that does not depend on which tile we are
+  // operating on; only necessary if r1 and r2 are within
+  // a minimum number of chemical bonds separation
+  if (inter_dat.pair_data.in_count_pair_striking_dist) {
+    // Load data into shared arrays
+    auto load_count_pair_conn_at_data = ([&](int tid) {
+      int n_conn_tot = inter_dat.r1.n_conn + inter_dat.r2.n_conn
+                       + inter_dat.r1.n_conn * inter_dat.r2.n_conn;
+      for (int count = tid; count < n_conn_tot; count += nt) {
+        if (count < inter_dat.r1.n_conn) {
+          int const conn_ind = count;
+          shared_m.conn_ats1[conn_ind] =
+              block_type_atoms_forming_chemical_bonds[block_type1][conn_ind];
+        } else if (count < inter_dat.r1.n_conn + inter_dat.r2.n_conn) {
+          int const conn_ind = count - inter_dat.r1.n_conn;
+          shared_m.conn_ats2[conn_ind] =
+              block_type_atoms_forming_chemical_bonds[block_type2][conn_ind];
+        } else {
+          int const conn_ind =
+              count - inter_dat.r1.n_conn - inter_dat.r2.n_conn;
+          int conn1 = conn_ind / inter_dat.r2.n_conn;
+          int conn2 = conn_ind % inter_dat.r2.n_conn;
+          shared_m.conn_seps[conn_ind] =
+              pose_stack_inter_block_bondsep[pose_ind][block_ind1][block_ind2]
+                                            [conn1][conn2];
+        }
+      }
+    });
+    // On CPU: a for loop executed once; on GPU threads within the
+    // workgroup working in parallel will just continue to work in
+    // parallel
+    DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(
+        load_count_pair_conn_at_data);
+  }
+
+  // Final data members
+  inter_dat.pair_data.global_params = global_params[0];
+
+  // Set initial energy totals to 0
+  inter_dat.pair_data.total_lk_ball_iso = 0;
+  inter_dat.pair_data.total_lk_ball = 0;
+  inter_dat.pair_data.total_lk_bridge = 0;
+  inter_dat.pair_data.total_lk_bridge_uncpl = 0;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_interres1_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+    TView<Int, 3, Dev> block_type_path_distance,
+    int tile_ind,
+    int start_atom1,
+    int n_atoms_to_load1,
+    LKBallScoringData<Real> &inter_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN>
+        &shared_m) {
+  auto store_n_pol_n_occ1 = ([&](int tid) {
+    int n_pol =
+        block_type_tile_n_polar_atoms[inter_dat.r1.block_type][tile_ind];
+    int n_occ =
+        block_type_tile_n_occluder_atoms[inter_dat.r1.block_type][tile_ind];
+    inter_dat.r1.n_polars = n_pol;
+    inter_dat.r1.n_occluders = n_occ;
+    if (tid == 0) {
+      shared_m.n_polars1 = n_pol;
+      shared_m.n_occluders1 = n_occ;
+    }
+  });
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(store_n_pol_n_occ1);
+
+  lk_ball_load_block_into_shared<
+      DeviceDispatch,
+      Dev,
+      nt,
+      TILE_SIZE,
+      MAX_N_WATER>(
+      pose_coords,
+      water_coords,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+      block_type_tile_lk_ball_params,
+      block_type_path_distance,
+      inter_dat.pair_data.pose_ind,
+      tile_ind,
+      inter_dat.r1,
+      n_atoms_to_load1,
+      start_atom1,
+      inter_dat.pair_data.in_count_pair_striking_dist,
+      shared_m.conn_ats1);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_interres2_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+    TView<Int, 3, Dev> block_type_path_distance,
+    int tile_ind,
+    int start_atom2,
+    int n_atoms_to_load2,
+    LKBallScoringData<Real> &inter_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN>
+        &shared_m) {
+  auto store_n_pol_n_occ2 = ([&](int tid) {
+    int n_pol =
+        block_type_tile_n_polar_atoms[inter_dat.r2.block_type][tile_ind];
+    int n_occ =
+        block_type_tile_n_occluder_atoms[inter_dat.r2.block_type][tile_ind];
+    inter_dat.r2.n_polars = n_pol;
+    inter_dat.r2.n_occluders = n_occ;
+    if (tid == 0) {
+      shared_m.n_polars2 = n_pol;
+      shared_m.n_occluders2 = n_occ;
+    }
+  });
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(store_n_pol_n_occ2);
+
+  lk_ball_load_block_into_shared<
+      DeviceDispatch,
+      Dev,
+      nt,
+      TILE_SIZE,
+      MAX_N_WATER>(
+      pose_coords,
+      water_coords,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+      block_type_tile_lk_ball_params,
+      block_type_path_distance,
+      inter_dat.pair_data.pose_ind,
+      tile_ind,
+      inter_dat.r2,
+      n_atoms_to_load2,
+      start_atom2,
+      inter_dat.pair_data.in_count_pair_striking_dist,
+      shared_m.conn_ats2);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Int,
+    typename Real,
+    int TILE_SIZE,
+    int MAX_N_CONN>
+void TMOL_DEVICE_FUNC lk_ball_load_tile_invariant_intrares_data(
+    TView<Int, 2, Dev> pose_stack_block_coord_offset,
+    TView<Int, 2, Dev> pose_stack_block_type,
+    TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
+    int const max_important_bond_separation,
+    int pose_ind,
+    int block_ind1,
+    int block_type1,
+    int n_atoms1,
+    LKBallScoringData<Real> &intra_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
+  intra_dat.pair_data.pose_ind = pose_ind;
+  intra_dat.r1.block_ind = block_ind1;
+  intra_dat.r2.block_ind = block_ind1;
+  intra_dat.r1.block_type = block_type1;
+  intra_dat.r2.block_type = block_type1;
+  intra_dat.r1.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind1];
+  intra_dat.r2.block_coord_offset = intra_dat.r1.block_coord_offset;
+  intra_dat.pair_data.max_important_bond_separation =
+      max_important_bond_separation;
+
+  // we are not going to load count pair data into shared memory because
+  // we are not going to use that data from shared memory; setting
+  // in_count_pair_striking_distance to false prevents downstream loading
+  // of count-pair data, which waste memory bandwidth
+  intra_dat.pair_data.min_separation = 0;
+  intra_dat.pair_data.in_count_pair_striking_dist = false;
+
+  intra_dat.r1.n_atoms = n_atoms1;
+  intra_dat.r2.n_atoms = n_atoms1;
+  intra_dat.r1.n_conn = 0;
+  intra_dat.r2.n_conn = 0;
+
+  // set the pointers in intra_dat to point at the
+  // shared-memory arrays. Note that these arrays will be reset
+  // later because which shared memory arrays we will use depends on
+  // which tile pair we are evaluating!
+  intra_dat.r1.pose_coords = shared_m.pose_coords1;
+  intra_dat.r2.pose_coords = shared_m.pose_coords2;
+  intra_dat.r1.water_coords = shared_m.water_coords1;
+  intra_dat.r2.water_coords = shared_m.water_coords2;
+  inter_dat.r1.polar_tile_inds = shared_m.polar_tile_inds1;
+  inter_dat.r2.polar_tile_inds = shared_m.polar_tile_inds2;
+  inter_dat.r1.occluder_tile_inds = shared_m.occluder_tile_inds1;
+  inter_dat.r2.occluder_tile_inds = shared_m.occluder_tile_inds2;
+  inter_dat.r1.lk_ball_params = shared_m.lk_ball_params1;
+  inter_dat.r2.lk_ball_params = shared_m.lk_ball_params2;
+
+  // these count pair arrays are not going to be used
+  intra_dat.r1.path_dist = 0;
+  intra_dat.r2.path_dist = 0;
+  intra_dat.pair_data.conn_seps = 0;
+
+  // Final data members
+  intra_dat.pair_data.global_params = global_params[0];
+  intra_dat.pair_data.total_lk_ball_iso = 0;
+  intra_dat.pair_data.total_lk_ball = 0;
+  intra_dat.pair_data.total_lk_bridge = 0;
+  intra_dat.pair_data.total_lk_bridge_uncpl = 0;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_intrares1_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+    int tile_ind,
+    int start_atom1,
+    int n_atoms_to_load1,
+    LKBallScoringData<Real> &intra_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN>
+        &shared_m) {
+  auto store_n_pol_n_occ1 = ([&](int tid) {
+    int n_pol =
+        block_type_tile_n_polar_atoms[intra_dat.r1.block_type][tile_ind];
+    int n_occ =
+        block_type_tile_n_occluder_atoms[intra_dat.r1.block_type][tile_ind];
+    intra_dat.r1.n_polars = n_pol;
+    intra_dat.r1.n_occluders = n_occ;
+    if (tid == 0) {
+      shared_m.n_polars1 = n_pol;
+      shared_m.n_occluders1 = n_occ;
+    }
+  });
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(store_n_don_n_acc1);
+  lk_ball_load_block_coords_and_params_into_shared<
+      DeviceDispatch,
+      Dev,
+      nt,
+      MAX_N_WATER>(
+      pose_coords,
+      water_coords,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+      block_type_tile_lk_ball_params,
+      intra_dat.pair_data.pose_ind,
+      tile_ind,
+      intra_dat.r1,
+      n_atoms_to_load1,
+      start_atom1);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC lk_ball_load_intrares2_tile_data_to_shared(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<LKBallTypeParams, 3, Dev> block_type_tile_lk_ball_params,
+    int tile_ind,
+    int start_atom2,
+    int n_atoms_to_load2,
+    LKBallScoringData<Real> &intra_dat,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN>
+        &shared_m) {
+  auto store_n_pol_n_occ2 = ([&](int tid) {
+    int n_pol =
+        block_type_tile_n_polar_atoms[intra_dat.r2.block_type][tile_ind];
+    int n_occ =
+        block_type_tile_n_occluder_atoms[intra_dat.r2.block_type][tile_ind];
+    intra_dat.r2.n_polars = n_pol;
+    intra_dat.r2.n_occluders = n_occ;
+    if (tid == 0) {
+      shared_m.n_polars2 = n_pol;
+      shared_m.n_occluders2 = n_occ;
+    }
+  });
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(store_n_don_n_acc2);
+  lk_ball_load_block_coords_and_params_into_shared<
+      DeviceDispatch,
+      Dev,
+      nt,
+      MAX_N_WATER>(
+      pose_coords,
+      water_coords,
+      block_type_tile_polar_inds,
+      block_type_tile_occluder_inds,
+      block_type_tile_lk_ball_params,
+      intra_dat.pair_data.pose_ind,
+      tile_ind,
+      intra_dat.r2,
+      n_atoms_to_load2,
+      start_atom2);
+}
+
+template <
+    int TILE_SIZE,
+    int MAX_N_CONN,
+    int MAX_N_WATER,
+    tmol::Device Dev,
+    typename Real>
+void TMOL_DEVICE_FUNC lk_ball_load_intrares_data_from_shared(
+    int tile_ind1,
+    int tile_ind2,
+    LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN, MAX_N_WATER>
+        &shared_m,
+    LKBallScoringData<Real> &intra_dat) {
+  // set the pointers in intra_dat to point at the shared-memory arrays
+  // If we are evaluating the energies between atoms in the same tile
+  // then only the "1" shared-memory arrays will be loaded with data;
+  // we will point the "2" memory pointers at the "1" arrays
+  bool same_tile = tile_ind1 == tile_ind2;
+  intra_dat.r1.pose_coords = shared_m.pose_coords1;
+  intra_dat.r2.pose_coords =
+      (same_tile ? shared_m.pose_coords1 : shared_m.pose_coords2);
+  intra_dat.r1.water_coords = shared_m.water_coords1;
+  intra_dat.r2.water_coords =
+      (same_tile ? shared_m.water_coords1 : shared_m.water_coords2);
+  intra_dat.r1.polar_tile_inds = shared_m.polar_inds1;
+  intra_dat.r1.occluder_tile_inds = shared_m.occluder_inds1;
+  intra_dat.r2.polar_tile_inds =
+      (same_tile ? shared_m.polar_inds1 : shared_m.polar_inds2);
+  intra_dat.r2.occluder_tile_inds =
+      (same_tile ? shared_m.occluder_inds1 : shared_m.occluder_inds2);
+  intra_dat.r1.lk_ball_params = shared_m.lk_ball_params1;
+  intra_dat.r2.lk_ball_params =
+      (same_tile ? shared_m.lk_ball_params1 : shared_m.lk_ball_params2);
+  if (same_tile) {
+    intra_dat.r2.n_polars = intra_dat.r1.n_polars;
+    intra_dat.r2.n_occluders = intra_dat.r1.n_occluders;
+  }
+}
+
+template <int MAX_N_WATER, typename Real>
+TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
+    int polar_ind,               // in [0:n_polar)
+    int occluder_ind,            // in [0:n_occluders)
+    int polar_atom_tile_ind,     // in [0:TILE_SIZE)
+    int occluder_atom_tile_ind,  // in [0:TILE_SIZE)
+    int polar_start,
+    int occluder_start,
+    LKBallSingleResData<Real> const &polar_block_dat,
+    LKBallSingleResData<Real> const &occluder_block_dat,
+    LKBallResPairData<Real> const &block_pair_dat,
+    int cp_separation) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  if (cp_separation <= 3) {
+    return lk_ball_Vt::Zero();
+  }
+
+  Real3 polar_xyz =
+      coord_from_shared(polar_block_dat.coords, polar_atom_tile_ind);
+  Real3 occluder_xyz =
+      coord_from_shared(occluder_block_dat.coords, occluder_atom_tile_ind);
+
+  Real const dist = distance<Real>::V(polar_xyz, occluder_xyz);
+
+  if (dist >= respair_dat.global_params.max_distance)
+    return lk_ball_Vt<Real>::Zero();
+
+  Eigen::Matrix<Real, 4, 3> wmat_polar;
+  Eigen::Matrix<Real, 4, 3> wmat_occluder;
+
+  for (int wi = 0; wi < MAX_N_WATER; wi++) {
+    wmat_polar.row(wi) = coord_from_shared(
+        polar_block_dat.water_coords, MAX_N_WATER * polar_atom_tile_ind + wi);
+    wmat_occluder.row(wi) = coord_from_shared(
+        occluder_block_dat.water_coords,
+        MAX_N_WATER * occluder_atom_tile_ind + wi);
+  }
+
+  return lk_ball_score<Real, MAX_N_WATER>::V(
+      polar_xyz,
+      occluder_xyz,
+      wmat_polar,
+      wmat_occluder,
+      cp_separation,
+      polar_block_dat.lk_ball_params[polar_atom_tile_ind],
+      occluder_block_dat.lk_ball_params[occluder_atom_tile_ind],
+      block_pair_dat.global_params);
+}
+
+// Calculate and write to global memory only the derivatives for the two
+// indicated atoms Does not return  the score
+template <int TILE_SIZE, int MAX_N_WATER, typename Real, tmol::Device Dev>
+TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
+    int polar_ind,               // in [0:n_polar)
+    int occluder_ind,            // in [0:n_occluders)
+    int polar_atom_tile_ind,     // in [0:TILE_SIZE)
+    int occluder_atom_tile_ind,  // in [0:TILE_SIZE)
+    int polar_start,
+    int occluder_start,
+    LKBallSingleResData<Real> const &polar_block_dat,
+    LKBallSingleResData<Real> const &occluder_block_dat,
+    LKBallResPairData<Real> const &block_pair_dat,
+    int cp_separation,
+    TView<Real, 2, Dev> dTdV,
+    TView<Eigen::Matrix<Real, 3, 1>, 3, Dev> dV_d_pose_coords,
+    TView<Eigen::Matrix<Real, 3, 1>, 4, Dev> dV_d_water_coords) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  if (cp_separation <= 3) {
+    return;
+  }
+
+  Real3 polar_xyz =
+      coord_from_shared(polar_block_dat.coords, polar_atom_tile_ind);
+  Real3 occluder_xyz =
+      coord_from_shared(occluder_block_dat.coords, occluder_atom_tile_ind);
+
+  auto const dist_r = distance<Real>::V_dV(polar_xyz, occluder_xyz);
+  if (dist_r.V >= respair_dat.global_params.max_distance) return;
+
+  Eigen::Matrix<Real, MAX_N_WATER, 3> wmat_polar;
+  Eigen::Matrix<Real, MAX_N_WATER, 3> wmat_occluder;
+  Eigen::Matrix<Real, n_lk_ball_score_types, 1> dTdV_local;
+
+  for (int i = 0; i < n_lk_ball_score_types; ++i) {
+    dTdV_local[i] = dTdV[block_pair_dat.pose_ind][i];
+  }
+
+  for (int wi = 0; wi < MAX_N_WATER; wi++) {
+    wmat_polar.row(wi) = coord_from_shared(
+        polar_block_dat.water_coords, MAX_N_WATER * polar_atom_tile_ind + wi);
+    wmat_occluder.row(wi) = coord_from_shared(
+        occluder_block_dat.water_coords,
+        MAX_N_WATER * occluder_atom_tile_ind + wi);
+  }
+
+  auto dV = lk_ball_score<Real, 4>::dV(
+      polar_xyz,
+      occluder_xyz,
+      wmat_polar,
+      wmat_occluder,
+      cp_separation,
+      polar_block_dat.lk_ball_params[polar_atom_tile_ind],
+      occluder_block_dat.lk_ball_params[occluder_atom_tile_ind],
+      block_pair_dat.global_params);
+
+  auto accum_derivs1 = ([&] TMOL_DEVICE_FUNC(
+                            LKBallSingleResData<Real> const &block_dat,
+                            int atom_ind,
+                            Real3 dV,
+                            lk_ball_score_type st) {
+    for (int j = 0; j < 3; ++j) {
+      if (dV[j] != 0) {
+        accumulate<Dev, Real>::add(
+            dV_d_pose_coords[st][block_pair_dat.pose_ind]
+                            [block_dat.block_coord_offset + atom_ind][j],
+            dTdV_local[st] * dV[j]);
+      }
+    }
+  });
+
+  auto accum_derivs4 = ([&] TMOL_DEVICE_FUNC(
+                            LKBallSingleResData<Real> const &block_dat,
+                            int atom_ind,
+                            lk_ball_dV_dReal3 const &dV) {
+    accum_derivs1(block_dat, atom_ind, dV.d_lkball_iso, w_lk_ball_iso);
+    accum_derivs1(block_dat, atom_ind, dV.d_lkball, w_lk_ball);
+    accum_derivs1(block_dat, atom_ind, dV.d_lkbridge, w_lk_bridge);
+    accum_derivs1(block_dat, atom_ind, dV.d_lkbridge_uncpl, w_lk_bridge_uncpl);
+  });
+
+  auto wate_accum_derivs1 = ([&] TMOL_DEVICE_FUNC(
+                                 LKBallSingleResData<Real> const &block_dat,
+                                 int atom_ind,
+                                 int water_ind WatersMat dV,
+                                 lk_ball_score_type st) {
+    for (int j = 0; j < 3; ++j) {
+      if (dV[j] != 0) {
+        accumulate<Dev, Real>::add(
+            dV_d_water_coords[st][block_pair_dat.pose_ind]
+                             [block_dat.block_coord_offset + atom_ind]
+                             [water_ind][j],
+            dTdV_local[st] * dV.row(water_ind)[j]);
+      }
+    }
+  });
+
+  auto water_accum_derivs4 = ([&] TMOL_DEVICE_FUNC(
+                                  LKBallSingleResData<Real> const &block_dat,
+                                  int atom_ind,
+                                  int water_ind,
+                                  lk_ball_dV_dWater const &dV) {
+    water_accum_derivs1(
+        block_dat, atom_ind, water_ind, dV.d_lkball_iso, w_lk_ball_iso);
+    water_accum_derivs1(block_dat, atom_ind, water_ind, dV.d_lkball, w_lk_ball);
+    water_accum_derivs1(
+        block_dat, atom_ind, water_ind, dV.d_lkbridge, w_lk_bridge);
+    water_accum_derivs1(
+        block_dat, atom_ind, water_ind, dV.d_lkbridge_uncpl, w_lk_bridge_uncpl);
+  });
+
+  accum_derivs4(polar_block_dat, polar_ind, dV.dI);
+  accum_derivs4(occluder_block_dat, occluder_ind, dV.dJ);
+  for (int i = 0; i < MAX_N_WATER; ++i) {
+    water_accum_derivs4(polar_block_dat, polar_ind, i, dV.dWI);
+    water_accum_derivs4(occluder_block_dat, occluder_ind, i, dV.dWJ);
+  }
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Func,
+    typename Real>
+void TMOL_DEVICE_FUNC eval_interres_pol_occ_pair_energies(
+    LKBallScoringData<Real> &inter_dat,
+    int start_atom1,
+    int start_atom2,
+    Func f) {
+  auto eval_scores_for_pol_occ_pairs = ([&](int tid) {
+    int const n_pol_occ_pairs =
+        inter_dat.r1.n_polars * inter_dat.r2.n_occluders
+        + inter_dat.r1.n_occluders * inter_dat.r2.n_polars;
+    for (int i = tid; i < n_pol_occ_pairs; i += nt) {
+      bool r1_polar = i < inter_dat.r1.n_polars * inter_dat.r2.n_occluders;
+      int pair_ind =
+          r1_polar ? i : i - inter_dat.r1.n_polars * inter_dat.r2.n_occluders;
+      LKBallSingleResData<Real> const &pol_dat =
+          r1_polar ? inter_dat.r1 : inter_dat.r2;
+      LKBallSingleResData<Real> const &occ_dat =
+          r1_polar ? inter_dat.r2 : inter_dat.r1;
+      int pol_ind = pair_ind / occ_dat.n_occluders;
+      int occ_ind = pair_ind % occ_dat.n_occluders;
+      int pol_start = r1_don ? start_atom1 : start_atom2;
+      int occ_start = r1_don ? start_atom2 : start_atom1;
+
+      lk_ball_Vt<Real> E =
+          f(pol_start, occ_start, pol_ind, occ_ind, inter_dat, r1_polar);
+
+      inter_dat.pair_data.total_lk_ball_iso += E.lkball_iso;
+      inter_dat.pair_data.total_lk_ball += E.lkball;
+      inter_dat.pair_data.total_lk_bridge += E.lkbridge;
+      inter_dat.pair_data.total_lk_bridge_uncpl += E.lkbridge_uncpl;
+    }
+  });
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(
+      eval_scores_for_don_acc_pairs);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Func,
+    typename Real>
+void TMOL_DEVICE_FUNC eval_intrares_pol_occ_pair_energies(
+    LKBallScoringData<Real> &intra_dat,
+    int start_atom1,
+    int start_atom2,
+    Func f) {
+  auto eval_scores_for_pol_occ_pairs = ([&](int tid) {
+    if (start_atom1 == start_atom2) {
+      int const n_pol_occ_pairs =
+          intra_dat.r1.n_polars * intra_dat.r1.n_occluders;
+      for (int i = tid; i < n_don_acc_pairs; i += nt) {
+        int pol_ind = i / intra_dat.r1.n_occluders;
+        int occ_ind = i % intra_dat.r1.n_occluders;
+
+        // An atom canot occlude itself
+        if (pol_ind == occ_ind) continue;
+
+        lk_ball_Vt<Real> E =
+            f(start_atom1, start_atom1, pol_ind, occ_ind, intra_dat, true);
+        intra_dat.pair_data.total_lk_ball_iso += E.lkball_iso;
+        intra_dat.pair_data.total_lk_ball += E.lkball;
+        intra_dat.pair_data.total_lk_bridge += E.lkbridge;
+        intra_dat.pair_data.total_lk_bridge_uncpl += E.lkbridge_uncpl;
+      }
+    } else {
+      int const n_pol_occ_pairs =
+          intra_dat.r1.n_polars * intra_dat.r2.n_occluders
+          + intra_dat.r1.n_occluders * intra_dat.r2.n_polars;
+      for (int i = tid; i < n_pol_occ_pairs; i += nt) {
+        bool r1_polar = i < intra_dat.r1.n_polars * intra_dat.r2.n_occluders;
+        int pair_ind =
+            r1_polar ? i : i - intra_dat.r1.n_polars * intra_dat.r2.n_occluders;
+        LKBallSingleResData<Real> const &occ_dat =
+            r1_polar ? intra_dat.r2 : intra_dat.r1;
+        int pol_ind = pair_ind / occ_dat.n_occluders;
+        int occ_ind = pair_ind % occ_dat.n_occluders;
+        int pol_start = r1_polar ? start_atom1 : start_atom2;
+        int occ_start = r1_polar ? start_atom2 : start_atom1;
+
+        lk_ball_Vt<Real> E =
+            f(pol_start, don_start, pol_ind, occ_ind, intra_dat, r1_polar);
+        intra_dat.pair_data.total_lk_ball_iso += E.lkball_iso;
+        intra_dat.pair_data.total_lk_ball += E.lkball;
+        intra_dat.pair_data.total_lk_bridge += E.lkbridge;
+        intra_dat.pair_data.total_lk_bridge_uncpl += E.lkbridge_uncpl;
+      }
+    }
+  });
+
+  DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(
+      eval_scores_for_don_acc_pairs);
+}
 
 }  // namespace potentials
 }  // namespace lk_ball

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -498,7 +498,6 @@ class LKBallSingleResData {
   int block_ind;
   int block_type;
   int block_coord_offset;
-  int water_coord_offset;
   int n_atoms;
   int n_conn;
   Real *pose_coords;
@@ -1135,8 +1134,8 @@ TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
       wmat_polar,
       wmat_occluder,
       cp_separation,
-      polar_block_dat.lk_ball_params[polar_atom_tile_ind],
-      occluder_block_dat.lk_ball_params[occluder_atom_tile_ind],
+      polar_block_dat.lk_ball_params[polar_ind],
+      occluder_block_dat.lk_ball_params[occluder_ind],
       block_pair_dat.global_params);
 }
 
@@ -1197,8 +1196,8 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
       wmat_polar,
       wmat_occluder,
       cp_separation,
-      polar_block_dat.lk_ball_params[polar_atom_tile_ind],
-      occluder_block_dat.lk_ball_params[occluder_atom_tile_ind],
+      polar_block_dat.lk_ball_params[polar_ind],
+      occluder_block_dat.lk_ball_params[occluder_ind],
       block_pair_dat.global_params);
 
   auto accum_derivs1 = ([&] TMOL_DEVICE_FUNC(

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
@@ -7,12 +7,12 @@ namespace lk_ball {
 namespace potentials {
 
 template struct LKBallPoseScoreDispatch<
-    DeviceOperations,
+    common::DeviceOperations,
     tmol::Device::CPU,
     float,
     int>;
 template struct LKBallPoseScoreDispatch<
-    DeviceOperations,
+    common::DeviceOperations,
     tmol::Device::CPU,
     double,
     int>;

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cpu.impl.hh>
+#include <tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+template struct LKBallPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CPU,
+    float,
+    int>;
+template struct LKBallPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CPU,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
@@ -7,12 +7,12 @@ namespace lk_ball {
 namespace potentials {
 
 template struct LKBallPoseScoreDispatch<
-    DeviceOperations,
+    common::DeviceOperations,
     tmol::Device::CUDA,
     float,
     int>;
 template struct LKBallPoseScoreDispatch<
-    DeviceOperations,
+    common::DeviceOperations,
     tmol::Device::CUDA,
     double,
     int>;

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
@@ -1,0 +1,23 @@
+#include <tmol/score/common/device_operations.cuda.impl.cuh>
+#include <tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh>
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+template struct LKBallPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CUDA,
+    float,
+    int>;
+template struct LKBallPoseScoreDispatch<
+    DeviceOperations,
+    tmol::Device::CUDA,
+    double,
+    int>;
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <Eigen/Core>
@@ -71,8 +72,7 @@ struct LKBallPoseScoreDispatch {
 
       TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
       TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-      TView<Int, 3, Dev> block_type_tile_polar_inds,
-      TView<Int, 3, Dev> block_type_tile_occluder_inds,
+      TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
       TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
       // How many chemical bonds separate all pairs of atoms
@@ -104,19 +104,17 @@ struct LKBallPoseScoreDispatch {
       // logic for deciding whether two atoms in those blocks should have their
       // interaction energies calculated: all should. intentionally small to
       // (possibly) fit in constant cache
-      TView<Int, 3, Dev>
-          pose_stack_min_bond_separation,  // ?? needed ?? I think so
+      TView<Int, 3, Dev> pose_stack_min_bond_separation,
 
       // dims: n-poses x max-n-blocks x max-n-blocks x
       // max-n-interblock-connections x max-n-interblock-connections
-      TView<Int, 5, Dev>
-          pose_stack_inter_block_bondsep,  // ?? needed ?? I think so
+      TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
 
       //////////////////////
       // Chemical properties
       // how many atoms for a given block
       // Dimsize n_block_types
-      TView<Int, 1, Dev> block_type_n_atoms,  // ?? needed ?? I think so
+      TView<Int, 1, Dev> block_type_n_atoms,
 
       // how many inter-block chemical bonds are there
       // Dimsize: n_block_types
@@ -128,8 +126,7 @@ struct LKBallPoseScoreDispatch {
 
       TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
       TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-      TView<Int, 3, Dev> block_type_tile_polar_inds,
-      TView<Int, 3, Dev> block_type_tile_occluder_inds,
+      TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
       TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
       // How many chemical bonds separate all pairs of atoms
@@ -141,7 +138,7 @@ struct LKBallPoseScoreDispatch {
 
       // LKBall potential parameters
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
-      TView<Int, 3, Dev> scratch_block_neighbors,  // from forward pass
+      TView<Int, 3, Dev> block_neighbors,  // from forward pass
       TView<Real, 2, Dev> dTdV)
       -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>>;
 };

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/TensorStruct.h>
+#include <tmol/utility/tensor/TensorUtil.h>
+#include <tmol/utility/nvtx.hh>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/geom.hh>
+#include <tmol/score/common/tuple.hh>
+
+#include <tmol/score/hbond/potentials/params.hh>
+
+namespace tmol {
+namespace score {
+namespace hbond {
+namespace potentials {
+
+template <typename Real, int N>
+using Vec = Eigen::Matrix<Real, N, 1>;
+
+template <
+    template <tmol::Device>
+    class DeviceOps,
+    tmol::Device Dev,
+    typename Real,
+    typename Int>
+struct LKBallPoseScoreDispatch {
+  static auto forward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      // dims: n-poses x max-n-blocks x max-n-blocks
+      // Quick lookup: given the inds of two blocks, ask: what is the minimum
+      // number of chemical bonds that separate any pair of atoms in those
+      // blocks? If this minimum is greater than the crossover, then no further
+      // logic for deciding whether two atoms in those blocks should have their
+      // interaction energies calculated: all should. intentionally small to
+      // (possibly) fit in constant cache
+      TView<Int, 3, Dev> pose_stack_min_bond_separation,
+
+      // dims: n-poses x max-n-blocks x max-n-blocks x
+      // max-n-interblock-connections x max-n-interblock-connections
+      TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      // TO DO: Rename since lots of atoms form chemical bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 3, Dev> block_type_tile_polar_inds,
+      TView<Int, 3, Dev> block_type_tile_occluder_inds,
+      TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+
+      // How many chemical bonds separate all pairs of atoms
+      // within each block type?
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, Dev> block_type_path_distance,
+
+      //////////////////////
+
+      // LKBall potential parameters
+      TView<LKBallGlobalParams<Real>, 1, Dev> global_params)
+      -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 3, Dev>>;
+
+  static auto backward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
+
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+      // dims: n-poses x max-n-blocks x max-n-blocks
+      // Quick lookup: given the inds of two blocks, ask: what is the minimum
+      // number of chemical bonds that separate any pair of atoms in those
+      // blocks? If this minimum is greater than the crossover, then no further
+      // logic for deciding whether two atoms in those blocks should have their
+      // interaction energies calculated: all should. intentionally small to
+      // (possibly) fit in constant cache
+      TView<Int, 3, Dev>
+          pose_stack_min_bond_separation,  // ?? needed ?? I think so
+
+      // dims: n-poses x max-n-blocks x max-n-blocks x
+      // max-n-interblock-connections x max-n-interblock-connections
+      TView<Int, 5, Dev>
+          pose_stack_inter_block_bondsep,  // ?? needed ?? I think so
+
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,  // ?? needed ?? I think so
+
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+      TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 3, Dev> block_type_tile_polar_inds,
+      TView<Int, 3, Dev> block_type_tile_occluder_inds,
+      TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+
+      // How many chemical bonds separate all pairs of atoms
+      // within each block type?
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, Dev> block_type_path_distance,
+
+      //////////////////////
+
+      // LKBall potential parameters
+      TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
+      TView<Int, 3, Dev> scratch_block_neighbors,  // from forward pass
+      TView<Real, 2, Dev> dTdV)
+      -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>>;
+};
+
+}  // namespace potentials
+}  // namespace hbond
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -73,7 +73,7 @@ struct LKBallPoseScoreDispatch {
       TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
       TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
       TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
-      TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+      TView<LKBallTypeParams<Real>, 3, Dev> block_type_tile_lk_ball_params,
 
       // How many chemical bonds separate all pairs of atoms
       // within each block type?
@@ -127,7 +127,7 @@ struct LKBallPoseScoreDispatch {
       TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
       TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
       TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
-      TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+      TView<LKBallTypeParams<Real>, 3, Dev> block_type_tile_lk_ball_params,
 
       // How many chemical bonds separate all pairs of atoms
       // within each block type?

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -140,7 +140,7 @@ struct LKBallPoseScoreDispatch {
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       TView<Int, 3, Dev> block_neighbors,  // from forward pass
       TView<Real, 2, Dev> dTdV)
-      -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>>;
+      -> std::tuple<TPack<Vec<Real, 3>, 2, Dev>, TPack<Vec<Real, 3>, 3, Dev>>;
 };
 
 }  // namespace potentials

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -14,11 +14,11 @@
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/tuple.hh>
 
-#include <tmol/score/hbond/potentials/params.hh>
+#include <tmol/score/lk_ball/potentials/params.hh>
 
 namespace tmol {
 namespace score {
-namespace hbond {
+namespace lk_ball {
 namespace potentials {
 
 template <typename Real, int N>
@@ -33,7 +33,7 @@ template <
 struct LKBallPoseScoreDispatch {
   static auto forward(
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
-      TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Vec<Real, 3>, 3, Dev> water_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
       TView<Int, 2, Dev> pose_stack_block_type,
 
@@ -70,8 +70,8 @@ struct LKBallPoseScoreDispatch {
       // TO DO: Rename since lots of atoms form chemical bonds
       TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
 
-      TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
-      TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
       TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
       TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
@@ -88,7 +88,7 @@ struct LKBallPoseScoreDispatch {
 
   static auto backward(
       TView<Vec<Real, 3>, 2, Dev> pose_coords,
-      TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Vec<Real, 3>, 3, Dev> water_coords,
       TView<Int, 2, Dev> pose_stack_block_coord_offset,
       TView<Int, 2, Dev> pose_stack_block_type,
 
@@ -124,8 +124,8 @@ struct LKBallPoseScoreDispatch {
       // Dimsize: n_block_types x max_n_interblock_bonds
       TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
 
-      TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
-      TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
       TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
       TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
@@ -144,6 +144,6 @@ struct LKBallPoseScoreDispatch {
 };
 
 }  // namespace potentials
-}  // namespace hbond
+}  // namespace lk_ball
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -23,7 +23,7 @@
 
 #include <tmol/score/lk_ball/potentials/lk_ball.hh>
 #include <tmol/score/lk_ball/potentials/params.hh>
-#include <tmol/score/lk_ball/potentials/lk_ball_pose_score.hh>
+// #include <tmol/score/lk_ball/potentials/lk_ball_pose_score.hh>
 
 // Operator definitions; safe for CPU compilation
 #include <moderngpu/operators.hxx>
@@ -67,1003 +67,1015 @@ template <
     tmol::Device Dev,
     typename Real,
     typename Int>
-auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
-    TView<Vec<Real, 3>, 2, Dev> pose_coords,
-    TView<Vec<Real, 3>, 2, Dev> water_coords,
-    TView<Int, 2, Dev> pose_stack_block_coord_offset,
-    TView<Int, 2, Dev> pose_stack_block_type,
+class LKBallPoseScoreDispatch {
+ public:
+  static auto forward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Vec<Real, 3>, 3, Dev> water_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
 
-    // For determining which atoms to retrieve from neighboring
-    // residues we have to know how the blocks in the Pose
-    // are connected
-    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
 
-    // dims: n-poses x max-n-blocks x max-n-blocks
-    // Quick lookup: given the inds of two blocks, ask: what is the minimum
-    // number of chemical bonds that separate any pair of atoms in those
-    // blocks? If this minimum is greater than the crossover, then no further
-    // logic for deciding whether two atoms in those blocks should have their
-    // interaction energies calculated: all should. intentionally small to
-    // (possibly) fit in constant cache
-    TView<Int, 3, Dev> pose_stack_min_bond_separation,
+      // dims: n-poses x max-n-blocks x max-n-blocks
+      // Quick lookup: given the inds of two blocks, ask: what is the minimum
+      // number of chemical bonds that separate any pair of atoms in those
+      // blocks? If this minimum is greater than the crossover, then no further
+      // logic for deciding whether two atoms in those blocks should have their
+      // interaction energies calculated: all should. intentionally small to
+      // (possibly) fit in constant cache
+      TView<Int, 3, Dev> pose_stack_min_bond_separation,
 
-    // dims: n-poses x max-n-blocks x max-n-blocks x
-    // max-n-interblock-connections x max-n-interblock-connections
-    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
+      // dims: n-poses x max-n-blocks x max-n-blocks x
+      // max-n-interblock-connections x max-n-interblock-connections
+      TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
 
-    //////////////////////
-    // Chemical properties
-    // how many atoms for a given block
-    // Dimsize n_block_types
-    TView<Int, 1, Dev> block_type_n_atoms,
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
 
-    // how many inter-block chemical bonds are there
-    // Dimsize: n_block_types
-    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
 
-    // what atoms form the inter-block chemical bonds
-    // Dimsize: n_block_types x max_n_interblock_bonds
-    // TO DO: Rename since lots of atoms form chemical bonds
-    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      // TO DO: Rename since lots of atoms form chemical bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
 
-    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
-    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-    TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
-    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+      TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
+      TView<LKBallTypeParams<Real>, 3, Dev> block_type_tile_lk_ball_params,
 
-    // How many chemical bonds separate all pairs of atoms
-    // within each block type?
-    // Dimsize: n_block_types x max_n_atoms x max_n_atoms
-    TView<Int, 3, Dev> block_type_path_distance,
+      // How many chemical bonds separate all pairs of atoms
+      // within each block type?
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, Dev> block_type_path_distance,
 
-    //////////////////////
+      //////////////////////
 
-    // LKBall potential parameters
-    TView<LKBallGlobalParams<Real>, 1, Dev> global_params)
-    -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 3, Dev>> {
-  using tmol::score::common::accumulate;
-  using Real3 = Vec<Real, 3>;
+      // LKBall potential parameters
+      TView<LKBallGlobalParams<Real>, 1, Dev> global_params)
+      -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 3, Dev>> {
+    using tmol::score::common::accumulate;
+    using Real3 = Vec<Real, 3>;
 
-  int const n_poses = pose_coords.size(0);
-  int const max_n_pose_atoms = water_coords.size(1);
-  int const max_n_blocks = pose_stack_block_type.size(1);
-  int const max_n_conn = pose_stack_inter_residue_connections.size(2);
-  int const n_block_types = block_type_n_atoms.size(0);
-  int const max_n_block_atoms = block_type_path_distance.size(1);
-  int const max_n_interblock_bonds =
-      block_type_atoms_forming_chemical_bonds.size(1);
-  int const max_n_all_bonds = block_type_all_bonds.size(1);
-  int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
+    int const n_poses = pose_coords.size(0);
+    int const max_n_pose_atoms = water_coords.size(1);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+    int const n_block_types = block_type_n_atoms.size(0);
+    int const max_n_block_atoms = block_type_path_distance.size(1);
+    int const max_n_interblock_bonds =
+        block_type_atoms_forming_chemical_bonds.size(1);
+    int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
-  assert(max_n_interblock_bonds <= MAX_N_CONN);
+    assert(max_n_interblock_bonds <= MAX_N_CONN);
 
-  assert(water_coords.size(0) == n_poses);
-  assert(water_coords.size(1) == max_n_pose_atoms);
-  assert(water_coords.size(2) == MAX_N_WATER);
+    assert(water_coords.size(0) == n_poses);
+    assert(water_coords.size(1) == max_n_pose_atoms);
+    assert(water_coords.size(2) == MAX_N_WATER);
 
-  assert(pose_stack_block_coord_offset.size(0) == n_poses);
-  assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
+    assert(pose_stack_block_coord_offset.size(0) == n_poses);
+    assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
 
-  assert(pose_stack_block_type.size(0) == n_poses);
+    assert(pose_stack_block_type.size(0) == n_poses);
 
-  assert(pose_stack_inter_residue_connections.size(0) == n_poses);
-  assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+    assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
 
-  assert(pose_stack_min_bond_separation.size(0) == n_poses);
-  assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
-  assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
+    assert(pose_stack_min_bond_separation.size(0) == n_poses);
+    assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
+    assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
 
-  assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
-  assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
-  assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
-  assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
-  assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
+    assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
+    assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
+    assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
+    assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
+    assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
 
-  assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+    assert(block_type_n_interblock_bonds.size(0) == n_block_types);
 
-  assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+    assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
 
-  assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
-  assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
-  assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
-  assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
-  assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
-  assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
-  assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
+    assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
+    assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
+    assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
+    assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
+    assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
+    assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
+    assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
+    assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
 
-  assert(block_type_path_distance.size(0) == n_block_types);
-  assert(block_type_path_distance.size(1) == max_n_block_atoms);
-  assert(block_type_path_distance.size(2) == max_n_block_atoms);
+    assert(block_type_path_distance.size(0) == n_block_types);
+    assert(block_type_path_distance.size(1) == max_n_block_atoms);
+    assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-  auto output_t = TPack<Real, 2, Dev>::zeros({n_lk_ball_score_types, n_poses});
-  auto output = output_t.view;
+    auto output_t =
+        TPack<Real, 2, Dev>::zeros({n_lk_ball_score_types, n_poses});
+    auto output = output_t.view;
 
-  auto scratch_block_spheres_t =
-      TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
-  auto scratch_block_spheres = scratch_block_spheres_t.view;
+    auto scratch_block_spheres_t =
+        TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+    auto scratch_block_spheres = scratch_block_spheres_t.view;
 
-  auto scratch_block_neighbors_t =
-      TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+    auto scratch_block_neighbors_t =
+        TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+    auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
-  // Optimal launch box on v100 and a100 is nt=32, vt=1
-  LAUNCH_BOX_32;
-  // Define nt and reduce_t
-  CTA_REAL_REDUCE_T_TYPEDEF;
+    // Optimal launch box on v100 and a100 is nt=32, vt=1
+    LAUNCH_BOX_32;
+    // Define nt and reduce_t
+    CTA_REAL_REDUCE_T_TYPEDEF;
 
-  auto eval_energies_only = ([=] TMOL_DEVICE_FUNC(int cta) {
-    // auto lk_ball_atom_energy =
-    //   // The typical idiom is that we lambda-capture the tensor(s) into which
-    //   // we will write the derivatives, but in the split scoring/derivative
-    //   // format, that doesn't happen here; as such, this function is
-    //   unnecessary
-    //     ([=] TMOL_DEVICE_FUNC(
-    //          int pol_ind,
-    //          int occ_ind,
-    //          int pol_tile_ind,
-    //          int occ_tile_ind,
-    //          int pol_start,
-    //          int occ_start,
-    //          LKBallSingleResData<Real> const &pol_dat,
-    //          LKBallSingleResData<Real> const &occ_dat,
-    //          LKBallResPairData<Real> const &respair_dat,
-    //          int cp_separation) {
-    //
-    //       lk_ball_Vt<Real> val = lk_ball_atom_energy_full<TILE_SIZE,
-    //       MAX_N_WATER>(
-    //           pol_ind,
-    //           occ_ind,
-    //           pol_tile_ind,
-    //           occ_tile_ind,
-    //           pol_start,
-    //           occ_start,
-    //           pol_dat,
-    //           occ_dat,
-    //           respair_dat,
-    //           cp_separation);
-    //       return val;
-    //     });
+    auto eval_energies_only = ([=] TMOL_DEVICE_FUNC(int cta) {
+      // auto lk_ball_atom_energy =
+      //   // The typical idiom is that we lambda-capture the tensor(s) into
+      //   which
+      //   // we will write the derivatives, but in the split scoring/derivative
+      //   // format, that doesn't happen here; as such, this function is
+      //   unnecessary
+      //     ([=] TMOL_DEVICE_FUNC(
+      //          int pol_ind,
+      //          int occ_ind,
+      //          int pol_tile_ind,
+      //          int occ_tile_ind,
+      //          int pol_start,
+      //          int occ_start,
+      //          LKBallSingleResData<Real> const &pol_dat,
+      //          LKBallSingleResData<Real> const &occ_dat,
+      //          LKBallResPairData<Real> const &respair_dat,
+      //          int cp_separation) {
+      //
+      //       lk_ball_Vt<Real> val = lk_ball_atom_energy_full<TILE_SIZE,
+      //       MAX_N_WATER>(
+      //           pol_ind,
+      //           occ_ind,
+      //           pol_tile_ind,
+      //           occ_tile_ind,
+      //           pol_start,
+      //           occ_start,
+      //           pol_dat,
+      //           occ_dat,
+      //           respair_dat,
+      //           cp_separation);
+      //       return val;
+      //     });
 
-    auto score_inter_lk_ball_atom_pair =
-        ([=] TMOL_DEVICE_FUNC(
-             int pol_start,
-             int occ_start,
-             int pol_ind,
-             int occ_ind,
-             LKBallScoringData<Real> const &inter_dat,
-             bool polar_first) {
-          int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
-                                 .pol_occ_tile_inds[pol_ind];
-          int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
-                                 .pol_occ_tile_inds[occ_ind];
-          int separation = interres_count_pair_separation<TILE_SIZE>(
-              inter_dat,
-              (polar_first ? pol_ind : occ_ind),
-              (polar_first ? occ_ind : pol_ind));
-          return lk_ball_atom_energy_full<TILE_SIZE, MAX_N_WATER>(
-              pol_ind,
-              occ_ind,
-              pol_tile_ind,
-              occ_tile_ind,
-              pol_start,
-              occ_start,
-              polar_first ? inter_dat.r1 : inter_dat.r2,
-              polar_first ? inter_dat.r2 : inter_dat.r1,
-              inter_dat.pair_data,
-              separation);
-        });
+      auto score_inter_lk_ball_atom_pair =
+          ([=] TMOL_DEVICE_FUNC(
+               int pol_start,
+               int occ_start,
+               int pol_ind,
+               int occ_ind,
+               LKBallScoringData<Real> &inter_dat,
+               bool polar_first) {
+            int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
+                                   .pol_occ_tile_inds[pol_ind];
+            int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
+                                   .pol_occ_tile_inds[occ_ind];
+            int separation = interres_count_pair_separation<TILE_SIZE>(
+                inter_dat,
+                (polar_first ? pol_ind : occ_ind),
+                (polar_first ? occ_ind : pol_ind));
+            lk_ball_Vt<Real> E = lk_ball_atom_energy_full<MAX_N_WATER>(
+                pol_ind,
+                occ_ind,
+                pol_tile_ind,
+                occ_tile_ind,
+                pol_start,
+                occ_start,
+                polar_first ? inter_dat.r1 : inter_dat.r2,
+                polar_first ? inter_dat.r2 : inter_dat.r1,
+                inter_dat.pair_data,
+                separation);
+            inter_dat.pair_data.total_lk_ball_iso += E.lkball_iso;
+            inter_dat.pair_data.total_lk_ball += E.lkball;
+            inter_dat.pair_data.total_lk_bridge += E.lkbridge;
+            inter_dat.pair_data.total_lk_bridge_uncpl += E.lkbridge_uncpl;
+          });
 
-    auto score_intra_lk_ball_atom_pair =
-        ([=] TMOL_DEVICE_FUNC(
-             int pol_start,
-             int occ_start,
-             int pol_ind,
-             int occ_ind,
-             LKBallScoringData<Real> const &intra_dat,
-             bool polar_first) {
-          int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
-                                 .pol_occ_tile_inds[pol_ind];
-          int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
-                                 .pol_occ_tile_inds[occ_ind];
-          int const pol_atom_ind = pol_start + pol_tile_ind;
-          int const occ_atom_ind = occ_start + occ_tile_ind;
+      auto score_intra_lk_ball_atom_pair =
+          ([=] TMOL_DEVICE_FUNC(
+               int pol_start,
+               int occ_start,
+               int pol_ind,
+               int occ_ind,
+               LKBallScoringData<Real> &intra_dat,
+               bool polar_first) {
+            int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
+                                   .pol_occ_tile_inds[pol_ind];
+            int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
+                                   .pol_occ_tile_inds[occ_ind];
+            int const pol_atom_ind = pol_start + pol_tile_ind;
+            int const occ_atom_ind = occ_start + occ_tile_ind;
 
-          int const separation =
-              block_type_path_distance[intra_dat.r1.block_type][pol_atom_ind]
-                                      [occ_atom_ind];
-          return lk_ball_atom_energy_full<TILE_SIZE, MAX_N_WATER>(
-              pol_ind,
-              occ_ind,
-              pol_tile_ind,
-              occ_tile_ind,
-              pol_start,
-              occ_start,
-              polar_first ? intra_dat.r1 : intra_dat.r2,
-              polar_first ? intra_dat.r2 : intra_dat.r1,
-              intra_dat.pair_data,
-              separation);
-        });
+            int const separation =
+                block_type_path_distance[intra_dat.r1.block_type][pol_atom_ind]
+                                        [occ_atom_ind];
+            lk_ball_Vt<Real> E = lk_ball_atom_energy_full<MAX_N_WATER>(
+                pol_ind,
+                occ_ind,
+                pol_tile_ind,
+                occ_tile_ind,
+                pol_start,
+                occ_start,
+                polar_first ? intra_dat.r1 : intra_dat.r2,
+                polar_first ? intra_dat.r2 : intra_dat.r1,
+                intra_dat.pair_data,
+                separation);
+            intra_dat.pair_data.total_lk_ball_iso += E.lkball_iso;
+            intra_dat.pair_data.total_lk_ball += E.lkball;
+            intra_dat.pair_data.total_lk_bridge += E.lkbridge;
+            intra_dat.pair_data.total_lk_bridge_uncpl += E.lkbridge_uncpl;
+          });
 
-    SHARED_MEMORY union shared_mem_union {
-      shared_mem_union() {}
-      LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
-      CTA_REAL_REDUCE_T_VARIABLE;
+      SHARED_MEMORY union shared_mem_union {
+        shared_mem_union() {}
+        LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
+        CTA_REAL_REDUCE_T_VARIABLE;
 
-    } shared;
+      } shared;
 
-    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
-    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
-    int const block_ind1 = block_ind_pair / max_n_blocks;
-    int const block_ind2 = block_ind_pair % max_n_blocks;
-    if (block_ind1 > block_ind2) {
-      return;
-    }
+      int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+      int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+      int const block_ind1 = block_ind_pair / max_n_blocks;
+      int const block_ind2 = block_ind_pair % max_n_blocks;
+      if (block_ind1 > block_ind2) {
+        return;
+      }
 
-    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
-      return;
-    }
+      if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+        return;
+      }
 
-    int const max_important_bond_separation = 4;
+      int const max_important_bond_separation = 4;
 
-    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
-    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+      int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+      int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
 
-    if (block_type1 < 0 || block_type2 < 0) {
-      return;
-    }
+      if (block_type1 < 0 || block_type2 < 0) {
+        return;
+      }
 
-    int const n_atoms1 = block_type_n_atoms[block_type1];
-    int const n_atoms2 = block_type_n_atoms[block_type2];
+      int const n_atoms1 = block_type_n_atoms[block_type1];
+      int const n_atoms2 = block_type_n_atoms[block_type2];
 
-    auto load_tile_invariant_interres_data =
-        ([=](int pose_ind,
-             int block_ind1,
-             int block_ind2,
-             int block_type1,
-             int block_type2,
-             int n_atoms1,
-             int n_atoms2,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
-              pose_stack_block_coord_offset,
-              pose_stack_block_type,
-              pose_stack_inter_residue_connections,
-              pose_stack_min_bond_separation,
-              pose_stack_inter_block_bondsep,
+      auto load_tile_invariant_interres_data =
+          ([=](int pose_ind,
+               int block_ind1,
+               int block_ind2,
+               int block_type1,
+               int block_type2,
+               int n_atoms1,
+               int n_atoms2,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
+                pose_stack_block_coord_offset,
+                pose_stack_block_type,
+                pose_stack_inter_residue_connections,
+                pose_stack_min_bond_separation,
+                pose_stack_inter_block_bondsep,
 
-              block_type_n_interblock_bonds,
-              block_type_atoms_forming_chemical_bonds,
-              global_params,
-              max_important_bond_separation,
-              pose_ind,
+                block_type_n_interblock_bonds,
+                block_type_atoms_forming_chemical_bonds,
+                global_params,
+                max_important_bond_separation,
+                pose_ind,
 
-              block_ind1,
-              block_ind2,
-              block_type1,
-              block_type2,
-              n_atoms1,
+                block_ind1,
+                block_ind2,
+                block_type1,
+                block_type2,
+                n_atoms1,
 
-              n_atoms2,
-              inter_dat,
-              shared.m);
-        });
+                n_atoms2,
+                inter_dat,
+                shared.m);
+          });
 
-    auto load_interres1_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom1,
-             int n_atoms_to_load1,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              block_type_path_distance,
-              tile_ind,
-              start_atom1,
-              n_atoms_to_load1,
-              inter_dat,
-              shared.m);
-        });
+      auto load_interres1_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom1,
+               int n_atoms_to_load1,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                block_type_path_distance,
+                tile_ind,
+                start_atom1,
+                n_atoms_to_load1,
+                inter_dat,
+                shared.m);
+          });
 
-    auto load_interres2_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom2,
-             int n_atoms_to_load2,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              block_type_path_distance,
-              tile_ind,
-              start_atom2,
-              n_atoms_to_load2,
-              inter_dat,
-              shared.m);
-        });
+      auto load_interres2_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom2,
+               int n_atoms_to_load2,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                block_type_path_distance,
+                tile_ind,
+                start_atom2,
+                n_atoms_to_load2,
+                inter_dat,
+                shared.m);
+          });
 
-    auto load_interres_data_from_shared =
-        ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
+      auto load_interres_data_from_shared =
+          ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
 
-    auto eval_interres_atom_pair_scores =
-        ([=](LKBallScoringData<Real> &inter_dat,
-             int start_atom1,
-             int start_atom2) {
-          eval_interres_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
-              inter_dat,
-              start_atom1,
-              start_atom2,
-              score_inter_lk_ball_atom_pair);
-        });
+      auto eval_interres_atom_pair_scores =
+          ([=](LKBallScoringData<Real> &inter_dat,
+               int start_atom1,
+               int start_atom2) {
+            eval_interres_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+                inter_dat,
+                start_atom1,
+                start_atom2,
+                score_inter_lk_ball_atom_pair);
+          });
 
-    auto store_calculated_energies = ([=](LKBallScoringData<Real> &score_dat,
-                                          shared_mem_union &shared) {
-      auto reduce_energies = ([&](int tid) {
-        Real const cta_total_lk_ball_iso =
-            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
-                score_dat.pair_data.total_lk_ball_iso,
-                shared,
-                mgpu::plus_t<Real>());
-        Real const cta_total_lk_ball =
-            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
-                score_dat.pair_data.total_lk_ball,
-                shared,
-                mgpu::plus_t<Real>());
-        Real const cta_total_lk_bridge =
-            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
-                score_dat.pair_data.total_lk_bridge,
-                shared,
-                mgpu::plus_t<Real>());
-        Real const cta_total_lk_bridge_uncpl =
-            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
-                score_dat.pair_data.total_lk_bridge_uncpl,
-                shared,
-                mgpu::plus_t<Real>());
+      auto store_calculated_energies =
+          ([=](LKBallScoringData<Real> &score_dat, shared_mem_union &shared) {
+            auto reduce_energies = ([&](int tid) {
+              Real const cta_total_lk_ball_iso =
+                  DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                      score_dat.pair_data.total_lk_ball_iso,
+                      shared,
+                      mgpu::plus_t<Real>());
+              Real const cta_total_lk_ball =
+                  DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                      score_dat.pair_data.total_lk_ball,
+                      shared,
+                      mgpu::plus_t<Real>());
+              Real const cta_total_lk_bridge =
+                  DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                      score_dat.pair_data.total_lk_bridge,
+                      shared,
+                      mgpu::plus_t<Real>());
+              Real const cta_total_lk_bridge_uncpl =
+                  DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                      score_dat.pair_data.total_lk_bridge_uncpl,
+                      shared,
+                      mgpu::plus_t<Real>());
 
-        if (tid == 0) {
-          accumulate<Dev, Real>::add(
-              output[w_lk_ball_iso][score_dat.pair_data.pose_ind],
-              cta_total_lk_ball_iso);
-          accumulate<Dev, Real>::add(
-              output[w_lk_ball][score_dat.pair_data.pose_ind],
-              cta_total_lk_ball);
-          accumulate<Dev, Real>::add(
-              output[w_lk_bridge][score_dat.pair_data.pose_ind],
-              cta_total_lk_bridge);
-          accumulate<Dev, Real>::add(
-              output[w_lk_bridge_uncpl][score_dat.pair_data.pose_ind],
-              cta_total_lk_bridge_uncpl);
-        }
-      });
-      DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(reduce_energies);
+              if (tid == 0) {
+                accumulate<Dev, Real>::add(
+                    output[w_lk_ball_iso][score_dat.pair_data.pose_ind],
+                    cta_total_lk_ball_iso);
+                accumulate<Dev, Real>::add(
+                    output[w_lk_ball][score_dat.pair_data.pose_ind],
+                    cta_total_lk_ball);
+                accumulate<Dev, Real>::add(
+                    output[w_lk_bridge][score_dat.pair_data.pose_ind],
+                    cta_total_lk_bridge);
+                accumulate<Dev, Real>::add(
+                    output[w_lk_bridge_uncpl][score_dat.pair_data.pose_ind],
+                    cta_total_lk_bridge_uncpl);
+              }
+            });
+            DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(
+                reduce_energies);
+          });
+
+      auto load_tile_invariant_intrares_data =
+          ([=](int pose_ind,
+               int block_ind1,
+               int block_type1,
+               int n_atoms1,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
+                pose_stack_block_coord_offset,
+                pose_stack_block_type,
+                global_params,
+                max_important_bond_separation,
+                pose_ind,
+                block_ind1,
+                block_type1,
+                n_atoms1,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares1_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom1,
+               int n_atoms_to_load1,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+
+                tile_ind,
+                start_atom1,
+                n_atoms_to_load1,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares2_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom2,
+               int n_atoms_to_load2,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                tile_ind,
+                start_atom2,
+                n_atoms_to_load2,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares_data_from_shared =
+          ([=](int tile_ind1,
+               int tile_ind2,
+               shared_mem_union &shared,
+               LKBallScoringData<Real> &intra_dat) {
+            lk_ball_load_intrares_data_from_shared(
+                tile_ind1, tile_ind2, shared.m, intra_dat);
+          });
+
+      auto eval_intrares_atom_pair_scores =
+          ([=](LKBallScoringData<Real> &intra_dat,
+               int start_atom1,
+               int start_atom2) {
+            eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+                intra_dat,
+                start_atom1,
+                start_atom2,
+                score_intra_lk_ball_atom_pair);
+          });
+
+      tmol::score::common::tile_evaluate_block_pair<
+          DeviceDispatch,
+          Dev,
+          LKBallScoringData<Real>,
+          LKBallScoringData<Real>,
+          Real,
+          TILE_SIZE>(
+          shared,
+          pose_ind,
+          block_ind1,
+          block_ind2,
+          block_type1,
+          block_type2,
+          n_atoms1,
+          n_atoms2,
+          load_tile_invariant_interres_data,
+          load_interres1_tile_data_to_shared,
+          load_interres2_tile_data_to_shared,
+          load_interres_data_from_shared,
+          eval_interres_atom_pair_scores,
+          store_calculated_energies,
+          load_tile_invariant_intrares_data,
+          load_intrares1_tile_data_to_shared,
+          load_intrares2_tile_data_to_shared,
+          load_intrares_data_from_shared,
+          eval_intrares_atom_pair_scores,
+          store_calculated_energies);
     });
 
-    auto load_tile_invariant_intrares_data =
-        ([=](int pose_ind,
-             int block_ind1,
-             int block_type1,
-             int n_atoms1,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
-              pose_stack_block_coord_offset,
-              pose_stack_block_type,
-              global_params,
-              max_important_bond_separation,
-              pose_ind,
-              block_ind1,
-              block_type1,
-              n_atoms1,
-              intra_dat,
-              shared.m);
-        });
+    ///////////////////////////////////////////////////////////////////////
 
-    auto load_intrares1_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom1,
-             int n_atoms_to_load1,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
+    // Three steps
+    // 0: setup
+    // 1: launch a kernel to find a small bounding sphere surrounding the
+    // blocks 2: launch a kernel to look for spheres that are within
+    // striking distance of each other 3: launch a kernel to evaluate
+    // lk-ball desolvation between pairs of blocks within striking distance
 
-              tile_ind,
-              start_atom1,
-              n_atoms_to_load1,
-              intra_dat,
-              shared.m);
-        });
+    // 0
+    // TO DO: let DeviceDispatch hold a cuda stream (??)
+    // at::cuda::CUDAStream wrapped_stream =
+    // at::cuda::getDefaultCUDAStream(); mgpu::standard_context_t
+    // context(wrapped_stream.stream());
+    int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
 
-    auto load_intrares2_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom2,
-             int n_atoms_to_load2,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              tile_ind,
-              start_atom2,
-              n_atoms_to_load2,
-              intra_dat,
-              shared.m);
-        });
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
+            pose_coords,
+            pose_stack_block_coord_offset,
+            pose_stack_block_type,
+            block_type_n_atoms,
+            scratch_block_spheres);
 
-    auto load_intrares_data_from_shared =
-        ([=](int tile_ind1,
-             int tile_ind2,
-             shared_mem_union &shared,
-             LKBallScoringData<Real> &intra_dat) {
-          lk_ball_load_intrares_data_from_shared(
-              tile_ind1, tile_ind2, shared.m, intra_dat);
-        });
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+            pose_coords,
+            pose_stack_block_coord_offset,
+            pose_stack_block_type,
+            block_type_n_atoms,
+            scratch_block_spheres,
+            scratch_block_neighbors,
+            Real(6.0));  // 6.0 hard coded here. Please fix! TEMP!
 
-    auto eval_intrares_atom_pair_scores =
-        ([=](LKBallScoringData<Real> &intra_dat,
-             int start_atom1,
-             int start_atom2) {
-          eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
-              intra_dat,
-              start_atom1,
-              start_atom2,
-              score_intra_lk_ball_atom_pair);
-        });
+    // 3 Only the forward pass in this calculation
+    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+        n_block_pairs, eval_energies_only);
 
-    tmol::score::common::tile_evaluate_block_pair<
-        DeviceDispatch,
-        Dev,
-        LKBallScoringData<Real>,
-        LKBallScoringData<Real>,
-        Real,
-        TILE_SIZE>(
-        shared,
-        pose_ind,
-        block_ind1,
-        block_ind2,
-        block_type1,
-        block_type2,
-        n_atoms1,
-        n_atoms2,
-        load_tile_invariant_interres_data,
-        load_interres1_tile_data_to_shared,
-        load_interres2_tile_data_to_shared,
-        load_interres_data_from_shared,
-        eval_interres_atom_pair_scores,
-        store_calculated_energies,
-        load_tile_invariant_intrares_data,
-        load_intrares1_tile_data_to_shared,
-        load_intrares2_tile_data_to_shared,
-        load_intrares_data_from_shared,
-        eval_intrares_atom_pair_scores,
-        store_calculated_energies);
-  });
+    return {output_t, scratch_block_neighbors_t};
+  }
 
-  ///////////////////////////////////////////////////////////////////////
+  static auto backward(
+      TView<Vec<Real, 3>, 2, Dev> pose_coords,
+      TView<Vec<Real, 3>, 3, Dev> water_coords,
+      TView<Int, 2, Dev> pose_stack_block_coord_offset,
+      TView<Int, 2, Dev> pose_stack_block_type,
 
-  // Three steps
-  // 0: setup
-  // 1: launch a kernel to find a small bounding sphere surrounding the
-  // blocks 2: launch a kernel to look for spheres that are within
-  // striking distance of each other 3: launch a kernel to evaluate
-  // lk-ball desolvation between pairs of blocks within striking distance
+      // For determining which atoms to retrieve from neighboring
+      // residues we have to know how the blocks in the Pose
+      // are connected
+      TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
 
-  // 0
-  // TO DO: let DeviceDispatch hold a cuda stream (??)
-  // at::cuda::CUDAStream wrapped_stream =
-  // at::cuda::getDefaultCUDAStream(); mgpu::standard_context_t
-  // context(wrapped_stream.stream());
-  int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
+      // dims: n-poses x max-n-blocks x max-n-blocks
+      // Quick lookup: given the inds of two blocks, ask: what is the minimum
+      // number of chemical bonds that separate any pair of atoms in those
+      // blocks? If this minimum is greater than the crossover, then no further
+      // logic for deciding whether two atoms in those blocks should have their
+      // interaction energies calculated: all should. intentionally small to
+      // (possibly) fit in constant cache
+      TView<Int, 3, Dev> pose_stack_min_bond_separation,
 
-  score::common::sphere_overlap::
-      compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
-          coords,
-          pose_stack_block_coord_offset,
-          pose_stack_block_type,
-          block_type_n_atoms,
-          scratch_block_spheres);
+      // dims: n-poses x max-n-blocks x max-n-blocks x
+      // max-n-interblock-connections x max-n-interblock-connections
+      TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
 
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
-          coords,
-          pose_stack_block_coord_offset,
-          pose_stack_block_type,
-          block_type_n_atoms,
-          scratch_block_spheres,
-          scratch_block_neighbors,
-          Real(5.5));  // 5.5A hard coded here. Please fix! TEMP!
+      //////////////////////
+      // Chemical properties
+      // how many atoms for a given block
+      // Dimsize n_block_types
+      TView<Int, 1, Dev> block_type_n_atoms,
 
-  // 3 Only the forward pass in this calculation
-  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-      n_block_pairs, eval_energies_only);
+      // how many inter-block chemical bonds are there
+      // Dimsize: n_block_types
+      TView<Int, 1, Dev> block_type_n_interblock_bonds,
 
-  return {output_t, scratch_block_neighbors};
-}
+      // what atoms form the inter-block chemical bonds
+      // Dimsize: n_block_types x max_n_interblock_bonds
+      TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
 
-template <
-    template <tmol::Device>
-    class DeviceDispatch,
-    tmol::Device Dev,
-    typename Real,
-    typename Int>
-auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
-    TView<Vec<Real, 3>, 2, Dev> pose_coords,
-    TView<Vec<Real, 3>, 2, Dev> water_coords,
-    TView<Int, 2, Dev> pose_stack_block_coord_offset,
-    TView<Int, 2, Dev> pose_stack_block_type,
+      TView<Int, 2, Dev> block_type_tile_n_polar_atoms,
+      TView<Int, 2, Dev> block_type_tile_n_occluder_atoms,
+      TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
+      TView<LKBallTypeParams<Real>, 3, Dev> block_type_tile_lk_ball_params,
 
-    // For determining which atoms to retrieve from neighboring
-    // residues we have to know how the blocks in the Pose
-    // are connected
-    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+      // How many chemical bonds separate all pairs of atoms
+      // within each block type?
+      // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+      TView<Int, 3, Dev> block_type_path_distance,
 
-    // dims: n-poses x max-n-blocks x max-n-blocks
-    // Quick lookup: given the inds of two blocks, ask: what is the minimum
-    // number of chemical bonds that separate any pair of atoms in those
-    // blocks? If this minimum is greater than the crossover, then no further
-    // logic for deciding whether two atoms in those blocks should have their
-    // interaction energies calculated: all should. intentionally small to
-    // (possibly) fit in constant cache
-    TView<Int, 3, Dev> pose_stack_min_bond_separation,
+      //////////////////////
 
-    // dims: n-poses x max-n-blocks x max-n-blocks x
-    // max-n-interblock-connections x max-n-interblock-connections
-    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
+      // LKBall potential parameters
+      TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
+      TView<Int, 3, Dev> scratch_block_neighbors,  // from forward pass
+      TView<Real, 2, Dev> dTdV)
+      -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>> {
+    using tmol::score::common::accumulate;
+    using Real3 = Vec<Real, 3>;
 
-    //////////////////////
-    // Chemical properties
-    // how many atoms for a given block
-    // Dimsize n_block_types
-    TView<Int, 1, Dev> block_type_n_atoms,
+    int const n_poses = pose_coords.size(0);
+    int const max_n_pose_atoms = water_coords.size(1);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+    int const n_block_types = block_type_n_atoms.size(0);
+    int const max_n_block_atoms = block_type_path_distance.size(1);
+    int const max_n_interblock_bonds =
+        block_type_atoms_forming_chemical_bonds.size(1);
+    int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
-    // how many inter-block chemical bonds are there
-    // Dimsize: n_block_types
-    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+    assert(max_n_interblock_bonds <= MAX_N_CONN);
 
-    // what atoms form the inter-block chemical bonds
-    // Dimsize: n_block_types x max_n_interblock_bonds
-    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+    assert(water_coords.size(0) == n_poses);
+    assert(water_coords.size(1) == max_n_pose_atoms);
+    assert(water_coords.size(2) == MAX_N_WATER);
 
-    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
-    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-    TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
-    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+    assert(pose_stack_block_coord_offset.size(0) == n_poses);
+    assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
 
-    // How many chemical bonds separate all pairs of atoms
-    // within each block type?
-    // Dimsize: n_block_types x max_n_atoms x max_n_atoms
-    TView<Int, 3, Dev> block_type_path_distance,
+    assert(pose_stack_block_type.size(0) == n_poses);
 
-    //////////////////////
+    assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+    assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
 
-    // LKBall potential parameters
-    TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
-    TView<Int, 3, Dev> scratch_block_neighbors,  // from forward pass
-    TView<Real, 2, Dev> dTdV)
-    -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>> {
-  using tmol::score::common::accumulate;
-  using Real3 = Vec<Real, 3>;
+    assert(pose_stack_min_bond_separation.size(0) == n_poses);
+    assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
+    assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
 
-  int const n_poses = pose_coords.size(0);
-  int const max_n_pose_atoms = water_coords.size(1);
-  int const max_n_blocks = pose_stack_block_type.size(1);
-  int const max_n_conn = pose_stack_inter_residue_connections.size(2);
-  int const n_block_types = block_type_n_atoms.size(0);
-  int const max_n_block_atoms = block_type_path_distance.size(1);
-  int const max_n_interblock_bonds =
-      block_type_atoms_forming_chemical_bonds.size(1);
-  int const max_n_all_bonds = block_type_all_bonds.size(1);
-  int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
+    assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
+    assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
+    assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
+    assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
+    assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
 
-  assert(max_n_interblock_bonds <= MAX_N_CONN);
+    assert(block_type_n_interblock_bonds.size(0) == n_block_types);
 
-  assert(water_coords.size(0) == n_poses);
-  assert(water_coords.size(1) == max_n_pose_atoms);
-  assert(water_coords.size(2) == MAX_N_WATER);
+    assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
 
-  assert(pose_stack_block_coord_offset.size(0) == n_poses);
-  assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
+    assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
+    assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
+    assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
+    assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
+    assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
+    assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
+    assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
+    assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
+    assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
+    assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
 
-  assert(pose_stack_block_type.size(0) == n_poses);
+    assert(block_type_path_distance.size(0) == n_block_types);
+    assert(block_type_path_distance.size(1) == max_n_block_atoms);
+    assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-  assert(pose_stack_inter_residue_connections.size(0) == n_poses);
-  assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+    assert(scratch_block_neighbors.size(0) == n_poses);
+    assert(scratch_block_neighbors.size(1) == max_n_blocks);
+    assert(scratch_block_neighbors.size(2) == max_n_blocks);
 
-  assert(pose_stack_min_bond_separation.size(0) == n_poses);
-  assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
-  assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
+    auto dV_d_pose_coords_t =
+        TPack<Vec<Real, 3>, 3, Dev>::zeros({2, n_poses, max_n_pose_atoms});
+    auto dV_d_pose_coords = dV_d_pose_coords_t.view;
 
-  assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
-  assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
-  assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
-  assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
-  assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
+    auto dV_d_water_coords_t = TPack<Vec<Real, 3>, 4, Dev>::zeros(
+        {2, n_poses, max_n_pose_atoms, MAX_N_WATER});
+    auto dV_d_water_coords = dV_d_water_coords_t.view;
 
-  assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+    // Optimal launch box on v100 and a100 is nt=32, vt=1
+    LAUNCH_BOX_32;
+    // Define nt and reduce_t
+    CTA_REAL_REDUCE_T_TYPEDEF;
 
-  assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+    auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
+      auto lk_ball_atom_derivs =
+          ([=] TMOL_DEVICE_FUNC(
+               int pol_ind,
+               int occ_ind,
+               int pol_tile_ind,
+               int occ_tile_ind,
+               int pol_start,
+               int occ_start,
+               LKBallSingleResData<Real> const &pol_dat,
+               LKBallSingleResData<Real> const &occ_dat,
+               LKBallResPairData<Real> const &respair_dat,
+               int cp_separation) {
+            // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
+            lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
+                pol_ind,
+                occ_ind,
+                pol_tile_ind,
+                occ_tile_ind,
+                pol_start,
+                occ_start,
+                pol_dat,
+                occ_dat,
+                respair_dat,
+                cp_separation,
+                dTdV,
+                dV_d_pose_coords,
+                dV_d_water_coords);
+          });
 
-  assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
-  assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
-  assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
-  assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
-  assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
-  assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
-  assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
+      auto dscore_inter_lk_ball_atom_pair =
+          ([=] TMOL_DEVICE_FUNC(
+               int pol_start,
+               int occ_start,
+               int pol_ind,
+               int occ_ind,
+               LKBallScoringData<Real> const &inter_dat,
+               bool polar_first) {
+            int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
+                                   .pol_occ_tile_inds[pol_ind];
+            int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
+                                   .pol_occ_tile_inds[occ_ind];
+            int separation = interres_count_pair_separation<TILE_SIZE>(
+                inter_dat,
+                (polar_first ? pol_ind : occ_ind),
+                (polar_first ? occ_ind : pol_ind));
+            lk_ball_atom_derivs(
+                pol_ind,
+                occ_ind,
+                pol_tile_ind,
+                occ_tile_ind,
+                pol_start,
+                occ_start,
+                polar_first ? inter_dat.r1 : inter_dat.r2,
+                polar_first ? inter_dat.r2 : inter_dat.r1,
+                inter_dat.pair_data,
+                separation);
+          });
 
-  assert(block_type_path_distance.size(0) == n_block_types);
-  assert(block_type_path_distance.size(1) == max_n_block_atoms);
-  assert(block_type_path_distance.size(2) == max_n_block_atoms);
+      auto dscore_intra_lk_ball_atom_pair =
+          ([=] TMOL_DEVICE_FUNC(
+               int pol_start,
+               int occ_start,
+               int pol_ind,
+               int occ_ind,
+               LKBallScoringData<Real> const &intra_dat,
+               bool polar_first) {
+            int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
+                                   .pol_occ_tile_inds[pol_ind];
+            int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
+                                   .pol_occ_tile_inds[occ_ind];
+            int const pol_atom_ind = pol_start + pol_tile_ind;
+            int const occ_atom_ind = occ_start + occ_tile_ind;
 
-  assert(scratch_block_neighbors.size(0) == n_poses);
-  assert(scratch_block_neighbors.size(1) == max_n_blocks);
-  assert(scratch_block_neighbors.size(2) == max_n_blocks);
+            int const separation =
+                block_type_path_distance[intra_dat.r1.block_type][pol_atom_ind]
+                                        [occ_atom_ind];
+            return lk_ball_atom_derivs(
+                pol_ind,
+                occ_ind,
+                pol_tile_ind,
+                occ_tile_ind,
+                pol_start,
+                occ_start,
+                polar_first ? intra_dat.r1 : intra_dat.r2,
+                polar_first ? intra_dat.r2 : intra_dat.r1,
+                intra_dat.pair_data,
+                separation);
+          });
 
-  auto dV_d_pose_coords_t =
-      TPack<Vec<Real, 3>, 3, D>::zeros({2, n_poses, max_n_pose_atoms});
-  auto dV_d_pose_coords = dV_d_pose_coords_t.view;
+      SHARED_MEMORY union shared_mem_union {
+        shared_mem_union() {}
+        LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
+        CTA_REAL_REDUCE_T_VARIABLE;
 
-  auto dV_d_water_coords_t = TPack<Vec<Real, 3>, 4, D>::zeros(
-      {2, n_poses, max_n_pose_atoms, MAX_N_WATER});
-  auto dV_d_water_coords = dV_d_water_coords_t.view;
+      } shared;
 
-  auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
-    auto lk_ball_atom_derivs = ([=] TMOL_DEVICE_FUNC(
-                                    int pol_ind,
-                                    int occ_ind,
-                                    int pol_tile_ind,
-                                    int occ_tile_ind,
-                                    int pol_start,
-                                    int occ_start,
-                                    LKBallSingleResData<Real> const &pol_dat,
-                                    LKBallSingleResData<Real> const &occ_dat,
-                                    LKBallResPairData<Real> const &respair_dat,
-                                    int cp_separation) {
-      // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
-      lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
-          pol_ind,
-          occ_ind,
-          pol_tile_ind,
-          occ_tile_ind,
-          pol_start,
-          occ_start,
-          pol_dat,
-          occ_dat,
-          respair_dat,
-          cp_separation,
-          dTdV,
-          dV_d_pose_coords,
-          dV_d_water_coords);
+      int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+      int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+      int const block_ind1 = block_ind_pair / max_n_blocks;
+      int const block_ind2 = block_ind_pair % max_n_blocks;
+      if (block_ind1 > block_ind2) {
+        return;
+      }
+
+      if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+        return;
+      }
+
+      int const max_important_bond_separation = 4;
+
+      int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+      int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+
+      if (block_type1 < 0 || block_type2 < 0) {
+        return;
+      }
+
+      int const n_atoms1 = block_type_n_atoms[block_type1];
+      int const n_atoms2 = block_type_n_atoms[block_type2];
+
+      auto load_tile_invariant_interres_data =
+          ([=](int pose_ind,
+               int block_ind1,
+               int block_ind2,
+               int block_type1,
+               int block_type2,
+               int n_atoms1,
+               int n_atoms2,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
+                pose_stack_block_coord_offset,
+                pose_stack_block_type,
+                pose_stack_inter_residue_connections,
+                pose_stack_min_bond_separation,
+                pose_stack_inter_block_bondsep,
+
+                block_type_n_interblock_bonds,
+                block_type_atoms_forming_chemical_bonds,
+                global_params,
+                max_important_bond_separation,
+                pose_ind,
+
+                block_ind1,
+                block_ind2,
+                block_type1,
+                block_type2,
+                n_atoms1,
+
+                n_atoms2,
+                inter_dat,
+                shared.m);
+          });
+
+      auto load_interres1_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom1,
+               int n_atoms_to_load1,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                block_type_path_distance,
+                tile_ind,
+                start_atom1,
+                n_atoms_to_load1,
+                inter_dat,
+                shared.m);
+          });
+
+      auto load_interres2_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom2,
+               int n_atoms_to_load2,
+               LKBallScoringData<Real> &inter_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                block_type_path_distance,
+                tile_ind,
+                start_atom2,
+                n_atoms_to_load2,
+                inter_dat,
+                shared.m);
+          });
+
+      auto load_interres_data_from_shared =
+          ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
+
+      auto eval_interres_atom_pair_scores =
+          ([=](LKBallScoringData<Real> &inter_dat,
+               int start_atom1,
+               int start_atom2) {
+            eval_interres_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+                inter_dat,
+                start_atom1,
+                start_atom2,
+                dscore_inter_lk_ball_atom_pair);
+          });
+
+      auto store_calculated_energies =
+          ([=](LKBallScoringData<Real> &score_dat, shared_mem_union &shared) {
+            // no op; only derivs, no scoring
+          });
+
+      auto load_tile_invariant_intrares_data =
+          ([=](int pose_ind,
+               int block_ind1,
+               int block_type1,
+               int n_atoms1,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
+                pose_stack_block_coord_offset,
+                pose_stack_block_type,
+                global_params,
+                max_important_bond_separation,
+                pose_ind,
+                block_ind1,
+                block_type1,
+                n_atoms1,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares1_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom1,
+               int n_atoms_to_load1,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+
+                tile_ind,
+                start_atom1,
+                n_atoms_to_load1,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares2_tile_data_to_shared =
+          ([=](int tile_ind,
+               int start_atom2,
+               int n_atoms_to_load2,
+               LKBallScoringData<Real> &intra_dat,
+               shared_mem_union &shared) {
+            lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+                pose_coords,
+                water_coords,
+                block_type_tile_n_polar_atoms,
+                block_type_tile_n_occluder_atoms,
+                block_type_tile_pol_occ_inds,
+                block_type_tile_lk_ball_params,
+                tile_ind,
+                start_atom2,
+                n_atoms_to_load2,
+                intra_dat,
+                shared.m);
+          });
+
+      auto load_intrares_data_from_shared =
+          ([=](int tile_ind1,
+               int tile_ind2,
+               shared_mem_union &shared,
+               LKBallScoringData<Real> &intra_dat) {
+            lk_ball_load_intrares_data_from_shared(
+                tile_ind1, tile_ind2, shared.m, intra_dat);
+          });
+
+      auto eval_intrares_atom_pair_scores =
+          ([=](LKBallScoringData<Real> &intra_dat,
+               int start_atom1,
+               int start_atom2) {
+            eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+                intra_dat,
+                start_atom1,
+                start_atom2,
+                dscore_intra_lk_ball_atom_pair);
+          });
+
+      tmol::score::common::tile_evaluate_block_pair<
+          DeviceDispatch,
+          Dev,
+          LKBallScoringData<Real>,
+          LKBallScoringData<Real>,
+          Real,
+          TILE_SIZE>(
+          shared,
+          pose_ind,
+          block_ind1,
+          block_ind2,
+          block_type1,
+          block_type2,
+          n_atoms1,
+          n_atoms2,
+          load_tile_invariant_interres_data,
+          load_interres1_tile_data_to_shared,
+          load_interres2_tile_data_to_shared,
+          load_interres_data_from_shared,
+          eval_interres_atom_pair_scores,
+          store_calculated_energies,
+          load_tile_invariant_intrares_data,
+          load_intrares1_tile_data_to_shared,
+          load_intrares2_tile_data_to_shared,
+          load_intrares_data_from_shared,
+          eval_intrares_atom_pair_scores,
+          store_calculated_energies);
     });
 
-    auto dscore_inter_lk_ball_atom_pair =
-        ([=] TMOL_DEVICE_FUNC(
-             int pol_start,
-             int occ_start,
-             int pol_ind,
-             int occ_ind,
-             LKBallScoringData<Real> const &inter_dat,
-             bool polar_first) {
-          int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
-                                 .pol_occ_tile_inds[pol_ind];
-          int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
-                                 .occ_tile_inds[occ_ind];
-          int separation = interres_count_pair_separation<TILE_SIZE>(
-              inter_dat,
-              (polar_first ? pol_ind : occ_ind),
-              (polar_first ? occ_ind : pol_ind));
-          lk_ball_atom_derivs(
-              pol_ind,
-              occ_ind,
-              pol_tile_ind,
-              occ_tile_ind,
-              pol_start,
-              occ_start,
-              polar_first ? inter_dat.r1 : inter_dat.r2,
-              polar_first ? inter_dat.r2 : inter_dat.r1,
-              inter_dat.pair_data,
-              separation);
-        });
+    // Since we have the sphere overlap results from the forward pass,
+    // there's only a single kernel launch here
+    int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
+    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+        n_block_pairs, eval_derivs);
 
-    auto dscore_intra_lk_ball_atom_pair =
-        ([=] TMOL_DEVICE_FUNC(
-             int pol_start,
-             int occ_start,
-             int pol_ind,
-             int occ_ind,
-             LKBallScoringData<Real> const &intra_dat,
-             bool polar_first) {
-          int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
-                                 .pol_occ_tile_inds[pol_ind];
-          int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
-                                 .occ_tile_inds[acc_ind];
-          int const don_atom_ind = don_start + don_tile_ind;
-          int const acc_atom_ind = acc_start + acc_tile_ind;
-
-          int const separation =
-              block_type_path_distance[intra_dat.r1.block_type][don_atom_ind]
-                                      [acc_atom_ind];
-          return lk_ball_atom_derivs(
-              don_ind,
-              acc_ind,
-              don_tile_ind,
-              acc_tile_ind,
-              don_start,
-              acc_start,
-              donor_first ? intra_dat.r1 : intra_dat.r2,
-              donor_first ? intra_dat.r2 : intra_dat.r1,
-              intra_dat.pair_data,
-              separation);
-        });
-
-    SHARED_MEMORY union shared_mem_union {
-      shared_mem_union() {}
-      LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
-      CTA_REAL_REDUCE_T_VARIABLE;
-
-    } shared;
-
-    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
-    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
-    int const block_ind1 = block_ind_pair / max_n_blocks;
-    int const block_ind2 = block_ind_pair % max_n_blocks;
-    if (block_ind1 > block_ind2) {
-      return;
-    }
-
-    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
-      return;
-    }
-
-    int const max_important_bond_separation = 4;
-
-    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
-    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
-
-    if (block_type1 < 0 || block_type2 < 0) {
-      return;
-    }
-
-    int const n_atoms1 = block_type_n_atoms[block_type1];
-    int const n_atoms2 = block_type_n_atoms[block_type2];
-
-    auto load_tile_invariant_interres_data =
-        ([=](int pose_ind,
-             int block_ind1,
-             int block_ind2,
-             int block_type1,
-             int block_type2,
-             int n_atoms1,
-             int n_atoms2,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
-              pose_stack_block_coord_offset,
-              pose_stack_block_type,
-              pose_stack_inter_residue_connections,
-              pose_stack_min_bond_separation,
-              pose_stack_inter_block_bondsep,
-
-              block_type_n_interblock_bonds,
-              block_type_atoms_forming_chemical_bonds,
-              global_params,
-              max_important_bond_separation,
-              pose_ind,
-
-              block_ind1,
-              block_ind2,
-              block_type1,
-              block_type2,
-              n_atoms1,
-
-              n_atoms2,
-              inter_dat,
-              shared.m);
-        });
-
-    auto load_interres1_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom1,
-             int n_atoms_to_load1,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              block_type_path_distance,
-              tile_ind,
-              start_atom1,
-              n_atoms_to_load1,
-              inter_dat,
-              shared.m);
-        });
-
-    auto load_interres2_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom2,
-             int n_atoms_to_load2,
-             LKBallScoringData<Real> &inter_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              block_type_path_distance,
-              tile_ind,
-              start_atom2,
-              n_atoms_to_load2,
-              inter_dat,
-              shared.m);
-        });
-
-    auto load_interres_data_from_shared =
-        ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
-
-    auto eval_interres_atom_pair_scores =
-        ([=](LKBallScoringData<Real> &inter_dat,
-             int start_atom1,
-             int start_atom2) {
-          eval_interres_don_acc_pair_energies<DeviceDispatch, Dev, nt>(
-              inter_dat,
-              start_atom1,
-              start_atom2,
-              dscore_inter_lk_ball_atom_pair);
-        });
-
-    auto store_calculated_energies =
-        ([=](LKBallScoringData<Real> &score_dat, shared_mem_union &shared) {
-          // no op; only derivs, no scoring
-        });
-
-    auto load_tile_invariant_intrares_data =
-        ([=](int pose_ind,
-             int block_ind1,
-             int block_type1,
-             int n_atoms1,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
-              pose_stack_block_coord_offset,
-              pose_stack_block_type,
-              global_params,
-              max_important_bond_separation,
-              pose_ind,
-              block_ind1,
-              block_type1,
-              n_atoms1,
-              intra_dat,
-              shared.m);
-        });
-
-    auto load_intrares1_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom1,
-             int n_atoms_to_load1,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-
-              tile_ind,
-              start_atom1,
-              n_atoms_to_load1,
-              intra_dat,
-              shared.m);
-        });
-
-    auto load_intrares2_tile_data_to_shared =
-        ([=](int tile_ind,
-             int start_atom2,
-             int n_atoms_to_load2,
-             LKBallScoringData<Real> &intra_dat,
-             shared_mem_union &shared) {
-          lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
-              pose_coords,
-              water_coords,
-              block_type_tile_n_polar_atoms,
-              block_type_tile_n_occluder_atoms,
-              block_type_tile_pol_occ_inds,
-              block_type_tile_lk_ball_params,
-              tile_ind,
-              start_atom2,
-              n_atoms_to_load2,
-              intra_dat,
-              shared.m);
-        });
-
-    auto load_intrares_data_from_shared =
-        ([=](int tile_ind1,
-             int tile_ind2,
-             shared_mem_union &shared,
-             LKBallScoringData<Real> &intra_dat) {
-          lk_ball_load_intrares_data_from_shared(
-              tile_ind1, tile_ind2, shared.m, intra_dat);
-        });
-
-    auto eval_intrares_atom_pair_scores =
-        ([=](LKBallScoringData<Real> &intra_dat,
-             int start_atom1,
-             int start_atom2) {
-          eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
-              intra_dat,
-              start_atom1,
-              start_atom2,
-              dscore_intra_lk_ball_atom_pair);
-        });
-
-    tmol::score::common::tile_evaluate_block_pair<
-        DeviceDispatch,
-        Dev,
-        LKBallScoringData<Real>,
-        LKBallScoringData<Real>,
-        Real,
-        TILE_SIZE>(
-        shared,
-        pose_ind,
-        block_ind1,
-        block_ind2,
-        block_type1,
-        block_type2,
-        n_atoms1,
-        n_atoms2,
-        load_tile_invariant_interres_data,
-        load_interres1_tile_data_to_shared,
-        load_interres2_tile_data_to_shared,
-        load_interres_data_from_shared,
-        eval_interres_atom_pair_scores,
-        store_calculated_energies,
-        load_tile_invariant_intrares_data,
-        load_intrares1_tile_data_to_shared,
-        load_intrares2_tile_data_to_shared,
-        load_intrares_data_from_shared,
-        eval_intrares_atom_pair_scores,
-        store_calculated_energies);
-  });
-
-  // Since we have the sphere overlap results from the forward pass,
-  // there's only a single kernel launch here
-  int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
-  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-      n_block_pairs, eval_derivs);
-
-  return {dV_d_pose_coords_t, dV_d_water_coords_t};
-}
+    return {dV_d_pose_coords_t, dV_d_water_coords_t};
+  }
+};
 
 }  // namespace potentials
 }  // namespace lk_ball

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -41,6 +41,7 @@ namespace potentials {
 template <typename Real, int N>
 using Vec = Eigen::Matrix<Real, N, 1>;
 
+// TO DO: standardize tiled inter-block count pair
 template <int TILE, typename InterEnergyData>
 EIGEN_DEVICE_FUNC int interres_count_pair_separation(
     InterEnergyData const &inter_dat, int atom_tile_ind1, int atom_tile_ind2) {

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -30,10 +30,8 @@
 
 #include <chrono>
 
-// The maximum number of inter-residue chemical bonds
-#define MAX_N_CONN 4
-#define MAX_N_WATER 4
-#define TILE_SIZE 32
+// #include <tmol/score/lk_ball/potentials/constants.hh>
+#include "constants.hh"
 
 namespace tmol {
 namespace score {

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -1,0 +1,1093 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/TensorStruct.h>
+#include <tmol/utility/tensor/TensorUtil.h>
+#include <tmol/utility/nvtx.hh>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/data_loading.hh>
+#include <tmol/score/common/diamond_macros.hh>
+#include <tmol/score/common/geom.hh>
+#include <tmol/score/common/launch_box_macros.hh>
+#include <tmol/score/common/sphere_overlap.impl.hh>
+#include <tmol/score/common/tile_atom_pair_evaluation.hh>
+#include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/warp_segreduce.hh>
+#include <tmol/score/common/warp_stride_reduce.hh>
+
+#include <tmol/score/lk_ball/potentials/lk_ball.hh>
+#include <tmol/score/lk_ball/potentials/params.hh>
+#include <tmol/score/lk_ball/potentials/lk_ball_pose_score.hh>
+
+// Operator definitions; safe for CPU compilation
+#include <moderngpu/operators.hxx>
+
+#include <chrono>
+
+// The maximum number of inter-residue chemical bonds
+#define MAX_N_CONN 4
+#define MAX_N_WATER 4
+#define TILE_SIZE 32
+
+namespace tmol {
+namespace score {
+namespace lk_ball {
+namespace potentials {
+
+template <typename Real, int N>
+using Vec = Eigen::Matrix<Real, N, 1>;
+
+template <int TILE, typename InterEnergyData>
+EIGEN_DEVICE_FUNC int interres_count_pair_separation(
+    InterEnergyData const &inter_dat, int atom_tile_ind1, int atom_tile_ind2) {
+  int separation = inter_dat.pair_data.min_separation;
+  if (separation <= inter_dat.pair_data.max_important_bond_separation) {
+    separation = common::count_pair::shared_mem_inter_block_separation<TILE>(
+        inter_dat.pair_data.max_important_bond_separation,
+        atom_tile_ind1,
+        atom_tile_ind2,
+        inter_dat.r1.n_conn,
+        inter_dat.r2.n_conn,
+        inter_dat.r1.path_dist,
+        inter_dat.r2.path_dist,
+        inter_dat.pair_data.conn_seps);
+  }
+  return separation;
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    typename Real,
+    typename Int>
+auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 2, Dev> water_coords,
+    TView<Int, 2, Dev> pose_stack_block_coord_offset,
+    TView<Int, 2, Dev> pose_stack_block_type,
+
+    // For determining which atoms to retrieve from neighboring
+    // residues we have to know how the blocks in the Pose
+    // are connected
+    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+    // dims: n-poses x max-n-blocks x max-n-blocks
+    // Quick lookup: given the inds of two blocks, ask: what is the minimum
+    // number of chemical bonds that separate any pair of atoms in those
+    // blocks? If this minimum is greater than the crossover, then no further
+    // logic for deciding whether two atoms in those blocks should have their
+    // interaction energies calculated: all should. intentionally small to
+    // (possibly) fit in constant cache
+    TView<Int, 3, Dev> pose_stack_min_bond_separation,
+
+    // dims: n-poses x max-n-blocks x max-n-blocks x
+    // max-n-interblock-connections x max-n-interblock-connections
+    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
+
+    //////////////////////
+    // Chemical properties
+    // how many atoms for a given block
+    // Dimsize n_block_types
+    TView<Int, 1, Dev> block_type_n_atoms,
+
+    // how many inter-block chemical bonds are there
+    // Dimsize: n_block_types
+    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+    // what atoms form the inter-block chemical bonds
+    // Dimsize: n_block_types x max_n_interblock_bonds
+    // TO DO: Rename since lots of atoms form chemical bonds
+    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+
+    // How many chemical bonds separate all pairs of atoms
+    // within each block type?
+    // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+    TView<Int, 3, Dev> block_type_path_distance,
+
+    //////////////////////
+
+    // LKBall potential parameters
+    TView<LKBallGlobalParams<Real>, 1, Dev> global_params)
+    -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 3, Dev>> {
+  using tmol::score::common::accumulate;
+  using Real3 = Vec<Real, 3>;
+
+  int const n_poses = pose_coords.size(0);
+  int const max_n_pose_atoms = water_coords.size(1);
+  int const max_n_blocks = pose_stack_block_type.size(1);
+  int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+  int const n_block_types = block_type_n_atoms.size(0);
+  int const max_n_block_atoms = block_type_atom_is_hydrogen.size(1);
+  int const max_n_interblock_bonds =
+      block_type_atoms_forming_chemical_bonds.size(1);
+  int const max_n_all_bonds = block_type_all_bonds.size(1);
+  int const max_n_tiles = block_type_tile_donH_inds.size(1);
+  int const max_n_donH_per_tile = block_type_tile_donH_inds.size(2);
+  int const max_n_acc_per_tile = block_type_tile_acc_inds.size(2);
+
+  assert(max_n_interblock_bonds <= MAX_N_CONN);
+
+  assert(water_coords.size(0) == n_poses);
+  assert(water_coords.size(1) == max_n_pose_atoms);
+  assert(water_coords.size(2) == MAX_N_WATER);
+
+  assert(pose_stack_block_coord_offset.size(0) == n_poses);
+  assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
+
+  assert(pose_stack_block_type.size(0) == n_poses);
+
+  assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+  assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+
+  assert(pose_stack_min_bond_separation.size(0) == n_poses);
+  assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
+  assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
+
+  assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
+  assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
+  assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
+
+  assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+
+  assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+
+  assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
+  assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
+  assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
+  assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
+  assert(block_type_tile_polar_inds.size(0) == n_block_types);
+  assert(block_type_tile_polar_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_polar_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_occluder_inds.size(0) == n_block_types);
+  assert(block_type_tile_occluder_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_occluder_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
+  assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
+  assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
+
+  assert(block_type_path_distance.size(0) == n_block_types);
+  assert(block_type_path_distance.size(1) == max_n_block_atoms);
+  assert(block_type_path_distance.size(2) == max_n_block_atoms);
+
+  auto output_t = TPack<Real, 2, Dev>::zeros({n_lk_ball_score_types, n_poses});
+  auto output = output_t.view;
+
+  auto scratch_block_spheres_t =
+      TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+  auto scratch_block_spheres = scratch_block_spheres_t.view;
+
+  auto scratch_block_neighbors_t =
+      TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+  auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+
+  // Optimal launch box on v100 and a100 is nt=32, vt=1
+  LAUNCH_BOX_32;
+  // Define nt and reduce_t
+  CTA_REAL_REDUCE_T_TYPEDEF;
+
+  auto eval_energies_only = ([=] TMOL_DEVICE_FUNC(int cta) {
+    // auto lk_ball_atom_energy =
+    //   // The typical idiom is that we lambda-capture the tensor(s) into which
+    //   // we will write the derivatives, but in the split scoring/derivative
+    //   // format, that doesn't happen here; as such, this function is
+    //   unnecessary
+    //     ([=] TMOL_DEVICE_FUNC(
+    //          int pol_ind,
+    //          int occ_ind,
+    //          int pol_tile_ind,
+    //          int occ_tile_ind,
+    //          int pol_start,
+    //          int occ_start,
+    //          LKBallSingleResData<Real> const &pol_dat,
+    //          LKBallSingleResData<Real> const &occ_dat,
+    //          LKBallResPairData<Real> const &respair_dat,
+    //          int cp_separation) {
+    //
+    //       lk_ball_Vt<Real> val = lk_ball_atom_energy_full<TILE_SIZE,
+    //       MAX_N_WATER>(
+    //           pol_ind,
+    //           occ_ind,
+    //           pol_tile_ind,
+    //           occ_tile_ind,
+    //           pol_start,
+    //           occ_start,
+    //           pol_dat,
+    //           occ_dat,
+    //           respair_dat,
+    //           cp_separation);
+    //       return val;
+    //     });
+
+    auto score_inter_lk_ball_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int pol_start,
+             int occ_start,
+             int pol_ind,
+             int occ_ind,
+             LKBallScoringData<Real> const &inter_dat,
+             bool polar_first) {
+          int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
+                                 .polar_tile_inds[pol_ind];
+          int occ_tile_ind = (donor_first ? inter_dat.r2 : inter_dat.r1)
+                                 .occluder_tile_inds[don_ind];
+          int separation = interres_count_pair_separation<TILE_SIZE>(
+              inter_dat,
+              (polar_first ? pol_ind : occ_ind),
+              (polar_first ? occ_ind : pol_ind));
+          return lk_ball_atom_energy_full<TILE_SIZE, MAX_N_WATER>(
+              pol_ind,
+              occ_ind,
+              pol_tile_ind,
+              occ_tile_ind,
+              pol_start,
+              occ_start,
+              polar_first ? inter_dat.r1 : inter_dat.r2,
+              polar_first ? inter_dat.r2 : inter_dat.r1,
+              inter_dat.pair_data,
+              separation);
+        });
+
+    auto score_intra_lk_ball_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int pol_start,
+             int occ_start,
+             int pol_ind,
+             int occ_ind,
+             LKBallScoringData<Real> const &intra_dat,
+             bool polar_first) {
+          int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
+                                 .polar_tile_inds[pol_ind];
+          int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
+                                 .occluder_tile_inds[occ_ind];
+          int const pol_atom_ind = pol_start + pol_tile_ind;
+          int const occ_atom_ind = occ_start + occ_tile_ind;
+
+          int const separation =
+              block_type_path_distance[intra_dat.r1.block_type][pol_atom_ind]
+                                      [occ_atom_ind];
+          return lk_ball_atom_energy_full<TILE_SIZE, MAX_N_WATER>(
+              pol_ind,
+              occ_ind,
+              pol_tile_ind,
+              occ_tile_ind,
+              pol_start,
+              occ_start,
+              polar_first ? intra_dat.r1 : intra_dat.r2,
+              polar_first ? intra_dat.r2 : intra_dat.r1,
+              intra_dat.pair_data,
+              separation);
+        });
+
+    SHARED_MEMORY union shared_mem_union {
+      shared_mem_union() {}
+      LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
+      CTA_REAL_REDUCE_T_VARIABLE;
+
+    } shared;
+
+    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+    int const block_ind1 = block_ind_pair / max_n_blocks;
+    int const block_ind2 = block_ind_pair % max_n_blocks;
+    if (block_ind1 > block_ind2) {
+      return;
+    }
+
+    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    int const max_important_bond_separation = 4;
+
+    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+
+    if (block_type1 < 0 || block_type2 < 0) {
+      return;
+    }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
+
+    auto load_tile_invariant_interres_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_ind2,
+             int block_type1,
+             int block_type2,
+             int n_atoms1,
+             int n_atoms2,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_block_type,
+              pose_stack_inter_residue_connections,
+              pose_stack_min_bond_separation,
+              pose_stack_inter_block_bondsep,
+
+              block_type_n_interblock_bonds,
+              block_type_atoms_forming_chemical_bonds,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+
+              block_ind1,
+              block_ind2,
+              block_type1,
+              block_type2,
+              n_atoms1,
+
+              n_atoms2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              block_type_path_distance,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              block_type_path_distance,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres_data_from_shared =
+        ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
+
+    auto eval_interres_atom_pair_scores =
+        ([=](LKBallScoringData<Real> &inter_dat,
+             int start_atom1,
+             int start_atom2) {
+          eval_interres_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+              inter_dat,
+              start_atom1,
+              start_atom2,
+              score_inter_lk_ball_atom_pair);
+        });
+
+    auto store_calculated_energies = ([=](LKBallScoringData<Real> &score_dat,
+                                          shared_mem_union &shared) {
+      auto reduce_energies = ([&](int tid) {
+        Real const cta_total_lk_ball_iso =
+            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                score_dat.pair_data.total_lk_ball_iso,
+                shared,
+                mgpu::plus_t<Real>());
+        Real const cta_total_lk_ball =
+            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                score_dat.pair_data.total_lk_ball,
+                shared,
+                mgpu::plus_t<Real>());
+        Real const cta_total_lk_bridge =
+            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                score_dat.pair_data.total_lk_bridge,
+                shared,
+                mgpu::plus_t<Real>());
+        Real const cta_total_lk_bridge_uncpl =
+            DeviceDispatch<Dev>::template reduce_in_workgroup<nt>(
+                score_dat.pair_data.total_lk_bridge_uncpl,
+                shared,
+                mgpu::plus_t<Real>());
+
+        if (tid == 0) {
+          accumulate<Dev, Real>::add(
+              output[w_lk_ball_iso][score_dat.pair_data.pose_ind],
+              cta_total_lk_ball_iso);
+          accumulate<Dev, Real>::add(
+              output[w_lk_ball][score_dat.pair_data.pose_ind],
+              cta_total_lk_ball);
+          accumulate<Dev, Real>::add(
+              output[w_lk_bridge][score_dat.pair_data.pose_ind],
+              cta_total_lk_bridge);
+          accumulate<Dev, Real>::add(
+              output[w_lk_bridge_uncpl][score_dat.pair_data.pose_ind],
+              cta_total_lk_bridge_uncpl);
+        }
+      });
+      DeviceDispatch<Dev>::template for_each_in_workgroup<nt>(reduce_energies);
+    });
+
+    auto load_tile_invariant_intrares_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_type1,
+             int n_atoms1,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_block_type,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_type1,
+              n_atoms1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares_data_from_shared =
+        ([=](int tile_ind1,
+             int tile_ind2,
+             shared_mem_union &shared,
+             LKBallScoringData<Real> &intra_dat) {
+          lk_ball_load_intrares_data_from_shared(
+              tile_ind1, tile_ind2, shared.m, intra_dat);
+        });
+
+    auto eval_intrares_atom_pair_scores =
+        ([=](LKBallScoringData<Real> &intra_dat,
+             int start_atom1,
+             int start_atom2) {
+          eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+              intra_dat,
+              start_atom1,
+              start_atom2,
+              score_intra_lk_ball_atom_pair);
+        });
+
+    tmol::score::common::tile_evaluate_block_pair<
+        DeviceDispatch,
+        Dev,
+        LKBallScoringData<Real>,
+        LKBallScoringData<Real>,
+        Real,
+        TILE_SIZE>(
+        shared,
+        pose_ind,
+        block_ind1,
+        block_ind2,
+        block_type1,
+        block_type2,
+        n_atoms1,
+        n_atoms2,
+        load_tile_invariant_interres_data,
+        load_interres1_tile_data_to_shared,
+        load_interres2_tile_data_to_shared,
+        load_interres_data_from_shared,
+        eval_interres_atom_pair_scores,
+        store_calculated_energies,
+        load_tile_invariant_intrares_data,
+        load_intrares1_tile_data_to_shared,
+        load_intrares2_tile_data_to_shared,
+        load_intrares_data_from_shared,
+        eval_intrares_atom_pair_scores,
+        store_calculated_energies);
+  });
+
+  ///////////////////////////////////////////////////////////////////////
+
+  // Three steps
+  // 0: setup
+  // 1: launch a kernel to find a small bounding sphere surrounding the
+  // blocks 2: launch a kernel to look for spheres that are within
+  // striking distance of each other 3: launch a kernel to evaluate
+  // lk-ball desolvation between pairs of blocks within striking distance
+
+  // 0
+  // TO DO: let DeviceDispatch hold a cuda stream (??)
+  // at::cuda::CUDAStream wrapped_stream =
+  // at::cuda::getDefaultCUDAStream(); mgpu::standard_context_t
+  // context(wrapped_stream.stream());
+  int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
+
+  score::common::sphere_overlap::
+      compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
+          coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          block_type_n_atoms,
+          scratch_block_spheres);
+
+  score::common::sphere_overlap::
+      detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+          coords,
+          pose_stack_block_coord_offset,
+          pose_stack_block_type,
+          block_type_n_atoms,
+          scratch_block_spheres,
+          scratch_block_neighbors,
+          Real(5.5));  // 5.5A hard coded here. Please fix! TEMP!
+
+  // 3 Only the forward pass in this calculation
+  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+      n_block_pairs, eval_energies_only);
+
+  return {output_t, scratch_block_neighbors};
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    typename Real,
+    typename Int>
+auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
+    TView<Vec<Real, 3>, 2, Dev> pose_coords,
+    TView<Vec<Real, 3>, 2, Dev> water_coords,
+    TView<Int, 2, Dev> pose_stack_block_coord_offset,
+    TView<Int, 2, Dev> pose_stack_block_type,
+
+    // For determining which atoms to retrieve from neighboring
+    // residues we have to know how the blocks in the Pose
+    // are connected
+    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+    // dims: n-poses x max-n-blocks x max-n-blocks
+    // Quick lookup: given the inds of two blocks, ask: what is the minimum
+    // number of chemical bonds that separate any pair of atoms in those
+    // blocks? If this minimum is greater than the crossover, then no further
+    // logic for deciding whether two atoms in those blocks should have their
+    // interaction energies calculated: all should. intentionally small to
+    // (possibly) fit in constant cache
+    TView<Int, 3, Dev>
+        pose_stack_min_bond_separation,  // ?? needed ?? I think so
+
+    // dims: n-poses x max-n-blocks x max-n-blocks x
+    // max-n-interblock-connections x max-n-interblock-connections
+    TView<Int, 5, Dev>
+        pose_stack_inter_block_bondsep,  // ?? needed ?? I think so
+
+    //////////////////////
+    // Chemical properties
+    // how many atoms for a given block
+    // Dimsize n_block_types
+    TView<Int, 1, Dev> block_type_n_atoms,  // ?? needed ?? I think so
+
+    // how many inter-block chemical bonds are there
+    // Dimsize: n_block_types
+    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+
+    // what atoms form the inter-block chemical bonds
+    // Dimsize: n_block_types x max_n_interblock_bonds
+    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+
+    TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
+    TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
+    TView<Int, 3, Dev> block_type_tile_polar_inds,
+    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_lk_ball_params,
+
+    // How many chemical bonds separate all pairs of atoms
+    // within each block type?
+    // Dimsize: n_block_types x max_n_atoms x max_n_atoms
+    TView<Int, 3, Dev> block_type_path_distance,
+
+    //////////////////////
+
+    // LKBall potential parameters
+    TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
+    TView<Int, 3, Dev> scratch_block_neighbors,  // from forward pass
+    TView<Real, 2, Dev> dTdV)
+    -> std::tuple<TPack<Vec<Real, 3>, 3, Dev>, TPack<Vec<Real, 3>, 4, Dev>> {
+  using tmol::score::common::accumulate;
+  using Real3 = Vec<Real, 3>;
+
+  int const n_poses = pose_coords.size(0);
+  int const max_n_pose_atoms = water_coords.size(1);
+  int const max_n_blocks = pose_stack_block_type.size(1);
+  int const max_n_conn = pose_stack_inter_residue_connections.size(2);
+  int const n_block_types = block_type_n_atoms.size(0);
+  int const max_n_block_atoms = block_type_atom_is_hydrogen.size(1);
+  int const max_n_interblock_bonds =
+      block_type_atoms_forming_chemical_bonds.size(1);
+  int const max_n_all_bonds = block_type_all_bonds.size(1);
+  int const max_n_tiles = block_type_tile_donH_inds.size(1);
+  int const max_n_donH_per_tile = block_type_tile_donH_inds.size(2);
+  int const max_n_acc_per_tile = block_type_tile_acc_inds.size(2);
+
+  assert(max_n_interblock_bonds <= MAX_N_CONN);
+
+  assert(water_coords.size(0) == n_poses);
+  assert(water_coords.size(1) == max_n_pose_atoms);
+  assert(water_coords.size(2) == MAX_N_WATER);
+
+  assert(pose_stack_block_coord_offset.size(0) == n_poses);
+  assert(pose_stack_block_coord_offset.size(1) == max_n_blocks);
+
+  assert(pose_stack_block_type.size(0) == n_poses);
+
+  assert(pose_stack_inter_residue_connections.size(0) == n_poses);
+  assert(pose_stack_inter_residue_connections.size(1) == max_n_blocks);
+
+  assert(pose_stack_min_bond_separation.size(0) == n_poses);
+  assert(pose_stack_min_bond_separation.size(1) == max_n_blocks);
+  assert(pose_stack_min_bond_separation.size(2) == max_n_blocks);
+
+  assert(pose_stack_inter_block_bondsep.size(0) == n_poses);
+  assert(pose_stack_inter_block_bondsep.size(1) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(2) == max_n_blocks);
+  assert(pose_stack_inter_block_bondsep.size(3) == max_n_interblock_bonds);
+  assert(pose_stack_inter_block_bondsep.size(4) == max_n_interblock_bonds);
+
+  assert(block_type_n_interblock_bonds.size(0) == n_block_types);
+
+  assert(block_type_atoms_forming_chemical_bonds.size(0) == n_block_types);
+
+  assert(block_type_tile_n_polar_atoms.size(0) == n_block_types);
+  assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
+  assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
+  assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
+  assert(block_type_tile_polar_inds.size(0) == n_block_types);
+  assert(block_type_tile_polar_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_polar_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_occluder_inds.size(0) == n_block_types);
+  assert(block_type_tile_occluder_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_occluder_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
+  assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
+  assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
+
+  assert(block_type_path_distance.size(0) == n_block_types);
+  assert(block_type_path_distance.size(1) == max_n_block_atoms);
+  assert(block_type_path_distance.size(2) == max_n_block_atoms);
+
+  assert(scratch_block_neighbors.size(0) == n_poses);
+  assert(scratch_block_neighbors.size(1) == max_n_blocks);
+  assert(scratch_block_neighbors.size(2) == max_n_blocks);
+
+  auto dV_d_pose_coords_t =
+      TPack<Vec<Real, 3>, 3, D>::zeros({2, n_poses, max_n_pose_atoms});
+  auto dV_d_pose_coords = dV_d_pose_coords_t.view;
+
+  auto dV_d_water_coords_t = TPack<Vec<Real, 3>, 4, D>::zeros(
+      {2, n_poses, max_n_pose_atoms, MAX_N_WATER});
+  auto dV_d_water_coords = dV_d_water_coords_t.view;
+
+  auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
+    auto lk_ball_atom_derivs = ([=] TMOL_DEVICE_FUNC(
+                                    int don_ind,
+                                    int acc_ind,
+                                    int don_tile_ind,
+                                    int acc_tile_ind,
+                                    int don_start,
+                                    int acc_start,
+                                    LKBallSingleResData<Real> const &don_dat,
+                                    LKBallSingleResData<Real> const &acc_dat,
+                                    LKBallResPairData<Real> const &respair_dat,
+                                    int cp_separation) {
+      // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
+      lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
+          don_ind,
+          acc_ind,
+          don_tile_ind,
+          acc_tile_ind,
+          don_start,
+          acc_start,
+          don_dat,
+          acc_dat,
+          respair_dat,
+          cp_separation,
+          dTdV,
+          dV_d_pose_coords,
+          dV_d_water_coords);
+    });
+
+    auto dscore_inter_lk_ball_atom_pair = ([=] TMOL_DEVICE_FUNC(
+                                               int don_start,
+                                               int acc_start,
+                                               int don_ind,
+                                               int acc_ind,
+                                               LKBallScoringData<Real> const
+                                                   &inter_dat,
+                                               bool donor_first) {
+      int don_tile_ind =
+          (donor_first ? inter_dat.r1 : inter_dat.r2).donH_tile_inds[don_ind];
+      int acc_tile_ind =
+          (donor_first ? inter_dat.r2 : inter_dat.r1).acc_tile_inds[acc_ind];
+      int separation = interres_count_pair_separation<TILE_SIZE>(
+          inter_dat,
+          (donor_first ? don_ind : acc_ind),
+          (donor_first ? acc_ind : don_ind));
+      lk_ball_atom_derivs(
+          don_ind,
+          acc_ind,
+          don_tile_ind,
+          acc_tile_ind,
+          don_start,
+          acc_start,
+          donor_first ? inter_dat.r1 : inter_dat.r2,
+          donor_first ? inter_dat.r2 : inter_dat.r1,
+          inter_dat.pair_data,
+          separation);
+    });
+
+    auto dscore_intra_lk_ball_atom_pair = ([=] TMOL_DEVICE_FUNC(
+                                               int don_start,
+                                               int acc_start,
+                                               int don_ind,
+                                               int acc_ind,
+                                               LKBallScoringData<Real> const
+                                                   &intra_dat,
+                                               bool donor_first) {
+      int don_tile_ind =
+          (donor_first ? intra_dat.r1 : intra_dat.r2).donH_tile_inds[don_ind];
+      int acc_tile_ind =
+          (donor_first ? intra_dat.r2 : intra_dat.r1).acc_tile_inds[acc_ind];
+      int const don_atom_ind = don_start + don_tile_ind;
+      int const acc_atom_ind = acc_start + acc_tile_ind;
+
+      int const separation =
+          block_type_path_distance[intra_dat.r1.block_type][don_atom_ind]
+                                  [acc_atom_ind];
+      return lk_ball_atom_derivs(
+          don_ind,
+          acc_ind,
+          don_tile_ind,
+          acc_tile_ind,
+          don_start,
+          acc_start,
+          donor_first ? intra_dat.r1 : intra_dat.r2,
+          donor_first ? intra_dat.r2 : intra_dat.r1,
+          intra_dat.pair_data,
+          separation);
+    });
+
+    SHARED_MEMORY union shared_mem_union {
+      shared_mem_union() {}
+      LKBallBlockPairSharedData<Real, TILE_SIZE, MAX_N_WATER, MAX_N_CONN> m;
+      CTA_REAL_REDUCE_T_VARIABLE;
+
+    } shared;
+
+    int const pose_ind = cta / (max_n_blocks * max_n_blocks);
+    int const block_ind_pair = cta % (max_n_blocks * max_n_blocks);
+    int const block_ind1 = block_ind_pair / max_n_blocks;
+    int const block_ind2 = block_ind_pair % max_n_blocks;
+    if (block_ind1 > block_ind2) {
+      return;
+    }
+
+    if (scratch_block_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    int const max_important_bond_separation = 4;
+
+    int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+    int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+
+    if (block_type1 < 0 || block_type2 < 0) {
+      return;
+    }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
+
+    auto load_tile_invariant_interres_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_ind2,
+             int block_type1,
+             int block_type2,
+             int n_atoms1,
+             int n_atoms2,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_tile_invariant_interres_data<DeviceDispatch, Dev, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_block_type,
+              pose_stack_inter_residue_connections,
+              pose_stack_min_bond_separation,
+              pose_stack_inter_block_bondsep,
+
+              block_type_n_interblock_bonds,
+              block_type_atoms_forming_chemical_bonds,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+
+              block_ind1,
+              block_ind2,
+              block_type1,
+              block_type2,
+              n_atoms1,
+
+              n_atoms2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_interres1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              block_type_path_distance,
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             LKBallScoringData<Real> &inter_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_interres2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              block_type_path_distance,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              inter_dat,
+              shared.m);
+        });
+
+    auto load_interres_data_from_shared =
+        ([=](int, int, shared_mem_union &, LKBallScoringData<Real> &) {});
+
+    auto eval_interres_atom_pair_scores =
+        ([=](LKBallScoringData<Real> &inter_dat,
+             int start_atom1,
+             int start_atom2) {
+          eval_interres_don_acc_pair_energies<DeviceDispatch, Dev, nt>(
+              inter_dat,
+              start_atom1,
+              start_atom2,
+              dscore_inter_lk_ball_atom_pair);
+        });
+
+    auto store_calculated_energies =
+        ([=](LKBallScoringData<Real> &score_dat, shared_mem_union &shared) {
+          // no op; only derivs, no scoring
+        });
+
+    auto load_tile_invariant_intrares_data =
+        ([=](int pose_ind,
+             int block_ind1,
+             int block_type1,
+             int n_atoms1,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_tile_invariant_intrares_data<DeviceDispatch, Dev, nt>(
+              pose_stack_block_coord_offset,
+              pose_stack_block_type,
+              global_params,
+              max_important_bond_separation,
+              pose_ind,
+              block_ind1,
+              block_type1,
+              n_atoms1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares1_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom1,
+             int n_atoms_to_load1,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_intrares1_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+
+              tile_ind,
+              start_atom1,
+              n_atoms_to_load1,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares2_tile_data_to_shared =
+        ([=](int tile_ind,
+             int start_atom2,
+             int n_atoms_to_load2,
+             LKBallScoringData<Real> &intra_dat,
+             shared_mem_union &shared) {
+          lk_ball_load_intrares2_tile_data_to_shared<DeviceDispatch, Dev, nt>(
+              pose_coords,
+              water_coords,
+              block_type_tile_n_polar_atoms,
+              block_type_tile_n_occluder_atoms,
+              block_type_tile_polar_inds,
+              block_type_tile_occluder_inds,
+              block_type_tile_lk_ball_params,
+              tile_ind,
+              start_atom2,
+              n_atoms_to_load2,
+              intra_dat,
+              shared.m);
+        });
+
+    auto load_intrares_data_from_shared =
+        ([=](int tile_ind1,
+             int tile_ind2,
+             shared_mem_union &shared,
+             LKBallScoringData<Real> &intra_dat) {
+          lk_ball_load_intrares_data_from_shared(
+              tile_ind1, tile_ind2, shared.m, intra_dat);
+        });
+
+    auto eval_intrares_atom_pair_scores =
+        ([=](LKBallScoringData<Real> &intra_dat,
+             int start_atom1,
+             int start_atom2) {
+          eval_intrares_pol_occ_pair_energies<DeviceDispatch, Dev, nt>(
+              intra_dat,
+              start_atom1,
+              start_atom2,
+              dscore_intra_lk_ball_atom_pair);
+        });
+
+    tmol::score::common::tile_evaluate_block_pair<
+        DeviceDispatch,
+        Dev,
+        LKBallScoringData<Real>,
+        LKBallScoringData<Real>,
+        Real,
+        TILE_SIZE>(
+        shared,
+        pose_ind,
+        block_ind1,
+        block_ind2,
+        block_type1,
+        block_type2,
+        n_atoms1,
+        n_atoms2,
+        load_tile_invariant_interres_data,
+        load_interres1_tile_data_to_shared,
+        load_interres2_tile_data_to_shared,
+        load_interres_data_from_shared,
+        eval_interres_atom_pair_scores,
+        store_calculated_energies,
+        load_tile_invariant_intrares_data,
+        load_intrares1_tile_data_to_shared,
+        load_intrares2_tile_data_to_shared,
+        load_intrares_data_from_shared,
+        eval_intrares_atom_pair_scores,
+        store_calculated_energies);
+  });
+
+  // Since we have the sphere overlap results from the forward pass,
+  // there's only a single kernel launch here
+  int const n_block_pairs = n_poses * max_n_blocks * max_n_blocks;
+  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+      n_block_pairs, eval_derivs);
+
+  return {dV_d_pose_coords_t, dV_d_water_coords_t};
+}
+
+}  // namespace potentials
+}  // namespace lk_ball
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -33,6 +33,8 @@
 // #include <tmol/score/lk_ball/potentials/constants.hh>
 #include "constants.hh"
 
+#include <iostream>  // TEMP!
+
 namespace tmol {
 namespace score {
 namespace lk_ball {
@@ -242,8 +244,8 @@ class LKBallPoseScoreDispatch {
                                    .pol_occ_tile_inds[occ_ind];
             int separation = interres_count_pair_separation<TILE_SIZE>(
                 inter_dat,
-                (polar_first ? pol_ind : occ_ind),
-                (polar_first ? occ_ind : pol_ind));
+                (polar_first ? pol_tile_ind : occ_tile_ind),
+                (polar_first ? occ_tile_ind : pol_tile_ind));
             lk_ball_Vt<Real> E = lk_ball_atom_energy_full<MAX_N_WATER>(
                 pol_ind,
                 occ_ind,
@@ -783,8 +785,8 @@ class LKBallPoseScoreDispatch {
                                    .pol_occ_tile_inds[occ_ind];
             int separation = interres_count_pair_separation<TILE_SIZE>(
                 inter_dat,
-                (polar_first ? pol_ind : occ_ind),
-                (polar_first ? occ_ind : pol_ind));
+                (polar_first ? pol_tile_ind : occ_tile_ind),
+                (polar_first ? occ_tile_ind : pol_tile_ind));
             lk_ball_atom_derivs(
                 pol_ind,
                 occ_ind,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -23,13 +23,14 @@
 
 #include <tmol/score/lk_ball/potentials/lk_ball.hh>
 #include <tmol/score/lk_ball/potentials/params.hh>
-// #include <tmol/score/lk_ball/potentials/lk_ball_pose_score.hh>
 
 // Operator definitions; safe for CPU compilation
 #include <moderngpu/operators.hxx>
 
 #include <chrono>
 
+// Definitions for TILE_SIZE and MAX_N_WATERS
+// Shared between this file and gen_pose_waters.impl.hh
 #include <tmol/score/lk_ball/potentials/constants.hh>
 
 namespace tmol {

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -30,10 +30,7 @@
 
 #include <chrono>
 
-// #include <tmol/score/lk_ball/potentials/constants.hh>
-#include "constants.hh"
-
-#include <iostream>  // TEMP!
+#include <tmol/score/lk_ball/potentials/constants.hh>
 
 namespace tmol {
 namespace score {
@@ -197,39 +194,6 @@ class LKBallPoseScoreDispatch {
     CTA_REAL_REDUCE_T_TYPEDEF;
 
     auto eval_energies_only = ([=] TMOL_DEVICE_FUNC(int cta) {
-      // auto lk_ball_atom_energy =
-      //   // The typical idiom is that we lambda-capture the tensor(s) into
-      //   which
-      //   // we will write the derivatives, but in the split scoring/derivative
-      //   // format, that doesn't happen here; as such, this function is
-      //   unnecessary
-      //     ([=] TMOL_DEVICE_FUNC(
-      //          int pol_ind,
-      //          int occ_ind,
-      //          int pol_tile_ind,
-      //          int occ_tile_ind,
-      //          int pol_start,
-      //          int occ_start,
-      //          LKBallSingleResData<Real> const &pol_dat,
-      //          LKBallSingleResData<Real> const &occ_dat,
-      //          LKBallResPairData<Real> const &respair_dat,
-      //          int cp_separation) {
-      //
-      //       lk_ball_Vt<Real> val = lk_ball_atom_energy_full<TILE_SIZE,
-      //       MAX_N_WATER>(
-      //           pol_ind,
-      //           occ_ind,
-      //           pol_tile_ind,
-      //           occ_tile_ind,
-      //           pol_start,
-      //           occ_start,
-      //           pol_dat,
-      //           occ_dat,
-      //           respair_dat,
-      //           cp_separation);
-      //       return val;
-      //     });
-
       auto score_inter_lk_ball_atom_pair =
           ([=] TMOL_DEVICE_FUNC(
                int pol_start,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -108,8 +108,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
     TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
     TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-    TView<Int, 3, Dev> block_type_tile_polar_inds,
-    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
     TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
     // How many chemical bonds separate all pairs of atoms
@@ -130,13 +129,11 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   int const max_n_blocks = pose_stack_block_type.size(1);
   int const max_n_conn = pose_stack_inter_residue_connections.size(2);
   int const n_block_types = block_type_n_atoms.size(0);
-  int const max_n_block_atoms = block_type_atom_is_hydrogen.size(1);
+  int const max_n_block_atoms = block_type_path_distance.size(1);
   int const max_n_interblock_bonds =
       block_type_atoms_forming_chemical_bonds.size(1);
   int const max_n_all_bonds = block_type_all_bonds.size(1);
-  int const max_n_tiles = block_type_tile_donH_inds.size(1);
-  int const max_n_donH_per_tile = block_type_tile_donH_inds.size(2);
-  int const max_n_acc_per_tile = block_type_tile_acc_inds.size(2);
+  int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
   assert(max_n_interblock_bonds <= MAX_N_CONN);
 
@@ -170,12 +167,9 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
   assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
   assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_polar_inds.size(0) == n_block_types);
-  assert(block_type_tile_polar_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_polar_inds.size(2) == TILE_SIZE);
-  assert(block_type_tile_occluder_inds.size(0) == n_block_types);
-  assert(block_type_tile_occluder_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_occluder_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
+  assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
   assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
   assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
   assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
@@ -242,9 +236,9 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
              LKBallScoringData<Real> const &inter_dat,
              bool polar_first) {
           int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
-                                 .polar_tile_inds[pol_ind];
-          int occ_tile_ind = (donor_first ? inter_dat.r2 : inter_dat.r1)
-                                 .occluder_tile_inds[don_ind];
+                                 .pol_occ_tile_inds[pol_ind];
+          int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
+                                 .pol_occ_tile_inds[occ_ind];
           int separation = interres_count_pair_separation<TILE_SIZE>(
               inter_dat,
               (polar_first ? pol_ind : occ_ind),
@@ -271,9 +265,9 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
              LKBallScoringData<Real> const &intra_dat,
              bool polar_first) {
           int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
-                                 .polar_tile_inds[pol_ind];
+                                 .pol_occ_tile_inds[pol_ind];
           int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
-                                 .occluder_tile_inds[occ_ind];
+                                 .pol_occ_tile_inds[occ_ind];
           int const pol_atom_ind = pol_start + pol_tile_ind;
           int const occ_atom_ind = occ_start + occ_tile_ind;
 
@@ -369,8 +363,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               block_type_path_distance,
               tile_ind,
@@ -391,8 +384,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               block_type_path_distance,
               tile_ind,
@@ -489,8 +481,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
 
               tile_ind,
@@ -511,8 +502,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               tile_ind,
               start_atom2,
@@ -635,19 +625,17 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
     // logic for deciding whether two atoms in those blocks should have their
     // interaction energies calculated: all should. intentionally small to
     // (possibly) fit in constant cache
-    TView<Int, 3, Dev>
-        pose_stack_min_bond_separation,  // ?? needed ?? I think so
+    TView<Int, 3, Dev> pose_stack_min_bond_separation,
 
     // dims: n-poses x max-n-blocks x max-n-blocks x
     // max-n-interblock-connections x max-n-interblock-connections
-    TView<Int, 5, Dev>
-        pose_stack_inter_block_bondsep,  // ?? needed ?? I think so
+    TView<Int, 5, Dev> pose_stack_inter_block_bondsep,
 
     //////////////////////
     // Chemical properties
     // how many atoms for a given block
     // Dimsize n_block_types
-    TView<Int, 1, Dev> block_type_n_atoms,  // ?? needed ?? I think so
+    TView<Int, 1, Dev> block_type_n_atoms,
 
     // how many inter-block chemical bonds are there
     // Dimsize: n_block_types
@@ -659,8 +647,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
 
     TView<Int, 3, Dev> block_type_tile_n_polar_atoms,
     TView<Int, 3, Dev> block_type_tile_n_occluder_atoms,
-    TView<Int, 3, Dev> block_type_tile_polar_inds,
-    TView<Int, 3, Dev> block_type_tile_occluder_inds,
+    TView<Int, 3, Dev> block_type_tile_pol_occ_inds,
     TView<Int, 3, Dev> block_type_tile_lk_ball_params,
 
     // How many chemical bonds separate all pairs of atoms
@@ -683,13 +670,11 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
   int const max_n_blocks = pose_stack_block_type.size(1);
   int const max_n_conn = pose_stack_inter_residue_connections.size(2);
   int const n_block_types = block_type_n_atoms.size(0);
-  int const max_n_block_atoms = block_type_atom_is_hydrogen.size(1);
+  int const max_n_block_atoms = block_type_path_distance.size(1);
   int const max_n_interblock_bonds =
       block_type_atoms_forming_chemical_bonds.size(1);
   int const max_n_all_bonds = block_type_all_bonds.size(1);
-  int const max_n_tiles = block_type_tile_donH_inds.size(1);
-  int const max_n_donH_per_tile = block_type_tile_donH_inds.size(2);
-  int const max_n_acc_per_tile = block_type_tile_acc_inds.size(2);
+  int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
   assert(max_n_interblock_bonds <= MAX_N_CONN);
 
@@ -723,12 +708,9 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
   assert(block_type_tile_n_polar_atoms.size(1) == max_n_tiles);
   assert(block_type_tile_n_occluder_atoms.size(0) == n_block_types);
   assert(block_type_tile_n_occluder_atoms.size(1) == max_n_tiles);
-  assert(block_type_tile_polar_inds.size(0) == n_block_types);
-  assert(block_type_tile_polar_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_polar_inds.size(2) == TILE_SIZE);
-  assert(block_type_tile_occluder_inds.size(0) == n_block_types);
-  assert(block_type_tile_occluder_inds.size(1) == max_n_tiles);
-  assert(block_type_tile_occluder_inds.size(2) == TILE_SIZE);
+  assert(block_type_tile_pol_occ_inds.size(0) == n_block_types);
+  assert(block_type_tile_pol_occ_inds.size(1) == max_n_tiles);
+  assert(block_type_tile_pol_occ_inds.size(2) == TILE_SIZE);
   assert(block_type_tile_lk_ball_params.size(0) == n_block_types);
   assert(block_type_tile_lk_ball_params.size(1) == max_n_tiles);
   assert(block_type_tile_lk_ball_params.size(2) == TILE_SIZE);
@@ -751,26 +733,26 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto lk_ball_atom_derivs = ([=] TMOL_DEVICE_FUNC(
-                                    int don_ind,
-                                    int acc_ind,
-                                    int don_tile_ind,
-                                    int acc_tile_ind,
-                                    int don_start,
-                                    int acc_start,
-                                    LKBallSingleResData<Real> const &don_dat,
-                                    LKBallSingleResData<Real> const &acc_dat,
+                                    int pol_ind,
+                                    int occ_ind,
+                                    int pol_tile_ind,
+                                    int occ_tile_ind,
+                                    int pol_start,
+                                    int occ_start,
+                                    LKBallSingleResData<Real> const &pol_dat,
+                                    LKBallSingleResData<Real> const &occ_dat,
                                     LKBallResPairData<Real> const &respair_dat,
                                     int cp_separation) {
       // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
       lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
-          don_ind,
-          acc_ind,
-          don_tile_ind,
-          acc_tile_ind,
-          don_start,
-          acc_start,
-          don_dat,
-          acc_dat,
+          pol_ind,
+          occ_ind,
+          pol_tile_ind,
+          occ_tile_ind,
+          pol_start,
+          occ_start,
+          pol_dat,
+          occ_dat,
           respair_dat,
           cp_separation,
           dTdV,
@@ -778,65 +760,65 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
           dV_d_water_coords);
     });
 
-    auto dscore_inter_lk_ball_atom_pair = ([=] TMOL_DEVICE_FUNC(
-                                               int don_start,
-                                               int acc_start,
-                                               int don_ind,
-                                               int acc_ind,
-                                               LKBallScoringData<Real> const
-                                                   &inter_dat,
-                                               bool donor_first) {
-      int don_tile_ind =
-          (donor_first ? inter_dat.r1 : inter_dat.r2).donH_tile_inds[don_ind];
-      int acc_tile_ind =
-          (donor_first ? inter_dat.r2 : inter_dat.r1).acc_tile_inds[acc_ind];
-      int separation = interres_count_pair_separation<TILE_SIZE>(
-          inter_dat,
-          (donor_first ? don_ind : acc_ind),
-          (donor_first ? acc_ind : don_ind));
-      lk_ball_atom_derivs(
-          don_ind,
-          acc_ind,
-          don_tile_ind,
-          acc_tile_ind,
-          don_start,
-          acc_start,
-          donor_first ? inter_dat.r1 : inter_dat.r2,
-          donor_first ? inter_dat.r2 : inter_dat.r1,
-          inter_dat.pair_data,
-          separation);
-    });
+    auto dscore_inter_lk_ball_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int pol_start,
+             int occ_start,
+             int pol_ind,
+             int occ_ind,
+             LKBallScoringData<Real> const &inter_dat,
+             bool polar_first) {
+          int pol_tile_ind = (polar_first ? inter_dat.r1 : inter_dat.r2)
+                                 .pol_occ_tile_inds[pol_ind];
+          int occ_tile_ind = (polar_first ? inter_dat.r2 : inter_dat.r1)
+                                 .occ_tile_inds[occ_ind];
+          int separation = interres_count_pair_separation<TILE_SIZE>(
+              inter_dat,
+              (polar_first ? pol_ind : occ_ind),
+              (polar_first ? occ_ind : pol_ind));
+          lk_ball_atom_derivs(
+              pol_ind,
+              occ_ind,
+              pol_tile_ind,
+              occ_tile_ind,
+              pol_start,
+              occ_start,
+              polar_first ? inter_dat.r1 : inter_dat.r2,
+              polar_first ? inter_dat.r2 : inter_dat.r1,
+              inter_dat.pair_data,
+              separation);
+        });
 
-    auto dscore_intra_lk_ball_atom_pair = ([=] TMOL_DEVICE_FUNC(
-                                               int don_start,
-                                               int acc_start,
-                                               int don_ind,
-                                               int acc_ind,
-                                               LKBallScoringData<Real> const
-                                                   &intra_dat,
-                                               bool donor_first) {
-      int don_tile_ind =
-          (donor_first ? intra_dat.r1 : intra_dat.r2).donH_tile_inds[don_ind];
-      int acc_tile_ind =
-          (donor_first ? intra_dat.r2 : intra_dat.r1).acc_tile_inds[acc_ind];
-      int const don_atom_ind = don_start + don_tile_ind;
-      int const acc_atom_ind = acc_start + acc_tile_ind;
+    auto dscore_intra_lk_ball_atom_pair =
+        ([=] TMOL_DEVICE_FUNC(
+             int pol_start,
+             int occ_start,
+             int pol_ind,
+             int occ_ind,
+             LKBallScoringData<Real> const &intra_dat,
+             bool polar_first) {
+          int pol_tile_ind = (polar_first ? intra_dat.r1 : intra_dat.r2)
+                                 .pol_occ_tile_inds[pol_ind];
+          int occ_tile_ind = (polar_first ? intra_dat.r2 : intra_dat.r1)
+                                 .occ_tile_inds[acc_ind];
+          int const don_atom_ind = don_start + don_tile_ind;
+          int const acc_atom_ind = acc_start + acc_tile_ind;
 
-      int const separation =
-          block_type_path_distance[intra_dat.r1.block_type][don_atom_ind]
-                                  [acc_atom_ind];
-      return lk_ball_atom_derivs(
-          don_ind,
-          acc_ind,
-          don_tile_ind,
-          acc_tile_ind,
-          don_start,
-          acc_start,
-          donor_first ? intra_dat.r1 : intra_dat.r2,
-          donor_first ? intra_dat.r2 : intra_dat.r1,
-          intra_dat.pair_data,
-          separation);
-    });
+          int const separation =
+              block_type_path_distance[intra_dat.r1.block_type][don_atom_ind]
+                                      [acc_atom_ind];
+          return lk_ball_atom_derivs(
+              don_ind,
+              acc_ind,
+              don_tile_ind,
+              acc_tile_ind,
+              don_start,
+              acc_start,
+              donor_first ? intra_dat.r1 : intra_dat.r2,
+              donor_first ? intra_dat.r2 : intra_dat.r1,
+              intra_dat.pair_data,
+              separation);
+        });
 
     SHARED_MEMORY union shared_mem_union {
       shared_mem_union() {}
@@ -914,8 +896,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               block_type_path_distance,
               tile_ind,
@@ -936,8 +917,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               block_type_path_distance,
               tile_ind,
@@ -997,8 +977,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
 
               tile_ind,
@@ -1019,8 +998,7 @@ auto LKBallPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
               water_coords,
               block_type_tile_n_polar_atoms,
               block_type_tile_n_occluder_atoms,
-              block_type_tile_polar_inds,
-              block_type_tile_occluder_inds,
+              block_type_tile_pol_occ_inds,
               block_type_tile_lk_ball_params,
               tile_ind,
               start_atom2,

--- a/tmol/score/lk_ball/potentials/params.hh
+++ b/tmol/score/lk_ball/potentials/params.hh
@@ -20,7 +20,6 @@ struct LKBallTypeParams {
   Real is_acceptor;
 };
 
-// same (for now) as LJGlobalParams
 template <typename Real>
 struct LKBallGlobalParams {
   Real lj_hbond_dis;

--- a/tmol/score/lk_ball/potentials/params.hh
+++ b/tmol/score/lk_ball/potentials/params.hh
@@ -26,7 +26,9 @@ struct LKBallGlobalParams {
   Real lj_hbond_dis;
   Real lj_hbond_OH_donor_dis;
   Real lj_hbond_hdis;
-  Real lkb_water_dist;  // needed by both watergen and scoring
+  Real lkb_water_dist;      // needed by both watergen and scoring
+  Real distance_threshold;  // maximum distance two heavy-atoms can be to have a
+                            // non-zero interaction energy
 };
 
 template <typename Int>

--- a/tmol/score/lk_ball/potentials/water.hh
+++ b/tmol/score/lk_ball/potentials/water.hh
@@ -6,6 +6,7 @@
 #include <cppitertools/range.hpp>
 
 #include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/tuple.hh>
 #include <tmol/score/hbond/identification.hh>
 
@@ -669,6 +670,494 @@ struct build_acc_water {
 };
 
 #undef def
+
+template <typename Real>
+class WaterGenSingleResData {
+ public:
+  int block_ind;
+  int block_type;
+  int block_coord_offset;
+  int n_atoms;
+  int n_conn;
+  Real *coords;
+  unsigned char n_donH;
+  unsigned char n_acc;
+  unsigned char *donH_tile_inds;
+  unsigned char *don_hvy_inds;  // index of heavy atom that given donH bonds;
+                                // NOTE: limit of 256 atoms per block.
+  unsigned char *which_donH_for_hvy;  // for the given donH, what's its index in
+                                      // the list of H's bound to it
+  unsigned char *acc_tile_inds;
+  // unsigned char *donH_type;
+  // unsigned char *acc_type;
+  unsigned char *acc_hybridization;
+  unsigned char *acc_n_attached_H;  // for the given acc, how many H's it have?
+};
+
+template <tmol::Device Dev, typename Real, typename Int>
+class WaterGenPoseContextData {
+ public:
+  int pose_ind;
+  LKBallWaterGenGlobalParams<Real> global_params;
+
+  // Tensors to help identify atoms outside of the target
+  // block
+  // If the hbond involves atoms from other residues, we need
+  // to be able to retrieve their coordinates
+  TView<Vec<Real, 3>, 2, Dev> coords;
+  TView<Int, 2, Dev> pose_stack_block_coord_offset;
+  TView<Int, 2, Dev> pose_stack_block_type;
+
+  // For determining which atoms to retrieve from neighboring
+  // residues we have to know how the blocks in the Pose
+  // are connected
+  TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections;
+
+  // And we need to know the properties of the block types
+  // that we are working with to iterate across chemical bonds
+  TView<Int, 1, Dev> block_type_n_all_bonds;
+  TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds;
+  TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges;
+  TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds;
+  TView<Int, 2, Dev> block_type_atom_is_hydrogen;
+};
+
+template <tmol::Device Dev, typename Real, typename Int>
+class WaterGenData {
+ public:
+  WaterGenSingleResData<Real> r_dat;
+  WaterGenPoseContextData<Dev, Real, Int> pose_context;
+};
+
+template <typename Real, int TILE_SIZE>
+struct WaterGenSharedData {
+  Real coords[TILE_SIZE * 3];  // 384 bytes for coords
+  unsigned char n_donH;        // 4 bytes for counts
+  unsigned char n_acc;
+  unsigned char don_inds[TILE_SIZE];  //
+  unsigned char don_hvy_inds[TILE_SIZE];
+  unsigned char which_don_for_hvy[TILE_SIZE];
+  unsigned char acc_inds[TILE_SIZE];
+  unsigned char acc_hybridization1[TILE_SIZE];
+  unsigned char acc_n_attached_H[TILE_SIZE];
+};
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Real,
+    typename Int>
+void TMOL_DEVICE_FUNC water_gen_load_block_coords_and_params_into_shared(
+    TView<Vec<Real, 3>, 2, Dev> coords,
+    TView<Int, 2, Dev> block_type_tile_n_donH,
+    TView<Int, 2, Dev> block_type_tile_n_acc,
+    TView<Int, 3, Dev> block_type_tile_donH_inds,
+    TView<Int, 3, Dev> block_type_tile_don_hvy_inds,
+    TView<Int, 3, Dev> block_type_tile_which_donH_for_hhvy,
+    TView<Int, 3, Dev> block_type_tile_acc_inds,
+    // TView<Int, 3, Dev> block_type_tile_donor_type,
+    // TView<Int, 3, Dev> block_type_tile_acceptor_type,
+    TView<Int, 3, Dev> block_type_tile_hybridization,
+    TView<Int, 3, Dev> block_type_tile_acc_n_attached_H,
+    int pose_ind,
+    int tile_ind,
+    WaterGenSingleResData<Real> &r_dat,
+    int n_atoms_to_load,
+    int start_atom) {
+  // pre-condition: n_atoms_to_load < TILE_SIZE
+  // Note that TILE_SIZE is not explicitly passed in, but is "present"
+  // in r_dat.coords allocation
+
+  r_dat.n_donH = block_type_tile_n_donH[r_dat.block_type][tile_ind];
+  r_dat.n_acc = block_type_tile_n_acc[r_dat.block_type][tile_ind];
+
+  DeviceDispatch<Dev>::template copy_contiguous_data<nt, 3>(
+      r_dat.coords,
+      reinterpret_cast<Real *>(
+          &coords[pose_ind][r_dat.block_coord_offset + start_atom]),
+      n_atoms_to_load * 3);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.donH_tile_inds,
+      &block_type_tile_donH_inds[r_dat.block_type][tile_ind][0],
+      r_dat.n_donH);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.don_hvy_inds,
+      &block_type_tile_don_hvy_inds[r_dat.block_type][tile_ind][0],
+      r_dat.n_donH);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.which_donH_for_hvy,
+      &block_type_tile_which_donH_for_hhvy[r_dat.block_type][tile_ind][0],
+      r_dat.n_donH);
+
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.acc_tile_inds,
+      &block_type_tile_acc_inds[r_dat.block_type][tile_ind][0],
+      r_dat.n_acc);
+  // DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+  //     r_dat.donH_type,
+  //     &block_type_tile_donor_type[r_dat.block_type][tile_ind][0],
+  //     r_dat.n_donH);
+  // DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+  //     r_dat.acc_type,
+  //     &block_type_tile_acceptor_type[r_dat.block_type][tile_ind][0],
+  //     r_dat.n_acc);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.acc_hybridization,
+      &block_type_tile_hybridization[r_dat.block_type][tile_ind][0],
+      r_dat.n_acc);
+  DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
+      r_dat.acc_n_attached_H,
+      &block_type_tile_acc_n_attached_H[r_dat.block_type][tile_ind][0],
+      r_dat.n_acc);
+}
+
+template <
+    template <tmol::Device>
+    class DeviceDispatch,
+    tmol::Device Dev,
+    int nt,
+    typename Int,
+    typename Real,
+    int TILE_SIZE>
+void TMOL_DEVICE_FUNC water_gen_load_tile_invariant_data(
+    TView<Vec<Real, 3>, 2, Dev> coords,
+    TView<Int, 2, Dev> pose_stack_block_coord_offset,
+    TView<Int, 2, Dev> pose_stack_block_type,
+    TView<Vec<Int, 2>, 3, Dev> pose_stack_inter_residue_connections,
+
+    TView<Int, 1, Dev> block_type_n_all_bonds,
+    TView<Vec<Int, 3>, 2, Dev> block_type_all_bonds,
+    TView<Vec<Int, 2>, 2, Dev> block_type_atom_all_bond_ranges,
+    TView<Int, 1, Dev> block_type_n_interblock_bonds,
+    TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
+    TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+
+    int pose_ind,
+    int block_ind,
+    int block_type,
+    int n_atoms,
+
+    WaterGenData<Dev, Real, Int> &water_gen_dat,
+    WaterGenSharedData<Real, TILE_SIZE> &shared_m) {
+  water_gen_dat.pose_context.pose_ind = pose_ind;
+  water_gen_dat.r_dat.block_ind = block_ind;
+  water_gen_dat.r_dat.block_type = block_type;
+  water_gen_dat.r_dat.block_coord_offset =
+      pose_stack_block_coord_offset[pose_ind][block_ind];
+  water_gen_dat.r_dat.n_atoms = n_atoms;
+  water_gen_dat.r_dat.n_conn = block_type_n_interblock_bonds[block_type];
+
+  // set the pointers in inter_dat to point at the shared-memory arrays
+  water_gen_dat.r_dat.coords = shared_m.coords;
+  water_gen_dat.r_dat.donH_tile_inds = shared_m.don_inds;
+  water_gen_dat.r_dat.acc_tile_inds = shared_m.acc_inds;
+  water_gen_dat.r_dat.donH_type = shared_m.don_type;
+  water_gen_dat.r_dat.acc_type = shared_m.acc_type;
+  water_gen_dat.r_dat.acc_hybridization = shared_m.acc_hybridization;
+
+  // Final data members
+  // Keep a "copy" of the tensors needed to traverse bonds during
+  // the water-building step so they can be passed in to the lower
+  // -level functions when needed; nvcc is smart enough not to
+  // duplicate the registers used here
+  water_gen_dat.pose_context.coords = coords;
+  water_gen_dat.pose_context.pose_stack_block_coord_offset =
+      pose_stack_block_coord_offset;
+  water_gen_dat.pose_context.pose_stack_block_type = pose_stack_block_type;
+  water_gen_dat.pose_context.pose_stack_inter_residue_connections =
+      pose_stack_inter_residue_connections;
+  water_gen_dat.pose_context.block_type_n_all_bonds = block_type_n_all_bonds;
+  water_gen_dat.pose_context.block_type_all_bonds = block_type_all_bonds;
+  water_gen_dat.pose_context.block_type_atom_all_bond_ranges =
+      block_type_atom_all_bond_ranges;
+  water_gen_dat.pose_context.block_type_atoms_forming_chemical_bonds =
+      block_type_atoms_forming_chemical_bonds;
+  water_gen_dat.pose_context.block_type_atom_is_hydrogen =
+      block_type_atom_is_hydrogen;
+}
+
+// Some coordinates are available in shared memory, some we will
+// have to go out to global memory for.
+template <int TILE_SIZE, typename Real, typename Int, tmol::Device Dev>
+TMOL_DEVICE_FUNC Eigen::Matrix<Real, 3, 1> load_coord(
+    bonded_atom::BlockCentricAtom<Int> bcat,
+    WaterGenSingleResData<Real> const &single_res_dat,
+    WaterGenPoseContextData<Dev, Real, Int> const &context_dat,
+    int tile_start) {
+  Eigen::Matrix<Real, 3, 1> xyz{Real(0), Real(0), Real(0)};
+  if (bcat.atom != -1) {
+    bool in_smem = false;
+    if (bcat.block == single_res_dat.block_ind) {
+      int bcat_tile_ind = bcat.atom - tile_start;
+      if (bcat_tile_ind >= 0 && bcat_tile_ind < TILE_SIZE) {
+        in_smem = true;
+        xyz = coord_from_shared(single_res_dat.coords, bcat_tile_ind);
+      }
+    }
+    if (!in_smem) {
+      // outside of tile or on other res, retrieve from global coords
+      int coord_offset =
+          (bcat.block == single_res_dat.block_ind
+               ? single_res_dat.block_coord_offset
+               : context_dat.pose_stack_block_coord_offset[context_dat.pose_ind]
+                                                          [bcat.block]);
+      xyz = context_dat.coords[context_dat.pose_ind][bcat.atom + coord_offset];
+    }
+  }
+  return xyz;
+}
+
+template <int TILE_SIZE, tmol::Device Dev, typename Real, typename Int>
+void TMOL_DEVICE_FUNC build_water_for_don(
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    WaterGenData<Dev, Real, Int> wat_gen_dat,
+    int tile_start,
+    int don_h_ind  // [0..n_donH)
+) {
+  using Real3 = Vec<Real, 3>;
+
+  auto res_dat = wat_gen_dat.r_dat;
+  auto context_dat = wat_gen_dat.pose_context;
+  int const don_h_atom_tile_ind = res_dat.donH_tile_inds[don_h_ind];
+  Real3 Hxyz = coord_from_shared(res_dat.coords, don_h_atom_tile_ind);
+  int const D = res_dat.don_hvy_inds[don_h_ind];
+
+  Real3 Dxyz = load_coord<TILE_SIZE>(D, res_dat, context_dat, tile_start);
+
+  auto Wxyz = build_don_water<Real>::V(
+      Dxyz, Hxyz, context_dat.global_params.lkb_water_dist);
+
+  // Now record the coordinates to global memory:
+  int const which_water = res_dat.which_donH_for_hvy[don_h_ind];
+
+  water_coords[context_dat.pose_ind][res_dat.block_coord_offset + D]
+              [which_water] = Wxyz;
+}
+
+template <int TILE_SIZE, tmol::Device Dev, typename Real, typename Int>
+void TMOL_DEVICE_FUNC build_water_for_acc(
+    TView<Real, 1, Dev> sp2_water_tors,
+    TView<Real, 1, Dev> sp3_water_tors,
+    TView<Real, 1, Dev> ring_water_tors,
+    TView<Vec<Real, 3>, 3, Dev> water_coords,
+    WaterGenData<Dev, Real, Int> wat_gen_dat,
+    int tile_start,
+    int acc_ind,   // [0..n_acc)
+    int water_ind  // [0..MAX_N_WATER)
+) {
+  using Real3 = Vec<Real, 3>;
+
+  auto res_dat = wat_gen_dat.r_dat;
+  auto context_dat = wat_gen_dat.pose_context;
+
+  unsigned char hyb = res_dat.acc_hybridization[acc_ind];
+  Real tor(0), ang(0);
+  if (hyb == hbond::AcceptorHybridization::sp2) {
+    if (water_ind >= sp2_water_tors.size(0)) {
+      return;
+    } else {
+      tor = sp2_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_sp2;
+    }
+  } else if (hyb == hbond::AcceptorHybridization::sp3) {
+    if (water_ind >= sp3_water_tors.size(0)) {
+      return;
+    } else {
+      tor = sp3_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_sp3;
+    }
+  } else if (hyb == hbond::AcceptorHybridization::ring) {
+    if (water_ind >= ring_water_tors.size(0)) {
+      return;
+    } else {
+      tor = ring_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_ring;
+    }
+  }
+
+  unsigned char acc_atom_tile_ind = res_dat.acc_tile_inds[acc_ind];
+
+  Real3 Axyz = coord_from_shared(res_dat.coords, acc_atom_tile_ind);
+  bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds{
+      context_dat.pose_stack_inter_residue_connections[context_dat.pose_ind],
+      context_dat.pose_stack_block_type[context_dat.pose_ind],
+      context_dat.block_type_n_all_bonds,
+      context_dat.block_type_all_bonds,
+      context_dat.block_type_atom_all_bond_ranges,
+      context_dat.block_type_atoms_forming_chemical_bonds};
+  bonded_atom::BlockCentricAtom<Int> A{
+      res_dat.block_ind, res_dat.block_type, tile_start + acc_atom_tile_ind};
+  auto acc_bases = hbond::BlockCentricAcceptorBases<Int>::for_acceptor(
+      A, hyb, bonds, context_dat.block_type_atom_is_hydrogen);
+
+  Real3 Bxyz =
+      load_coord<TILE_SIZE>(acc_bases.B, res_dat, context_dat, tile_start);
+  Real3 B0xyz =
+      load_coord<TILE_SIZE>(acc_bases.B0, res_dat, context_dat, tile_start);
+
+  if (hyb == hbond::AcceptorHybridization::ring) {
+    // take the bisector of the line between B and B0 to build from
+    Bxyz = (Bxyz + B0xyz) / 2;
+  }
+
+  auto Wxyz = build_acc_water<Real>::V(
+      Axyz, Bxyz, B0xyz, context_dat.global_params.lkb_water_dist, ang, tor);
+
+  // Now record the coordinates to global memory:
+  // offset the water by the number of polar hydrogens on
+  // this acceptor
+  unsigned char water_offset = res_dat.acc_n_attached_H[acc_ind];
+
+  water_coords[context_dat.pose_ind][res_dat.block_coord_offset + A.atom]
+              [water_ind + water_offset] = Wxyz;
+}
+
+template <int TILE_SIZE, tmol::Device Dev, typename Real, typename Int>
+void TMOL_DEVICE_FUNC d_build_water_for_don(
+    TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
+    TView<Vec<Real, 3>, 2, Dev> dE_d_pose_coords,
+    WaterGenData<Dev, Real, Int> wat_gen_dat,
+    int tile_start,
+    int don_h_ind  // [0..n_donH)
+) {
+  using Real3 = Vec<Real, 3>;
+
+  auto res_dat = wat_gen_dat.r_dat;
+  auto context_dat = wat_gen_dat.pose_context;
+  int const don_h_atom_tile_ind = res_dat.donH_tile_inds[don_h_ind];
+
+  Real3 Hxyz = coord_from_shared(res_dat.coords, don_h_atom_tile_ind);
+  int const D = res_dat.don_hvy_inds[don_h_ind];
+  Real3 Dxyz = load_coord<TILE_SIZE>(D, res_dat, context_dat, tile_start);
+
+  auto dW = build_don_water<Real>::dV(
+      Dxyz, Hxyz, context_dat.global_params.lkb_water_dist);
+  int const which_water = res_dat.which_donH_for_hvy[don_h_ind];
+
+  // water_coords[context_dat.pose_ind][res_dat.block_coord_offset +
+  // D][which_water] = Wxyz;
+  int const pose_ind = wat_gen_dat.pose_context.pose_ind;
+  int const D_atom_pose_ind = res_dat.block_coord_offset + D;
+  int const H_atom_pose_ind =
+      res_dat.block_coord_offset + tile_start + don_h_atom_tile_ind;
+  Real3 dE_dW = dE_dWxyz[pose_ind][D_atom_pose_ind][which_water];
+
+  common::accumulate<Dev, Vec<Real, 3>>::add(
+      dE_d_pose_coords[pose_ind][D_atom_pose_ind], dW.dD * dE_dW);
+  common::accumulate<Dev, Vec<Real, 3>>::add(
+      dE_d_pose_coords[pose_ind][H_atom_pose_ind], dW.dH * dE_dW);
+}
+
+template <int TILE_SIZE, tmol::Device Dev, typename Real, typename Int>
+void TMOL_DEVICE_FUNC d_build_water_for_acc(
+    TView<Real, 1, Dev> sp2_water_tors,
+    TView<Real, 1, Dev> sp3_water_tors,
+    TView<Real, 1, Dev> ring_water_tors,
+    TView<Vec<Real, 3>, 3, Dev> dE_dWxyz,
+    TView<Vec<Real, 3>, 2, Dev> dE_d_pose_coords,
+    WaterGenData<Dev, Real, Int> wat_gen_dat,
+    int tile_start,
+    int acc_ind,   // [0..n_acc)
+    int water_ind  // [0..MAX_N_WATER)
+) {
+  using Real3 = Vec<Real, 3>;
+  auto res_dat = wat_gen_dat.r_dat;
+  auto context_dat = wat_gen_dat.pose_context;
+
+  unsigned char hyb = res_dat.acc_hybridization[acc_ind];
+  Real tor(0), ang(0);
+  if (hyb == hbond::AcceptorHybridization::sp2) {
+    if (water_ind >= sp2_water_tors.size(0)) {
+      return;
+    } else {
+      tor = sp2_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_sp2;
+    }
+  } else if (hyb == hbond::AcceptorHybridization::sp3) {
+    if (water_ind >= sp3_water_tors.size(0)) {
+      return;
+    } else {
+      tor = sp3_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_sp3;
+    }
+  } else if (hyb == hbond::AcceptorHybridization::ring) {
+    if (water_ind >= ring_water_tors.size(0)) {
+      return;
+    } else {
+      tor = ring_water_tors[water_ind];
+      ang = context_dat.global_params.lkb_water_angle_ring;
+    }
+  }
+
+  unsigned char acc_atom_tile_ind = res_dat.acc_tile_inds[acc_ind];
+
+  Real3 Axyz = coord_from_shared(res_dat.coords, acc_atom_tile_ind);
+  bonded_atom::BlockCentricIndexedBonds<Int, Dev> bonds{
+      context_dat.pose_stack_inter_residue_connections[context_dat.pose_ind],
+      context_dat.pose_stack_block_type[context_dat.pose_ind],
+      context_dat.block_type_n_all_bonds,
+      context_dat.block_type_all_bonds,
+      context_dat.block_type_atom_all_bond_ranges,
+      context_dat.block_type_atoms_forming_chemical_bonds};
+  bonded_atom::BlockCentricAtom<Int> A{
+      res_dat.block_ind, res_dat.block_type, tile_start + acc_atom_tile_ind};
+  auto acc_bases = hbond::BlockCentricAcceptorBases<Int>::for_acceptor(
+      A, hyb, bonds, context_dat.block_type_atom_is_hydrogen);
+
+  Real3 Bxyz =
+      load_coord<TILE_SIZE>(acc_bases.B, res_dat, context_dat, tile_start);
+  Real3 B0xyz =
+      load_coord<TILE_SIZE>(acc_bases.B0, res_dat, context_dat, tile_start);
+
+  if (hyb == hbond::AcceptorHybridization::ring) {
+    // take the bisector of the line between B and B0 to build from
+    Bxyz = (Bxyz + B0xyz) / 2;
+  }
+
+  auto dW = build_acc_water<Real>::dV(
+      Axyz, Bxyz, B0xyz, context_dat.global_params.lkb_water_dist, ang, tor);
+
+  // Now record the coordinates to global memory:
+  // offset the water by the number of polar hydrogens on
+  // this acceptor
+  unsigned char water_offset = res_dat.acc_n_attached_H[acc_ind];
+
+  int const pose_ind = context_dat.pose_ind;
+  int const A_atom_pose_ind = res_dat.block_coord_offset + A.atom;
+  int const B_atom_pose_ind =
+      (acc_bases.B.block_ind == A.block_ind
+           ? res_dat.block_coord_offset
+           : context_dat.pose_stack_block_coord_offset[pose_ind]
+                                                      [acc_bases.B.block_ind])
+      + A.atom;
+  int const B0_atom_pose_ind =
+      (acc_bases.B0.block_ind == A.block_ind
+           ? res_dat.block_coord_offset
+           : context_dat.pose_stack_block_coord_offset[pose_ind]
+                                                      [acc_bases.B0.block_ind])
+      + A.atom;
+
+  Real3 dE_dW = dE_dWxyz[pose_ind][A_atom_pose_ind][water_ind + water_offset];
+
+  common::accumulate<Dev, Vec<Real, 3>>::add(
+      dE_d_pose_coords[pose_ind][A_atom_pose_ind], dE_dW * dW.dA);
+  if (hyb == hbond::AcceptorHybridization::ring) {
+    // Since the Bxyz coordinate for ring acceptors is the
+    // bisector of the B and B0 atoms, apply half of the
+    // derivative to B and half to B0
+    common::accumulate<Dev, Vec<Real, 3>>::add(
+        dE_d_pose_coords[pose_ind][B_atom_pose_ind], dE_dW * dW.dB * 0.5);
+    common::accumulate<Dev, Vec<Real, 3>>::add(
+        dE_d_pose_coords[pose_ind][B0_atom_pose_ind], dE_dW * dW.dB * 0.5);
+  } else {
+    common::accumulate<Dev, Vec<Real, 3>>::add(
+        dE_d_pose_coords[pose_ind][B_atom_pose_ind], dE_dW * dW.dB);
+  }
+  common::accumulate<Dev, Vec<Real, 3>>::add(
+      dE_d_pose_coords[pose_ind][B0_atom_pose_ind], dE_dW * dW.dB0);
+}
 
 }  // namespace potentials
 }  // namespace lk_ball

--- a/tmol/score/lk_ball/potentials/water.hh
+++ b/tmol/score/lk_ball/potentials/water.hh
@@ -832,6 +832,7 @@ void TMOL_DEVICE_FUNC water_gen_load_tile_invariant_data(
     TView<Int, 1, Dev> block_type_n_interblock_bonds,
     TView<Int, 2, Dev> block_type_atoms_forming_chemical_bonds,
     TView<Int, 2, Dev> block_type_atom_is_hydrogen,
+    TView<LKBallWaterGenGlobalParams<Real>, 1, Dev> global_params,
 
     int pose_ind,
     int block_ind,
@@ -841,6 +842,7 @@ void TMOL_DEVICE_FUNC water_gen_load_tile_invariant_data(
     WaterGenData<Dev, Real, Int> &water_gen_dat,
     WaterGenSharedData<Real, TILE_SIZE> &shared_m) {
   water_gen_dat.pose_context.pose_ind = pose_ind;
+  water_gen_dat.pose_context.global_params = global_params[0];
   water_gen_dat.r_dat.block_ind = block_ind;
   water_gen_dat.r_dat.block_type = block_type;
   water_gen_dat.r_dat.block_coord_offset =
@@ -851,6 +853,7 @@ void TMOL_DEVICE_FUNC water_gen_load_tile_invariant_data(
   // set the pointers in inter_dat to point at the shared-memory arrays
   water_gen_dat.r_dat.coords = shared_m.coords;
   water_gen_dat.r_dat.donH_tile_inds = shared_m.don_inds;
+  water_gen_dat.r_dat.don_hvy_inds = shared_m.don_hvy_inds;
   water_gen_dat.r_dat.which_donH_for_hvy = shared_m.which_donH_for_hvy;
   water_gen_dat.r_dat.acc_tile_inds = shared_m.acc_inds;
   water_gen_dat.r_dat.acc_hybridization = shared_m.acc_hybridization;
@@ -932,6 +935,13 @@ void TMOL_DEVICE_FUNC build_water_for_don(
 
   // Now record the coordinates to global memory:
   int const which_water = res_dat.which_donH_for_hvy[don_h_ind];
+
+  // printf("build don %d %d %d %d (%6.3f, %6.3f, %6.3f), (%6.3f, %6.3f, %6.3f)
+  // --> (%6.3f, %6.3f, %6.3f)\n",
+  //   res_dat.block_ind, don_h_atom_tile_ind, Dind, which_water,
+  //   Hxyz[0], Hxyz[1], Hxyz[2],
+  //   Dxyz[0], Dxyz[1], Dxyz[2],
+  //   Wxyz[0], Wxyz[1], Wxyz[2]);
 
   water_coords[context_dat.pose_ind][res_dat.block_coord_offset + Dind]
               [which_water] = Wxyz;

--- a/tmol/score/lk_ball/potentials/water.hh
+++ b/tmol/score/lk_ball/potentials/water.hh
@@ -1145,13 +1145,13 @@ void TMOL_DEVICE_FUNC d_build_water_for_acc(
            ? res_dat.block_coord_offset
            : context_dat
                  .pose_stack_block_coord_offset[pose_ind][acc_bases.B.block])
-      + A.atom;
+      + acc_bases.B.atom;
   int const B0_atom_pose_ind =
       (acc_bases.B0.block == A.block
            ? res_dat.block_coord_offset
            : context_dat
                  .pose_stack_block_coord_offset[pose_ind][acc_bases.B0.block])
-      + A.atom;
+      + acc_bases.B0.atom;
 
   Real3 dE_dW = dE_dWxyz[pose_ind][A_atom_pose_ind][water_ind + water_offset];
 

--- a/tmol/score/lk_ball/script_modules.py
+++ b/tmol/score/lk_ball/script_modules.py
@@ -90,6 +90,7 @@ class _LKBallScoreModule(torch.jit.ScriptModule):
                         param_resolver.global_params.lj_hbond_OH_donor_dis,
                         param_resolver.global_params.lj_hbond_hdis,
                         param_resolver.global_params.lkb_water_dist,
+                        param_resolver.global_params.max_dis,
                     ]
                 ),
                 dim=1,

--- a/tmol/score/score_types.py
+++ b/tmol/score/score_types.py
@@ -14,5 +14,9 @@ class ScoreType(AutoNumber):
     fa_lk = ()
     fa_elec = ()
     hbond = ()
+    lk_ball_iso = ()
+    lk_ball = ()
+    lk_bridge = ()
+    lk_bridge_uncpl = ()
     # keep this one last
     n_score_types = ()

--- a/tmol/score/terms/lk_ball_creator.py
+++ b/tmol/score/terms/lk_ball_creator.py
@@ -6,13 +6,17 @@ import torch
 
 @score_term_creator
 class LKBallTermCreator(TermCreator):
-    _score_types = [ScoreType.lk_ball]
+    _score_types = [
+        ScoreType.lk_ball_iso,
+        ScoreType.lk_ball.ScoreType.lk_bridge,
+        ScoreType.lk_bridge_uncpl,
+    ]
 
     @classmethod
     def create_term(cls, param_db: ParameterDatabase, device: torch.device):
-        import tmol.score.elec.elec_energy_term
+        import tmol.score.lk_ball.lk_ball_energy_term
 
-        return tmol.score.elec.elec_energy_term.ElecEnergyTerm(param_db, device)
+        return tmol.score.lk_ball.lk_ball_energy_term.LKBallEnergyTerm(param_db, device)
 
     @classmethod
     def score_types(cls):

--- a/tmol/score/terms/lk_ball_creator.py
+++ b/tmol/score/terms/lk_ball_creator.py
@@ -8,7 +8,8 @@ import torch
 class LKBallTermCreator(TermCreator):
     _score_types = [
         ScoreType.lk_ball_iso,
-        ScoreType.lk_ball.ScoreType.lk_bridge,
+        ScoreType.lk_ball,
+        ScoreType.lk_bridge,
         ScoreType.lk_bridge_uncpl,
     ]
 

--- a/tmol/score/terms/lk_ball_creator.py
+++ b/tmol/score/terms/lk_ball_creator.py
@@ -1,0 +1,19 @@
+from tmol.score.terms.term_creator import TermCreator, score_term_creator
+from tmol.score.score_types import ScoreType
+from tmol.database import ParameterDatabase
+import torch
+
+
+@score_term_creator
+class LKBallTermCreator(TermCreator):
+    _score_types = [ScoreType.lk_ball]
+
+    @classmethod
+    def create_term(cls, param_db: ParameterDatabase, device: torch.device):
+        import tmol.score.elec.elec_energy_term
+
+        return tmol.score.elec.elec_energy_term.ElecEnergyTerm(param_db, device)
+
+    @classmethod
+    def score_types(cls):
+        return cls._score_types

--- a/tmol/tests/autograd.py
+++ b/tmol/tests/autograd.py
@@ -10,9 +10,18 @@ from torch.autograd import gradcheck
 
 
 def gradcheck(
-    func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, nfail=0, raise_exception=True
+    func,
+    inputs,
+    eps=1e-6,
+    atol=1e-5,
+    rtol=1e-3,
+    nfail=0,
+    raise_exception=True,
+    nondet_tol=0,
 ):
-    torch.autograd.gradcheck(func, inputs, eps=eps, atol=atol, rtol=rtol)
+    torch.autograd.gradcheck(
+        func, inputs, eps=eps, atol=atol, rtol=rtol, nondet_tol=nondet_tol
+    )
 
 
 class VectorizedOp:

--- a/tmol/tests/score/hbond/test_hbond_dependent_term.py
+++ b/tmol/tests/score/hbond/test_hbond_dependent_term.py
@@ -1,3 +1,5 @@
+import numpy
+
 from tmol.pose.packed_block_types import PackedBlockTypes, residue_types_from_residues
 from tmol.score.hbond.hbond_dependent_term import HBondDependentTerm
 
@@ -37,3 +39,59 @@ def test_hbond_dep_term_setup_packed_block_types(
         hbdt.setup_block_type(bt)
 
     hbdt.setup_packed_block_types(pbt)
+
+
+def test_hbond_dep_term_setup_ser_block_type(
+    default_database, rts_ubq_res, torch_device
+):
+    bt_list = residue_types_from_residues(rts_ubq_res)
+    ser_bt = next(bt for bt in bt_list if bt.name == "SER")
+
+    hbdt = HBondDependentTerm(default_database, torch_device)
+    hbdt.setup_block_type(ser_bt)
+
+    assert hasattr(ser_bt, "hbbt_params")
+    ser_hbbt_params = ser_bt.hbbt_params
+
+    numpy.testing.assert_equal(
+        numpy.array([2], dtype=numpy.int32), ser_hbbt_params.tile_n_donH
+    )
+    numpy.testing.assert_equal(
+        numpy.array([2], dtype=numpy.int32), ser_hbbt_params.tile_n_don_hvy
+    )
+    numpy.testing.assert_equal(
+        numpy.array([2], dtype=numpy.int32), ser_hbbt_params.tile_n_acc
+    )
+
+    def at_ind(target):
+        return ser_bt.atom_to_idx[target]
+
+    gold_H_inds = numpy.full((1, 32), -1, dtype=numpy.int32)
+    gold_H_inds[0, 0] = at_ind("H")
+    gold_H_inds[0, 1] = at_ind("HG")
+    numpy.testing.assert_equal(gold_H_inds, ser_hbbt_params.tile_donH_inds)
+
+    gold_hvy_don_inds = numpy.full((1, 32), -1, dtype=numpy.int32)
+    gold_hvy_don_inds[0, 0] = at_ind("N")
+    gold_hvy_don_inds[0, 1] = at_ind("OG")
+    numpy.testing.assert_equal(gold_hvy_don_inds, ser_hbbt_params.tile_don_hvy_inds)
+    numpy.testing.assert_equal(gold_hvy_don_inds, ser_hbbt_params.tile_donH_hvy_inds)
+
+    gold_tile_which_donH_of_donH_hvy = numpy.full((1, 32), -1, dtype=numpy.int32)
+    gold_tile_which_donH_of_donH_hvy[0, 0] = 0
+    gold_tile_which_donH_of_donH_hvy[0, 1] = 0
+    numpy.testing.assert_equal(
+        gold_tile_which_donH_of_donH_hvy, ser_hbbt_params.tile_which_donH_of_donH_hvy
+    )
+
+    gold_acc_inds = numpy.full((1, 32), -1, dtype=numpy.int32)
+    gold_acc_inds[0, 0] = at_ind("O")
+    gold_acc_inds[0, 1] = at_ind("OG")
+    numpy.testing.assert_equal(gold_acc_inds, ser_hbbt_params.tile_acc_inds)
+
+    gold_tile_acceptor_n_attached_H = numpy.full((1, 32), -1, dtype=numpy.int32)
+    gold_tile_acceptor_n_attached_H[0, 0] = 0
+    gold_tile_acceptor_n_attached_H[0, 1] = 1
+    numpy.testing.assert_equal(
+        gold_tile_acceptor_n_attached_H, ser_hbbt_params.tile_acceptor_n_attached_H
+    )

--- a/tmol/tests/score/lk_ball/test_baseline.py
+++ b/tmol/tests/score/lk_ball/test_baseline.py
@@ -26,3 +26,26 @@ def test_baseline_comparison(ubq_rosetta_baseline, torch_device):
     scores = {term: float(intra_container[term]) for term in expected_scores.keys()}
 
     assert scores == approx(expected_scores, rel=1e-3)
+
+
+def test_score_ubq(ubq_res, torch_device):
+    expected_scores = {
+        "lk_ball": 171.47,
+        "lk_ball_iso": 421.006,
+        "lk_ball_bridge": 1.578,
+        "lk_ball_bridge_uncpl": 10.99,
+    }
+
+    test_system = PackedResidueSystem.from_residues(ubq_res)
+
+    score_system = ScoreSystem.build_for(
+        test_system, {LKBallScore}, score_method_to_even_weights_dict(LKBallScore)
+    )
+    coords = coords_for(test_system, score_system)
+
+    intra_container = score_system.intra_forward(coords)
+    scores = {term: float(intra_container[term]) for term in expected_scores.keys()}
+    print("scores")
+    print(scores)
+
+    assert scores == approx(expected_scores, rel=1e-3)

--- a/tmol/tests/score/lk_ball/test_baseline.py
+++ b/tmol/tests/score/lk_ball/test_baseline.py
@@ -30,10 +30,10 @@ def test_baseline_comparison(ubq_rosetta_baseline, torch_device):
 
 def test_score_ubq(ubq_res, torch_device):
     expected_scores = {
-        "lk_ball": 171.47,
-        "lk_ball_iso": 421.006,
-        "lk_ball_bridge": 1.578,
-        "lk_ball_bridge_uncpl": 10.99,
+        "lk_ball": 171.19293212890625,
+        "lk_ball_iso": 421.0059509277344,
+        "lk_ball_bridge": 1.5785887241363525,
+        "lk_ball_bridge_uncpl": 10.994599342346191,
     }
 
     test_system = PackedResidueSystem.from_residues(ubq_res)
@@ -45,7 +45,5 @@ def test_score_ubq(ubq_res, torch_device):
 
     intra_container = score_system.intra_forward(coords)
     scores = {term: float(intra_container[term]) for term in expected_scores.keys()}
-    print("scores")
-    print(scores)
 
     assert scores == approx(expected_scores, rel=1e-3)

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -13,9 +13,6 @@ def test_smoke(default_database, torch_device):
     lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
 
     assert lk_ball_energy.device == torch_device
-    assert lk_ball_energy.hb_param_db.global_param_table.device == torch_device
-    assert lk_ball_energy.hb_param_db.pair_param_table.device == torch_device
-    assert lk_ball_energy.hb_param_db.pair_poly_table.device == torch_device
 
 
 def test_annotate_restypes(

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -23,11 +23,27 @@ def test_annotate_restypes(
 
     pbt = fresh_default_packed_block_types
 
-    for rt in pbt.active_block_types:
-        lk_ball_energy.setup_block_type(rt)
-        assert hasattr(rt, "hbbt_params")
+    first_params = {}
+    for bt in pbt.active_block_types:
+        lk_ball_energy.setup_block_type(bt)
+        assert hasattr(bt, "hbbt_params")
+        first_params[bt.name] = bt.hbbt_params
+
+    for bt in pbt.active_block_types:
+        # test that block-type annotation is not repeated;
+        # original annotation is still present in the bt
+        lk_ball_energy.setup_block_type(bt)
+        assert first_params[bt.name] is bt.hbbt_params
+
     lk_ball_energy.setup_packed_block_types(pbt)
     assert hasattr(pbt, "lk_ball_params")
+
+    init_pbt_lk_ball_params = pbt.lk_ball_params
+    lk_ball_energy.setup_packed_block_types(pbt)
+    # test that the initial packed-block-types annotation
+    # has not been repeated; initial annotation is still
+    # present in the pbt
+    assert init_pbt_lk_ball_params is pbt.lk_ball_params
 
     assert pbt.lk_ball_params.tile_n_polar_atoms.device == torch_device
     assert pbt.lk_ball_params.tile_n_occluder_atoms.device == torch_device

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -1,0 +1,135 @@
+import numpy
+import torch
+
+from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
+
+# from tmol.score.lk_ball.params import LKBallTypeParams
+from tmol.pose.packed_block_types import residue_types_from_residues, PackedBlockTypes
+from tmol.pose.pose_stack_builder import PoseStackBuilder
+
+from tmol.tests.autograd import gradcheck
+
+
+def test_smoke(default_database, torch_device):
+
+    lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+
+    assert lk_ball_energy.device == torch_device
+    assert lk_ball_energy.hb_param_db.global_param_table.device == torch_device
+    assert lk_ball_energy.hb_param_db.pair_param_table.device == torch_device
+    assert lk_ball_energy.hb_param_db.pair_poly_table.device == torch_device
+
+
+def test_annotate_restypes(
+    fresh_default_packed_block_types, default_database, torch_device
+):
+
+    lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+
+    pbt = fresh_default_packed_block_types
+
+    for rt in pbt.active_block_types:
+        lk_ball_energy.setup_block_type(rt)
+        assert hasattr(rt, "hbbt_params")
+    lk_ball_energy.setup_packed_block_types(pbt)
+    assert hasattr(pbt, "lk_ball_params")
+
+    assert pbt.lk_ball_params.tile_n_polar_atoms.device == torch_device
+    assert pbt.lk_ball_params.tile_n_occluder_atoms.device == torch_device
+    assert pbt.lk_ball_params.tile_pol_occ_inds.device == torch_device
+    assert pbt.lk_ball_params.tile_lk_ball_params.device == torch_device
+
+
+def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_device):
+    gold_vals = numpy.array(
+        [[421.00595092], [171.192932], [1.57858872], [10.99459934]], dtype=numpy.float32
+    )
+    lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res, device=torch_device
+    )
+    for bt in p1.packed_block_types.active_block_types:
+        lk_ball_energy.setup_block_type(bt)
+    lk_ball_energy.setup_packed_block_types(p1.packed_block_types)
+    lk_ball_energy.setup_poses(p1)
+
+    lk_ball_pose_scorer = lk_ball_energy.render_whole_pose_scoring_module(p1)
+
+    coords = torch.nn.Parameter(p1.coords.clone())
+    scores = lk_ball_pose_scorer(coords)
+
+    # make sure we're still good
+    torch.arange(100, device=torch_device)
+    numpy.testing.assert_allclose(
+        gold_vals, scores.cpu().detach().numpy(), atol=1e-3, rtol=1e-3
+    )
+
+
+def test_whole_pose_scoring_module_gradcheck_partial_pose(
+    rts_ubq_res, default_database, torch_device
+):
+
+    lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[6:12], device=torch_device
+    )
+    for bt in p1.packed_block_types.active_block_types:
+        lk_ball_energy.setup_block_type(bt)
+    lk_ball_energy.setup_packed_block_types(p1.packed_block_types)
+    lk_ball_energy.setup_poses(p1)
+
+    lk_ball_pose_scorer = lk_ball_energy.render_whole_pose_scoring_module(p1)
+
+    weights = torch.tensor(
+        [[0.75], [1.25], [0.625], [0.8125]], dtype=torch.float32, device=torch_device
+    )
+    # print(weights.shape)
+
+    def score(coords):
+        scores = lk_ball_pose_scorer(coords)
+
+        wtd_score = torch.sum(weights * scores)
+        # print("wtd_score:", wtd_score.item(), weights.detach().cpu().numpy(), scores.detach().cpu().numpy() )
+        return wtd_score
+
+    gradcheck(
+        score,
+        (p1.coords.requires_grad_(True),),
+        eps=1e-3,
+        atol=1e-2,
+        rtol=1e-2,
+        nondet_tol=1e-3,
+    )
+
+
+def test_whole_pose_scoring_module_10(rts_ubq_res, default_database, torch_device):
+    n_poses = 10
+    gold_vals = numpy.tile(
+        numpy.array(
+            [[421.00595092], [171.192932], [1.57858872], [10.99459934]],
+            dtype=numpy.float32,
+        ),
+        (n_poses),
+    )
+    lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res, device=torch_device
+    )
+    pn = PoseStackBuilder.from_poses([p1] * n_poses, device=torch_device)
+
+    for bt in pn.packed_block_types.active_block_types:
+        lk_ball_energy.setup_block_type(bt)
+    lk_ball_energy.setup_packed_block_types(pn.packed_block_types)
+    lk_ball_energy.setup_poses(pn)
+
+    lk_ball_pose_scorer = lk_ball_energy.render_whole_pose_scoring_module(pn)
+
+    coords = torch.nn.Parameter(pn.coords.clone())
+    scores = lk_ball_pose_scorer(coords)
+
+    # make sure we're still good
+    torch.arange(100, device=torch_device)
+
+    numpy.testing.assert_allclose(
+        gold_vals, scores.cpu().detach().numpy(), atol=1e-5, rtol=1e-5
+    )

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -3,8 +3,6 @@ import torch
 
 from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
 
-# from tmol.score.lk_ball.params import LKBallTypeParams
-from tmol.pose.packed_block_types import residue_types_from_residues, PackedBlockTypes
 from tmol.pose.pose_stack_builder import PoseStackBuilder
 
 from tmol.tests.autograd import gradcheck
@@ -83,13 +81,11 @@ def test_whole_pose_scoring_module_gradcheck_partial_pose(
     weights = torch.tensor(
         [[0.75], [1.25], [0.625], [0.8125]], dtype=torch.float32, device=torch_device
     )
-    # print(weights.shape)
 
     def score(coords):
         scores = lk_ball_pose_scorer(coords)
 
         wtd_score = torch.sum(weights * scores)
-        # print("wtd_score:", wtd_score.item(), weights.detach().cpu().numpy(), scores.detach().cpu().numpy() )
         return wtd_score
 
     gradcheck(

--- a/tmol/tests/score/test_score_function_benchmarks.py
+++ b/tmol/tests/score/test_score_function_benchmarks.py
@@ -40,12 +40,11 @@ def dont_test_res_centric_score_benchmark_setup(
 
 @pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10, 30, 100]))
 @pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
-# @pytest.mark.parametrize(
-#     "energy_term",
-#     [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm],
-#     ids=["ljlk", "elec", "hbond", "lk_ball"],
-# )
-@pytest.mark.parametrize("energy_term", [LKBallEnergyTerm], ids=["lk_ball"])
+@pytest.mark.parametrize(
+    "energy_term",
+    [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm],
+    ids=["ljlk", "elec", "hbond", "lk_ball"],
+)
 @pytest.mark.benchmark(group="res_centric_score_components")
 def test_res_centric_score_benchmark(
     benchmark,

--- a/tmol/tests/score/test_score_function_benchmarks.py
+++ b/tmol/tests/score/test_score_function_benchmarks.py
@@ -40,11 +40,12 @@ def dont_test_res_centric_score_benchmark_setup(
 
 @pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10, 30, 100]))
 @pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
-@pytest.mark.parametrize(
-    "energy_term",
-    [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm],
-    ids=["ljlk", "elec", "hbond", "lk_ball"],
-)
+# @pytest.mark.parametrize(
+#     "energy_term",
+#     [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm],
+#     ids=["ljlk", "elec", "hbond", "lk_ball"],
+# )
+@pytest.mark.parametrize("energy_term", [LKBallEnergyTerm], ids=["lk_ball"])
 @pytest.mark.benchmark(group="res_centric_score_components")
 def test_res_centric_score_benchmark(
     benchmark,

--- a/tmol/tests/score/test_score_function_benchmarks.py
+++ b/tmol/tests/score/test_score_function_benchmarks.py
@@ -10,6 +10,7 @@ from tmol.pose.pose_stack_builder import PoseStackBuilder
 from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
 from tmol.score.elec.elec_energy_term import ElecEnergyTerm
 from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
+from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
 
 
 @pytest.mark.parametrize("energy_term", [LJLKEnergyTerm], ids=["ljlk"])
@@ -41,8 +42,8 @@ def dont_test_res_centric_score_benchmark_setup(
 @pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
 @pytest.mark.parametrize(
     "energy_term",
-    [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm],
-    ids=["ljlk", "elec", "hbond"],
+    [LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm],
+    ids=["ljlk", "elec", "hbond", "lk_ball"],
 )
 @pytest.mark.benchmark(group="res_centric_score_components")
 def test_res_centric_score_benchmark(
@@ -105,8 +106,8 @@ def test_res_centric_score_benchmark(
 @pytest.mark.parametrize("benchmark_pass", ["forward", "full", "backward"])
 @pytest.mark.parametrize(
     "energy_terms",
-    [[LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm]],
-    ids=["ljlk_elec_hbond"],
+    [[LJLKEnergyTerm, ElecEnergyTerm, HBondEnergyTerm, LKBallEnergyTerm]],
+    ids=["ljlk_elec_hbond_lkb"],
 )
 @pytest.mark.benchmark(group="res_centric_combined_score_components")
 def test_combined_res_centric_score_benchmark(


### PR DESCRIPTION
Res-centric implementation of the lk_ball energy term. The term loads tiles of atoms from residue 1 and residue 2 into shared memory and iterates across polar/occluder pairs, one thread per polar/occluder pair. The thread then evaluates all water/occluder and then water/water interactions. The kernels use lots of registers and the low occupancy is surely the source of the comparatively poor performance of this term compared to LJ/elec/hbonds. Various attempts to speed up this code by 1) load balancing water/occluder and water/water interactions or 2) loading fewer coordinates into registers at a time, have not yielded any performance benefits. Accepting this implementation and moving forward.