### PR TITLE
Fix disulfide term's handling of placeholder residues (i.e. block type == -1)

### DIFF
--- a/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
+++ b/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
@@ -81,6 +81,9 @@ auto DisulfidePoseScoreDispatch<DeviceDispatch, D, Real, Int>::f(
     auto& pose_dV_dx = dV_dx[0][pose_index];
 
     int block_type_index = pose_stack_block_type[pose_index][block_index];
+    if (block_type_index < 0) {
+      return;
+    }
     int block_atom_offset =
         pose_stack_block_coord_offset[pose_index][block_index];
 


### PR DESCRIPTION
Add new unit test for jagged poses which contain placeholder residues which failed in the absence of the if (block_type != -1) check