### PR TITLE
Add a reusable context to pose_stack_from_biotite

### DIFF
--- a/tmol/chemical/restypes.py
+++ b/tmol/chemical/restypes.py
@@ -1,3 +1,4 @@
+import copy
 from enum import IntEnum
 
 from frozendict import frozendict
@@ -613,13 +614,12 @@ class ResidueTypeSet:
 
     @classmethod
     def _default_refined_cache(cls) -> Mapping[int, RefinedResidueType]:
-        """``id(raw residue) -> RefinedResidueType`` for the default DB's residues.
+        """``id(raw residue) -> RefinedResidueType`` prototype for the default DB.
 
         Refining a residue is expensive, and ligand-extended DBs reuse the
-        default residue objects by reference, so caching lets them skip
-        rebuilding the standard residues. Only the default DB's (immortal,
-        singleton) objects are cached, so ids are stable and differently-defined
-        ligands sharing a name are always rebuilt.
+        default residue objects, so caching them here.
+
+        These are prototypes only: callers get a shallow copy.
         """
         if cls.__refined_cache is None:
             default_residues = ParameterDatabase.get_default().chemical.residues
@@ -628,9 +628,11 @@ class ResidueTypeSet:
 
     @classmethod
     def from_database(cls, chemical_db: PatchedChemicalDatabase):
+        # Load and copy the default cache
+        #   -> copy so later mutations do not modify cache
         cache = cls._default_refined_cache()
         residue_types = [
-            cache[id(r)] if id(r) in cache else cls._refine(r)
+            copy.copy(cache[id(r)]) if id(r) in cache else cls._refine(r)
             for r in chemical_db.residues
         ]
         restype_map = groupby(lambda restype: restype.name3, residue_types)

--- a/tmol/chemical/restypes.py
+++ b/tmol/chemical/restypes.py
@@ -598,6 +598,7 @@ class RefinedResidueType(RawResidueType):
 @attr.s(auto_attribs=True)
 class ResidueTypeSet:
     __default = None
+    __refined_cache = None
 
     @classmethod
     def get_default(cls) -> "ResidueTypeSet":
@@ -607,9 +608,29 @@ class ResidueTypeSet:
         return cls.__default
 
     @classmethod
+    def _refine(cls, r: RawResidueType) -> RefinedResidueType:
+        return cattr.structure(cattr.unstructure(r), RefinedResidueType)
+
+    @classmethod
+    def _default_refined_cache(cls) -> Mapping[int, RefinedResidueType]:
+        """``id(raw residue) -> RefinedResidueType`` for the default DB's residues.
+
+        Refining a residue is expensive, and ligand-extended DBs reuse the
+        default residue objects by reference, so caching lets them skip
+        rebuilding the standard residues. Only the default DB's (immortal,
+        singleton) objects are cached, so ids are stable and differently-defined
+        ligands sharing a name are always rebuilt.
+        """
+        if cls.__refined_cache is None:
+            default_residues = ParameterDatabase.get_default().chemical.residues
+            cls.__refined_cache = {id(r): cls._refine(r) for r in default_residues}
+        return cls.__refined_cache
+
+    @classmethod
     def from_database(cls, chemical_db: PatchedChemicalDatabase):
+        cache = cls._default_refined_cache()
         residue_types = [
-            cattr.structure(cattr.unstructure(r), RefinedResidueType)
+            cache[id(r)] if id(r) in cache else cls._refine(r)
             for r in chemical_db.residues
         ]
         restype_map = groupby(lambda restype: restype.name3, residue_types)

--- a/tmol/io/pose_stack_from_biotite.py
+++ b/tmol/io/pose_stack_from_biotite.py
@@ -24,9 +24,15 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class BiotitePoseBuildContext:
-    """Immutable context for canonical-form-based pose construction."""
+    """Immutable, structure-independent construction context.
 
