### PR TITLE
Fix an out-of-bounds read in LKBall

### DIFF
--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1178,7 +1178,7 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
   Eigen::Matrix<Real, n_lk_ball_score_types, 1> dTdV_local;
 
   for (int i = 0; i < n_lk_ball_score_types; ++i) {
-    dTdV_local[i] = dTdV[block_pair_dat.pose_ind][i];
+    dTdV_local[i] = dTdV[i][block_pair_dat.pose_ind];
   }
   for (int wi = 0; wi < MAX_N_WATER; wi++) {
     wmat_polar.row(wi) = coord_from_shared(


### PR DESCRIPTION
I mistook the dimension ordering in the backward pass for lk-ball. I discovered this by adding boundary assertions to TensorAccessor.h and then doing a lot of printf debugging.

We really need a way to conditionally compile in boundary-check statements into one of the unit test executions, e.g. the cpu-only version.