### PR TITLE
Update ATen dispatch calls to use Tensor::options() rather than Tensor::type()

### DIFF
--- a/tmol/io/details/compiled/compiled.ops.cpp
+++ b/tmol/io/details/compiled/compiled.ops.cpp
@@ -42,7 +42,7 @@ class PoseLeafAtomGen : public torch::autograd::Function<PoseLeafAtomGen> {
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        orig_coords.type(), "leaf_atom_gen_op", ([&] {
+        orig_coords.options(), "leaf_atom_gen_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -112,7 +112,7 @@ class PoseLeafAtomGen : public torch::autograd::Function<PoseLeafAtomGen> {
     auto dE_d_new_coords = grad_outputs[0];
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        orig_coords.type(), "leaf_atom_gen_backward", ([&] {
+        orig_coords.options(), "leaf_atom_gen_backward", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -195,7 +195,7 @@ Tensor resolve_his_tautomerization(
     Tensor his_atom_inds,
     Tensor his_remapping_dst_index) {
   at::Tensor his_taut;
-  TMOL_DISPATCH_FLOATING_DEVICE(coords.type(), "resolve_his_taut", ([&] {
+  TMOL_DISPATCH_FLOATING_DEVICE(coords.options(), "resolve_his_taut", ([&] {
                                   using Real = scalar_t;
                                   constexpr tmol::Device Dev = device_t;
 

--- a/tmol/kinematics/compiled/compiled_ops.cpp
+++ b/tmol/kinematics/compiled/compiled_ops.cpp
@@ -36,7 +36,7 @@ class KinematicOp : public torch::autograd::Function<KinematicOp> {
 
     using Int = int32_t;
 
-    TMOL_DISPATCH_FLOATING_DEVICE(dofs.type(), "forward_kin_op", ([&] {
+    TMOL_DISPATCH_FLOATING_DEVICE(dofs.options(), "forward_kin_op", ([&] {
                                     using Real = scalar_t;
                                     constexpr tmol::Device Dev = device_t;
 
@@ -70,7 +70,7 @@ class KinematicOp : public torch::autograd::Function<KinematicOp> {
     at::Tensor dV_ddof;
     using Int = int32_t;
     auto dVdx = grad_outputs[0];
-    TMOL_DISPATCH_FLOATING_DEVICE(HTs.type(), "kin_deriv_op", ([&] {
+    TMOL_DISPATCH_FLOATING_DEVICE(HTs.options(), "kin_deriv_op", ([&] {
                                     using Real = scalar_t;
                                     constexpr tmol::Device Dev = device_t;
 
@@ -124,7 +124,7 @@ Tensor forward_only_op(
 
   using Int = int32_t;
 
-  TMOL_DISPATCH_FLOATING_DEVICE(dofs.type(), "forward_kin_only_op", ([&] {
+  TMOL_DISPATCH_FLOATING_DEVICE(dofs.options(), "forward_kin_only_op", ([&] {
                                   using Real = scalar_t;
                                   constexpr tmol::Device Dev = device_t;
 
@@ -151,7 +151,9 @@ auto get_kfo_indices_for_atoms(
   at::Tensor kfo_2_orig_mapping_tp;
   at::Tensor atom_kfo_index;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_coord_offset.type(), "get_kfo_indices_for_atoms", ([&] {
+      pose_stack_block_coord_offset.options(),
+      "get_kfo_indices_for_atoms",
+      ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -184,7 +186,7 @@ auto get_kfo_atom_parents(
   at::Tensor kfo_parent_atoms;
   at::Tensor kfo_grandparent_atoms;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "get_kfo_atom_parents", ([&] {
+      pose_stack_block_type.options(), "get_kfo_atom_parents", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -223,7 +225,7 @@ auto get_children(
   at::Tensor is_atom_jump;
 
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "get_children", ([&] {
+      pose_stack_block_type.options(), "get_children", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -261,7 +263,7 @@ auto get_id_and_frame_xyz(
   at::Tensor keep_dof_fixed;
 
   TMOL_DISPATCH_INDEX_DEVICE(
-      parents.type(), "get_id_and_frame_xyz", ([&] {
+      parents.options(), "get_id_and_frame_xyz", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -306,7 +308,7 @@ auto calculate_ff_edge_delays(
   Tensor delay_for_edge;
   Tensor toposort_index_for_edge;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "calculate_ff_edge_delays", ([&] {
+      pose_stack_block_type.options(), "calculate_ff_edge_delays", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -350,7 +352,7 @@ auto get_jump_atom_indices(
   Tensor pose_stack_atom_for_jump;
   Tensor pose_stack_atom_for_root_jump;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "calculate_ff_edge_delays", ([&] {
+      pose_stack_block_type.options(), "calculate_ff_edge_delays", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -382,7 +384,7 @@ auto get_block_parent_connectivity_from_toposort(
     Tensor block_type_polymeric_conn_index) -> Tensor {
   Tensor pose_stack_block_in_and_first_out;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "calculate_ff_edge_delays", ([&] {
+      pose_stack_block_type.options(), "calculate_ff_edge_delays", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -445,7 +447,7 @@ auto get_scans2(
   Tensor scans_bw;
   Tensor gens_bw;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "calculate_ff_edge_delays", ([&] {
+      pose_stack_block_type.options(), "calculate_ff_edge_delays", ([&] {
         using Int = int32_t;  // ONLY 32-bit integers supported! No atomicAdd
                               // for signed 64-bit integers in CUDA
         constexpr tmol::Device Dev = device_t;
@@ -534,7 +536,7 @@ auto minimizer_map_from_movemap(
   // Minimizer map: a boolean vector of the DOFs that are free
   Tensor minimizer_map;
   TMOL_DISPATCH_INDEX_DEVICE(
-      pose_stack_block_type.type(), "minimizer_map_from_movemap", ([&] {
+      pose_stack_block_type.options(), "minimizer_map_from_movemap", ([&] {
         using Int = int32_t;
         constexpr tmol::Device Dev = device_t;
 

--- a/tmol/pack/rotamer/dunbrack/compiled.ops.cpp
+++ b/tmol/pack/rotamer/dunbrack/compiled.ops.cpp
@@ -71,7 +71,7 @@ std::vector<Tensor> dun_sample_chi(
 
   try {
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "dunbrack_sample_chi", ([&] {
+        coords.options(), "dunbrack_sample_chi", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
           auto result = DunbrackChiSampler<DispatchMethod, Dev, Real, Int>::f(

--- a/tmol/pack/sim_anneal/compiled/compiled.ops.cpp
+++ b/tmol/pack/sim_anneal/compiled/compiled.ops.cpp
@@ -91,7 +91,7 @@ Tensor register_standard_random_rotamer_picker(
   using Int = int32_t;
   try {
     TMOL_DISPATCH_FLOATING_DEVICE(
-        context_coords.type(), "register_rot_picker", ([&] {
+        context_coords.options(), "register_rot_picker", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -145,30 +145,31 @@ Tensor register_standard_metropolis_accept_or_rejector(
     Tensor annealer) {
   using Int = int32_t;
   try {
-    TMOL_DISPATCH_FLOATING_DEVICE(context_coords.type(), "register_mc", ([&] {
-                                    using Real = scalar_t;
-                                    constexpr tmol::Device Dev = device_t;
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        context_coords.options(), "register_mc", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
 
-                                    using tmol::score::common::ForallDispatch;
-                                    MetropolisAcceptRejectStepRegistrator<
-                                        ForallDispatch,
-                                        Dev,
-                                        Real,
-                                        Int>::
-                                        f(TCAST(temperature),
-                                          TCAST(context_coords),
-                                          TCAST(context_coord_offsets),
-                                          TCAST(context_block_type),
-                                          TCAST(alternate_coords),
-                                          TCAST(alternate_coord_offsets),
-                                          TCAST(alternate_ids),
-                                          TCAST(rotamer_component_energies),
-                                          TCAST(accepted),
-                                          TCAST(block_type_n_atoms),
-                                          Int(max_n_atoms),
-                                          TCAST(score_events),
-                                          TCAST(annealer));
-                                  }));
+          using tmol::score::common::ForallDispatch;
+          MetropolisAcceptRejectStepRegistrator<
+              ForallDispatch,
+              Dev,
+              Real,
+              Int>::
+              f(TCAST(temperature),
+                TCAST(context_coords),
+                TCAST(context_coord_offsets),
+                TCAST(context_block_type),
+                TCAST(alternate_coords),
+                TCAST(alternate_coord_offsets),
+                TCAST(alternate_ids),
+                TCAST(rotamer_component_energies),
+                TCAST(accepted),
+                TCAST(block_type_n_atoms),
+                Int(max_n_atoms),
+                TCAST(score_events),
+                TCAST(annealer));
+        }));
   } catch (at::Error err) {
     std::cerr << "caught exception:\n"
               << err.what_without_backtrace() << std::endl;
@@ -227,7 +228,7 @@ Tensor pick_random_rotamers(
 
   try {
     TMOL_DISPATCH_FLOATING_DEVICE(
-        context_coords.type(), "score_op", ([&] {
+        context_coords.options(), "score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -281,7 +282,7 @@ Tensor metropolis_accept_reject(
 
   try {
     TMOL_DISPATCH_FLOATING_DEVICE(
-        context_coords.type(), "score_op", ([&] {
+        context_coords.options(), "score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 

--- a/tmol/pose/compiled/apsp_vestibule.ops.cpp
+++ b/tmol/pose/compiled/apsp_vestibule.ops.cpp
@@ -15,39 +15,15 @@ namespace pose {
 using torch::Tensor;
 
 void apsp_op(Tensor stacked_distances, int64_t cutoff) {
-  TMOL_DISPATCH_INDEX_DEVICE(stacked_distances.type(), "stacked_apsp_op", ([&] {
-                               using Int = index_t;
-                               constexpr tmol::Device Dev = device_t;
+  TMOL_DISPATCH_INDEX_DEVICE(
+      stacked_distances.options(), "stacked_apsp_op", ([&] {
+        using Int = index_t;
+        constexpr tmol::Device Dev = device_t;
 
-                               AllPairsShortestPathsDispatch<Dev, Int>::f(
-                                   TCAST(stacked_distances), int(cutoff));
-                             }));
+        AllPairsShortestPathsDispatch<Dev, Int>::f(
+            TCAST(stacked_distances), int(cutoff));
+      }));
 };
-
-// void limited_sparse_apsp_op(
-//   Tensor n_conn_for_nodes,
-//   Tensor conn_offset_for_nodes,
-//   Tensor connections_for_nodes,
-//   int limit
-// ) {
-//   using Int = int32_t;
-//
-//   TMOL_DISPATCH_INDEX_DEVICE(
-//       n_conn_for_nodes.type(), "limited_apsp_sparse_op", ([&] {
-//         using Int = index_t;
-//         constexpr tmol::Device Dev = device_t;
-//
-//         LimitedSparseAllPairsShortestPathsDispatch<Dev, Int>::f(
-// 	  TCAST(n_conn_for_nodes),
-// 	  TCAST(conn_offset_for_nodes),
-// 	  TCAST(connections_for_nodes),
-// 	  limit
-// 	);
-//       }));
-// };
-
-// static auto registry = torch::jit::RegisterOperators()
-//   .op("tmol::apsp_op", &apsp_op);
 
 // Macro indirection to force TORCH_EXTENSION_NAME macro expansion
 // See https://stackoverflow.com/a/3221914

--- a/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
+++ b/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
@@ -53,7 +53,7 @@ class BackboneTorsionPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "omega_pose_score_op", ([&] {
+        coords.options(), "omega_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -152,7 +152,7 @@ class BackboneTorsionPoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "disulfide_pose_score_backward", ([&] {
+          coords.options(), "disulfide_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/cartbonded/potentials/compiled.ops.cpp
+++ b/tmol/score/cartbonded/potentials/compiled.ops.cpp
@@ -51,7 +51,7 @@ class CartBondedPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "cartbonded_pose_score_op", ([&] {
+        coords.options(), "cartbonded_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -148,7 +148,7 @@ class CartBondedPoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "cartbonded_pose_score_backward", ([&] {
+          coords.options(), "cartbonded_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/constraint/potentials/compiled.ops.cpp
+++ b/tmol/score/constraint/potentials/compiled.ops.cpp
@@ -35,7 +35,7 @@ class GetTorsionAngleOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "get_torsion_angle_op", ([&] {
+        coords.options(), "get_torsion_angle_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/disulfide/potentials/compiled.ops.cpp
+++ b/tmol/score/disulfide/potentials/compiled.ops.cpp
@@ -43,7 +43,7 @@ class DisulfidePoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "disulfide_pose_score_op", ([&] {
+        coords.options(), "disulfide_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -122,7 +122,7 @@ class DisulfidePoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "disulfide_pose_score_backward", ([&] {
+          coords.options(), "disulfide_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/dunbrack/potentials/compiled.ops.cpp
+++ b/tmol/score/dunbrack/potentials/compiled.ops.cpp
@@ -72,7 +72,7 @@ class DunbrackPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "dunbrack_pose_score_op", ([&] {
+        coords.options(), "dunbrack_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -247,7 +247,7 @@ class DunbrackPoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "dunbrack_pose_score_backward", ([&] {
+          coords.options(), "dunbrack_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -49,7 +49,7 @@ class ElecPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "elec_pose_score_op", ([&] {
+        coords.options(), "elec_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -155,7 +155,7 @@ class ElecPoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "elec_pose_score_backward", ([&] {
+          coords.options(), "elec_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -66,7 +66,7 @@ class HBondPoseScoresOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "hbond_pose_score_op", ([&] {
+        coords.options(), "hbond_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -210,7 +210,7 @@ class HBondPoseScoresOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "hbond_pose_score_backward", ([&] {
+          coords.options(), "hbond_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -51,7 +51,7 @@ class LJLKPoseScoreOp
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        coords.type(), "ljlk_pose_score_op", ([&] {
+        coords.options(), "ljlk_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -164,7 +164,7 @@ class LJLKPoseScoreOp
       auto dTdV = grad_outputs[0];
 
       TMOL_DISPATCH_FLOATING_DEVICE(
-          coords.type(), "ljlk_pose_score_backward", ([&] {
+          coords.options(), "ljlk_pose_score_backward", ([&] {
             using Real = scalar_t;
             constexpr tmol::Device Dev = device_t;
 
@@ -293,7 +293,7 @@ Tensor rotamer_pair_energies_op(
       TPack<int64_t, 1, tmol::Device::CPU>::zeros({1});
 
   TMOL_DISPATCH_FLOATING_DEVICE(
-      context_coords.type(), "score_op", ([&] {
+      context_coords.options(), "score_op", ([&] {
         using Real = scalar_t;
         constexpr tmol::Device Dev = device_t;
 
@@ -363,7 +363,7 @@ Tensor register_lj_lk_rotamer_pair_energy_eval(
   using Int = int32_t;
 
   TMOL_DISPATCH_FLOATING_DEVICE(
-      context_coords.type(), "score_op", ([&] {
+      context_coords.options(), "score_op", ([&] {
         using Real = scalar_t;
         constexpr tmol::Device Dev = device_t;
 

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -59,7 +59,7 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        pose_coords.type(), "watergen_op", ([&] {
+        pose_coords.options(), "watergen_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -169,7 +169,7 @@ class PoseWaterGen : public torch::autograd::Function<PoseWaterGen> {
     auto dE_dWxyz = grad_outputs[0];
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        pose_coords.type(), "WaterGenOpBackward", ([&] {
+        pose_coords.options(), "WaterGenOpBackward", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -313,7 +313,7 @@ Tensor rotamer_pair_energies(
   constexpr int MAX_WATER = 4;
 
   TMOL_DISPATCH_FLOATING_DEVICE(
-      context_coords.type(), "rotamer_rpe_evaluation", ([&] {
+      context_coords.options(), "rotamer_rpe_evaluation", ([&] {
         using Real = scalar_t;
         constexpr tmol::Device Dev = device_t;
 
@@ -379,7 +379,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     using Int = int32_t;
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        pose_coords.type(), "lk_ball_pose_score_op", ([&] {
+        pose_coords.options(), "lk_ball_pose_score_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 
@@ -482,7 +482,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     }
 
     TMOL_DISPATCH_FLOATING_DEVICE(
-        pose_coords.type(), "lk_ball_pose_score_backward", ([&] {
+        pose_coords.options(), "lk_ball_pose_score_backward", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
 

--- a/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
+++ b/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
@@ -132,5 +132,5 @@ class TestCartBondedEnergyTerm(EnergyTermTestBase):
     ):
         resnums = [(0, 4)]
         return super().test_block_scoring_reweighted_gradcheck(
-            ubq_pdb, default_database, torch_device, resnums=resnums
+            ubq_pdb, default_database, torch_device, resnums=resnums, nondet_tol=1e-5
         )

--- a/tmol/utility/function_dispatch/aten.hh
+++ b/tmol/utility/function_dispatch/aten.hh
@@ -2,16 +2,17 @@
 
 #include <ATen/Dispatch.h>
 #include <tmol/utility/tensor/TensorAccessor.h>
+#include <iostream>
 
 #ifdef WITH_CUDA
 
 #define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)                 \
   [&] {                                                                \
-    if (TYPE.device() == at::DeviceType::CPU) {                        \
+    if (TYPE.device().is_cpu()) {                                      \
       constexpr tmol::Device device_t = tmol::Device::CPU;             \
       AT_DISPATCH_FLOATING_TYPES(                                      \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
-    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+    } else if (TYPE.device().is_cuda()) {                              \
       constexpr tmol::Device device_t = tmol::Device::CUDA;            \
       AT_DISPATCH_FLOATING_TYPES(                                      \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
@@ -24,11 +25,11 @@
 
 #define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)                 \
   [&] {                                                                \
-    if (TYPE.device() == at::DeviceType::CPU) {                        \
+    if (TYPE.device().is_cpu()) {                                      \
       constexpr tmol::Device device_t = tmol::Device::CPU;             \
       AT_DISPATCH_FLOATING_TYPES(                                      \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
-    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+    } else if (TYPE.device().is_cuda()) {                              \
       AT_ERROR("Unsupported cuda tensor, non-cuda build.");            \
     } else {                                                           \
       AT_ERROR("Unsupported device type.");                            \
@@ -41,11 +42,11 @@
 
 #define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)                    \
   [&] {                                                                \
-    if (TYPE.device() == at::DeviceType::CPU) {                        \
+    if (TYPE.device().is_cpu()) {                                      \
       constexpr tmol::Device device_t = tmol::Device::CPU;             \
       AT_DISPATCH_INDEX_TYPES(                                         \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
-    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+    } else if (TYPE.device().is_cuda()) {                              \
       constexpr tmol::Device device_t = tmol::Device::CUDA;            \
       AT_DISPATCH_INDEX_TYPES(                                         \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
@@ -58,11 +59,11 @@
 
 #define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)                    \
   [&] {                                                                \
-    if (TYPE.device() == at::DeviceType::CPU) {                        \
+    if (TYPE.device().is_cpu()) {                                      \
       constexpr tmol::Device device_t = tmol::Device::CPU;             \
       AT_DISPATCH_INDEX_TYPES(                                         \
           c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
-    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+    } else if (TYPE.device().is_cuda()) {                              \
       AT_ERROR("Unsupported cuda tensor, non-cuda build.");            \
     } else {                                                           \
       AT_ERROR("Unsupported device type.");                            \

--- a/tmol/utility/function_dispatch/aten.hh
+++ b/tmol/utility/function_dispatch/aten.hh
@@ -5,68 +5,68 @@
 
 #ifdef WITH_CUDA
 
-#define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)       \
-  [&] {                                                      \
-    if (TYPE.device_type() == at::DeviceType::CPU) {         \
-      constexpr tmol::Device device_t = tmol::Device::CPU;   \
-                                                             \
-      AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, __VA_ARGS__);   \
-    } else if (TYPE.device_type() == at::DeviceType::CUDA) { \
-      constexpr tmol::Device device_t = tmol::Device::CUDA;  \
-                                                             \
-      AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, __VA_ARGS__);   \
-    } else {                                                 \
-      AT_ERROR("Unsupported tensor device type.");           \
-    }                                                        \
+#define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)                 \
+  [&] {                                                                \
+    if (TYPE.device() == at::DeviceType::CPU) {                        \
+      constexpr tmol::Device device_t = tmol::Device::CPU;             \
+      AT_DISPATCH_FLOATING_TYPES(                                      \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+      constexpr tmol::Device device_t = tmol::Device::CUDA;            \
+      AT_DISPATCH_FLOATING_TYPES(                                      \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else {                                                           \
+      AT_ERROR("Unsupported tensor device type.");                     \
+    }                                                                  \
   }();
 
 #else
 
-#define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)       \
-  [&] {                                                      \
-    if (TYPE.device_type() == at::DeviceType::CPU) {         \
-      constexpr tmol::Device device_t = tmol::Device::CPU;   \
-                                                             \
-      AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, __VA_ARGS__);   \
-    } else if (TYPE.device_type() == at::DeviceType::CUDA) { \
-      AT_ERROR("Unsupported cuda tensor, non-cuda build.");  \
-    } else {                                                 \
-      AT_ERROR("Unsupported device type.");                  \
-    }                                                        \
+#define TMOL_DISPATCH_FLOATING_DEVICE(TYPE, NAME, ...)                 \
+  [&] {                                                                \
+    if (TYPE.device() == at::DeviceType::CPU) {                        \
+      constexpr tmol::Device device_t = tmol::Device::CPU;             \
+      AT_DISPATCH_FLOATING_TYPES(                                      \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+      AT_ERROR("Unsupported cuda tensor, non-cuda build.");            \
+    } else {                                                           \
+      AT_ERROR("Unsupported device type.");                            \
+    }                                                                  \
   }();
 
 #endif
 
 #ifdef WITH_CUDA
 
-#define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)          \
-  [&] {                                                      \
-    if (TYPE.device_type() == at::DeviceType::CPU) {         \
-      constexpr tmol::Device device_t = tmol::Device::CPU;   \
-                                                             \
-      AT_DISPATCH_INDEX_TYPES(TYPE, NAME, __VA_ARGS__);      \
-    } else if (TYPE.device_type() == at::DeviceType::CUDA) { \
-      constexpr tmol::Device device_t = tmol::Device::CUDA;  \
-                                                             \
-      AT_DISPATCH_INDEX_TYPES(TYPE, NAME, __VA_ARGS__);      \
-    } else {                                                 \
-      AT_ERROR("Unsupported tensor device type.");           \
-    }                                                        \
+#define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)                    \
+  [&] {                                                                \
+    if (TYPE.device() == at::DeviceType::CPU) {                        \
+      constexpr tmol::Device device_t = tmol::Device::CPU;             \
+      AT_DISPATCH_INDEX_TYPES(                                         \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+      constexpr tmol::Device device_t = tmol::Device::CUDA;            \
+      AT_DISPATCH_INDEX_TYPES(                                         \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else {                                                           \
+      AT_ERROR("Unsupported tensor device type.");                     \
+    }                                                                  \
   }();
 
 #else
 
-#define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)          \
-  [&] {                                                      \
-    if (TYPE.device_type() == at::DeviceType::CPU) {         \
-      constexpr tmol::Device device_t = tmol::Device::CPU;   \
-                                                             \
-      AT_DISPATCH_INDEX_TYPES(TYPE, NAME, __VA_ARGS__);      \
-    } else if (TYPE.device_type() == at::DeviceType::CUDA) { \
-      AT_ERROR("Unsupported cuda tensor, non-cuda build.");  \
-    } else {                                                 \
-      AT_ERROR("Unsupported device type.");                  \
-    }                                                        \
+#define TMOL_DISPATCH_INDEX_DEVICE(TYPE, NAME, ...)                    \
+  [&] {                                                                \
+    if (TYPE.device() == at::DeviceType::CPU) {                        \
+      constexpr tmol::Device device_t = tmol::Device::CPU;             \
+      AT_DISPATCH_INDEX_TYPES(                                         \
+          c10::typeMetaToScalarType(TYPE.dtype()), NAME, __VA_ARGS__); \
+    } else if (TYPE.device() == at::DeviceType::CUDA) {                \
+      AT_ERROR("Unsupported cuda tensor, non-cuda build.");            \
+    } else {                                                           \
+      AT_ERROR("Unsupported device type.");                            \
+    }                                                                  \
   }();
 
 #endif


### PR DESCRIPTION
This enables compatibility w/ torch2.6

Note: we do not update the testing env.