-    canonical_form: CanonicalForm
+    Holds only the pieces that depend on the parameter database / ligand set
+    (not on any particular input structure), so it can be built once and reused
+    across many structures that share the same ligand(s). The per-structure
+    canonical form is computed separately by ``pose_stack_from_biotite`` for
+    each input structure.
+    """
+
     canonical_ordering: CanonicalOrdering
     packed_block_types: PackedBlockTypes
     parameter_database: ParameterDatabase
@@ -38,7 +44,6 @@ def build_context_from_biotite(
     biotite_structure: biotite.structure.AtomArray | biotite.structure.AtomArrayStack,
     torch_device: torch.device,
     param_db: ParameterDatabase | None = None,
-    missing_density_distance_threshold: float = 2.4,
     prepare_ligands: bool = False,
     ligand_ph: float = 7.4,
     strict_atom_types: bool = False,
@@ -49,19 +54,22 @@ def build_context_from_biotite(
     # (OptHSampler). Opt in explicitly once that is fixed.
     sample_proton_chi: bool = False,
 ) -> BiotitePoseBuildContext:
-    """Build immutable construction context from a Biotite structure.
+    """Build the structure-independent construction context.
+
+    The returned context holds only database/ligand-derived pieces (canonical
+    ordering, residue-type set, packed block types, parameter database); it does
+    not depend on the input structure's coordinates and can be reused across
+    structures sharing the same ligand(s). ``biotite_structure`` is used only to
+    detect and prepare ligands (when ``prepare_ligands=True``).
 
     Args:
-        biotite_structure: Input AtomArray or AtomArrayStack.
+        biotite_structure: Input AtomArray or AtomArrayStack. Used only for
+            ligand detection/preparation when ``prepare_ligands=True``.
         torch_device: Target torch device.
         param_db: Optional parameter database. When provided, canonical ordering,
             residue types, and packed block types are built from this database.
             If prepare_ligands=True, it is extended with ligand data. If None,
             defaults are used.
-        missing_density_distance_threshold: Distance threshold in Angstroms.
-            Adjacent residues whose closest inter-atom distance exceeds this
-            value are treated as disconnected (upper/lower connects broken).
-            Set to 0 to disable. Default is 2.4.
         prepare_ligands: If True, detect and prepare non-standard residues
             (via ``tmol.ligand``, which uses RDKit for atom typing and
             residue-type construction).
@@ -83,8 +91,8 @@ def build_context_from_biotite(
             used when prepare_ligands=True).
 
     Returns:
-        BiotitePoseBuildContext containing canonical form, ordering,
-        packed block types, parameter database, and residue type set.
+        BiotitePoseBuildContext containing canonical ordering, packed block
+        types, parameter database, and residue type set.
     """
     if prepare_ligands:
         from tmol.ligand import prepare_ligands as _prepare_ligands
@@ -101,18 +109,11 @@ def build_context_from_biotite(
             sample_proton_chi=sample_proton_chi,
             strict_ligands=strict_ligands,
         )
