### PR TITLE
unpin torch from 2.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-torch == 2.6
+torch >= 2.5.1
 numpy # NOTE we get numpy from conda to ensure compat with numba
 astor
 attrs != 22.2.0 # problem unpickling tmol/tests/data/rosetta_baseline/1ubq.scores.pickle in 22.2.0 (see https://github.com/python-attrs/attrs/pull/1085)


### PR DESCRIPTION
I tested torch 2.5.1 with tmol and it works fine. Let's loosen the requirements.in a bit.