### PR TITLE
Fix bug with strides of 0 for non-Scalar enable_tensor_views of tensors

### DIFF
--- a/tmol/tests/kinematics/test_script_modules.py
+++ b/tmol/tests/kinematics/test_script_modules.py
@@ -49,7 +49,7 @@ def test_kinematic_torch_op_backward_benchmark(benchmark, ubq_system, torch_devi
     kop = KinematicModule(tkinforest, torch_device)
 
     refold_kincoords = kop(tdofs.raw)
-    total = refold_kincoords.sum()
+    total = torch.sum(refold_kincoords[:, :])
 
     @benchmark
     def refold_grad():
@@ -127,7 +127,7 @@ def test_kinematic_torch_op_smoke(
     coords = kop(tdofs.raw)
     coords.register_hook(torch_backward_coverage)
 
-    total = coords.sum()
+    total = torch.sum(coords[:, :])
     total.backward()
 
     assert tdofs.raw.grad is not None

--- a/tmol/utility/tensor/TensorUtil.h
+++ b/tmol/utility/tensor/TensorUtil.h
@@ -133,6 +133,24 @@ auto view_tensor(at::Tensor input_t) -> tmol::TView<T, N, D, P> {
         " d: ",
         d);
   }
+
+  // All classes w/ an associated enable_tensor_view must
+  // consume contiguous blocks of memory
+  int64_t target_stride = 1;
+  for (int d = input_t.dim() - 1; d >= N; --d) {
+    TORCH_CHECK(
+        input_t.stride(d) == target_stride,
+        " stride for input tensor at dimension ",
+        d,
+        " must match the target stride of ",
+        target_stride,
+        " to ensure that memory is allocated in a ",
+        "contiguous block, but a stride of ",
+        input_t.stride(d),
+        " was found instead.");
+    target_stride *= input_t.size(d);
+  }
+
   TORCH_CHECK(
       input_t.device().type() == D,
       "view_tensor of incorrect device type.",

--- a/tmol/utility/tensor/TensorUtil.h
+++ b/tmol/utility/tensor/TensorUtil.h
@@ -124,7 +124,15 @@ auto view_tensor(at::Tensor input_t) -> tmol::TView<T, N, D, P> {
         " expected: ",
         consumed_dims(d - N));
   }
-
+  for (int d = N; d < input_t.dim(); ++d) {
+    TORCH_CHECK(
+        input_t.stride(d) != 0,
+        "stride of zero for view_tensor is incompatible for consumed "
+        "dimension. Did torch.sum() or torch.expand() yeild a tensor with a "
+        "stride of 0?",
+        " d: ",
+        d);
+  }
   TORCH_CHECK(
       input_t.device().type() == D,
       "view_tensor of incorrect device type.",


### PR DESCRIPTION
In its backward-pass, torch.sum(t) returns a scalar, t2, which masquerades as a tensor with the same shape as t, except its strides will give it away as not being a real tensor: they will all be 0. But, if t is a tensor of coordinates and we use TCAST to coerce the t2 tensor into a TView<Eigen::Matrix<float, 3, 1>, N, D>, then the fact that dE_dx and dE_dy and dE_dz all have the same address (because a stride of 0 means "ignore the index in the given dimension" and a tensor with only strides of zeros means "ignore all the indices used to look up data, there is only one value") will be LOST and the dE_dy and dE_dz values will be read off the end of the array! Oh no!

To fix this, we can simply look at any consumed dimension as determined by the enable_tensor_view<SomeClass<T>> class and assert that the consumed dimension(s) has (have) a non-zero stride. Any other stride besides zero is fine.