### PR TITLE
Dimaio/block pair scoring

### DIFF
--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -199,7 +199,7 @@ class LJLKPoseScoreOp
   static Tensor forward(
       AutogradContext* ctx,
       Tensor coords,
-      Tensor posck_stack_block_coord_offset,
+      Tensor pose_stack_block_coord_offset,
 
       Tensor pose_stack_block_type,
       Tensor pose_stack_min_bond_separation,
@@ -216,7 +216,7 @@ class LJLKPoseScoreOp
       Tensor type_params,
       Tensor global_params) {
     at::Tensor score;
-    at::Tensor dscore_dcoords;
+    at::Tensor block_neighbors;
 
     using Int = int32_t;
 
@@ -226,9 +226,9 @@ class LJLKPoseScoreOp
           constexpr tmol::Device Dev = device_t;
 
           auto result =
-              LJLKPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::f(
+              LJLKPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::forward(
                   TCAST(coords),
-                  TCAST(posck_stack_block_coord_offset),
+                  TCAST(pose_stack_block_coord_offset),
 
                   TCAST(pose_stack_block_type),
                   TCAST(pose_stack_min_bond_separation),
@@ -243,36 +243,97 @@ class LJLKPoseScoreOp
                   TCAST(block_type_path_distance),
 
                   TCAST(type_params),
-                  TCAST(global_params),
-                  coords.requires_grad());
+                  TCAST(global_params));
 
           score = std::get<0>(result).tensor;
-          dscore_dcoords = std::get<1>(result).tensor;
+          block_neighbors = std::get<1>(result).tensor;
         }));
 
-    ctx->save_for_backward({dscore_dcoords});
+    ctx->save_for_backward(
+        {coords,
+         pose_stack_block_coord_offset,
+
+         pose_stack_block_type,
+         pose_stack_min_bond_separation,
+         pose_stack_inter_block_bondsep,
+         block_type_n_atoms,
+         block_type_n_heavy_atoms_in_tile,
+
+         block_type_heavy_atoms_in_tile,
+         block_type_atom_types,
+         block_type_n_interblock_bonds,
+         block_type_atoms_forming_chemical_bonds,
+         block_type_path_distance,
+
+         type_params,
+         global_params,
+         block_neighbors});
+
     return score;
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
-    auto saved_grads = ctx->get_saved_variables();
-
-    tensor_list result;
-
-    for (auto& saved_grad : saved_grads) {
-      auto ingrad = grad_outputs[0];
-      while (ingrad.dim() < saved_grad.dim()) {
-        ingrad = ingrad.unsqueeze(-1);
-      }
-
-      result.emplace_back(saved_grad * ingrad);
-    }
+    auto saved = ctx->get_saved_variables();
 
     int i = 0;
-    auto dscore_dcoords = result[i++];
+
+    auto coords = saved[i++];
+    auto pose_stack_block_coord_offset = saved[i++];
+
+    auto pose_stack_block_type = saved[i++];
+    auto pose_stack_min_bond_separation = saved[i++];
+    auto pose_stack_inter_block_bondsep = saved[i++];
+    auto block_type_n_atoms = saved[i++];
+    auto block_type_n_heavy_atoms_in_tile = saved[i++];
+
+    auto block_type_heavy_atoms_in_tile = saved[i++];
+    auto block_type_atom_types = saved[i++];
+    auto block_type_n_interblock_bonds = saved[i++];
+    auto block_type_atoms_forming_chemical_bonds = saved[i++];
+    auto block_type_path_distance = saved[i++];
+
+    auto type_params = saved[i++];
+    auto global_params = saved[i++];
+    auto block_neighbors = saved[i++];
+
+    at::Tensor dV_d_pose_coords, dV_d_water_coords;
+    using Int = int32_t;
+
+    auto dTdV = grad_outputs[0];
+
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        coords.type(), "ljlk_pose_score_backward", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+
+          auto result =
+              LJLKPoseScoreDispatch<common::DeviceOperations, Dev, Real, Int>::
+                  backward(
+                      TCAST(coords),
+                      TCAST(pose_stack_block_coord_offset),
+
+                      TCAST(pose_stack_block_type),
+                      TCAST(pose_stack_min_bond_separation),
+                      TCAST(pose_stack_inter_block_bondsep),
+                      TCAST(block_type_n_atoms),
+                      TCAST(block_type_n_heavy_atoms_in_tile),
+
+                      TCAST(block_type_heavy_atoms_in_tile),
+                      TCAST(block_type_atom_types),
+                      TCAST(block_type_n_interblock_bonds),
+                      TCAST(block_type_atoms_forming_chemical_bonds),
+                      TCAST(block_type_path_distance),
+
+                      TCAST(type_params),
+                      TCAST(global_params),
+                      TCAST(block_neighbors),
+                      TCAST(dTdV));
+
+          dV_d_pose_coords = result.tensor;
+        }));
 
     return {
-        dscore_dcoords,
+        dV_d_pose_coords,
         torch::Tensor(),
 
         torch::Tensor(),
@@ -288,8 +349,7 @@ class LJLKPoseScoreOp
         torch::Tensor(),
 
         torch::Tensor(),
-        torch::Tensor(),
-    };
+        torch::Tensor()};
   }
 };
 

