### PR TITLE
Release TMol v0.1.47

### DIFF
--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -63,9 +63,9 @@ on:
         default: ""
         description: >
           Override CMAKE_CUDA_ARCHITECTURES (semicolon-separated SM list). When
-          empty, defaults to "80;86;89;90" (CUDA<13) or "80;86;89;90;100"
-          (CUDA>=13). Set e.g. "75;80;89" for the Colab/T4 wheel; sm_75 is kept
-          out of the default lists so datacenter wheels stay lean.
+          empty, this workflow defaults to "75;80;86;89;90" (CUDA<13) or
+          "80;86;89;90;100" (CUDA>=13). Set e.g. "75;80;89" to make the
+          Colab/T4 wheel's supported architectures explicit.
 
 jobs:
   build-wheel:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,17 +141,17 @@ jobs:
             runs-on: ubuntu-22.04
             label: "py3.12 pt2.10 x86_64 manylinux cu128"
 
-          # ── x86_64 py3.12 Colab wheel (T4/sm_75, torch 2.8 cu128) ──
-          # The ONLY wheel that carries sm_75. Matches Colab runtime 2025.10
-          # (Python 3.12, torch 2.8, T4); archs cover T4(75)/A100(80)/L4(89).
+          # ── x86_64 py3.12 Colab wheel (T4/sm_75, torch 2.11 cu128) ──
+          # Matches the current Colab runtime (Python 3.12, torch 2.11, T4);
+          # explicit archs cover T4(75)/A100(80)/L4(89).
           - python-version: "3.12"
             container-image: nvcr.io/nvidia/pytorch:25.02-py3
-            torch-version: "2.8"
-            torch-package-version: "2.8.0"
+            torch-version: "2.11"
+            torch-package-version: "2.11.0"
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu128"
             cuda-archs: "75;80;89"
             runs-on: ubuntu-22.04
-            label: "py3.12 pt2.8 x86_64 Colab cu128"
+            label: "py3.12 pt2.11 x86_64 Colab cu128"
 
           # ── ARM64 py3.11 ──
           - python-version: "3.11"
@@ -403,7 +403,7 @@ jobs:
             --platform manylinux_2_28_aarch64 \
             --require cu132torch2.12:cp311:x86_64 \
             --require cu129torch2.8:cp312:x86_64 \
-            --require cu128torch2.8:cp312:x86_64 \
+            --require cu128torch2.11:cp312:x86_64 \
             --require cu130torch2.9:cp312:x86_64 \
             --require cu130torch2.10:cp312:x86_64 \
             --require cu128torch2.10:cp312:x86_64 \

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -43,16 +43,16 @@ jobs:
             label: "smoke py3.12 pt2.8 cu129 x86_64"
           - python-version: "3.12"
             python-tag: "312"
-            torch-version: "2.8"
-            torch-package-version: "2.8.0"
+            torch-version: "2.11"
+            torch-package-version: "2.11.0"
             torch-index-url: "https://download.pytorch.org/whl/cu128"
-            local-tag: "cu128torch2.8"
+            local-tag: "cu128torch2.11"
             enable-cuda: true
             cuda-archs: "75;80;89"
             container-image: nvcr.io/nvidia/pytorch:25.02-py3
             runs-on: ubuntu-22.04
             arch: x86_64
-            label: "smoke py3.12 pt2.8 cu128 Colab x86_64"
+            label: "smoke py3.12 pt2.11 cu128 Colab x86_64"
           - python-version: "3.12"
             python-tag: "312"
             torch-version: "2.9"
