### PR TITLE
Fix out-of-bounds bug in omega that produces NaNs in jagged PosesStacks

### DIFF
--- a/tmol/score/omega/potentials/omega_pose_score.impl.hh
+++ b/tmol/score/omega/potentials/omega_pose_score.impl.hh
@@ -73,6 +73,10 @@ auto OmegaPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
   auto func = ([=] TMOL_DEVICE_FUNC(int pose_index, int block_index) {
     int block_type_index = pose_stack_block_type[pose_index][block_index];
 
+    if (block_type_index < 0) {
+      return;
+    }
+
     int block_coord_offset =
         pose_stack_block_coord_offset[pose_index][block_index];
 
@@ -114,6 +118,7 @@ auto OmegaPoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
 
     accumulate<D, Real>::add(V[0][pose_index], common::get<0>(omega));
     for (int j = 0; j < 4; ++j) {
+      Vec<Real, 3> j_deriv = common::get<1>(omega).row(j);
       accumulate<D, Vec<Real, 3>>::add(
           dV_dx[0][pose_index][omega_indices[j]], common::get<1>(omega).row(j));
     }

--- a/tmol/tests/score/omega/test_omega_energy_term.py
+++ b/tmol/tests/score/omega/test_omega_energy_term.py
@@ -76,6 +76,30 @@ def test_whole_pose_scoring_module_single(
     )
 
 
+def test_whole_pose_scoring_module_jagged(
+    rts_ubq_res, default_database, torch_device: torch.device
+):
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[:4], device=torch_device
+    )
+    p2 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[:6], device=torch_device
+    )
+    poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
+
+    omega_energy = OmegaEnergyTerm(param_db=default_database, device=torch_device)
+    for bt in poses.packed_block_types.active_block_types:
+        omega_energy.setup_block_type(bt)
+    omega_energy.setup_packed_block_types(poses.packed_block_types)
+    omega_energy.setup_poses(poses)
+
+    omega_pose_scorer = omega_energy.render_whole_pose_scoring_module(poses)
+    scores = omega_pose_scorer(poses.coords)
+
+    # make sure we're still good
+    torch.arange(100, device=torch_device)
+
+
 def test_whole_pose_scoring_module_10(
     rts_ubq_res, default_database, torch_device: torch.device
 ):

--- a/tmol/tests/score/omega/test_omega_energy_term.py
+++ b/tmol/tests/score/omega/test_omega_energy_term.py
@@ -94,7 +94,7 @@ def test_whole_pose_scoring_module_jagged(
     omega_energy.setup_poses(poses)
 
     omega_pose_scorer = omega_energy.render_whole_pose_scoring_module(poses)
-    scores = omega_pose_scorer(poses.coords)
+    omega_pose_scorer(poses.coords)
 
     # make sure we're still good
     torch.arange(100, device=torch_device)


### PR DESCRIPTION
The score terms need checks for block types with sentinel values of `-1` so that jagged PoseStacks do not produce out-of-bounds reads / writes. This PR adds a unit test for omega scoring with jagged PoseStacks