### PR TITLE
Aleaverfay/fix dun score termini

### DIFF
--- a/tmol/score/dunbrack/params.py
+++ b/tmol/score/dunbrack/params.py
@@ -706,6 +706,11 @@ class DunbrackParamResolver(ValidateAttrs):
         torch_device: torch.device,
     ) -> DunbrackParams:
         nstacks = res_names.shape[0]
+        # print("nstacks", nstacks)
+        # print("phi", phi.shape)
+        # print("psi", psi.shape)
+        # print("chi", chi.shape)
+
         assert phi.shape[0] == nstacks
         assert psi.shape[0] == nstacks
         assert chi.shape[0] == nstacks

--- a/tmol/score/dunbrack/potentials/potentials.hh
+++ b/tmol/score/dunbrack/potentials/potentials.hh
@@ -80,14 +80,11 @@ def measure_dihedrals_V_dV(
     ddihe_dxyz[i](3, 0) = dihe.dV_dL(0);
     ddihe_dxyz[i](3, 1) = dihe.dV_dL(1);
     ddihe_dxyz[i](3, 2) = dihe.dV_dL(2);
-  } else if (at1 == -1) {
-    // -1 is sentinel value for undefined phi dihedral
-    printf("dunbrack: at1 is -1, %d: %d %d %d %d\n", i, at1, at2, at3, at4);
+  } else if (at1 == -2) {
+    // -2 is sentinel value for undefined phi dihedral
     dihedrals[i] = -60.0 * M_PI / 180;
   } else if (at1 == -2) {
-    // -2 is sentinel value for undefined psi dihedral
-    printf("dunbrack: at1 is -2, %d: %d %d %d %d\n", i, at1, at2, at3, at4);
-
+    // -3 is sentinel value for undefined psi dihedral
     dihedrals[i] = 60.0 * M_PI / 180;
   }
 }

--- a/tmol/score/dunbrack/potentials/potentials.hh
+++ b/tmol/score/dunbrack/potentials/potentials.hh
@@ -82,9 +82,12 @@ def measure_dihedrals_V_dV(
     ddihe_dxyz[i](3, 2) = dihe.dV_dL(2);
   } else if (at1 == -1) {
     // -1 is sentinel value for undefined phi dihedral
+    printf("dunbrack: at1 is -1, %d: %d %d %d %d\n", i, at1, at2, at3, at4);
     dihedrals[i] = -60.0 * M_PI / 180;
   } else if (at1 == -2) {
     // -2 is sentinel value for undefined psi dihedral
+    printf("dunbrack: at1 is -2, %d: %d %d %d %d\n", i, at1, at2, at3, at4);
+
     dihedrals[i] = 60.0 * M_PI / 180;
   }
 }

--- a/tmol/score/modules/dunbrack.py
+++ b/tmol/score/modules/dunbrack.py
@@ -70,65 +70,31 @@ def get_dunbrack_phi_psi_chi(
     dun_phi[:, 0] = resids
     dun_psi[:, 0] = resids
 
-    dun_chi1 = numpy.array(
-        [
+    def nab_chi(chi_name, chi_ind):
+        dun_chi = numpy.array(
             [
-                x["residue_index"],
-                0,
-                x["atom_index_a"],
-                x["atom_index_b"],
-                x["atom_index_c"],
-                x["atom_index_d"],
-            ]
-            for x in system.torsion_metadata[system.torsion_metadata["name"] == "chi1"]
-        ],
-        dtype=numpy.int32,
-    )
+                [
+                    x["residue_index"],
+                    chi_ind,
+                    x["atom_index_a"],
+                    x["atom_index_b"],
+                    x["atom_index_c"],
+                    x["atom_index_d"],
+                ]
+                for x in system.torsion_metadata[
+                    system.torsion_metadata["name"] == chi_name
+                ]
+            ],
+            dtype=numpy.int32,
+        )
+        if dun_chi.shape[0] == 0:
+            dun_chi = numpy.zeros((0, 6), dtype=numpy.int32)
+        return dun_chi
 
-    dun_chi2 = numpy.array(
-        [
-            [
-                x["residue_index"],
-                1,
-                x["atom_index_a"],
-                x["atom_index_b"],
-                x["atom_index_c"],
-                x["atom_index_d"],
-            ]
-            for x in system.torsion_metadata[system.torsion_metadata["name"] == "chi2"]
-        ],
-        dtype=numpy.int32,
-    )
-
-    dun_chi3 = numpy.array(
-        [
-            [
-                x["residue_index"],
-                2,
-                x["atom_index_a"],
-                x["atom_index_b"],
-                x["atom_index_c"],
-                x["atom_index_d"],
-            ]
-            for x in system.torsion_metadata[system.torsion_metadata["name"] == "chi3"]
-        ],
-        dtype=numpy.int32,
-    )
-
-    dun_chi4 = numpy.array(
-        [
-            [
-                x["residue_index"],
-                3,
-                x["atom_index_a"],
-                x["atom_index_b"],
-                x["atom_index_c"],
-                x["atom_index_d"],
-            ]
-            for x in system.torsion_metadata[system.torsion_metadata["name"] == "chi4"]
-        ],
-        dtype=numpy.int32,
-    )
+    dun_chi1 = nab_chi("chi1", 0)
+    dun_chi2 = nab_chi("chi2", 1)
+    dun_chi3 = nab_chi("chi3", 2)
+    dun_chi4 = nab_chi("chi4", 3)
 
     # merge the 4 chi tensors, sorting by residue index and chi index
     join_chi = numpy.concatenate((dun_chi1, dun_chi2, dun_chi3, dun_chi4), 0)

