### PR TITLE
First attempt at resetting R3 count-pair style i to i+2 connectivity

### DIFF
--- a/tmol/io/pose_stack_construction.py
+++ b/tmol/io/pose_stack_construction.py
@@ -20,7 +20,8 @@ def pose_stack_from_canonical_form(
     res_not_connected: Optional[Tensor[torch.bool][:, :, 2]] = None,
     return_chain_ind: bool = False,
     return_atom_mapping: bool = False,
-):
+    hack_rosetta3_i_ip2_count_pair: bool = False,
+) -> PoseStack:
     """Create a PoseStack, resolving which block type is requested by the
     presence and absence of the provided atoms for each residue type.
     There are five required arguments and several optional arguments.
@@ -194,6 +195,7 @@ def pose_stack_from_canonical_form(
         res_type_variants,
         found_disulfides,
         res_not_connected,
+        hack_rosetta3_i_ip2_count_pair,
     )
 
     # 6


### PR DESCRIPTION
A little hacked together piece of code to set the i-to-i+2 chemical bond separation count to have C of residue i and N of residue i+2 be treated at full strength to match Rosetta3's count pair "logic"