### PR TITLE
Key on hash of cart-bonded params in PBT caching

### DIFF
--- a/tmol/database/scoring/cartbonded.py
+++ b/tmol/database/scoring/cartbonded.py
@@ -1,6 +1,8 @@
 import attr
 import cattr
 import yaml
+import json
+import hashlib
 
 from typing import Tuple
 
@@ -61,9 +63,18 @@ class CartRes:
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class CartBondedDatabase:
     residue_params: dict[str, CartRes]
+    hash: str
 
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
-        return cattr.structure(raw, cls)
+            resparam_dict = yaml.safe_load(infile)
+            resparam_dict["hash"] = cls.generate_hash(resparam_dict)
+
+        return cattr.structure(resparam_dict, cls)
+
+    @classmethod
+    def generate_hash(cls, resparam_dict):
+        serialized = json.dumps(resparam_dict, sort_keys=True)
+        hash_value = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+        return hash_value

--- a/tmol/database/scoring/cartbonded.py
+++ b/tmol/database/scoring/cartbonded.py
@@ -69,12 +69,18 @@ class CartBondedDatabase:
     def from_file(cls, path):
         with open(path, "r") as infile:
             resparam_dict = yaml.safe_load(infile)
-            resparam_dict["hash"] = cls.generate_hash(resparam_dict)
+            resparam_dict["hash"] = cls._generate_hash(resparam_dict)
 
         return cattr.structure(resparam_dict, cls)
 
     @classmethod
-    def generate_hash(cls, resparam_dict):
+    def from_cartres_dict(cls, cartres_dict: dict[str, CartRes]):
+        resparam_dict = cattr.unstructure(cartres_dict)
+        hash = cls._generate_hash(resparam_dict)
+        return cls(residue_params=cartres_dict, hash=hash)
+
+    @classmethod
+    def _generate_hash(cls, resparam_dict):
         serialized = json.dumps(resparam_dict, sort_keys=True)
         hash_value = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
         return hash_value

--- a/tmol/score/cartbonded/cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/cartbonded_energy_term.py
@@ -1,5 +1,6 @@
 import torch
 import numpy
+import attrs
 
 from itertools import permutations
 
@@ -13,6 +14,26 @@ from tmol.pose.pose_stack import PoseStack
 from tmol.score.common.hash_util import make_hashtable_keys_values, add_to_hashtable
 
 debug = False
+
+
+@attrs.define(auto_attribs=True, slots=True, frozen=True)
+class CartBondedBlockAnnotations:
+    cartbonded_subgraphs: torch.Tensor
+    cartbonded_subgraph_type_counts: torch.Tensor
+    cartbonded_subgraph_type_offsets: torch.Tensor
+    cartbonded_params: dict
+
+
+@attrs.define(auto_attribs=True, slots=True, frozen=True)
+class CartBondedPackedBlockTypesAnnotations:
+    cartbonded_subgraphs: torch.Tensor
+    cartbonded_subgraph_offsets: torch.Tensor
+    cartbonded_subgraph_type_counts: torch.Tensor
+    cartbonded_subgraph_type_offsets: torch.Tensor
+    cartbonded_max_subgraphs_per_block: int
+    cartbonded_atom_unique_id_index: dict
+    cartbonded_params_hash_keys: torch.Tensor
+    cartbonded_params_hash_values: torch.Tensor
 
 
 class CartBondedEnergyTerm(AtomTypeDependentTerm):
@@ -33,6 +54,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         self.improper_roots = find_improper_roots(param_db.scoring.cartbonded)
 
         self.cart_database = param_db.scoring.cartbonded
+        self.hash = self.cart_database.hash
         self.device = device
 
     @classmethod
@@ -168,11 +190,17 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
 
     def setup_block_type(self, block_type: RefinedResidueType):
         super(CartBondedEnergyTerm, self).setup_block_type(block_type)
-        if hasattr(block_type, "cartbonded_subgraphs"):
-            assert hasattr(block_type, "cartbonded_subgraph_type_counts")
-            assert hasattr(block_type, "cartbonded_subgraph_type_offsets")
-            assert hasattr(block_type, "cartbonded_params")
+        if (
+            hasattr(block_type, "cartbonded_annotations")
+            and self.hash in block_type.cartbonded_annotations
+        ):
             return
