### PR TITLE
Activate the missing `ref` energy in the beta2016_score_function

### DIFF
--- a/tmol/score/__init__.py
+++ b/tmol/score/__init__.py
@@ -44,5 +44,6 @@ def beta2016_score_function(
     sfxn.set_weight(ScoreType.dunbrack_rot, 0.76)
     sfxn.set_weight(ScoreType.dunbrack_rotdev, 0.69)
     sfxn.set_weight(ScoreType.dunbrack_semirot, 0.78)
+    sfxn.set_weight(ScoreType.ref, 1.0)
 
     return sfxn


### PR DESCRIPTION
The ref term was overlooked in the function that returns tmol's version of the beta2016 score term. Oops! Let's go ahead an activate it now.