### PR TITLE
use header only nvtx3

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,6 +10,6 @@ pytest-cov
 pytest-instafail
 pytest-repeat
 pytest-watch
-pytest-benchmark
+pytest-benchmark>=5.1.0
 seaborn
 pip-tools

--- a/tmol/tests/benchmark.py
+++ b/tmol/tests/benchmark.py
@@ -60,6 +60,8 @@ def make_fixture(
     warner=warnings,
     disabled=False,
     cprofile=False,
+    cprofile_loops=None,
+    cprofile_dump=None,
     **extra_info,
 ):
     """Create a pytest_benchmark fixture.
@@ -87,6 +89,8 @@ def make_fixture(
         warner=warner,
         disabled=disabled,
         cprofile=cprofile,
+        cprofile_loops=cprofile_loops,
+        cprofile_dump=cprofile_dump,
     )
 
     benchmark.extra_info.update(extra_info)
@@ -127,6 +131,8 @@ def make_subfixture(
         warner=parent._warner,
         disabled=parent.disabled,
         cprofile=parent.cprofile,
+        cprofile_loops=parent.cprofile_loops,
+        cprofile_dump=parent.cprofile_dump,
     )
 
     benchmark.extra_info.update(parent.extra_info)

--- a/tmol/utility/cpp_extension.py
+++ b/tmol/utility/cpp_extension.py
@@ -94,6 +94,9 @@ def _augment_kwargs(name, sources, **kwargs):
         kwargs["extra_cflags"] += ["-DWITH_CUDA"]
         kwargs["extra_cuda_cflags"] += ["-DWITH_CUDA"]
 
+    if os.environ.get("TMOL_TORCH_EXTENSIONS_VERBOSE"):
+        kwargs["verbose"] = True
+
     return kwargs
 
 

--- a/tmol/utility/nvtx.hh
+++ b/tmol/utility/nvtx.hh
@@ -2,7 +2,7 @@
 
 #if defined(WITH_CUDA) && defined(WITH_NVTX)
 
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 #define nvtx_range_push(n) nvtxRangePushA(n)
 #define nvtx_range_pop() nvtxRangePop()


### PR DESCRIPTION
With the most recent pytorch release (2.5.1) I've seen some linking failures related to nvtx: `undefined symbol: nvtxRangePushA`. This seems to be because `libtorch_cuda` no longer links `libnvToolsExt.so`. Luckily [nvtx](https://github.com/NVIDIA/NVTX) is now header only so the resolution is simple.