@@ -399,7 +399,7 @@ jobs:
         include:
           - { python-version: "3.11", python-tag: "311", torch-package-version: "2.12.0", torch-minor: "2.12", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.12", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
           - { python-version: "3.12", python-tag: "312", torch-package-version: "2.8.0", torch-minor: "2.8", torch-index-url: "https://download.pytorch.org/whl/cu129", local-tag: "cu129torch2.8", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64, gpu-runtime: true }
-          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.8.0", torch-minor: "2.8", torch-index-url: "https://download.pytorch.org/whl/cu128", local-tag: "cu128torch2.8", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.11.0", torch-minor: "2.11", torch-index-url: "https://download.pytorch.org/whl/cu128", local-tag: "cu128torch2.11", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
           - { python-version: "3.12", python-tag: "312", torch-package-version: "2.9.1", torch-minor: "2.9", torch-index-url: "https://download.pytorch.org/whl/cu130", local-tag: "cu130torch2.9", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
           - { python-version: "3.12", python-tag: "312", torch-package-version: "2.10.0", torch-minor: "2.10", torch-index-url: "https://download.pytorch.org/whl/cu130", local-tag: "cu130torch2.10", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
           - { python-version: "3.12", python-tag: "312", torch-package-version: "2.10.0", torch-minor: "2.10", torch-index-url: "https://download.pytorch.org/whl/cu128", local-tag: "cu128torch2.10", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.46"
+version = "0.1.47"
 
 dependencies = [
     # Core ML framework

--- a/tmol/__init__.py
+++ b/tmol/__init__.py
@@ -29,6 +29,12 @@ with contextlib.suppress(Exception):
 from tmol.chemical.restypes import one2three, three2one
 from tmol.database import ParameterDatabase
 from tmol.io import pose_stack_from_pdb
+from tmol.io.visualize import (
+    pose_stack_to_pdb_string,
+    selection_gallery,
+    switchable_view,
+    view,
+)
 from tmol.io.canonical_ordering import (
     CanonicalOrdering,
     canonical_form_from_pdb,

--- a/tmol/io/__init__.py
+++ b/tmol/io/__init__.py
@@ -4,6 +4,20 @@ from typing import Optional, Union
 from tmol.types.functional import validate_args
 from tmol.types.torch import Tensor
 from tmol.pose.pose_stack import PoseStack
+from tmol.io.visualize import (
+    pose_stack_to_pdb_string,
+    selection_gallery,
+    switchable_view,
+    view,
+)
+
+__all__ = [
+    "pose_stack_from_pdb",
+    "pose_stack_to_pdb_string",
+    "selection_gallery",
+    "switchable_view",
+    "view",
+]
 
 
 @validate_args

--- a/tmol/io/visualize.py
+++ b/tmol/io/visualize.py
@@ -1,0 +1,505 @@
+"""Small, notebook-friendly visualization helpers for molecular structures.
+
+Optional display dependencies are imported only when a helper is called, so
+importing :mod:`tmol.io.visualize` does not require IPython or py3Dmol.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from html import escape
+from io import StringIO
+from os import PathLike
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Mapping
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from biotite.structure import AtomArray, AtomArrayStack
+    from tmol.pose.pose_stack import PoseStack
+
+    StructureInput = PoseStack | AtomArray | AtomArrayStack | str | PathLike[str]
+else:
+    AtomArray = Any
+    AtomArrayStack = Any
+    PoseStack = Any
+    StructureInput = Any
+
+
+def pose_stack_to_pdb_string(pose_stack: PoseStack) -> str:
+    """Convert a ``PoseStack`` into PDB text suitable for molecular viewers."""
+    from tmol.io.pdb_parsing import to_pdb
+    from tmol.io.write_pose_stack_pdb import atom_records_from_pose_stack
+
+    return to_pdb(atom_records_from_pose_stack(pose_stack))
+
+
+def _is_biotite_structure(model: object) -> bool:
+    try:
+        from biotite.structure import AtomArray, AtomArrayStack
+    except ImportError:
+        return False
+    return isinstance(model, (AtomArray, AtomArrayStack))
+
+
+def _is_atom_array(model: object) -> bool:
+    try:
+        from biotite.structure import AtomArray
+    except ImportError:
+        return False
+    return isinstance(model, AtomArray)
+
+
+def _biotite_to_pdb_string(model: AtomArray | AtomArrayStack) -> str:
+    """Serialize a Biotite structure with Biotite's PDB writer."""
+    try:
+        from biotite.structure.io.pdb import PDBFile
+    except ImportError as exc:
+        raise ImportError("Viewing a Biotite structure requires biotite.") from exc
+
+    pdb_file = PDBFile()
+    # Biotite warns when PDB's fixed-width compatibility format cannot carry
+    # every annotation. The viewer only consumes coordinates and connectivity,
+    # so these warnings are expected and would otherwise become alarming red
+    # stderr boxes in rendered notebooks.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        pdb_file.set_structure(model)
+    output = StringIO()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        pdb_file.write(output)
+    return output.getvalue()
+
+
+def _pdb_text(model: StructureInput) -> str:
+    if isinstance(model, PathLike):
+        return Path(model).read_text()
+
+    if isinstance(model, str):
+        candidate = Path(model)
+        if "\n" not in model and candidate.exists():
+            return candidate.read_text()
+        return model
+
+    if _is_biotite_structure(model):
+        return _biotite_to_pdb_string(model)
+
+    # Keep the PoseStack import lazy: importing this module should not load
+    # compiled TMol code merely to render PDB text or a Biotite AtomArray.
+    from tmol.pose.pose_stack import PoseStack
+
+    if isinstance(model, PoseStack):
+        return pose_stack_to_pdb_string(model)
+
+    raise TypeError(
+        "Expected a PoseStack, Biotite AtomArray/AtomArrayStack, PDB text, "
+        "or a path to a PDB file; "
+        f"received {type(model)!r}"
+    )
+
+
+def _first_model_atom_serials(pdb_text: str) -> list[int]:
+    """Return atom serials from the first PDB model."""
+    serials = []
+    in_model = False
+    for line in pdb_text.splitlines():
+        if line.startswith("MODEL"):
+            if in_model and serials:
+                break
+            in_model = True
+            continue
+        if line.startswith("ENDMDL") and serials:
+            break
+        if line.startswith(("ATOM  ", "HETATM")):
+            try:
+                serials.append(int(line[6:11]))
+            except ValueError:
+                # Biotite emits valid serials; this fallback keeps hand-written
+                # PDB snippets usable with py3Dmol.
+                serials.append(len(serials) + 1)
+    return serials
+
+
+def _boolean_mask(mask: object, expected_length: int, *, name: str) -> list[bool]:
+    """Normalize a one-dimensional boolean atom mask."""
+    if hasattr(mask, "detach"):
+        mask = mask.detach().cpu().numpy()
+
+    import numpy
+
+    values = numpy.asarray(mask)
+    if values.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if values.dtype.kind != "b":
+        raise TypeError(f"{name} must contain boolean values")
+    if len(values) != expected_length:
+        raise ValueError(
+            f"{name} has length {len(values)}; expected {expected_length} atoms"
+        )
+    return values.tolist()
+
+
+def _safe_json(payload: object) -> str:
+    """Encode JSON without allowing data to terminate an HTML script element."""
+    return (
+        json.dumps(payload, ensure_ascii=False)
+        .replace("&", r"\u0026")
+        .replace("<", r"\u003c")
+        .replace(">", r"\u003e")
+        .replace("\u2028", r"\u2028")
+        .replace("\u2029", r"\u2029")
+    )
+
+
+def _display_html(html: str):
+    try:
+        from IPython.display import HTML
+    except ImportError as exc:
+        raise ImportError(
+            "switchable_view() and selection_gallery() require IPython."
+        ) from exc
+    return HTML(html)
+
+
+def _viewer_html(viewer: object) -> str:
+    """Render a py3Dmol viewer through py3Dmol's supported notebook path."""
+    make_html = getattr(viewer, "_make_html", None)
+    if not callable(make_html):
+        raise RuntimeError("The installed py3Dmol version cannot render HTML")
+    return str(make_html())
+
+
+def _add_hover_labels(viewer) -> None:
+    hover_in = """function(atom,viewer) {
+        if(!atom.label) {
+            atom.label = viewer.addLabel(
+                atom.chain + ':' + atom.resn + '(' + atom.resi + '):' +
+                atom.atom + '(idx' + atom.serial + ')',
+                {position: atom, backgroundColor:"white", fontColor:"black"}
+            );
+        }
+    }"""
+    hover_out = """function(atom,viewer) {
+        if(atom.label) {
+            viewer.removeLabel(atom.label);
+            delete atom.label;
+        }
+    }"""
+    viewer.setHoverable({}, True, hover_in, hover_out)
+
+
+def view(
+    model: StructureInput,
+    *,
+    width: int = 720,
+    height: int = 420,
+    style: Literal["cartoon", "stick"] = "cartoon",
+    background_color: str = "white",
+    cartoon_color: str = "spectrum",
+    show_sidechains: bool = True,
+    show_heteroatoms: bool = True,
+    show_hover: bool = True,
+    zoom_to: dict | None = None,
+    highlighted: object | None = None,
+    highlight_color: str = "#e83e8c",
+):
+    """Create a draggable py3Dmol viewer for a molecular structure.
+
+    ``model`` may be a :class:`PoseStack`, a Biotite ``AtomArray`` or
+    ``AtomArrayStack``, PDB text, or a PDB path. ``highlighted`` is an optional
+    boolean mask over the atoms in the first model; highlighted atoms are shown
+    as thicker sticks and spheres. The return value remains a real
+    ``py3Dmol.view`` object for compatibility with existing notebooks.
+    """
+    try:
+        import py3Dmol
+    except ImportError as exc:
+        raise ImportError(
+            "tmol.view() requires py3Dmol. Install it with "
+            "`python -m pip install py3Dmol` or `python -m pip install -e '.[docs]'`."
+        ) from exc
+
+    pdb_text = _pdb_text(model)
+    serials = _first_model_atom_serials(pdb_text)
+    highlighted_serials: list[int] = []
+    if highlighted is not None:
+        mask = _boolean_mask(highlighted, len(serials), name="highlighted")
+        highlighted_serials = [
+            serial for serial, selected in zip(serials, mask) if selected
+        ]
+
+    viewer = py3Dmol.view(width=width, height=height)
+    viewer.addModel(pdb_text, "pdb")
+    viewer.setBackgroundColor(background_color)
+
+    if style == "stick":
+        viewer.setStyle({}, {"stick": {"colorscheme": "greenCarbon", "radius": 0.18}})
+    elif style == "cartoon":
+        viewer.setStyle({}, {"cartoon": {"color": cartoon_color}})
+        if show_sidechains:
+            viewer.addStyle(
+                {"not": {"hetflag": True}},
+                {"stick": {"radius": 0.08, "opacity": 0.55}},
+            )
+    else:
+        raise ValueError("style must be either 'cartoon' or 'stick'")
+
+    if show_heteroatoms:
+        viewer.setStyle(
+            {"hetflag": True},
+            {"stick": {"colorscheme": "orangeCarbon", "radius": 0.22}},
+        )
+
+    if highlighted_serials:
+        viewer.addStyle(
+            {"serial": highlighted_serials},
+            {
+                "stick": {"color": highlight_color, "radius": 0.28},
+                "sphere": {"color": highlight_color, "radius": 0.45},
+            },
+        )
+
+    if show_hover:
+        _add_hover_labels(viewer)
+
+    if zoom_to is None:
+        viewer.zoomTo()
+    else:
+        viewer.zoomTo(zoom_to)
+
+    return viewer
+
+
+def switchable_view(
+    structures: Mapping[str, StructureInput],
+    *,
+    notes: Mapping[str, str] | None = None,
+    width: int = 720,
+    height: int = 420,
+):
+    """Return HTML that switches one 3Dmol viewer among labeled structures.
+
+    Args:
+        structures: Ordered mapping of display labels to structures accepted by
+            :func:`view`.
+        notes: Optional mapping of structure labels to short explanatory text.
+        width: Viewer width in pixels.
+        height: Viewer height in pixels.
+    """
+    if not structures:
+        raise ValueError("structures must contain at least one labeled structure")
+
+    notes = notes or {}
+    root_id = f"tmol-switch-{uuid4().hex}"
+    select_id = f"{root_id}-select"
+    panels = []
+    options = []
+    for index, (label, model) in enumerate(structures.items()):
+        viewer = view(model, width=width, height=height)
+        panel_id = f"{root_id}-panel-{index}"
+        note = str(notes.get(label, ""))
+        options.append(f'<option value="{index}">{escape(str(label))}</option>')
+        panels.append(f"""
+<section id="{panel_id}" class="tmol-switch-panel"
+         style="position:absolute;inset:0;visibility:{'visible' if index == 0 else 'hidden'}">
+  <div class="tmol-viewer-note">{escape(note)}</div>
+  {_viewer_html(viewer)}
+</section>""")
+    html = f"""
+<div class="tmol-switchable-view" id="{root_id}" style="max-width:{width}px">
+  <label>Structure: <select id="{select_id}">{''.join(options)}</select></label>
+  <div style="position:relative;width:100%;height:{height + 32}px">
+    {''.join(panels)}
+  </div>
+</div>
+<script>
+(() => {{
+  const root = document.getElementById({json.dumps(root_id)});
+  const select = document.getElementById({json.dumps(select_id)});
+  const panels = root.querySelectorAll('.tmol-switch-panel');
+  select.addEventListener('change', () => {{
+    panels.forEach((panel, index) => {{
+      panel.style.visibility = index === Number(select.value) ? 'visible' : 'hidden';
+    }});
+    window.dispatchEvent(new Event('resize'));
+  }});
+}})();
+</script>
+"""
+    return _display_html(html)
+
+
+def _selection_mask(atom_array: AtomArray, selection: object, label: str) -> list[bool]:
+    if isinstance(selection, str):
+        query = getattr(atom_array, "mask", None)
+        if not callable(query):
+            raise TypeError(
+                f"Selection {label!r} is a query string, but this AtomArray "
+                "does not provide a callable mask() method"
+            )
+        selection = query(selection)
+    return _boolean_mask(selection, len(atom_array), name=f"selection {label!r}")
+
+
+def selection_gallery(
+    atom_array: AtomArray,
+    selections: Mapping[str, object],
+    *,
+    width: int = 720,
+    height: int = 420,
+    highlight_color: str = "#e83e8c",
+):
+    """Return one interactive viewer for several labeled AtomArray selections.
+
+    Selection values may be boolean atom masks. Query strings are also accepted
+    when the supplied AtomArray provides a callable ``aa.mask(query)`` method.
+    Selection results are resolved in Python and exact PDB atom serials are
+    baked into the HTML. This avoids viewer-side query-language differences
+    and remains exact when atom names or residue identifiers are duplicated.
+    Clicking a label restyles the same model and animates the camera to the
+    selected atoms, following the AtomWorks selection-gallery interaction.
+    """
+    if not _is_atom_array(atom_array):
+        raise TypeError("selection_gallery() expects a Biotite AtomArray")
+    if not selections:
+        raise ValueError("selections must contain at least one labeled selection")
+    width = int(width)
+    height = int(height)
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be positive")
+
+    pdb_text = _biotite_to_pdb_string(atom_array)
+    serials = _first_model_atom_serials(pdb_text)
+    if len(serials) != len(atom_array):
+        raise ValueError(
+            "The serialized AtomArray atom count does not match the input array"
+        )
+
+    gallery = []
+    for label, selection in selections.items():
+        mask = _selection_mask(atom_array, selection, str(label))
+        selected_serials = [
+            serial for serial, selected in zip(serials, mask) if selected
+        ]
+        gallery.append({"label": str(label), "serials": selected_serials})
+
+    root_id = f"tmol-selection-{uuid4().hex}"
+    controls_id = f"{root_id}-controls"
+    viewer_id = f"{root_id}-viewer"
+    html = f"""
+<script src="https://cdn.jsdelivr.net/npm/3dmol@2.4.2/build/3Dmol-min.js"></script>
+<style>
+  #{root_id} {{
+    border: 1px solid var(--pst-color-border, #ccc);
+    border-radius: 8px;
+    max-width: {width}px;
+    overflow: hidden;
+  }}
+  #{controls_id} {{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.7rem;
+    background: var(--pst-color-surface, #f4f4f4);
+  }}
+  #{controls_id} button {{
+    border: 1px solid var(--pst-color-border, #bbb);
+    border-radius: 999px;
+    background: var(--pst-color-on-surface, #fff);
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.85em;
+    padding: 0.25rem 0.8rem;
+  }}
+  #{controls_id} button.active {{
+    color: #fff;
+  }}
+  #{viewer_id} {{ position: relative; width: 100%; height: {height}px; }}
+  #{root_id} .tmol-selection-hint {{
+    font-size: 0.78em;
+    opacity: 0.65;
+    padding: 0.35rem 0.9rem;
+  }}
+</style>
+<div id="{root_id}">
+  <div id="{controls_id}"></div>
+  <div id="{viewer_id}"></div>
+  <div class="tmol-selection-hint">
+    pick a selection · drag to rotate · scroll to zoom · click a highlighted atom to label it
+  </div>
+</div>
+<script>
+(() => {{
+  const root = document.getElementById({json.dumps(root_id)});
+  const controls = document.getElementById({json.dumps(controls_id)});
+  const viewerElement = document.getElementById({json.dumps(viewer_id)});
+  const pdb = {_safe_json(pdb_text)};
+  const presets = {_safe_json(gallery)};
+  const highlightColor = {_safe_json(highlight_color)};
+
+  function initialize() {{
+    if (!window.$3Dmol) {{
+      window.setTimeout(initialize, 50);
+      return;
+    }}
+    const viewer = window.$3Dmol.createViewer(
+      viewerElement, {{backgroundColor: "white"}}
+    );
+    viewer.addModel(pdb, "pdb");
+    const buttons = presets.map((preset, index) => {{
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = preset.label;
+      button.addEventListener("click", () => apply(index));
+      controls.appendChild(button);
+      return button;
+    }});
+
+    function apply(index) {{
+      const preset = presets[index];
+      const selection = preset.serials.length
+        ? {{serial: preset.serials}}
+        : {{}};
+      viewer.removeAllLabels();
+      viewer.setStyle(
+        {{}}, {{cartoon: {{color: "lightgrey", opacity: 0.55}}}}
+      );
+      if (preset.serials.length) {{
+        viewer.addStyle(selection, {{
+          stick: {{color: highlightColor, radius: 0.18}},
+          sphere: {{color: highlightColor, radius: 0.35}},
+          cartoon: {{color: highlightColor}}
+        }});
+        viewer.setClickable(selection, true, (atom) => {{
+          viewer.addLabel(
+            atom.chain + ":" + atom.resn + atom.resi + ":" + atom.atom,
+            {{
+              position: atom,
+              backgroundColor: "0x1b1b1b",
+              backgroundOpacity: 0.85,
+              fontColor: "white",
+              fontSize: 11
+            }}
+          );
+          viewer.render();
+        }});
+      }}
+      buttons.forEach((button, buttonIndex) => {{
+        const active = buttonIndex === index;
+        button.className = active ? "active" : "";
+        button.style.backgroundColor = active ? highlightColor : "";
+        button.style.borderColor = active ? highlightColor : "";
+      }});
+      viewer.zoomTo(selection, 400);
+      viewer.render();
+    }}
+
+    apply(0);
+  }}
+  initialize();
+}})();
+</script>
+"""
+    return _display_html(html)

--- a/tmol/optimization/lbfgs_armijo.py
+++ b/tmol/optimization/lbfgs_armijo.py
@@ -156,7 +156,7 @@ class LBFGS_Armijo(Optimizer):
         max_iter (int): maximal number of iterations (default: 200)
         rtol (float): relative tolerance (default: 1e-6)
         atol (float): absolute tolerance (default: 0)
-        gradtol (float): an absolute tolerance on max_i df/dx_i (default: 1e-4)
+        gradtol (float): an absolute tolerance on max_i |df/dx_i| (default: 1)
         history_size (int): update history size (default: 128).
     """
 
@@ -523,7 +523,7 @@ class LBFGS_Armijo(Optimizer):
                 closure()
 
             ctx.flat_grad = ctx.param.grad.data.view(-1)  # Direct reference
-            max_grad = ctx.flat_grad.max().item()
+            max_grad = ctx.flat_grad.abs().max().item()
 
             # update func eval
             current_evals += self.ls_func_evals

--- a/tmol/score/constraint/constraint_energy_term.py
+++ b/tmol/score/constraint/constraint_energy_term.py
@@ -112,7 +112,7 @@ class ConstraintEnergyTerm(EnergyTerm):
 
         def nearest_angle_radians(angle, x0):
             return angle - (
-                round_away_from_zero((angle - x0) / (math.pi * 2)) * (math.pi / 2)
+                round_away_from_zero((angle - x0) / (math.pi * 2)) * (math.pi * 2)
             )
 
         z = (nearest_angle_radians(angles, x0) - x0) / sd

--- a/tmol/tests/io/test_visualize.py
+++ b/tmol/tests/io/test_visualize.py
@@ -1,0 +1,199 @@
+"""Pure-Python tests for notebook visualization helpers."""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import biotite.structure as struc
+import numpy
+import pytest
+
+from tmol.io import visualize
+
+
+def _atom_array() -> struc.AtomArray:
+    atoms = struc.AtomArray(3)
+    atoms.coord = numpy.array([[0.0, 0.0, 0.0], [1.4, 0.0, 0.0], [2.1, 1.2, 0.0]])
+    atoms.chain_id = numpy.array(["A", "A", "A"])
+    atoms.res_id = numpy.array([1, 1, 1])
+    atoms.res_name = numpy.array(["GLY", "GLY", "GLY"])
+    atoms.atom_name = numpy.array(["N", "CA", "C"])
+    atoms.element = numpy.array(["N", "C", "C"])
+    atoms.hetero = numpy.array([False, False, False])
+    return atoms
+
+
+def test_module_import_does_not_require_display_dependencies(monkeypatch):
+    module_path = Path(visualize.__file__)
+    spec = importlib.util.spec_from_file_location(
+        "_tmol_visualize_lazy_test", module_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "py3Dmol" or name.startswith("IPython"):
+            raise AssertionError(f"optional dependency imported eagerly: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+
+def test_biotite_atom_array_and_stack_are_written_as_pdb():
+    atoms = _atom_array()
+    pdb_text = visualize._pdb_text(atoms)
+    assert " GLY A   1" in pdb_text
+    assert len(visualize._first_model_atom_serials(pdb_text)) == len(atoms)
+
+    stack = struc.stack([atoms, atoms.copy()])
+    stack_text = visualize._pdb_text(stack)
+    assert "MODEL        1" in stack_text
+    assert "MODEL        2" in stack_text
+
+
+class _Viewer:
+    def __init__(self):
+        self.models = []
+        self.styles = []
+        self.added_styles = []
+
+    def addModel(self, text, file_format):
+        self.models.append((text, file_format))
+
+    def setBackgroundColor(self, color):
+        self.background = color
+
+    def setStyle(self, selection, style):
+        self.styles.append((selection, style))
+
+    def addStyle(self, selection, style):
+        self.added_styles.append((selection, style))
+
+    def setHoverable(self, *args):
+        self.hover = args
+
+    def zoomTo(self, *args):
+        self.zoom = args
+
+    def _make_html(self):
+        return '<div class="mock-py3dmol-viewer"></div>'
+
+
+def test_view_highlights_validated_biotite_mask(monkeypatch):
+    viewer = _Viewer()
+    monkeypatch.setitem(
+        sys.modules,
+        "py3Dmol",
+        SimpleNamespace(view=lambda **kwargs: viewer),
+    )
+
+    result = visualize.view(
+        _atom_array(),
+        highlighted=numpy.array([False, True, False]),
+        show_hover=False,
+    )
+
+    assert result is viewer
+    assert viewer.models[0][1] == "pdb"
+    selection, style = viewer.added_styles[-1]
+    assert selection == {"serial": [2]}
+    assert set(style) == {"stick", "sphere"}
+
+
+@pytest.mark.parametrize(
+    ("mask", "error"),
+    [
+        ([True, False], ValueError),
+        ([1, 0, 0], TypeError),
+        ([[True, False, False]], ValueError),
+    ],
+)
+def test_view_rejects_invalid_highlight_masks(monkeypatch, mask, error):
+    monkeypatch.setitem(
+        sys.modules,
+        "py3Dmol",
+        SimpleNamespace(view=lambda **kwargs: _Viewer()),
+    )
+    with pytest.raises(error):
+        visualize.view(_atom_array(), highlighted=mask, show_hover=False)
+
+
+def test_switchable_view_escapes_payload_and_uses_unique_ids(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "py3Dmol",
+        SimpleNamespace(view=lambda **kwargs: _Viewer()),
+    )
+    unsafe = "</script><img src=x onerror=alert(1)>"
+    first = visualize.switchable_view({"before": "ATOM\n"}, notes={"before": unsafe})
+    second = visualize.switchable_view({"before": "ATOM\n"})
+
+    assert unsafe not in first.data
+    assert "&lt;/script&gt;" in first.data
+    first_match = re.search(r'id="(tmol-switch-[a-f0-9]+)"', first.data)
+    second_match = re.search(r'id="(tmol-switch-[a-f0-9]+)"', second.data)
+    assert first_match is not None
+    assert second_match is not None
+    first_id = first_match.group(1)
+    second_id = second_match.group(1)
+    assert first_id != second_id
+    assert "mock-py3dmol-viewer" in first.data
+    assert "visibility:visible" in first.data
+    assert "window.dispatchEvent(new Event('resize'))" in first.data
+
+
+def test_selection_gallery_uses_one_switchable_viewer_and_escapes_payload():
+    atoms = _atom_array()
+    unsafe_label = "</script><selected>"
+    first = visualize.selection_gallery(
+        atoms,
+        {
+            unsafe_label: numpy.array([False, True, False]),
+            "all": numpy.array([True, True, True]),
+        },
+    )
+    second = visualize.selection_gallery(
+        atoms, {"other": numpy.array([True, False, False])}
+    )
+
+    assert unsafe_label not in first.data
+    assert r"\u003c/script\u003e\u003cselected\u003e" in first.data
+    assert '"serials": [2]' in first.data
+    assert '"serials": [1, 2, 3]' in first.data
+    assert first.data.count("$3Dmol.createViewer") == 1
+    assert "viewer.zoomTo(selection, 400)" in first.data
+    assert 'button.addEventListener("click"' in first.data
+    first_match = re.search(r'id="(tmol-selection-[a-f0-9]+)"', first.data)
+    second_match = re.search(r'id="(tmol-selection-[a-f0-9]+)"', second.data)
+    assert first_match is not None
+    assert second_match is not None
+    assert first_match.group(1) != second_match.group(1)
+
+
+def test_query_selection_uses_mask_method_when_available():
+    class QueryArray:
+        def __len__(self):
+            return 3
+
+        def mask(self, query):
+            assert query == "chain A"
+            return numpy.array([True, False, True])
+
+    assert visualize._selection_mask(QueryArray(), "chain A", "protein") == [
+        True,
+        False,
+        True,
+    ]
+
+
+def test_query_selection_requires_mask_method():
+    with pytest.raises(TypeError, match=r"callable mask\(\)"):
+        visualize._selection_mask(_atom_array(), "chain A", "protein")

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -49,6 +49,22 @@ def test_lbfgs_armijo():
     assert score_start > score_stop
 
 
+def test_large_negative_gradient_does_not_converge():
+    x = torch.zeros(1, dtype=torch.float64, requires_grad=True)
+    optimizer = LBFGS_Armijo([x], max_iter=2, rtol=1e-6, atol=1e-6, gradtol=1.0)
+
+    def closure():
+        optimizer.zero_grad()
+        loss = -10 * x.sum()
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+
+    assert optimizer.state[x]["n_iter"] == 2
+    torch.testing.assert_close(x.grad, torch.tensor([-10.0], dtype=x.dtype))
+
+
 @pytest.mark.xfail(reason="sparse tensor _copy failure in torch 1.6")
 def test_lbfgs_armijo_sparse():
     indices = torch.LongTensor([[0, 0, 1], [0, 1, 1]])

--- a/tmol/tests/score/constraint/test_constraint_energy_term.py
+++ b/tmol/tests/score/constraint/test_constraint_energy_term.py
@@ -3,6 +3,8 @@ import numpy
 import torch
 import math
 import pytest
+import sys
+import types
 
 from tmol.pose.constraint_set import ConstraintSet
 from tmol.score.constraint.constraint_energy_term import ConstraintEnergyTerm
@@ -139,6 +141,46 @@ def test_get_torsion_angle(torch_device):
     gold_vals = torch.tensor([-3.141593, 0.0])
     angles = ConstraintEnergyTerm.get_torsion_angle_test(tnsor)
     numpy.testing.assert_allclose(gold_vals.cpu(), angles.cpu(), atol=1e-5, rtol=1e-5)
+
+
+def _circularharmonic_from_angles(monkeypatch, angles, x0, sd=0.5, offset=1.25):
+    module_name = "tmol.score.constraint.potentials.compiled"
+    compiled = types.ModuleType(module_name)
+
+    def get_torsion_angle(atoms):
+        return atoms[:, 0, 0]
+
+    compiled.get_torsion_angle = get_torsion_angle
+    monkeypatch.setitem(sys.modules, module_name, compiled)
+
+    atoms = torch.zeros((len(angles), 4, 3), dtype=torch.float64)
+    atoms[:, 0, 0] = torch.tensor(angles, dtype=atoms.dtype)
+    atoms.requires_grad_()
+    params = torch.tensor([x0, sd, offset], dtype=atoms.dtype).repeat(len(angles), 1)
+
+    scores = ConstraintEnergyTerm.circularharmonic(atoms, params)
+    scores.sum().backward()
+    return scores.detach(), atoms.grad[:, 0, 0]
+
+
+def test_circularharmonic_periodic_values_and_derivatives(monkeypatch):
+    x0 = 0.2
+    x = 0.7
+    scores, derivatives = _circularharmonic_from_angles(
+        monkeypatch, [x - 2 * math.pi, x, x + 2 * math.pi], x0
+    )
+
+    torch.testing.assert_close(scores, torch.full_like(scores, 2.25))
+    torch.testing.assert_close(derivatives, torch.full_like(derivatives, 4.0))
+
+
+def test_circularharmonic_minus_pi_plus_pi_branch_equivalence(monkeypatch):
+    scores, derivatives = _circularharmonic_from_angles(
+        monkeypatch, [-math.pi, math.pi], math.pi - 0.4
+    )
+
+    torch.testing.assert_close(scores, torch.full_like(scores, 1.89))
+    torch.testing.assert_close(derivatives, torch.full_like(derivatives, 3.2))
 
 
 def add_constraints_to_all_poses(pose_stack):


### PR DESCRIPTION
## Summary
- release current DNA/RNA-enabled master as v0.1.47
- update the Colab wheel lane for Python 3.12, PyTorch 2.11, CUDA 12.8, and T4/A100/L4 architectures
- include notebook visualization helpers plus regression-tested LBFGS and circular-harmonic corrections

## Test plan
- [x] pre-commit (clang-format, black, flake8)
- [x] workflow YAML and release-matrix validation
- [ ] full Wheel smoke matrix, including `cu128torch2.11-cp312-x86_64`
- [ ] publish workflow and release-manifest verification after tagging