-        cf = canonical_form_from_biotite(
-            biotite_structure,
-            torch_device,
-            co=co,
-            missing_density_distance_threshold=missing_density_distance_threshold,
-        )
         rts = ResidueTypeSet.from_database(param_db.chemical)
         pbt = PackedBlockTypes.from_restype_list(
-            rts.chem_db, rts, rts.residue_types, cf.coords.device
+            rts.chem_db, rts, rts.residue_types, torch_device
         )
         return BiotitePoseBuildContext(
-            canonical_form=cf,
             canonical_ordering=co,
             packed_block_types=pbt,
             parameter_database=param_db,
@@ -121,26 +122,13 @@ def build_context_from_biotite(
 
     if param_db is None:
         co = canonical_ordering_for_biotite()
-        cf = canonical_form_from_biotite(
-            biotite_structure,
-            torch_device,
-            co=co,
-            missing_density_distance_threshold=missing_density_distance_threshold,
-        )
-        pbt = packed_block_types_for_biotite(cf.coords.device)
+        pbt = packed_block_types_for_biotite(torch_device)
         db = _paramdb_for_biotite()
         rts = _restype_set_for_biotite()
     else:
         db = param_db
         co, rts, pbt = _derived_types_for_param_db(db, torch_device)
-        cf = canonical_form_from_biotite(
-            biotite_structure,
-            torch_device,
-            co=co,
-            missing_density_distance_threshold=missing_density_distance_threshold,
-        )
     return BiotitePoseBuildContext(
-        canonical_form=cf,
         canonical_ordering=co,
         packed_block_types=pbt,
         parameter_database=db,
@@ -164,16 +152,28 @@ def pose_stack_from_biotite(
     # produce NaN pose coordinates (OptHSampler). Opt in once that is fixed.
     sample_proton_chi: bool = False,
     return_context: bool = False,
+    context: BiotitePoseBuildContext | None = None,
     **kwargs: object,
 ) -> PoseStack | tuple[PoseStack, dict] | tuple[PoseStack, BiotitePoseBuildContext]:
     """Build a PoseStack from the output generated by Biotite.
+
+    To score many structures that share the same ligand(s) efficiently, build
+    the (expensive, structure-independent) context once and reuse it::
+
+        context = build_context_from_biotite(struct0, dev, prepare_ligands=True)
+        for struct in structures:
+            pose_stack = pose_stack_from_biotite(struct, dev, context=context)
+
+    Reusing a context skips rebuilding the parameter database, canonical
+    ordering, residue-type set, and packed block types; only the per-structure
+    canonical form is recomputed (see the ``context`` arg).
 
     Args:
         biotite_structure: A Biotite AtomArray or AtomArrayStack.
         torch_device: Target PyTorch device.
         param_db: Optional ParameterDatabase. When provided, conversion and pose
             construction use this database. If prepare_ligands=True, it is
-            extended with ligand data.
+            extended with ligand data. Mutually exclusive with ``context``.
         missing_density_distance_threshold: Distance threshold in Angstroms.
             Adjacent residues whose closest inter-atom distance exceeds this
             value are treated as disconnected (upper/lower connects broken).
@@ -212,23 +212,49 @@ def pose_stack_from_biotite(
         create_dunbrack_sampler_from_database,
     )
 
-    context = build_context_from_biotite(
+    if context is not None:
+        if param_db is not None:
+            raise ValueError(
+                "Pass either context= or param_db=, not both; the context "
+                "already carries its parameter database."
+            )
+        if prepare_ligands:
+            raise ValueError(
+                "context= already contains prepared ligands; do not also pass "
+                "prepare_ligands=True."
+            )
+        if context.packed_block_types.device.type != torch_device.type:
+            raise ValueError(
+                "context was built for device "
+                f"'{context.packed_block_types.device}' but torch_device is "
+                f"'{torch_device}'; they must match."
+            )
+    else:
+        context = build_context_from_biotite(
+            biotite_structure,
+            torch_device,
+            param_db=param_db,
+            prepare_ligands=prepare_ligands,
+            ligand_ph=ligand_ph,
+            strict_atom_types=strict_atom_types,
+            strict_ligands=strict_ligands,
+            ligand_params_files=ligand_params_files,
+            sample_proton_chi=sample_proton_chi,
+        )
+
+    # The canonical form is per-structure, so it is always computed here for the
+    # given structure (never carried in the reusable context).
+    cf = canonical_form_from_biotite(
         biotite_structure,
         torch_device,
-        param_db=param_db,
+        co=context.canonical_ordering,
         missing_density_distance_threshold=missing_density_distance_threshold,
-        prepare_ligands=prepare_ligands,
-        ligand_ph=ligand_ph,
-        strict_atom_types=strict_atom_types,
-        strict_ligands=strict_ligands,
-        ligand_params_files=ligand_params_files,
-        sample_proton_chi=sample_proton_chi,
     )
 
     result = pose_stack_from_canonical_form(
         context.canonical_ordering,
         context.packed_block_types,
-        *context.canonical_form,
+        *cf,
         return_block_has_missing_atoms=True,
         **kwargs,
     )

--- a/tmol/tests/chemical/test_residue.py
+++ b/tmol/tests/chemical/test_residue.py
@@ -1,3 +1,4 @@
+import attr
 import cattr
 import numpy
 
@@ -6,6 +7,7 @@ from tmol.chemical.restypes import (
     RefinedResidueType,
     ResidueTypeSet,
 )
+from tmol.database.chemical import RawResidueType
 
 
 def test_refined_residue_construction_smoke(default_database):
@@ -93,6 +95,40 @@ def test_residue_type_set_get_default():
     restype_set1 = ResidueTypeSet.get_default()
     restype_set2 = ResidueTypeSet.get_default()
     assert restype_set1 is restype_set2
+
+
+def test_from_database_reuses_default_refined_objects(default_database):
+    """Standard residues reuse the cached RefinedResidueType objects."""
+    default_ids = {id(rt) for rt in ResidueTypeSet.get_default().residue_types}
+
+    s = ResidueTypeSet.from_database(default_database.chemical)
+    # every standard residue is the already-built (cached) refined object
+    for rt in s.residue_types:
+        assert id(rt) in default_ids
+
+    # a second build reuses the same objects rather than rebuilding them
+    s2 = ResidueTypeSet.from_database(default_database.chemical)
+    assert all(a is b for a, b in zip(s.residue_types, s2.residue_types))
+
+
+def test_from_database_builds_non_default_residue_fresh(default_database):
+    """A residue not among the default (immortal) objects is built fresh."""
+    chem = default_database.chemical
+    # a distinct copy of an existing residue: identical content, new object id,
+    # standing in for an injected ligand (which is likewise a new RawResidueType).
+    original = chem.residues[0]
+    copy = cattr.structure(cattr.unstructure(original), RawResidueType)
+    assert copy is not original
+    extended = attr.evolve(chem, residues=(*chem.residues, copy))
+
+    default_ids = {id(rt) for rt in ResidueTypeSet.get_default().residue_types}
+    s = ResidueTypeSet.from_database(extended)
+
+    # standard residues still reuse the cached objects ...
+    for rt in s.residue_types[: len(chem.residues)]:
+        assert id(rt) in default_ids
+    # ... and the appended non-default residue is a freshly built object
+    assert id(s.residue_types[-1]) not in default_ids
 
 
 def test_build_ideal_coords_smoke(default_database):

--- a/tmol/tests/chemical/test_residue.py
+++ b/tmol/tests/chemical/test_residue.py
@@ -97,38 +97,38 @@ def test_residue_type_set_get_default():
     assert restype_set1 is restype_set2
 
 
-def test_from_database_reuses_default_refined_objects(default_database):
-    """Standard residues reuse the cached RefinedResidueType objects."""
-    default_ids = {id(rt) for rt in ResidueTypeSet.get_default().residue_types}
+def test_from_database_caching(default_database):
+    """Standard residues are served from a cache, but as independent instances.
 
-    s = ResidueTypeSet.from_database(default_database.chemical)
-    # every standard residue is the already-built (cached) refined object
-    for rt in s.residue_types:
-        assert id(rt) in default_ids
-
-    # a second build reuses the same objects rather than rebuilding them
-    s2 = ResidueTypeSet.from_database(default_database.chemical)
-    assert all(a is b for a, b in zip(s.residue_types, s2.residue_types))
-
-
-def test_from_database_builds_non_default_residue_fresh(default_database):
-    """A residue not among the default (immortal) objects is built fresh."""
+    Residue types are annotated in place (samplers setattr mc_fingerprints /
+    rotamer_kinforest onto them), so each ResidueTypeSet must own distinct
+    objects or those annotations would leak between sets. The expensive eagerly
+    -built fields are still shared, so standard residues are never rebuilt.
+    """
     chem = default_database.chemical
-    # a distinct copy of an existing residue: identical content, new object id,
-    # standing in for an injected ligand (which is likewise a new RawResidueType).
-    original = chem.residues[0]
-    copy = cattr.structure(cattr.unstructure(original), RawResidueType)
-    assert copy is not original
-    extended = attr.evolve(chem, residues=(*chem.residues, copy))
+    s1 = ResidueTypeSet.from_database(chem)
+    s2 = ResidueTypeSet.from_database(chem)
 
-    default_ids = {id(rt) for rt in ResidueTypeSet.get_default().residue_types}
-    s = ResidueTypeSet.from_database(extended)
+    for a, b in zip(s1.residue_types, s2.residue_types):
+        # distinct instances, so in-place annotations cannot leak ...
+        assert a is not b
+        # ... but the expensive derived fields are reused, not recomputed
+        assert a.ideal_coords is b.ideal_coords
+        assert a.path_distance is b.path_distance
 
-    # standard residues still reuse the cached objects ...
-    for rt in s.residue_types[: len(chem.residues)]:
-        assert id(rt) in default_ids
-    # ... and the appended non-default residue is a freshly built object
-    assert id(s.residue_types[-1]) not in default_ids
+    s1.residue_types[0].some_test_annotation = object()
+    assert not hasattr(s2.residue_types[0], "some_test_annotation")
+    assert not hasattr(
+        ResidueTypeSet.from_database(chem).residue_types[0], "some_test_annotation"
+    )
+
+    # a residue that is not one of the default DB's objects (as an injected
+    # ligand would be) is built fresh rather than served from the cache
+    copied = cattr.structure(cattr.unstructure(chem.residues[0]), RawResidueType)
+    extended = attr.evolve(chem, residues=(*chem.residues, copied))
+    s3 = ResidueTypeSet.from_database(extended)
+    assert len(s3.residue_types) == len(chem.residues) + 1
+    assert s3.residue_types[-1].ideal_coords is not s1.residue_types[0].ideal_coords
 
 
 def test_build_ideal_coords_smoke(default_database):

--- a/tmol/tests/io/test_pose_stack_from_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite.py
@@ -49,7 +49,7 @@ def test_load_score_roundtrip_cif(pdb_code, tmp_path):
 
 def test_build_context_from_biotite_smoke(biotite_1ubq, torch_device):
     context = build_context_from_biotite(biotite_1ubq, torch_device=torch_device)
-    assert context.canonical_form.coords.device == torch_device
+    assert context.packed_block_types.device.type == torch_device.type
 
 
 def test_canonical_form_from_biotite_smoke(biotite_1r21, torch_device):

--- a/tmol/tests/io/test_pose_stack_from_biotite_context_reuse.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite_context_reuse.py
@@ -1,0 +1,126 @@
+"""Correctness of the ``context=`` reuse path in ``pose_stack_from_biotite``.
+
+Scoring many structures that share one ligand can build the expensive,
+structure-independent ``BiotitePoseBuildContext`` once and reuse it, recomputing
+only the per-structure canonical form. These tests check that reusing a context
+reproduces the ``prepare_ligands=True`` result and is stable across repeats.
+"""
+
+from pathlib import Path
+
+import biotite.structure as struc
+import biotite.structure.io
+import pytest
+import torch
+
+from tmol.database import ParameterDatabase
+from tmol.io.pose_stack_from_biotite import (
+    build_context_from_biotite,
+    pose_stack_from_biotite,
+)
+from tmol.ligand.registry import clear_cache
+
+PLI_DATA_DIR = Path(__file__).parent.parent / "data" / "protein_ligand_test"
+TARGET = "ace"
+N_REPEATS = 3
+
+
+@pytest.fixture(autouse=True)
+def _clear_ligand_cache() -> None:
+    clear_cache()
+
+
+def _load_complex_cif(target: str) -> struc.AtomArray:
+    cif_path = PLI_DATA_DIR / f"{target}.tmol.nomin.cif"
+    structure = biotite.structure.io.load_structure(
+        str(cif_path), model=1, include_bonds=True
+    )
+    if isinstance(structure, struc.AtomArrayStack):
+        structure = structure[0]
+    return structure
+
+
+def _params_files(target: str = TARGET) -> list[str]:
+    return [str(PLI_DATA_DIR / f"{target}.xtal-lig.mmff94.tmol")]
+
+
+def _build_context(structure, torch_device):
+    return build_context_from_biotite(
+        structure,
+        torch_device,
+        prepare_ligands=True,
+        ligand_params_files=_params_files(),
+        param_db=ParameterDatabase.get_default(),
+    )
+
+
+def _assert_pose_stacks_equal(a, b) -> None:
+    assert a.coords.shape == b.coords.shape
+    assert torch.equal(a.block_type_ind, b.block_type_ind)
+    assert torch.equal(a.real_atoms, b.real_atoms)
+    real = a.real_atoms
+    assert torch.allclose(a.coords[real], b.coords[real], atol=1e-5, equal_nan=True)
+
+
+def test_reused_context_matches_prepare_ligands(torch_device):
+    """A pose built from a reused context equals one built with prepare_ligands."""
+    structure = _load_complex_cif(TARGET)
+
+    reference, _ = pose_stack_from_biotite(
+        structure,
+        torch_device,
+        prepare_ligands=True,
+        ligand_params_files=_params_files(),
+        param_db=ParameterDatabase.get_default(),
+        no_optH=True,
+        return_context=True,
+    )
+
+    context = _build_context(structure, torch_device)
+    pose_stack = pose_stack_from_biotite(
+        structure, torch_device, context=context, no_optH=True
+    )
+    _assert_pose_stacks_equal(reference, pose_stack)
+
+
+def test_repeated_calls_with_same_context_stable(torch_device):
+    """Reusing one context across repeated calls is stable."""
+    structure = _load_complex_cif(TARGET)
+    context = _build_context(structure, torch_device)
+
+    first = pose_stack_from_biotite(
+        structure, torch_device, context=context, no_optH=True
+    )
+    for _ in range(N_REPEATS):
+        pose_stack = pose_stack_from_biotite(
+            structure, torch_device, context=context, no_optH=True
+        )
+        _assert_pose_stacks_equal(first, pose_stack)
+
+
+def test_context_and_param_db_mutually_exclusive(torch_device):
+    """Supplying both context= and param_db= is ambiguous and should raise."""
+    structure = _load_complex_cif(TARGET)
+    context = _build_context(structure, torch_device)
+
+    with pytest.raises(ValueError):
+        pose_stack_from_biotite(
+            structure,
+            torch_device,
+            context=context,
+            param_db=ParameterDatabase.get_default(),
+        )
+
+
+def test_context_and_prepare_ligands_mutually_exclusive(torch_device):
+    """Supplying both context= and prepare_ligands=True should raise."""
+    structure = _load_complex_cif(TARGET)
+    context = _build_context(structure, torch_device)
+
+    with pytest.raises(ValueError):
+        pose_stack_from_biotite(
+            structure,
+            torch_device,
+            context=context,
+            prepare_ligands=True,
+        )

--- a/tmol/tests/ligand/test_ligand_pipeline.py
+++ b/tmol/tests/ligand/test_ligand_pipeline.py
@@ -196,19 +196,19 @@ def test_ddg_from_cif_complex_with_onthefly_ligand_prep(
         return_context=True,
     )
 
-    # Locate the ligand (PSE) block(s) via the canonical form rather than
+    # Locate the ligand (PSE) block(s) from the pose's block types rather than
     # assuming a fixed position in the pose.
-    co = context.canonical_ordering
-    res_types = context.canonical_form.res_types[0]
+    pbt = pose_stack.packed_block_types
+    block_type_ind = pose_stack.block_type_ind[0]
     n_blocks = pose_stack.max_n_blocks
 
     ligand_mask = torch.zeros((1, n_blocks), dtype=torch.bool, device=torch_device)
     block_names = []
-    for block_idx in range(min(n_blocks, res_types.shape[0])):
-        res_type_id = int(res_types[block_idx])
-        if res_type_id < 0:
+    for block_idx in range(n_blocks):
+        bt_ind = int(block_type_ind[block_idx])
+        if bt_ind < 0:
             continue
-        name = co.restype_io_equiv_classes[res_type_id]
+        name = pbt.active_block_types[bt_ind].name3
         block_names.append(name)
         if name == "PSE":
             ligand_mask[0, block_idx] = True

--- a/tmol/tests/ligand/test_protein_ligand_ddg.py
+++ b/tmol/tests/ligand/test_protein_ligand_ddg.py
@@ -80,17 +80,17 @@ def _load_complex_cif(target: str):
     return structure
 
 
-def _ligand_block_mask(pose_stack, context, torch_device: torch.device) -> torch.Tensor:
-    co = context.canonical_ordering
-    res_types = context.canonical_form.res_types[0]
+def _ligand_block_mask(pose_stack, torch_device: torch.device) -> torch.Tensor:
+    pbt = pose_stack.packed_block_types
+    block_type_ind = pose_stack.block_type_ind[0]
     n_blocks = pose_stack.max_n_blocks
     ligand_mask = torch.zeros((1, n_blocks), dtype=torch.bool, device=torch_device)
     found = False
-    for block_idx in range(min(n_blocks, res_types.shape[0])):
-        res_type_id = int(res_types[block_idx])
-        if res_type_id < 0:
+    for block_idx in range(n_blocks):
+        bt_ind = int(block_type_ind[block_idx])
+        if bt_ind < 0:
             continue
-        if co.restype_io_equiv_classes[res_type_id] == LIGAND_RES_NAME:
+        if pbt.active_block_types[bt_ind].name3 == LIGAND_RES_NAME:
             ligand_mask[0, block_idx] = True
             found = True
     assert found, f"{LIGAND_RES_NAME} ligand block not found in pose"
@@ -117,7 +117,7 @@ def _weighted_ddg_from_fixtures(target: str, torch_device: torch.device) -> floa
         return_context=True,
     )
 
-    ligand_mask = _ligand_block_mask(pose_stack, context, torch_device)
+    ligand_mask = _ligand_block_mask(pose_stack, torch_device)
     sfxn = beta2016_score_function(torch_device, param_db=context.parameter_database)
     ddg = calculate_block_pair_ddg(
         pose_stack,


### PR DESCRIPTION
Allows faster rescoring of multiple poses with the same ligand:
```
        context = build_context_from_biotite(struct0, dev, prepare_ligands=True)
        for struct in structures:
            pose_stack = pose_stack_from_biotite(struct, dev, context=context)
```

Adds caching of the default databases' RTSs so adding a ligand to default DB does not trigger expensive recomputation.