### PR TITLE
Fix score function factory behavior for hbonds

### DIFF
--- a/tmol/score/score_function.py
+++ b/tmol/score/score_function.py
@@ -57,8 +57,11 @@ class ScoreFunction:
         term = ScoreTermFactory.create_term_for_score_type(
             st, self._param_db, self._device
         )
-        for st in term.score_types():
-            self._term_for_st[st.value] = term
+        # sanity check: if the ScoreTermFactory returns the wrong term,
+        # we want to know
+        assert st in term.score_types()
+        for tst in term.score_types():
+            self._term_for_st[tst.value] = term
         self._all_terms_unordered.append(term)
         self._all_terms_out_of_date = True
         if term.n_bodies() == 1:

--- a/tmol/score/terms/hbond_creator.py
+++ b/tmol/score/terms/hbond_creator.py
@@ -10,9 +10,9 @@ class HBondTermCreator(TermCreator):
 
     @classmethod
     def create_term(cls, param_db: ParameterDatabase, device: torch.device):
-        import tmol.score.elec.elec_energy_term
+        import tmol.score.hbond.hbond_energy_term
 
-        return tmol.score.elec.elec_energy_term.ElecEnergyTerm(param_db, device)
+        return tmol.score.hbond.hbond_energy_term.HBondEnergyTerm(param_db, device)
 
     @classmethod
     def score_types(cls):

--- a/tmol/tests/score/hbond/test_hbond_energy_term.py
+++ b/tmol/tests/score/hbond/test_hbond_energy_term.py
@@ -2,6 +2,8 @@ import numpy
 import torch
 
 from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
+from tmol.score.score_function import ScoreFunction
+from tmol.score.score_types import ScoreType
 from tmol.pose.packed_block_types import residue_types_from_residues, PackedBlockTypes
 from tmol.pose.pose_stack_builder import PoseStackBuilder
 
@@ -15,6 +17,13 @@ def test_smoke(default_database, torch_device):
     assert hbond_energy.hb_param_db.global_param_table.device == torch_device
     assert hbond_energy.hb_param_db.pair_param_table.device == torch_device
     assert hbond_energy.hb_param_db.pair_poly_table.device == torch_device
+
+
+def test_hbond_in_sfxn(default_database, torch_device):
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.hbond, 1.0)
+    assert len(sfxn.all_terms()) == 1
+    assert isinstance(sfxn.all_terms()[0], HBondEnergyTerm)
 
 
 def test_annotate_restypes(ubq_res, default_database, torch_device):


### PR DESCRIPTION
Just an absolutely egregious copy-and-paste error: the logic for activating a score did not previously check to make sure that the EnergyTerm that gets activated is the one actually responsible for calculating energies for the score-type whose weight is being set. So I am adding that assertion statement as well.