### PR TITLE
Aleaverfay/create atom index mapping b/w PoseStack and CanonicalForm

### DIFF
--- a/tmol/io/details/select_from_canonical.py
+++ b/tmol/io/details/select_from_canonical.py
@@ -297,17 +297,16 @@ def take_block_type_atoms_from_canonical(
     missing_atoms = torch.zeros(
         (n_poses, max_n_blocks, pbt.max_n_atoms), dtype=torch.int32, device=pbt.device
     )
+    real_canonical_atom_inds = canonical_atom_inds[real_atoms]
     block_coords[real_atoms] = coords[
-        nz_real_pose_ind, nz_real_block_ind, canonical_atom_inds[real_atoms]
+        nz_real_pose_ind, nz_real_block_ind, real_canonical_atom_inds
     ]
     missing_atoms[real_atoms] = (
-        atom_is_present[
-            nz_real_pose_ind, nz_real_block_ind, canonical_atom_inds[real_atoms]
-        ]
+        atom_is_present[nz_real_pose_ind, nz_real_block_ind, real_canonical_atom_inds]
         == 0
     ).to(torch.int32)
 
-    return block_coords, missing_atoms, real_atoms
+    return (block_coords, missing_atoms, real_atoms, real_canonical_atom_inds)
 
 
 @validate_args

--- a/tmol/io/pose_stack_construction.py
+++ b/tmol/io/pose_stack_construction.py
@@ -13,6 +13,7 @@ def pose_stack_from_canonical_form(
     find_additional_disulfides: Optional[bool] = True,
     res_not_connected: Optional[Tensor[torch.bool][:, :, 2]] = None,
     return_chain_ind: bool = False,
+    return_atom_mapping: bool = False,
 ):
     """Create a PoseStack given atom coordinates in canonical ordering
 
@@ -83,6 +84,30 @@ def pose_stack_from_canonical_form(
 
     return_chain_ind: return the chain-index tensor that has been "left-justified"
         from the chain
+
+    return_atom_mapping: return the mapping for atoms in the canonical-form tensor
+        to their PoseStack index; this could be used to update the coordinates
+        in a PoseStack without rebuilding it (as long as the chemical identity
+        is meant to be unchanged) or to perhaps remap derivatives to or from
+        pose stack ordering. If requested, the atom mapping will be the last two
+        arguments returned by this function, as two tensors:
+            ps, t1, t2 = pose_stack_from_canonical_form(
+                ...,
+                return_atom_mapping=True
+            )
+            can_ord_coords[
+                t1[:, 0], t1[:, 1], t1[:, 2]
+            ] = ps.coords[
+                t2[:, 0], t2[:, 1]
+            ]
+        where t1 is a tensor nats x 3 where
+        - position [i, 0] is the pose index
+        - position [i, 1] is the residue index, and
+        - position [i, 2] is the canonical-ordering atom index
+        and t2 is a tensor nats x 2 where
+        - position [i, 0] is the pose index, and
+        - position [i, 1] is the pose-ordered atom index
+
     """
 
     from tmol.io.details.canonical_packed_block_types import (
@@ -114,6 +139,7 @@ def pose_stack_from_canonical_form(
     #         any others that may have been provided
     # step 7: if any atoms missing, build them
     # step 8: construct PoseStack object
+    # step 9: construct the forward/reverse atom mapping indices if required
 
     if atom_is_present is None:
         atom_is_present = torch.all(torch.logical_not(torch.isnan(coords)), dim=3)
@@ -165,7 +191,12 @@ def pose_stack_from_canonical_form(
     )
 
     # 6
-    block_coords, missing_atoms, real_atoms = take_block_type_atoms_from_canonical(
+    (
+        block_coords,
+        missing_atoms,
+        real_atoms,
+        real_canonical_atom_inds,
+    ) = take_block_type_atoms_from_canonical(
         pbt, block_types64, coords, atom_is_present
     )
 
@@ -188,11 +219,12 @@ def pose_stack_from_canonical_form(
         return x.to(torch.int32)
 
     # 8
+    block_coord_offset64 = i64(block_coord_offset)
     ps = PoseStack(
         packed_block_types=pbt,
         coords=pose_stack_coords,
         block_coord_offset=block_coord_offset,
-        block_coord_offset64=i64(block_coord_offset),
+        block_coord_offset64=block_coord_offset64,
         inter_residue_connections=inter_residue_connections,
         inter_residue_connections64=inter_residue_connections64,
         inter_block_bondsep=inter_block_bondsep,
@@ -201,7 +233,44 @@ def pose_stack_from_canonical_form(
         block_type_ind64=block_types64,
         device=pbt.device,
     )
+
+    # 9
+    if return_atom_mapping:
+        (
+            nz_block_layout_pose_ind,
+            nz_block_layout_block_ind,
+            nz_block_at_ind,
+        ) = torch.nonzero(real_atoms, as_tuple=True)
+        pose_atom_ind = (
+            block_coord_offset64[nz_block_layout_pose_ind, nz_block_layout_block_ind]
+            + nz_block_at_ind
+        )
+
+        def _u1(x):
+            return x.unsqueeze(1)
+
+        can_atom_mapping = torch.cat(
+            (
+                _u1(nz_block_layout_pose_ind),
+                _u1(nz_block_layout_res_ind),
+                _u1(real_canonical_atom_inds),
+            ),
+            dim=1,
+        )
+        ps_atom_mapping = torch.cat((nz_block_layout_pose_ind, pose_atom_ind), dim=1)
+
     if return_chain_ind:
-        return (ps, chain_id)
+        if return_atom_mapping:
+            return (
+                ps,
+                chain_id,
+                can_atom_mapping,
+                ps_atom_mapping,
+            )
+        else:
+            return (ps, chain_id)
     else:
-        return ps
+        if return_atom_mapping:
+            return (ps, can_atom_mapping, ps_atom_mapping)
+        else:
+            return ps

--- a/tmol/io/pose_stack_construction.py
+++ b/tmol/io/pose_stack_construction.py
@@ -252,12 +252,18 @@ def pose_stack_from_canonical_form(
         can_atom_mapping = torch.cat(
             (
                 _u1(nz_block_layout_pose_ind),
-                _u1(nz_block_layout_res_ind),
+                _u1(nz_block_layout_block_ind),
                 _u1(real_canonical_atom_inds),
             ),
             dim=1,
         )
-        ps_atom_mapping = torch.cat((nz_block_layout_pose_ind, pose_atom_ind), dim=1)
+        ps_atom_mapping = torch.cat(
+            (
+                _u1(nz_block_layout_pose_ind),
+                _u1(pose_atom_ind),
+            ),
+            dim=1,
+        )
 
     if return_chain_ind:
         if return_atom_mapping:

--- a/tmol/tests/io/details/test_build_missing_leaf_atoms.py
+++ b/tmol/tests/io/details/test_build_missing_leaf_atoms.py
@@ -42,7 +42,7 @@ def test_build_missing_leaf_atoms(torch_device, ubq_pdb):
         inter_block_bondsep64,
     ) = assign_block_types(pbt, ch_id, can_rts, res_type_variants, found_disulfides)
 
-    block_coords, missing_atoms, real_atoms = take_block_type_atoms_from_canonical(
+    block_coords, missing_atoms, real_atoms, _ = take_block_type_atoms_from_canonical(
         pbt, block_types64, coords, at_is_pres
     )
 
@@ -165,6 +165,7 @@ def test_build_missing_leaf_atoms_backwards(torch_device, ubq_pdb):
                 block_coords,
                 missing_atoms,
                 real_atoms,
+                _,
             ) = take_block_type_atoms_from_canonical(
                 pbt, block_types64, self.coords, at_is_pres
             )
@@ -234,7 +235,7 @@ def test_coord_sum_gradcheck(torch_device, ubq_pdb):
         inter_block_bondsep64,
     ) = assign_block_types(pbt, ch_id, can_rts, res_type_variants, found_disulfides)
 
-    block_coords, missing_atoms, real_atoms = take_block_type_atoms_from_canonical(
+    block_coords, missing_atoms, real_atoms, _ = take_block_type_atoms_from_canonical(
         pbt, block_types64, coords, at_is_pres
     )
 
@@ -298,7 +299,7 @@ def test_build_missing_hydrogens_and_oxygens_gradcheck(ubq_pdb, torch_device):
         inter_block_bondsep64,
     ) = assign_block_types(pbt, ch_id, can_rts, res_type_variants, found_disulfides)
 
-    block_coords, missing_atoms, real_atoms = take_block_type_atoms_from_canonical(
+    block_coords, missing_atoms, real_atoms, _ = take_block_type_atoms_from_canonical(
         pbt, block_types64, coords, at_is_pres
     )
 

--- a/tmol/tests/io/details/test_select_from_canonical.py
+++ b/tmol/tests/io/details/test_select_from_canonical.py
@@ -245,17 +245,22 @@ def test_take_block_type_atoms_from_canonical(torch_device, ubq_pdb):
         inter_block_bondsep64,
     ) = assign_block_types(pbt, ch_id, can_rts, res_type_variants, found_disulfides)
 
-    block_coords, missing_atoms, real_atoms = take_block_type_atoms_from_canonical(
-        pbt, block_types64, coords, at_is_pres
-    )
+    (
+        block_coords,
+        missing_atoms,
+        real_atoms,
+        real_canonical_atom_inds,
+    ) = take_block_type_atoms_from_canonical(pbt, block_types64, coords, at_is_pres)
 
     assert block_coords.device == torch_device
     assert missing_atoms.device == torch_device
     assert block_types64.device == torch_device
+    assert real_canonical_atom_inds.device == torch_device
 
     assert block_coords.shape == (1, can_rts.shape[1], pbt.max_n_atoms, 3)
     assert missing_atoms.shape == block_coords.shape[:3]
     assert real_atoms.shape == missing_atoms.shape
+    assert real_canonical_atom_inds.dtype == torch.int64
 
     block_coords = block_coords.cpu().numpy()
 


### PR DESCRIPTION
Adding an extra argument to the pose_stack_from_canonical_form function, return_atom_mapping, that will cause the function to return a mapping between the atom indices in the input canonical form and the atom indices in the pose stack that was created. This mapping will ease the access into and out of PoseStack.

From the documentation:
```
return_atom_mapping: return the mapping for atoms in the canonical-form tensor
        to their PoseStack index; this could be used to update the coordinates
        in a PoseStack without rebuilding it (as long as the chemical identity
        is meant to be unchanged) or to perhaps remap derivatives to or from
        pose stack ordering. If requested, the atom mapping will be the last two
        arguments returned by this function, as two tensors:
            ps, t1, t2 = pose_stack_from_canonical_form(
                ...,
                return_atom_mapping=True
            )
            can_ord_coords[
                t1[:, 0], t1[:, 1], t1[:, 2]
            ] = ps.coords[
                t2[:, 0], t2[:, 1]
            ]
        where t1 is a tensor nats x 3 where
        - position [i, 0] is the pose index
        - position [i, 1] is the residue index, and
        - position [i, 2] is the canonical-ordering atom index
        and t2 is a tensor nats x 2 where
        - position [i, 0] is the pose index, and
        - position [i, 1] is the pose-ordered atom index
```