### PR TITLE
Aleaverfay/small fixes

### DIFF
--- a/tmol/io/details/his_taut_resolution.py
+++ b/tmol/io/details/his_taut_resolution.py
@@ -76,7 +76,7 @@ def resolve_his_tautomerization(
     )
 
     return (
-        torch.tensor(his_taut, dtype=torch.int32, device=coords.device),
+        his_taut.to(dtype=torch.int32, device=coords.device),
         res_type_variants,
         resolved_coords,
         resolved_atom_is_present,

--- a/tmol/score/__init__.py
+++ b/tmol/score/__init__.py
@@ -4,18 +4,9 @@ from typing import Optional
 from tmol.database import ParameterDatabase
 
 
-@toolz.functoolz.memoize
-def beta2016_score_function(
+def _non_memoized_beta2016(
     device: torch.device, param_db: Optional[ParameterDatabase] = None
 ):
-    """Return a ScoreFunction implementing the beta_nov2016 score function
-    of Rosetta3.
-
-    See:
-    https://pubs.acs.org/doi/10.1021/acs.jctc.6b0081 and
-    https://pubs.acs.org/doi/full/10.1021/acs.jctc.7b00125
-    """
-
     from tmol.database import ParameterDatabase
     from .score_function import ScoreFunction
     from .score_types import ScoreType
@@ -47,3 +38,18 @@ def beta2016_score_function(
     sfxn.set_weight(ScoreType.ref, 1.0)
 
     return sfxn
+
+
+@toolz.functoolz.memoize
+def beta2016_score_function(
+    device: torch.device, param_db: Optional[ParameterDatabase] = None
+):
+    """Return a ScoreFunction implementing the beta_nov2016 score function
+    of Rosetta3.
+
+    See:
+    https://pubs.acs.org/doi/10.1021/acs.jctc.6b0081 and
+    https://pubs.acs.org/doi/full/10.1021/acs.jctc.7b00125
+    """
+
+    return _non_memoized_beta2016(device, param_db)

--- a/tmol/score/cartbonded/cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/cartbonded_energy_term.py
@@ -48,7 +48,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         return tmol.score.terms.cartbonded_creator.CartBondedTermCreator.score_types()
 
     def n_bodies(self):
-        return 1
+        return 2
 
     def find_subgraphs(self, bonds, block_type):  # noqa: C901
         lengths = []

--- a/tmol/score/disulfide/disulfide_energy_term.py
+++ b/tmol/score/disulfide/disulfide_energy_term.py
@@ -32,7 +32,7 @@ class DisulfideEnergyTerm(EnergyTerm):
         return tmol.score.terms.disulfide_creator.DisulfideTermCreator.score_types()
 
     def n_bodies(self):
-        return 1
+        return 2
 
     def setup_block_type(self, block_type: RefinedResidueType):
         super(DisulfideEnergyTerm, self).setup_block_type(block_type)

--- a/tmol/score/score_function.py
+++ b/tmol/score/score_function.py
@@ -21,6 +21,8 @@ class ScoreFunction:
         self._all_terms_unordered = []
         self._all_terms_out_of_date = False
 
+        self._all_score_types = []
+
         self._one_body_terms = []
         self._one_body_terms_unordered = []
         self._one_body_terms_out_of_date = False
@@ -89,28 +91,43 @@ class ScoreFunction:
         Do not modify this list directly
         """
         if self._all_terms_out_of_date:
-            self._all_terms = self.get_sorted_terms(self._all_terms_unordered)
+            self._all_terms, self._all_score_types = self.get_sorted_terms(
+                self._all_terms_unordered
+            )
             self._all_terms_out_of_date = False
 
         return self._all_terms
 
+    def all_score_types(self):
+        if self._all_terms_out_of_date:
+            self._all_terms, self._all_score_types = self.get_sorted_terms(
+                self._all_terms_unordered
+            )
+            self._all_terms_out_of_date = False
+
+        return self._all_score_types
+
     def one_body_terms(self):
         if self._one_body_terms_out_of_date:
-            self._one_body_terms = self.get_sorted_terms(self._one_body_terms_unordered)
+            self._one_body_terms, _ = self.get_sorted_terms(
+                self._one_body_terms_unordered
+            )
             self._one_body_terms_out_of_date = False
 
         return self._one_body_terms
 
     def two_body_terms(self):
         if self._two_body_terms_out_of_date:
-            self._two_body_terms = self.get_sorted_terms(self._two_body_terms_unordered)
+            self._two_body_terms, _ = self.get_sorted_terms(
+                self._two_body_terms_unordered
+            )
             self._two_body_terms_out_of_date = False
 
         return self._two_body_terms
 
     def multi_body_terms(self):
         if self._multi_body_terms_out_of_date:
-            self._multi_body_terms = self.get_sorted_terms(
+            self._multi_body_terms, _ = self.get_sorted_terms(
                 self._multi_body_terms_unordered
             )
             self._multi_body_terms_out_of_date = False
@@ -177,6 +194,7 @@ class ScoreFunction:
     @staticmethod
     def get_sorted_terms(term_list):
         sorted_term_list = []
+        sorted_score_type_list = []
         term_covered = [False] * ScoreType.n_score_types.value
         terms_by_st = [None] * ScoreType.n_score_types.value
         for term in term_list:
@@ -195,7 +213,8 @@ class ScoreFunction:
                     sorted_term_list.append(term)
                     for term_st in term.score_types():
                         term_covered[term_st.value] = True
-        return sorted_term_list
+                        sorted_score_type_list.append(term_st)
+        return sorted_term_list, sorted_score_type_list
 
 
 class WholePoseScoringModule:

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -157,16 +157,7 @@ def test_score_function_all_score_types(ubq_pdb):
 
 
 def test_score_function_one_body_terms_getter():
-    from tmol.score.backbone_torsion.bb_torsion_energy_term import (
-        BackboneTorsionEnergyTerm,
-    )
-    from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
-    from tmol.score.disulfide.disulfide_energy_term import DisulfideEnergyTerm
     from tmol.score.dunbrack.dunbrack_energy_term import DunbrackEnergyTerm
-    from tmol.score.elec.elec_energy_term import ElecEnergyTerm
-    from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
-    from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
-    from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
     from tmol.score.ref.ref_energy_term import RefEnergyTerm
 
     device = torch.device("cpu")
@@ -192,12 +183,10 @@ def test_score_function_two_body_terms_getter():
     )
     from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
     from tmol.score.disulfide.disulfide_energy_term import DisulfideEnergyTerm
-    from tmol.score.dunbrack.dunbrack_energy_term import DunbrackEnergyTerm
     from tmol.score.elec.elec_energy_term import ElecEnergyTerm
     from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
     from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
     from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
-    from tmol.score.ref.ref_energy_term import RefEnergyTerm
 
     device = torch.device("cpu")
     sfxn = _non_memoized_beta2016(device)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -1,6 +1,7 @@
 import torch
 import numpy
 
+from tmol.score import _non_memoized_beta2016
 from tmol.score.score_function import ScoreFunction
 from tmol.score.score_types import ScoreType
 from tmol.pose.pose_stack_builder import PoseStackBuilder
@@ -108,3 +109,156 @@ def test_virtual_residue_scoring(ubq_pdb, torch_device):
 
     torch.testing.assert_close(scores_wo_vrt, scores_w_vrt)
     torch.testing.assert_close(unweighted_scores_wo_vrt, unweighted_scores_w_vrt)
+
+
+def test_score_function_all_score_types(ubq_pdb):
+    device = torch.device("cpu")
+    ps = pose_stack_from_pdb(ubq_pdb, device)
+    sfxn = beta2016_score_function(device)
+
+    wpsm = sfxn.render_whole_pose_scoring_module(ps)
+    unweighted_scores = wpsm.unweighted_scores(ps.coords)
+    score_types = sfxn.all_score_types()
+    unweighted_score_map = {
+        st: unweighted_scores[i, :].detach().cpu().numpy()
+        for i, st in enumerate(score_types)
+    }
+
+    def n(x):
+        return numpy.array(x)
+
+    gold_score_map = {
+        ScoreType.cart_lengths: n([37.762318]),
+        ScoreType.cart_angles: n([183.56915]),
+        ScoreType.cart_torsions: n([50.584225]),
+        ScoreType.cart_impropers: n([9.430529]),
+        ScoreType.cart_hxltorsions: n([47.41971]),
+        ScoreType.disulfide: n([0.0]),
+        ScoreType.fa_ljatr: n([-417.9582]),
+        ScoreType.fa_ljrep: n([240.7147]),
+        ScoreType.fa_lk: n([298.27637]),
+        ScoreType.fa_elec: n([-136.454]),
+        ScoreType.hbond: n([-55.675613]),
+        ScoreType.lk_ball_iso: n([422.03955]),
+        ScoreType.lk_ball: n([172.19647]),
+        ScoreType.lk_bridge: n([1.5785888]),
+        ScoreType.lk_bridge_uncpl: n([10.9946]),
+        ScoreType.rama: n([-12.743372]),
+        ScoreType.omega: n([4.100171]),
+        ScoreType.ref: n([-41.275]),
+        ScoreType.dunbrack_rot: n([70.64968]),
+        ScoreType.dunbrack_rotdev: n([240.31009]),
+        ScoreType.dunbrack_semirot: n([99.660904]),
+    }
+    for st in score_types:
+        numpy.testing.assert_allclose(
+            unweighted_score_map[st], gold_score_map[st], rtol=1e-4, atol=1e-4
+        )
+
+
+def test_score_function_one_body_terms_getter():
+    from tmol.score.backbone_torsion.bb_torsion_energy_term import (
+        BackboneTorsionEnergyTerm,
+    )
+    from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
+    from tmol.score.disulfide.disulfide_energy_term import DisulfideEnergyTerm
+    from tmol.score.dunbrack.dunbrack_energy_term import DunbrackEnergyTerm
+    from tmol.score.elec.elec_energy_term import ElecEnergyTerm
+    from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
+    from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
+    from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
+    from tmol.score.ref.ref_energy_term import RefEnergyTerm
+
+    device = torch.device("cpu")
+    sfxn = _non_memoized_beta2016(device)
+    assert sfxn._one_body_terms_out_of_date
+
+    terms_1b = sfxn.one_body_terms()
+    assert not sfxn._one_body_terms_out_of_date
+
+    valid_one_body_terms = [DunbrackEnergyTerm, RefEnergyTerm]
+    for term in terms_1b:
+        found = False
+        for valid_option in valid_one_body_terms:
+            if isinstance(term, valid_option):
+                found = True
+                break
+        assert found
+
+
+def test_score_function_two_body_terms_getter():
+    from tmol.score.backbone_torsion.bb_torsion_energy_term import (
+        BackboneTorsionEnergyTerm,
+    )
+    from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
+    from tmol.score.disulfide.disulfide_energy_term import DisulfideEnergyTerm
+    from tmol.score.dunbrack.dunbrack_energy_term import DunbrackEnergyTerm
+    from tmol.score.elec.elec_energy_term import ElecEnergyTerm
+    from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
+    from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
+    from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
+    from tmol.score.ref.ref_energy_term import RefEnergyTerm
+
+    device = torch.device("cpu")
+    sfxn = _non_memoized_beta2016(device)
+    assert sfxn._two_body_terms_out_of_date
+
+    terms_2b = sfxn.two_body_terms()
+    assert not sfxn._two_body_terms_out_of_date
+
+    valid_two_body_terms = [
+        BackboneTorsionEnergyTerm,
+        CartBondedEnergyTerm,
+        DisulfideEnergyTerm,
+        ElecEnergyTerm,
+        HBondEnergyTerm,
+        LJLKEnergyTerm,
+        LKBallEnergyTerm,
+    ]
+    for term in terms_2b:
+        found = False
+        for valid_option in valid_two_body_terms:
+            if isinstance(term, valid_option):
+                found = True
+                break
+        assert found
+
+
+def test_score_function_all_terms_getter():
+    from tmol.score.backbone_torsion.bb_torsion_energy_term import (
+        BackboneTorsionEnergyTerm,
+    )
+    from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
+    from tmol.score.disulfide.disulfide_energy_term import DisulfideEnergyTerm
+    from tmol.score.dunbrack.dunbrack_energy_term import DunbrackEnergyTerm
+    from tmol.score.elec.elec_energy_term import ElecEnergyTerm
+    from tmol.score.hbond.hbond_energy_term import HBondEnergyTerm
+    from tmol.score.ljlk.ljlk_energy_term import LJLKEnergyTerm
+    from tmol.score.lk_ball.lk_ball_energy_term import LKBallEnergyTerm
+    from tmol.score.ref.ref_energy_term import RefEnergyTerm
+
+    device = torch.device("cpu")
+    sfxn = _non_memoized_beta2016(device)
+    assert sfxn._all_terms_out_of_date
+
+    all_terms = sfxn.all_terms()
+    assert not sfxn._all_terms_out_of_date
+
+    valid_terms = [
+        DunbrackEnergyTerm,
+        RefEnergyTerm,
+        BackboneTorsionEnergyTerm,
+        CartBondedEnergyTerm,
+        DisulfideEnergyTerm,
+        ElecEnergyTerm,
+        HBondEnergyTerm,
+        LJLKEnergyTerm,
+        LKBallEnergyTerm,
+    ]
+    for term in all_terms:
+        found = False
+        for valid_option in valid_terms:
+            if isinstance(term, valid_option):
+                found = True
+                break
+        assert found

--- a/tmol/utility/nvtx.hh
+++ b/tmol/utility/nvtx.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(WITH_CUDA) && defined(WITH_NVTX)
+#if defined(WITH_CUDA) && defined(WITH_NVTX) && defined(__NVCC__)
 
 #include <nvtx3/nvToolsExt.h>
 


### PR DESCRIPTION
Fix a handful of warnings and a compilation issue.

Also add a much-needed function to `ScoreFunction` that lists the currently active set of `ScoreType`s that the `ScoreFunction` is using so that we can iterate across the tensor returned by `WholePoseScoringModule::unweighted_scores` and report which term has which weight.