+
+        # if hasattr(block_type, "cartbonded_subgraphs"):
+        #     assert hasattr(block_type, "cartbonded_subgraph_type_counts")
+        #     assert hasattr(block_type, "cartbonded_subgraph_type_offsets")
+        #     assert hasattr(block_type, "cartbonded_params")
+        #     return
 
         # Get the subgraphs for this block type
         lengths, angles, torsions, improper = self.find_subgraphs(
@@ -195,28 +223,36 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
             block_type.base_name if block_type.base_name != "CYD" else "CYS"
         )
         cartbonded_params = self.get_params_for_res(temp_hack_base_name)
-        setattr(block_type, "cartbonded_subgraphs", cart_subgraphs)
-        setattr(
-            block_type, "cartbonded_subgraph_type_counts", cart_subgraph_type_counts
+        cb_block_ann = CartBondedBlockAnnotations(
+            cartbonded_subgraphs=cart_subgraphs,
+            cartbonded_subgraph_type_counts=cart_subgraph_type_counts,
+            cartbonded_subgraph_type_offsets=cart_subgraph_type_offsets,
+            cartbonded_params=cartbonded_params,
         )
-        setattr(
-            block_type, "cartbonded_subgraph_type_offsets", cart_subgraph_type_offsets
-        )
-        setattr(block_type, "cartbonded_params", cartbonded_params)
+        if not hasattr(block_type, "cartbonded_annotations"):
+            setattr(block_type, "cartbonded_annotations", {})
+        block_type.cartbonded_annotations[self.hash] = cb_block_ann
 
     def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
         super(CartBondedEnergyTerm, self).setup_packed_block_types(packed_block_types)
-        if hasattr(packed_block_types, "cartbonded_subgraphs"):
-            assert hasattr(packed_block_types, "cartbonded_subgraph_offsets")
-            assert hasattr(packed_block_types, "cartbonded_max_subgraphs_per_block")
-            assert hasattr(packed_block_types, "cartbonded_atom_unique_id_index")
-            assert hasattr(packed_block_types, "cartbonded_params_hash_keys")
-            assert hasattr(packed_block_types, "cartbonded_params_hash_values")
+
+        if (
+            hasattr(packed_block_types, "cartbonded_annotations")
+            and self.hash in packed_block_types.cartbonded_annotations
+        ):
             return
+
+        # if hasattr(packed_block_types, "cartbonded_subgraphs"):
+        #     assert hasattr(packed_block_types, "cartbonded_subgraph_offsets")
+        #     assert hasattr(packed_block_types, "cartbonded_max_subgraphs_per_block")
+        #     assert hasattr(packed_block_types, "cartbonded_atom_unique_id_index")
+        #     assert hasattr(packed_block_types, "cartbonded_params_hash_keys")
+        #     assert hasattr(packed_block_types, "cartbonded_params_hash_values")
+        #     return
 
         # Aggregate the subgraphs and collect metadata
         total_subgraphs = sum(
-            bt.cartbonded_subgraphs.shape[0]
+            bt.cartbonded_annotations[self.hash].cartbonded_subgraphs.shape[0]
             for bt in packed_block_types.active_block_types
         )
         subgraphs = numpy.full((total_subgraphs, 4), -1, dtype=numpy.int32)
@@ -227,11 +263,11 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         max_subgraphs_per_block = 0
         for block_type in packed_block_types.active_block_types:
             subgraph_offsets.append(offset)
-
-            n_subgraphs = block_type.cartbonded_subgraphs.shape[0]
-            subgraph_type_counts.append(block_type.cartbonded_subgraph_type_counts)
-            subgraph_type_offsets.append(block_type.cartbonded_subgraph_type_offsets)
-            subgraphs[offset : offset + n_subgraphs] = block_type.cartbonded_subgraphs
+            bt_params = block_type.cartbonded_annotations[self.hash]
+            n_subgraphs = bt_params.cartbonded_subgraphs.shape[0]
+            subgraph_type_counts.append(bt_params.cartbonded_subgraph_type_counts)
+            subgraph_type_offsets.append(bt_params.cartbonded_subgraph_type_offsets)
+            subgraphs[offset : offset + n_subgraphs] = bt_params.cartbonded_subgraphs
             offset += n_subgraphs
 
             max_subgraphs_per_block = max(
@@ -247,21 +283,6 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         )
         subgraph_type_offsets = torch.from_numpy(subgraph_type_offsets).to(
             device=self.device
-        )
-        setattr(packed_block_types, "cartbonded_subgraphs", subgraphs)
-        setattr(packed_block_types, "cartbonded_subgraph_offsets", subgraph_offsets)
-        setattr(
-            packed_block_types, "cartbonded_subgraph_type_counts", subgraph_type_counts
-        )
-        setattr(
-            packed_block_types,
-            "cartbonded_subgraph_type_offsets",
-            subgraph_type_offsets,
-        )
-        setattr(
-            packed_block_types,
-            "cartbonded_max_subgraphs_per_block",
-            max_subgraphs_per_block,
         )
 
         # Aggregate the params
@@ -280,14 +301,19 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
                     cbet_atom_unique_id_index[at] = len(cbet_atom_unique_id_index)
 
         for bt in packed_block_types.active_block_types:
-            for key in bt.cartbonded_params:
+            bt_params = bt.cartbonded_annotations[self.hash]
+
+            for key in bt_params.cartbonded_params:
                 for at in key:
                     if at not in cbet_atom_unique_id_index:
                         cbet_atom_unique_id_index[at] = len(cbet_atom_unique_id_index)
 
         # Calculate the total number of params
         n_total_params = sum(
-            [len(bt.cartbonded_params) for bt in packed_block_types.active_block_types]
+            [
+                len(bt.cartbonded_annotations[self.hash].cartbonded_params)
+                for bt in packed_block_types.active_block_types
+            ]
         ) + len(wildcard_params)
 
         # Construct the params hash with the given scaling factor
@@ -296,7 +322,9 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         # Fill the hash table
         cur_val = 0
         for bt in packed_block_types.active_block_types:
-            for key_w_str, value in bt.cartbonded_params.items():
+
+            bt_params = bt.cartbonded_annotations[self.hash]
+            for key_w_str, value in bt_params.cartbonded_params.items():
                 key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)
                 add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
                 cur_val += 1
