### PR TITLE
Fix bug in unresolved atom id resolution

### DIFF
--- a/tmol/score/common/uaid_util.hh
+++ b/tmol/score/common/uaid_util.hh
@@ -32,7 +32,7 @@ TMOL_DEVICE_FUNC int resolve_atom_from_uaid(
     int block_coord_offset =
         pose_stack_block_coord_offset[pose_index][block_index];
     return block_coord_offset + uaid.atom_id;  // The actual global atom index
-  } else {  // We need to follow to another block
+  } else if (uaid.conn_id != -1) {  // We need to follow to another block
     int connection_index = uaid.conn_id;
     int sep = uaid.n_bonds_from_conn;
 
@@ -60,6 +60,9 @@ TMOL_DEVICE_FUNC int resolve_atom_from_uaid(
     int block_coord_offset =
         pose_stack_block_coord_offset[pose_index][other_block_index];
     return block_coord_offset + idx;
+  } else {
+    // printf("uaid with both -1 for atom_id and conn_id\n");
+    return -1;
   }
 }
 

--- a/tmol/score/unresolved_atom.pybind.hh
+++ b/tmol/score/unresolved_atom.pybind.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <tmol/utility/tensor/pybind.h>
+#include "unresolved_atom.hh"
+
+namespace pybind11 {
+namespace detail {
+
+template <typename Int>
+struct npy_format_descriptor_name<tmol::UnresolvedAtomID<Int>> {
+  static constexpr auto name =
+      npy_format_descriptor_name<Int>::name + _("UnresolvedAtomID");
+};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/tmol/tests/score/common/test_uaid_util.py
+++ b/tmol/tests/score/common/test_uaid_util.py
@@ -1,17 +1,86 @@
 import numpy
 import torch
+import pytest
 
 from tmol.tests.score.common.uaid_util import resolve_uaids
 
 
-def test_resolve_uaids_smoke():
+@pytest.fixture
+def uaid_pose_stack():
+    n_blocks = 6
+
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    pose_stack_inter_block_connections = torch.zeros(
+        (1, n_blocks, 2, 2), dtype=torch.int32
+    )
+    # first residue
+    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
+    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
+    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
+    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
+    # 2nd residue
+    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
+    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
+    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
+    # 3rd residue
+    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
+    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
+    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
+    # 4th residue
+    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
+    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
+    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
+    # 5th residue
+    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
+    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
+    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
+    # 6th residue
+    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
+    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
+    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
+
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+    # consider backbone to be 0-2
+    block_type_atom_downstream_of_conn[0, 0, 0] = 0
+    block_type_atom_downstream_of_conn[0, 0, 1] = 1
+    block_type_atom_downstream_of_conn[0, 0, 2] = 2
+    block_type_atom_downstream_of_conn[0, 1, 0] = 2
+    block_type_atom_downstream_of_conn[0, 1, 1] = 1
+    block_type_atom_downstream_of_conn[0, 1, 2] = 0
+
+    return (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+
+def test_resolve_uaids_smoke(uaid_pose_stack):
     uaids = torch.zeros((1, 3), dtype=torch.int32)
     block_inds = torch.zeros((1,), dtype=torch.int32)
     pose_inds = torch.zeros((1,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, 1), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, 1), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.zeros((1, 1, 2, 2), dtype=torch.int32)
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
 
     resolved = resolve_uaids(
         uaids,
@@ -27,18 +96,18 @@ def test_resolve_uaids_smoke():
     assert resolved[0] == 0
 
 
-def test_resolve_uaids_intra_res():
-    n_blocks = 6
+def test_resolve_uaids_intra_res(uaid_pose_stack):
     n_uaids = 4
     uaids = torch.zeros((n_uaids, 3), dtype=torch.int32)
     block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
     pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.zeros(
-        (1, n_blocks, 2, 2), dtype=torch.int32
-    )
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
 
     uaids[0, 0] = 3
     uaids[1, 0] = 4
@@ -49,13 +118,6 @@ def test_resolve_uaids_intra_res():
     block_inds[1] = 2
     block_inds[2] = 3
     block_inds[3] = 4
-
-    pose_stack_block_coord_offset[0, 0] = 0
-    pose_stack_block_coord_offset[0, 1] = 20
-    pose_stack_block_coord_offset[0, 2] = 40
-    pose_stack_block_coord_offset[0, 3] = 60
-    pose_stack_block_coord_offset[0, 4] = 80
-    pose_stack_block_coord_offset[0, 5] = 100
 
     resolved = resolve_uaids(
         uaids,
@@ -75,70 +137,25 @@ def test_resolve_uaids_intra_res():
     numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
 
 
-def test_resolve_uaids_inter_res():
-    n_blocks = 6
+def test_resolve_uaids_inter_res(uaid_pose_stack):
     n_uaids = 4
     uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
     block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
     pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.zeros(
-        (1, n_blocks, 2, 2), dtype=torch.int32
-    )
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
 
-    uaids[0, 1] = 1
-    uaids[1, 1] = 1
-    uaids[2, 1] = 1
-    uaids[3, 1] = 1
-    uaids[0, 2] = 0
-    uaids[1, 2] = 0
-    uaids[2, 2] = 0
-    uaids[3, 2] = 0
+    (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
+
+    uaids[:] = torch.tensor([-1, 1, 0], dtype=torch.int32)
 
     block_inds[0] = 1
     block_inds[1] = 2
     block_inds[2] = 3
     block_inds[3] = 4
-
-    pose_stack_block_coord_offset[0, 0] = 0
-    pose_stack_block_coord_offset[0, 1] = 20
-    pose_stack_block_coord_offset[0, 2] = 40
-    pose_stack_block_coord_offset[0, 3] = 60
-    pose_stack_block_coord_offset[0, 4] = 80
-    pose_stack_block_coord_offset[0, 5] = 100
-
-    # first residue
-    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
-    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
-    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
-    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
-    # 2nd residue
-    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
-    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
-    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
-    # 3rd residue
-    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
-    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
-    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
-    # 4th residue
-    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
-    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
-    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
-    # 5th residue
-    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
-    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
-    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
-    # 6th residue
-    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
-    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
-    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
 
     resolved = resolve_uaids(
         uaids,
@@ -154,78 +171,32 @@ def test_resolve_uaids_inter_res():
     numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
 
 
-def test_resolve_uaids_inter_res2():
-    n_blocks = 6
+def test_resolve_uaids_inter_res2(uaid_pose_stack):
     n_uaids = 4
     uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
     block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
     pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.zeros(
-        (1, n_blocks, 2, 2), dtype=torch.int32
-    )
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
 
     uaids[0, 1] = 0
-    uaids[1, 1] = 0
-    uaids[2, 1] = 1
-    uaids[3, 1] = 1
     uaids[0, 2] = 0
+    uaids[1, 1] = 0
     uaids[1, 2] = 1
+    uaids[2, 1] = 1
     uaids[2, 2] = 0
+    uaids[3, 1] = 1
     uaids[3, 2] = 1
 
     block_inds[0] = 1
     block_inds[1] = 2
     block_inds[2] = 3
     block_inds[3] = 4
-
-    pose_stack_block_coord_offset[0, 0] = 0
-    pose_stack_block_coord_offset[0, 1] = 20
-    pose_stack_block_coord_offset[0, 2] = 40
-    pose_stack_block_coord_offset[0, 3] = 60
-    pose_stack_block_coord_offset[0, 4] = 80
-    pose_stack_block_coord_offset[0, 5] = 100
-
-    # first residue
-    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
-    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
-    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
-    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
-    # 2nd residue
-    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
-    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
-    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
-    # 3rd residue
-    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
-    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
-    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
-    # 4th residue
-    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
-    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
-    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
-    # 5th residue
-    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
-    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
-    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
-    # 6th residue
-    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
-    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
-    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
-
-    # consider backbone to be 0-2
-    block_type_atom_downstream_of_conn[0, 0, 0] = 0
-    block_type_atom_downstream_of_conn[0, 0, 1] = 1
-    block_type_atom_downstream_of_conn[0, 0, 2] = 2
-    block_type_atom_downstream_of_conn[0, 1, 0] = 2
-    block_type_atom_downstream_of_conn[0, 1, 1] = 1
-    block_type_atom_downstream_of_conn[0, 1, 2] = 0
 
     resolved = resolve_uaids(
         uaids,
@@ -241,18 +212,11 @@ def test_resolve_uaids_inter_res2():
     numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
 
 
-def test_resolve_uaids_unresolved_connection():
-    n_blocks = 6
+def test_resolve_uaids_unresolved_connection(uaid_pose_stack):
     n_uaids = 2
     uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
     block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
     pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.full(
-        (1, n_blocks, 2, 2), -1, dtype=torch.int32
-    )
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
 
     uaids[0, 1] = 0
     uaids[1, 1] = 1
@@ -262,51 +226,12 @@ def test_resolve_uaids_unresolved_connection():
     block_inds[0] = 0
     block_inds[1] = 5
 
-    pose_stack_block_coord_offset[0, 0] = 0
-    pose_stack_block_coord_offset[0, 1] = 20
-    pose_stack_block_coord_offset[0, 2] = 40
-    pose_stack_block_coord_offset[0, 3] = 60
-    pose_stack_block_coord_offset[0, 4] = 80
-    pose_stack_block_coord_offset[0, 5] = 100
-
-    # first residue
-    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
-    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
-    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
-    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
-    # 2nd residue
-    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
-    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
-    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
-    # 3rd residue
-    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
-    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
-    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
-    # 4th residue
-    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
-    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
-    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
-    # 5th residue
-    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
-    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
-    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
-    # 6th residue
-    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
-    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
-    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
-
-    # consider backbone to be 0-2
-    block_type_atom_downstream_of_conn[0, 0, 0] = 0
-    block_type_atom_downstream_of_conn[0, 0, 1] = 1
-    block_type_atom_downstream_of_conn[0, 0, 2] = 2
-    block_type_atom_downstream_of_conn[0, 1, 0] = 2
-    block_type_atom_downstream_of_conn[0, 1, 1] = 1
-    block_type_atom_downstream_of_conn[0, 1, 2] = 0
+    (
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
 
     resolved = resolve_uaids(
         uaids,
@@ -322,67 +247,21 @@ def test_resolve_uaids_unresolved_connection():
     numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
 
 
-def test_resolve_unspecified_uaids():
-    n_blocks = 6
+def test_resolve_unspecified_uaids(uaid_pose_stack):
     n_uaids = 2
     uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
     block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
     pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
-    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
-    pose_stack_inter_block_connections = torch.full(
-        (1, n_blocks, 2, 2), -1, dtype=torch.int32
-    )
-    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    (
+        pose_stack_block_type,
+        pose_stack_block_coord_offset,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    ) = uaid_pose_stack
 
     block_inds[0] = 1
     block_inds[1] = 2
-
-    pose_stack_block_coord_offset[0, 0] = 0
-    pose_stack_block_coord_offset[0, 1] = 20
-    pose_stack_block_coord_offset[0, 2] = 40
-    pose_stack_block_coord_offset[0, 3] = 60
-    pose_stack_block_coord_offset[0, 4] = 80
-    pose_stack_block_coord_offset[0, 5] = 100
-
-    # first residue
-    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
-    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
-    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
-    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
-    # 2nd residue
-    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
-    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
-    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
-    # 3rd residue
-    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
-    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
-    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
-    # 4th residue
-    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
-    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
-    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
-    # 5th residue
-    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
-    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
-    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
-    # 6th residue
-    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
-    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
-    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
-    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
-
-    # consider backbone to be 0-2
-    block_type_atom_downstream_of_conn[0, 0, 0] = 0
-    block_type_atom_downstream_of_conn[0, 0, 1] = 1
-    block_type_atom_downstream_of_conn[0, 0, 2] = 2
-    block_type_atom_downstream_of_conn[0, 1, 0] = 2
-    block_type_atom_downstream_of_conn[0, 1, 1] = 1
-    block_type_atom_downstream_of_conn[0, 1, 2] = 0
 
     resolved = resolve_uaids(
         uaids,

--- a/tmol/tests/score/common/test_uaid_util.py
+++ b/tmol/tests/score/common/test_uaid_util.py
@@ -1,0 +1,398 @@
+import numpy
+import torch
+
+from tmol.tests.score.common.uaid_util import resolve_uaids
+
+
+def test_resolve_uaids_smoke():
+    uaids = torch.zeros((1, 3), dtype=torch.int32)
+    block_inds = torch.zeros((1,), dtype=torch.int32)
+    pose_inds = torch.zeros((1,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, 1), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, 1), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.zeros((1, 1, 2, 2), dtype=torch.int32)
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+    assert resolved.device == torch.device("cpu")
+    assert resolved.shape == (1,)
+    assert resolved[0] == 0
+
+
+def test_resolve_uaids_intra_res():
+    n_blocks = 6
+    n_uaids = 4
+    uaids = torch.zeros((n_uaids, 3), dtype=torch.int32)
+    block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.zeros(
+        (1, n_blocks, 2, 2), dtype=torch.int32
+    )
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    uaids[0, 0] = 3
+    uaids[1, 0] = 4
+    uaids[2, 0] = 5
+    uaids[3, 0] = 6
+
+    block_inds[0] = 1
+    block_inds[1] = 2
+    block_inds[2] = 3
+    block_inds[3] = 4
+
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+    block_inds64 = block_inds.to(torch.int64)
+    pose_inds64 = pose_inds.to(torch.int64)
+    resolved_gold = (
+        pose_stack_block_coord_offset[pose_inds64, block_inds64] + uaids[:, 0]
+    )
+    numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
+
+
+def test_resolve_uaids_inter_res():
+    n_blocks = 6
+    n_uaids = 4
+    uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
+    block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.zeros(
+        (1, n_blocks, 2, 2), dtype=torch.int32
+    )
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    uaids[0, 1] = 1
+    uaids[1, 1] = 1
+    uaids[2, 1] = 1
+    uaids[3, 1] = 1
+    uaids[0, 2] = 0
+    uaids[1, 2] = 0
+    uaids[2, 2] = 0
+    uaids[3, 2] = 0
+
+    block_inds[0] = 1
+    block_inds[1] = 2
+    block_inds[2] = 3
+    block_inds[3] = 4
+
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    # first residue
+    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
+    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
+    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
+    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
+    # 2nd residue
+    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
+    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
+    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
+    # 3rd residue
+    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
+    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
+    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
+    # 4th residue
+    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
+    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
+    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
+    # 5th residue
+    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
+    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
+    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
+    # 6th residue
+    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
+    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
+    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+    resolved_gold = torch.tensor([40, 60, 80, 100], dtype=torch.int32)
+    numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
+
+
+def test_resolve_uaids_inter_res2():
+    n_blocks = 6
+    n_uaids = 4
+    uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
+    block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.zeros(
+        (1, n_blocks, 2, 2), dtype=torch.int32
+    )
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    uaids[0, 1] = 0
+    uaids[1, 1] = 0
+    uaids[2, 1] = 1
+    uaids[3, 1] = 1
+    uaids[0, 2] = 0
+    uaids[1, 2] = 1
+    uaids[2, 2] = 0
+    uaids[3, 2] = 1
+
+    block_inds[0] = 1
+    block_inds[1] = 2
+    block_inds[2] = 3
+    block_inds[3] = 4
+
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    # first residue
+    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
+    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
+    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
+    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
+    # 2nd residue
+    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
+    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
+    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
+    # 3rd residue
+    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
+    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
+    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
+    # 4th residue
+    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
+    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
+    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
+    # 5th residue
+    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
+    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
+    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
+    # 6th residue
+    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
+    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
+    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
+
+    # consider backbone to be 0-2
+    block_type_atom_downstream_of_conn[0, 0, 0] = 0
+    block_type_atom_downstream_of_conn[0, 0, 1] = 1
+    block_type_atom_downstream_of_conn[0, 0, 2] = 2
+    block_type_atom_downstream_of_conn[0, 1, 0] = 2
+    block_type_atom_downstream_of_conn[0, 1, 1] = 1
+    block_type_atom_downstream_of_conn[0, 1, 2] = 0
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+    resolved_gold = torch.tensor([2, 21, 80, 101], dtype=torch.int32)
+    numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
+
+
+def test_resolve_uaids_unresolved_connection():
+    n_blocks = 6
+    n_uaids = 2
+    uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
+    block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.full(
+        (1, n_blocks, 2, 2), -1, dtype=torch.int32
+    )
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    uaids[0, 1] = 0
+    uaids[1, 1] = 1
+    uaids[0, 2] = 0
+    uaids[1, 2] = 0
+
+    block_inds[0] = 0
+    block_inds[1] = 5
+
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    # first residue
+    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
+    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
+    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
+    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
+    # 2nd residue
+    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
+    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
+    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
+    # 3rd residue
+    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
+    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
+    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
+    # 4th residue
+    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
+    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
+    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
+    # 5th residue
+    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
+    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
+    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
+    # 6th residue
+    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
+    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
+    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
+
+    # consider backbone to be 0-2
+    block_type_atom_downstream_of_conn[0, 0, 0] = 0
+    block_type_atom_downstream_of_conn[0, 0, 1] = 1
+    block_type_atom_downstream_of_conn[0, 0, 2] = 2
+    block_type_atom_downstream_of_conn[0, 1, 0] = 2
+    block_type_atom_downstream_of_conn[0, 1, 1] = 1
+    block_type_atom_downstream_of_conn[0, 1, 2] = 0
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+    resolved_gold = torch.tensor([-1, -1], dtype=torch.int32)
+    numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())
+
+
+def test_resolve_unspecified_uaids():
+    n_blocks = 6
+    n_uaids = 2
+    uaids = torch.full((n_uaids, 3), -1, dtype=torch.int32)
+    block_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_inds = torch.zeros((n_uaids,), dtype=torch.int32)
+    pose_stack_block_coord_offset = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_block_type = torch.zeros((1, n_blocks), dtype=torch.int32)
+    pose_stack_inter_block_connections = torch.full(
+        (1, n_blocks, 2, 2), -1, dtype=torch.int32
+    )
+    block_type_atom_downstream_of_conn = torch.zeros((1, 2, 20), dtype=torch.int32)
+
+    block_inds[0] = 1
+    block_inds[1] = 2
+
+    pose_stack_block_coord_offset[0, 0] = 0
+    pose_stack_block_coord_offset[0, 1] = 20
+    pose_stack_block_coord_offset[0, 2] = 40
+    pose_stack_block_coord_offset[0, 3] = 60
+    pose_stack_block_coord_offset[0, 4] = 80
+    pose_stack_block_coord_offset[0, 5] = 100
+
+    # first residue
+    pose_stack_inter_block_connections[0, 0, 0, 0] = -1
+    pose_stack_inter_block_connections[0, 0, 0, 1] = -1
+    pose_stack_inter_block_connections[0, 0, 1, 0] = 1
+    pose_stack_inter_block_connections[0, 0, 1, 1] = 0
+    # 2nd residue
+    pose_stack_inter_block_connections[0, 1, 0, 0] = 0
+    pose_stack_inter_block_connections[0, 1, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 1, 1, 0] = 2
+    pose_stack_inter_block_connections[0, 1, 1, 1] = 0
+    # 3rd residue
+    pose_stack_inter_block_connections[0, 2, 0, 0] = 1
+    pose_stack_inter_block_connections[0, 2, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 2, 1, 0] = 3
+    pose_stack_inter_block_connections[0, 2, 1, 1] = 0
+    # 4th residue
+    pose_stack_inter_block_connections[0, 3, 0, 0] = 2
+    pose_stack_inter_block_connections[0, 3, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 3, 1, 0] = 4
+    pose_stack_inter_block_connections[0, 3, 1, 1] = 0
+    # 5th residue
+    pose_stack_inter_block_connections[0, 4, 0, 0] = 3
+    pose_stack_inter_block_connections[0, 4, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 4, 1, 0] = 5
+    pose_stack_inter_block_connections[0, 4, 1, 1] = 0
+    # 6th residue
+    pose_stack_inter_block_connections[0, 5, 0, 0] = 4
+    pose_stack_inter_block_connections[0, 5, 0, 1] = 1
+    pose_stack_inter_block_connections[0, 5, 1, 0] = -1
+    pose_stack_inter_block_connections[0, 5, 1, 1] = -1
+
+    # consider backbone to be 0-2
+    block_type_atom_downstream_of_conn[0, 0, 0] = 0
+    block_type_atom_downstream_of_conn[0, 0, 1] = 1
+    block_type_atom_downstream_of_conn[0, 0, 2] = 2
+    block_type_atom_downstream_of_conn[0, 1, 0] = 2
+    block_type_atom_downstream_of_conn[0, 1, 1] = 1
+    block_type_atom_downstream_of_conn[0, 1, 2] = 0
+
+    resolved = resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )
+
+    resolved_gold = torch.tensor([-1, -1], dtype=torch.int32)
+    numpy.testing.assert_equal(resolved_gold.numpy(), resolved.numpy())

--- a/tmol/tests/score/common/uaid_util.py
+++ b/tmol/tests/score/common/uaid_util.py
@@ -1,0 +1,23 @@
+from tmol.utility.cpp_extension import load, modulename, relpaths
+
+
+# ok, we are going to load the uaid_util.pybind.cc file
+def resolve_uaids(
+    uaids,
+    block_inds,
+    pose_inds,
+    pose_stack_block_coord_offset,
+    pose_stack_block_type,
+    pose_stack_inter_block_connections,
+    block_type_atom_downstream_of_conn,
+):
+    compiled = load(modulename(__name__), relpaths(__file__, "uaid_util.pybind.cc"))
+    return compiled.resolve_uaids(
+        uaids,
+        block_inds,
+        pose_inds,
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn,
+    )

--- a/tmol/tests/score/common/uaid_util.pybind.cc
+++ b/tmol/tests/score/common/uaid_util.pybind.cc
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <tmol/utility/tensor/pybind.h>
+#include <tmol/score/common/uaid_util.hh>
+#include <tmol/score/unresolved_atom.pybind.hh>
+
+namespace tmol {
+namespace test {
+namespace score {
+namespace common {
+
+template <typename Real, int N>
+using Vec = Eigen::Matrix<Real, N, 1>;
+
+template <typename Int, tmol::Device D>
+at::Tensor resolve_uaids(
+    TView<UnresolvedAtomID<Int>, 1, D> uaids,
+    TView<Int, 1, D> block_inds,
+    TView<Int, 1, D> pose_inds,
+    TView<Int, 2, D> pose_stack_block_coord_offset,
+    TView<Int, 2, D> pose_stack_block_type,
+    TView<Vec<Int, 2>, 3, D> pose_stack_inter_block_connections,
+    TView<Int, 3, D> block_type_atom_downstream_of_conn) {
+  int const n_uaids = uaids.size(0);
+  int const n_poses = pose_stack_inter_block_connections.size(0);
+  int const max_n_blocks = pose_stack_block_coord_offset.size(1);
+  int const max_n_conn = pose_stack_inter_block_connections.size(2);
+  int const n_block_types = block_type_atom_downstream_of_conn.size(0);
+
+  assert(block_inds.size(0) == n_uaids);
+  assert(pose_inds.size(0) == n_uaids);
+  assert(pose_stack_block_coord_offset.size(0) == n_poses);
+  assert(pose_stack_block_type.size(0) == n_poses);
+  assert(pose_stack_block_type.size(1) == max_n_blocks);
+  assert(pose_stack_inter_block_connections.size(1) == max_n_blocks);
+  assert(block_type_atom_downstream_of_conn.size(1) == max_n_conn);
+
+  auto outputs_t = TPack<Int, 1, D>::zeros({n_uaids});
+  auto outputs = outputs_t.view;
+  for (int i = 0; i < n_uaids; ++i) {
+    outputs[i] = tmol::score::common::resolve_atom_from_uaid(
+        uaids[i],
+        block_inds[i],
+        pose_inds[i],
+        pose_stack_block_coord_offset,
+        pose_stack_block_type,
+        pose_stack_inter_block_connections,
+        block_type_atom_downstream_of_conn);
+  }
+
+  return outputs_t.tensor;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  using namespace pybind11::literals;
+
+  m.def(
+      "resolve_uaids",
+      &resolve_uaids<int32_t, tmol::Device::CPU>,
+      "uaids"_a,
+      "block_inds"_a,
+      "pose_inds"_a,
+      "pose_stack_block_coord_offset"_a,
+      "pose_stack_block_type"_a,
+      "pose_stack_inter_block_connections"_a,
+      "block_type_atom_downstream_of_conn"_a);
+}
+
+}  // namespace common
+}  // namespace score
+}  // namespace test
+}  // namespace tmol


### PR DESCRIPTION
The unresolved-atom-id resolution code should also handle cases when UAIDs specify the "this is not a real UAID" condition. Previously, it just accessed out of bounds memory locations. Oops.

I have now added unit tests for UAID resolution as well. This test hits the case where the old resolve_atom_from_uaid function would have read out of bounds (though, that would not necessarily have triggered a failure).