### PR TITLE
Remove the code path that allowed PDBInfo to hold None arrays

### DIFF
--- a/tmol/io/pose_stack_construction.py
+++ b/tmol/io/pose_stack_construction.py
@@ -5,7 +5,7 @@ from tmol.types.torch import Tensor
 from tmol.types.array import NDArray
 from typing import Optional
 from tmol.types.functional import validate_args
-from tmol.pose.pdb_info import PDBInfo
+from tmol.pose.pdb_info import PDBInfo, DEFAULT_ATOM_OCCUPANCY, DEFAULT_ATOM_B_FACTOR
 from tmol.pose.pose_stack import PoseStack
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.io.canonical_ordering import CanonicalOrdering
@@ -302,25 +302,23 @@ def pose_stack_from_canonical_form(
     if atom_occupancy is not None or atom_b_factor is not None:
         real_block_atoms = real_block_atoms.cpu().numpy()
         pose_at_is_real = pose_at_is_real.cpu().numpy()
+    atom_occupancy_pose_layout = numpy.full(
+        pose_stack_coords.shape[:2], DEFAULT_ATOM_OCCUPANCY, dtype=numpy.float32
+    )
     if atom_occupancy is not None:
-        atom_occupancy_pose_layout = numpy.full(
-            pose_stack_coords.shape[:2], 1.0, dtype=numpy.float32
-        )
         atom_occupancy_pose_layout[pose_at_is_real] = atom_occupancy[real_block_atoms]
-        atom_occupancy = atom_occupancy_pose_layout
+    atom_b_factor_pose_layout = numpy.full(
+        pose_stack_coords.shape[:2], DEFAULT_ATOM_B_FACTOR, dtype=numpy.float32
+    )
     if atom_b_factor is not None:
-        atom_b_factor_pose_layout = numpy.full(
-            pose_stack_coords.shape[:2], 0.0, dtype=numpy.float32
-        )
         atom_b_factor_pose_layout[pose_at_is_real] = atom_b_factor[real_block_atoms]
-        atom_b_factor = atom_b_factor_pose_layout
 
     pdb_info = PDBInfo(
         residue_labels=res_labels,
         residue_insertion_codes=res_ins_codes,
         chain_labels=chain_labels,
-        atom_occupancy=atom_occupancy,
-        atom_b_factor=atom_b_factor,
+        atom_occupancy=atom_occupancy_pose_layout,
+        atom_b_factor=atom_b_factor_pose_layout,
     )
 
     block_coord_offset64 = i64(block_coord_offset)

--- a/tmol/io/pose_stack_deconstruction.py
+++ b/tmol/io/pose_stack_deconstruction.py
@@ -57,46 +57,33 @@ def canonical_form_from_pose_stack(
     ]
 
     expanded_coords, real_expanded_pose_ats = pose_stack.expand_coords()
-    if (
-        pose_stack.pdb_info.atom_occupancy is not None
-        or pose_stack.pdb_info.atom_b_factor is not None
-    ):
-        real_expanded_pose_ats = real_expanded_pose_ats.cpu().numpy()
-        real_atoms = pose_stack.real_atoms.cpu().numpy()
+    real_atoms = pose_stack.real_atoms.cpu().numpy()
 
-        nz_pose_ind_for_real_atom_np = nz_pose_ind_for_real_atom.cpu().numpy()
-        nz_res_ind_for_real_atom_np = nz_res_ind_for_real_atom.cpu().numpy()
-        real_canonical_atom_inds_for_bt_np = (
-            real_canonical_atom_inds_for_bt.cpu().numpy()
-        )
+    nz_pose_ind_for_real_atom_np = nz_pose_ind_for_real_atom.cpu().numpy()
+    nz_res_ind_for_real_atom_np = nz_res_ind_for_real_atom.cpu().numpy()
+    real_canonical_atom_inds_for_bt_np = real_canonical_atom_inds_for_bt.cpu().numpy()
 
-    if pose_stack.pdb_info.atom_b_factor is not None:
-        expanded_b_factor = numpy.full(
-            (n_poses, max_n_res, max_n_canonical_atoms),
-            DEFAULT_ATOM_B_FACTOR,
-            dtype=numpy.float32,
-        )
-        expanded_b_factor[
-            nz_pose_ind_for_real_atom_np,
-            nz_res_ind_for_real_atom_np,
-            real_canonical_atom_inds_for_bt_np,
-        ] = pose_stack.pdb_info.atom_b_factor[real_atoms]
-    else:
-        expanded_b_factor = None
+    expanded_b_factor = numpy.full(
+        (n_poses, max_n_res, max_n_canonical_atoms),
+        DEFAULT_ATOM_B_FACTOR,
+        dtype=numpy.float32,
+    )
+    expanded_b_factor[
+        nz_pose_ind_for_real_atom_np,
+        nz_res_ind_for_real_atom_np,
+        real_canonical_atom_inds_for_bt_np,
+    ] = pose_stack.pdb_info.atom_b_factor[real_atoms]
 
-    if pose_stack.pdb_info.atom_occupancy is not None:
-        expanded_occupancy = numpy.full(
-            (n_poses, max_n_res, max_n_canonical_atoms),
-            DEFAULT_ATOM_OCCUPANCY,
-            dtype=numpy.float32,
-        )
-        expanded_occupancy[
-            nz_pose_ind_for_real_atom_np,
-            nz_res_ind_for_real_atom_np,
-            real_canonical_atom_inds_for_bt_np,
-        ] = pose_stack.pdb_info.atom_occupancy[real_atoms]
-    else:
-        expanded_occupancy = None
+    expanded_occupancy = numpy.full(
+        (n_poses, max_n_res, max_n_canonical_atoms),
+        DEFAULT_ATOM_OCCUPANCY,
+        dtype=numpy.float32,
+    )
+    expanded_occupancy[
+        nz_pose_ind_for_real_atom_np,
+        nz_res_ind_for_real_atom_np,
+        real_canonical_atom_inds_for_bt_np,
+    ] = pose_stack.pdb_info.atom_occupancy[real_atoms]
 
     cf_coords = torch.full(
         (n_poses, max_n_res, max_n_canonical_atoms, 3),

--- a/tmol/io/write_pose_stack_pdb.py
+++ b/tmol/io/write_pose_stack_pdb.py
@@ -2,7 +2,6 @@ import numpy
 import torch
 
 from tmol.io.pdb_parsing import atom_record_dtype
-from tmol.pose.pdb_info import DEFAULT_ATOM_B_FACTOR, DEFAULT_ATOM_OCCUPANCY
 from tmol.pose.pose_stack import PoseStack
 from tmol.pose.packed_block_types import PackedBlockTypes
 from tmol.types.array import NDArray
@@ -81,8 +80,8 @@ def atom_records_from_coords(
     residue_labels: Optional[NDArray[int][:, :]],
     residue_insertion_codes: Optional[NDArray[object][:, :]],
     chain_labels: Optional[NDArray[object][:, :]],
-    atom_occupancy: Optional[NDArray[numpy.float32][:, :]],
-    atom_b_factor: Optional[NDArray[numpy.float32][:, :]],
+    atom_occupancy: NDArray[numpy.float32][:, :],
+    atom_b_factor: NDArray[numpy.float32][:, :],
 ) -> NDArray[atom_record_dtype][:]:
     """Create a numpy array holding the atom records needed to write a
     PDB file from the coordinates and block types of a stack of structures,
@@ -274,15 +273,7 @@ def atom_records_from_coords(
         if residue_insertion_codes is not None
         else " "
     )
-    results["occupancy"] = (
-        atom_occupancy[atom_is_real]
-        if atom_occupancy is not None
-        else DEFAULT_ATOM_OCCUPANCY
-    )
-    results["b"] = (
-        atom_b_factor[atom_is_real]
-        if atom_b_factor is not None
-        else DEFAULT_ATOM_B_FACTOR
-    )
+    results["occupancy"] = atom_occupancy[atom_is_real]
+    results["b"] = atom_b_factor[atom_is_real]
 
     return results


### PR DESCRIPTION
Remove the code path that allowed PDBInfo to hold None for atom occupancies and bfactors.

The class itself does not hint that None is a valid option for these tensors, and it does not truly make sense to preserve the idea that there might not be values for these when having a default value is totally reasonable / workable.

If the user passes None in for these arguments in pose_stack_from_canonical_form, instead, a numpy array of the appropriate shape and filled with the default values will be created. Thereafter, anyone interacting with these arrays need not worry that they are actually None.