@@ -308,13 +336,20 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
 
         hash_keys_tensor = torch.from_numpy(hash_keys).to(device=self.device)
         hash_values_tensor = torch.from_numpy(hash_values).to(device=self.device)
-        setattr(
-            packed_block_types,
-            "cartbonded_atom_unique_id_index",
-            cbet_atom_unique_id_index,
+
+        cb_pbt_ann = CartBondedPackedBlockTypesAnnotations(
+            cartbonded_subgraphs=subgraphs,
+            cartbonded_subgraph_offsets=subgraph_offsets,
+            cartbonded_subgraph_type_counts=subgraph_type_counts,
+            cartbonded_subgraph_type_offsets=subgraph_type_offsets,
+            cartbonded_max_subgraphs_per_block=max_subgraphs_per_block,
+            cartbonded_atom_unique_id_index=cbet_atom_unique_id_index,
+            cartbonded_params_hash_keys=hash_keys_tensor,
+            cartbonded_params_hash_values=hash_values_tensor,
         )
-        setattr(packed_block_types, "cartbonded_params_hash_keys", hash_keys_tensor)
-        setattr(packed_block_types, "cartbonded_params_hash_values", hash_values_tensor)
+        if not hasattr(packed_block_types, "cartbonded_annotations"):
+            setattr(packed_block_types, "cartbonded_annotations", {})
+        packed_block_types.cartbonded_annotations[self.hash] = cb_pbt_ann
 
     def setup_poses(self, poses: PoseStack):
         super(CartBondedEnergyTerm, self).setup_poses(poses)
@@ -335,15 +370,17 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         def _t(ts):
             return tuple(map(lambda t: t.to(torch.float), ts))
 
+        print("Cart bonded get_score_term_attributes:", self.hash)
+        pbt_cb_ann = pbt.cartbonded_annotations[self.hash]
         return [
             pose_stack.inter_residue_connections,
             pbt.atom_paths_from_conn,
             pbt.atom_unique_ids,
             pbt.atom_wildcard_ids,
-            pbt.cartbonded_params_hash_keys,
-            pbt.cartbonded_params_hash_values,
-            pbt.cartbonded_subgraphs,
-            pbt.cartbonded_subgraph_offsets,
-            pbt.cartbonded_subgraph_type_counts,
-            pbt.cartbonded_subgraph_type_offsets,
+            pbt_cb_ann.cartbonded_params_hash_keys,
+            pbt_cb_ann.cartbonded_params_hash_values,
+            pbt_cb_ann.cartbonded_subgraphs,
+            pbt_cb_ann.cartbonded_subgraph_offsets,
+            pbt_cb_ann.cartbonded_subgraph_type_counts,
+            pbt_cb_ann.cartbonded_subgraph_type_offsets,
         ]

--- a/tmol/score/cartbonded/cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/cartbonded_energy_term.py
@@ -370,7 +370,6 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         def _t(ts):
             return tuple(map(lambda t: t.to(torch.float), ts))
 
-        print("Cart bonded get_score_term_attributes:", self.hash)
         pbt_cb_ann = pbt.cartbonded_annotations[self.hash]
         return [
             pose_stack.inter_residue_connections,

--- a/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
+++ b/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
@@ -1,5 +1,7 @@
 import torch
+import attrs
 
+from tmol.database.scoring.cartbonded import CartBondedDatabase
 from tmol.score.cartbonded.cartbonded_energy_term import CartBondedEnergyTerm
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.tests.score.common.test_energy_term import EnergyTermTestBase
@@ -79,6 +81,81 @@ def test_annotate_restypes(
         cartbonded_subgraphs
         is pbt.cartbonded_annotations[cartbonded_energy.hash].cartbonded_subgraphs
     )
+
+
+def test_hack_cartbonded_params(
+    fresh_default_packed_block_types, default_database, torch_device: torch.device
+):
+    # let's define a new set of cartbonded parameters where we have changed the
+    # ideal CA-CB bond length for alanine
+    cartb_db = default_database.scoring.cartbonded
+    ala_res_params = cartb_db.residue_params["ALA"]
+    ind_of_cacb_length_param = next(
+        i
+        for i, param in enumerate(ala_res_params.length_parameters)
+        if param.atm1 == "CA" and param.atm2 == "CB"
+    )
+    new_ca_cb_length_params = (
+        ala_res_params.length_parameters[:ind_of_cacb_length_param]
+        + (
+            attrs.evolve(
+                ala_res_params.length_parameters[ind_of_cacb_length_param], x0=2.0
+            ),
+        )
+        + ala_res_params.length_parameters[ind_of_cacb_length_param + 1 :]
+    )
+    new_ala_res_params = attrs.evolve(
+        ala_res_params, length_parameters=new_ca_cb_length_params
+    )
+    new_residue_params = dict(cartb_db.residue_params)
+    new_residue_params["ALA"] = new_ala_res_params
+
+    new_cartb_db = CartBondedDatabase.from_cartres_dict(new_residue_params)
+    new_scoring_db = attrs.evolve(default_database.scoring, cartbonded=new_cartb_db)
+    new_database = attrs.evolve(default_database, scoring=new_scoring_db)
+
+    pbt = fresh_default_packed_block_types
+
+    dflt_cartbonded_energy = CartBondedEnergyTerm(
+        param_db=default_database, device=torch_device
+    )
+    new_cartbonded_energy = CartBondedEnergyTerm(
+        param_db=new_database, device=torch_device
+    )
+    assert dflt_cartbonded_energy.hash != new_cartbonded_energy.hash
+
+    for bt in pbt.active_block_types:
+        dflt_cartbonded_energy.setup_block_type(bt)
+        new_cartbonded_energy.setup_block_type(bt)
+    dflt_cartbonded_energy.setup_packed_block_types(pbt)
+    new_cartbonded_energy.setup_packed_block_types(pbt)
+
+    assert dflt_cartbonded_energy.hash in pbt.cartbonded_annotations
+    assert new_cartbonded_energy.hash in pbt.cartbonded_annotations
+
+    ala_bt = next(bt for bt in pbt.active_block_types if bt.name == "ALA")
+    dflt_ala_cartb_params = ala_bt.cartbonded_annotations[dflt_cartbonded_energy.hash]
+    new_ala_cartb_params = ala_bt.cartbonded_annotations[new_cartbonded_energy.hash]
+
+    dflt_ala_params = dflt_ala_cartb_params.cartbonded_params
+    new_ala_params = new_ala_cartb_params.cartbonded_params
+
+    for key in dflt_ala_params:
+        dflt_param = dflt_ala_params[key]
+        new_param = new_ala_params[key]
+        if key == ("UNIQUE_ID:ALA:CA", "UNIQUE_ID:ALA:CB"):
+            assert len(dflt_param) == len(new_param)
+            for i, (dflt_subparam, new_subparam) in enumerate(
+                zip(dflt_param, new_param)
+            ):
+                if i == 1:
+                    assert new_subparam == 2.0
+                    assert dflt_subparam != new_subparam
+                else:
+                    assert dflt_subparam == new_subparam
+
+        else:
+            assert dflt_param == new_param
 
 
 class TestCartBondedEnergyTerm(EnergyTermTestBase):

--- a/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
+++ b/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
@@ -46,8 +46,8 @@ def test_annotate_twice(fresh_default_restype_set, default_database, torch_devic
         cartbonded_energy_device.setup_block_type(bt)
     cartbonded_energy_device.setup_packed_block_types(pbt_device)
 
-    assert hasattr(pbt_cpu, "cartbonded_params_hash_keys")
-    assert hasattr(pbt_device, "cartbonded_params_hash_keys")
+    assert hasattr(pbt_cpu, "cartbonded_annotations")
+    assert hasattr(pbt_device, "cartbonded_annotations")
 
 
 def test_annotate_restypes(
@@ -64,20 +64,21 @@ def test_annotate_restypes(
         cartbonded_energy.setup_block_type(bt)
     cartbonded_energy.setup_packed_block_types(pbt)
 
-    assert hasattr(pbt, "cartbonded_subgraphs")
-    assert hasattr(pbt, "cartbonded_subgraph_offsets")
-    assert hasattr(pbt, "cartbonded_max_subgraphs_per_block")
-    assert hasattr(pbt, "cartbonded_params_hash_keys")
-    assert hasattr(pbt, "cartbonded_params_hash_values")
+    assert hasattr(pbt, "cartbonded_annotations")
+    assert cartbonded_energy.hash in pbt.cartbonded_annotations
+    cb_pbt_ann = pbt.cartbonded_annotations[cartbonded_energy.hash]
 
-    assert pbt.cartbonded_subgraphs.device == torch_device
-    assert pbt.cartbonded_subgraph_offsets.device == torch_device
-    assert pbt.cartbonded_params_hash_keys.device == torch_device
-    assert pbt.cartbonded_params_hash_values.device == torch_device
+    assert cb_pbt_ann.cartbonded_subgraphs.device == torch_device
+    assert cb_pbt_ann.cartbonded_subgraph_offsets.device == torch_device
+    assert cb_pbt_ann.cartbonded_params_hash_keys.device == torch_device
+    assert cb_pbt_ann.cartbonded_params_hash_values.device == torch_device
 
-    cartbonded_subgraphs = pbt.cartbonded_subgraphs
+    cartbonded_subgraphs = cb_pbt_ann.cartbonded_subgraphs
     cartbonded_energy.setup_packed_block_types(pbt)
-    assert cartbonded_subgraphs is pbt.cartbonded_subgraphs
+    assert (
+        cartbonded_subgraphs
+        is pbt.cartbonded_annotations[cartbonded_energy.hash].cartbonded_subgraphs
+    )
 
 
 class TestCartBondedEnergyTerm(EnergyTermTestBase):


### PR DESCRIPTION
Add sha1 hash to cartbonded parameter set so that different cartbonded parameter sets can be cached in the block types and PBTs.