--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -30,6 +30,8 @@ template <typename Real>
 class LJLKScoringData {
  public:
   int pose_ind;
+  int block_ind1;
+  int block_ind2;
   LJLKSingleResData<Real> r1;
   LJLKSingleResData<Real> r2;
   int max_important_bond_separation;
@@ -174,6 +176,8 @@ void TMOL_DEVICE_FUNC ljlk_load_tile_invariant_interres_data(
     LJLKScoringData<Real> &inter_dat,
     LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
   inter_dat.pose_ind = pose_ind;
+  inter_dat.block_ind1 = block_ind1;
+  inter_dat.block_ind2 = block_ind2;
   inter_dat.r1.block_type = block_type1;
   inter_dat.r2.block_type = block_type2;
   inter_dat.r1.block_coord_offset =
@@ -357,6 +361,8 @@ void TMOL_DEVICE_FUNC ljlk_load_tile_invariant_intrares_data(
     LJLKScoringData<Real> &intra_dat,
     LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> &shared_m) {
   intra_dat.pose_ind = pose_ind;
+  intra_dat.block_ind1 = block_ind1;
+  intra_dat.block_ind2 = block_ind1;
   intra_dat.r1.block_type = block_type1;
   intra_dat.r2.block_type = block_type1;
   intra_dat.r1.block_coord_offset =
@@ -554,6 +560,10 @@ TMOL_DEVICE_FUNC Real lj_atom_energy_and_derivs_full(
                     [score_dat.r1.block_coord_offset + atom_tile_ind1
                      + start_atom1][j],
           lj_dxyz_at1[j]);
+      // auto pose_idx = score_dat.pose_ind
+      // auto block_idx = score_dat
+      // accumulate<D, Real>::add(
+      //   dV_dcoords[0][pose_idx]
     }
   }
 

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.hh
@@ -81,7 +81,7 @@ struct LJLKPoseScoreDispatch {
       TView<LJGlobalParams<Real>, 1, D> global_params,
       bool compute_derivs
 
-      ) -> std::tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 3, D>>;
+      ) -> std::tuple<TPack<Real, 4, D>, TPack<Vec<Real, 3>, 3, D>>;
 };
 
 }  // namespace potentials

--- a/tmol/tests/score/ljlk/test_ljlk_energy_term.py
+++ b/tmol/tests/score/ljlk/test_ljlk_energy_term.py
@@ -373,7 +373,6 @@ def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_de
     torch.arange(100, device=torch_device)
 
     numpy.set_printoptions(precision=10)
-    # print(scores.cpu().detach().numpy())
 
     numpy.testing.assert_allclose(gold_vals, scores.cpu().detach().numpy(), atol=1e-4)
 