--- a/tmol/tests/score/dunbrack/test_baseline.py
+++ b/tmol/tests/score/dunbrack/test_baseline.py
@@ -24,15 +24,22 @@ def test_dun_baseline_comparison(ubq_system, torch_device):
     # fa_dun_dev 239.723
     # fa_dun_rot 71.703
     # fa_dun_semi 99.705
+    #
+    # Obs as of 2023/8/3:
     # the discrepency appears to be that residue 1 and residue N are still not getting scored?
     # in R3:
     #                           fa_dun_dev fa_dun_rot fa_dun_semi
     #   MET:NtermProteinFull_1	2.60383    5.11634	  0
+    #
+    # Fix on 2023/8/21:
+    # MET:nterm is now being scored; GLY:cterm would not get scored in any case
+    # dunbrack_rot -- 66.5865 --> 70.649; 4.0625
+    # dunbrack_rotdev -- 237.8934 --> 240.3100; 2.4166
     assert intra_container["dunbrack_rot"].detach().cpu().numpy() == approx(
-        66.5865, rel=1e-3
+        70.6497, rel=1e-3
     )
     assert intra_container["dunbrack_rotdev"].detach().cpu().numpy() == approx(
-        237.8934, rel=1e-3
+        240.3100, rel=1e-3
     )
     assert intra_container["dunbrack_semirot"].detach().cpu().numpy() == approx(
         99.6609, rel=1e-3

--- a/tmol/tests/score/modules/test_dunbrack.py
+++ b/tmol/tests/score/modules/test_dunbrack.py
@@ -95,3 +95,27 @@ def test_dunbrack_for_stacked_system(ubq_system: PackedResidueSystem):
 
     sumtot = torch.sum(tot)
     sumtot.backward()
+
+
+def test_dunbrack_for_jagged_system(ubq_res):
+    ubq_system1 = PackedResidueSystem.from_residues(ubq_res[0:40])
+    ubq_system2 = PackedResidueSystem.from_residues(ubq_res[0:60])
+
+    twoubq = PackedResidueSystemStack((ubq_system1, ubq_system2))
+
+    stacked_score = ScoreSystem.build_for(
+        twoubq,
+        {DunbrackScore},
+        weights={"dunbrack_rot": 1.0, "dunbrack_rotdev": 2.0, "dunbrack_semirot": 3.0},
+    )
+
+    coords = coords_for(twoubq, stacked_score)
+    tot = stacked_score.intra_total(coords)
+
+    forward = stacked_score.intra_forward(coords)
+    assert len(forward) == 3
+    for terms in forward.values():
+        assert len(terms) == 2
+
+    sumtot = torch.sum(tot)
+    sumtot.backward()

--- a/tmol/tests/score/modules/test_dunbrack.py
+++ b/tmol/tests/score/modules/test_dunbrack.py
@@ -106,7 +106,7 @@ def test_dunbrack_for_jagged_system(ubq_res):
     stacked_score = ScoreSystem.build_for(
         twoubq,
         {DunbrackScore},
-        weights={"dunbrack_rot": 1.0, "dunbrack_rotdev": 2.0, "dunbrack_semirot": 3.0},
+        weights={"dunbrack_rot": 0.7, "dunbrack_rotdev": 0.7, "dunbrack_semirot": 0.7},
     )
 
     coords = coords_for(twoubq, stacked_score)


### PR DESCRIPTION
There were two problems previously that kept the dunbrack scoring machinery from properly evaluating the energies for terminal residues:

1. The code was using the sentinel value "-1" to represent too many things: in one step, that an atom defining a certain chi dihedral was not resolvable because, e.g., that atom would need to live inside residue i-1 for the very first residue or inside residue i+1 for the last residue; in another step, -1 represented that a residue did not exist or was not described by the dunbrack library (e.g. ALA or a ligand). The code was written to intercept the first case to define phi as the neutral -60 and psi as the neutral +60, but it never got the chance because the second case caused the residues to be skipped over entirely.
2. The code was trying to decide how to handle residue types based on their full names as opposed to their base names, so MET:nterm was being treaded as if it was not a residue type that Dunbrack had anything to say about (akin to ALA or a ligand)

The code now evaluates properly for the n-term of 1ubq