@@ -381,8 +380,6 @@ def test_whole_pose_scoring_module_smoke(rts_ubq_res, default_database, torch_de
 def test_whole_pose_scoring_module_gradcheck(
     rts_ubq_res, default_database, torch_device
 ):
-    # gold_vals = numpy.array([[-7.691674], [3.6182203]], dtype=numpy.float32)
-
     ljlk_energy = LJLKEnergyTerm(param_db=default_database, device=torch_device)
     p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
         res=rts_ubq_res[0:4], device=torch_device
@@ -402,9 +399,8 @@ def test_whole_pose_scoring_module_gradcheck(
         score,
         (p1.coords.requires_grad_(True),),
         eps=1e-3,
-        atol=5e-3,
-        rtol=5e-3,
-        nondet_tol=1e-6,
+        atol=1e-3,
+        nondet_tol=1e-6,  # fd this is necessary here...
     )
 
 
@@ -434,9 +430,8 @@ def test_whole_pose_scoring_reweighted_gradcheck(
         score,
         (p1.coords.requires_grad_(True),),
         eps=1e-3,
-        atol=5e-3,
-        rtol=5e-3,
-        nondet_tol=1e-6,
+        atol=1e-3,
+        nondet_tol=1e-6,  # fd this is necessary here...
     )
 
 

--- a/tmol/tests/score/ljlk/test_ljlk_energy_term.py
+++ b/tmol/tests/score/ljlk/test_ljlk_energy_term.py
@@ -393,17 +393,51 @@ def test_whole_pose_scoring_module_gradcheck(
     ljlk_energy.setup_poses(p1)
 
     ljlk_pose_scorer = ljlk_energy.render_whole_pose_scoring_module(p1)
-    # for ch in ljlk_pose_scorer.children():
-    #     print("child")
-    #     print(ch)
-
-    # coords = torch.nn.Parameter(p1.coords.clone())
 
     def score(coords):
         scores = ljlk_pose_scorer(coords)
         return torch.sum(scores)
 
-    gradcheck(score, (p1.coords.requires_grad_(True),), eps=1e-3, atol=5e-3, rtol=5e-3)
+    gradcheck(
+        score,
+        (p1.coords.requires_grad_(True),),
+        eps=1e-3,
+        atol=5e-3,
+        rtol=5e-3,
+        nondet_tol=1e-6,
+    )
+
+
+def test_whole_pose_scoring_reweighted_gradcheck(
+    rts_ubq_res, default_database, torch_device
+):
+    # gold_vals = numpy.array([[-7.691674], [3.6182203]], dtype=numpy.float32)
+
+    ljlk_energy = LJLKEnergyTerm(param_db=default_database, device=torch_device)
+    p1 = PoseStackBuilder.one_structure_from_polymeric_residues(
+        res=rts_ubq_res[0:4], device=torch_device
+    )
+    for bt in p1.packed_block_types.active_block_types:
+        ljlk_energy.setup_block_type(bt)
+    ljlk_energy.setup_packed_block_types(p1.packed_block_types)
+    ljlk_energy.setup_poses(p1)
+
+    ljlk_pose_scorer = ljlk_energy.render_whole_pose_scoring_module(p1)
+
+    def score(coords):
+        scores = ljlk_pose_scorer(coords)
+        mask = torch.ones_like(scores)
+        mask[0:2, 0:2] = 2.0
+        return torch.sum(mask * scores)
+
+    gradcheck(
+        score,
+        (p1.coords.requires_grad_(True),),
+        eps=1e-3,
+        atol=5e-3,
+        rtol=5e-3,
+        nondet_tol=1e-6,
+    )
 
 
 def test_whole_pose_scoring_module_10(rts_ubq_res, default_database, torch_device):


### PR DESCRIPTION
Adds block-pair scoring to ljlk.  The scoring module now returns an nsubterm x npose x nblock x nblock tensor where element [i,j,k,l] is the score of subterm i (fa_atr/rep/sol), pose j, between blocks k and l.

The implementation now no longer computes derivatives in the forward pass but rather stashes the interaction graph during forward and performs another kernel launch in backwards to compute gradients.

This strategy allows reweighing the interaction graph in loss computation.  A new test is added to evaluate this.

To do before merge:
- ensure this still works with other pose scoring tests
- split lj to ljatr and ljrep subterms