### PR TITLE
[codex] Speed up prebuilt-wheel scoring and packing workflows

### DIFF
--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -37,6 +37,59 @@ member. Group similarly sized structures when practical, and use a score
 function built from the same parameter database as poses with custom residue or
 ligand types.
 
+## Accelerate repeated nucleic-acid scoring
+
+DNA and RNA torsion scoring consists of many small tensor operations. For a
+fixed pose layout, opt into CUDA Graph capture when the scorer will be evaluated
+repeatedly:
+
+```python
+scorer = sfxn.render_whole_pose_scoring_module(batch, cuda_graph=True)
+
+# New coordinate values are allowed; shape, dtype, and device must stay fixed.
+scores = scorer(coords)
+scores.sum().backward()  # gradients remain supported
+```
+
+Capture adds a one-time setup cost and retains static graph buffers, so leave it
+off for a scorer used only once. The option captures the pure-PyTorch
+nucleic-acid torsion and carbohydrate `sugar_bb` terms when present; TMol's C++
+score operators remain eager. Keep minimization eager: small score and gradient
+rounding differences can send a nonlinear line search to a different local
+minimum.
+
+### H200 decision data
+
+The production-wheel benchmark used Torch 2.13.0, CUDA 13.2, and one H200, with
+runtime JIT disabled. For 1BNA, graphing the nucleic-acid term reduced median
+whole-score latency from 3.936 to 1.188 ms forward and from 8.754 to 2.240 ms
+forward plus backward at batch 1. At batch 64, the corresponding measurements
+were 4.585 to 2.265 ms and 11.766 to 6.009 ms. Output and coordinate-gradient
+maximum absolute differences were at most 1.7e-4 and 7.7e-6 in this matrix.
+
+A cold-process capture took about 3.0 seconds, so this option pays off after
+roughly 500 repeated forward-plus-backward evaluations or 1,100 forward-only
+evaluations at batch 1. It is not a faster first call. Capturing inside
+minimization was rejected even though it ran faster: the small numerical change
+altered the LBFGS trajectory and final local minimum.
+
+On the ten-sugar 4BYH fixture, graphing `sugar_bb` reduced full carbohydrate
+forward latency from 2.094 to 1.441 ms and forward plus backward from 4.778 to
+2.018 ms at batch 1. Capture took 0.172 seconds after normal scorer warmup;
+output and gradient maximum absolute differences were 1.6e-5 and 4.8e-7.
+
+For independent variants, batch packing is the safer high-throughput operation.
+Four protein--ligand or protein--DNA mutations packed about 3--4 times faster
+than four sequential calls, with the requested residue identities preserved.
+FP32 Cartesian minimization can amplify sub-milliscale score differences into
+different local minima; compare final energies and constraints, and split cases
+when exact trajectory reproducibility is required.
+
+The block-pair interaction reduction now sums through a broadcast mask instead
+of materializing expanded boolean-index results. On an eight-complex PPI batch,
+this changed median interface-score latency from 18.798 to 16.313 ms and peak
+allocated memory from 5.20 to 2.72 GiB, without changing the scoring kernels.
+
 ## Time CUDA work correctly
 
 CUDA launches are asynchronous. Warm up the rendered module, synchronize on both

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -47,8 +47,8 @@ load when their public objects are first requested, so benchmark complete
 workflows rather than treating import time as eliminated work.
 
 Across eight order-balanced processes in the same environment, median default
-database construction decreased from 1.950 to 0.710 s, a cysteine-rich PPI pose
-load from 6.653 to 1.446 s, and scorer rendering from 1.824 to 0.766 s. Peak host
+database construction decreased from 1.924 to 0.624 s, a cysteine-rich PPI pose
+load from 6.394 to 0.901 s, and scorer rendering from 1.793 to 0.766 s. Peak host
 RSS decreased from about 1.48 to 1.35 GiB; GPU peak memory was unchanged.
 Serialized scoring tables are memory-mapped while loading; an isolated repeated
 Dunbrack table load decreased from 24.15 to 11.94 ms without changing the

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -47,8 +47,9 @@ repeatedly:
 scorer = sfxn.render_whole_pose_scoring_module(batch, cuda_graph=True)
 
 # New coordinate values are allowed; shape, dtype, and device must stay fixed.
+coords = batch.coords.detach().clone().requires_grad_(True)
 scores = scorer(coords)
-scores.sum().backward()  # gradients remain supported
+(coord_grad,) = torch.autograd.grad(scores.sum(), coords)
 ```
 
 Capture adds a one-time setup cost and retains static graph buffers, so leave it

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -37,47 +37,57 @@ member. Group similarly sized structures when practical, and use a score
 function built from the same parameter database as poses with custom residue or
 ligand types.
 
-## Accelerate repeated nucleic-acid scoring
+## Accelerate repeated fixed-layout scoring
 
-DNA and RNA torsion scoring consists of many small tensor operations. For a
-fixed pose layout, opt into CUDA Graph capture when the scorer will be evaluated
-repeatedly:
+For a fixed pose layout, opt into CUDA Graph capture when the scorer will be
+evaluated repeatedly. Capture only the path that the workflow needs to limit
+retained static buffers:
 
 ```python
-scorer = sfxn.render_whole_pose_scoring_module(batch, cuda_graph=True)
+inference_scorer = sfxn.render_whole_pose_scoring_module(
+    batch, cuda_graph="forward"
+)
+scores = inference_scorer(batch.coords)
 
-# New coordinate values are allowed; shape, dtype, and device must stay fixed.
+gradient_scorer = sfxn.render_whole_pose_scoring_module(
+    batch, cuda_graph="forward_backward"
+)
 coords = batch.coords.detach().clone().requires_grad_(True)
-scores = scorer(coords)
+scores = gradient_scorer(coords)
 (coord_grad,) = torch.autograd.grad(scores.sum(), coords)
 ```
 
-Capture adds a one-time setup cost and retains static graph buffers, so leave it
-off for a scorer used only once. The option captures the pure-PyTorch
-nucleic-acid torsion and carbohydrate `sugar_bb` terms when present; TMol's C++
-score operators remain eager. Keep minimization eager: small score and gradient
-rounding differences can send a nonlinear line search to a different local
-minimum.
+New coordinate values are allowed; shape, dtype, and device must stay fixed.
+Forward-only replay reuses its output buffer, so clone a score tensor that must
+survive the next scorer call.
+Passing `cuda_graph=True` captures both paths for a mixed workload. Non-default
+requests for unsummed or unweighted terms remain eager. Capture adds a one-time
+setup cost and retains static graph buffers, so leave it off for a scorer used
+only once. Keep minimization eager by default: small score and gradient rounding
+differences can send a nonlinear line search to a different local minimum.
 
 ### H200 decision data
 
 The production-wheel benchmark used Torch 2.13.0, CUDA 13.2, and one H200, with
-runtime JIT disabled. For 1BNA, graphing the nucleic-acid term reduced median
-whole-score latency from 3.936 to 1.188 ms forward and from 8.754 to 2.240 ms
-forward plus backward at batch 1. At batch 64, the corresponding measurements
-were 4.585 to 2.265 ms and 11.766 to 6.009 ms. Output and coordinate-gradient
-maximum absolute differences were at most 1.7e-4 and 7.7e-6 in this matrix.
+runtime JIT disabled. Whole-scorer capture changed median batch-1 latency as
+follows:
 
-A cold-process capture took about 3.0 seconds, so this option pays off after
-roughly 500 repeated forward-plus-backward evaluations or 1,100 forward-only
-evaluations at batch 1. It is not a faster first call. Capturing inside
-minimization was rejected even though it ran faster: the small numerical change
-altered the LBFGS trajectory and final local minimum.
+| Input | Path | Eager (ms) | Graphed (ms) | Capture (s) |
+| --- | --- | ---: | ---: | ---: |
+| 1UBQ | forward | 0.627 | 0.498 | 0.010 |
+| 1UBQ | forward + backward | 1.166 | 0.740 | 0.451 |
+| 1S78 PPI | forward | 2.013 | 1.929 | 0.014 |
+| 1S78 PPI | forward + backward | 3.207 | 3.116 | 0.404 |
+| 1BNA | forward | 3.899 | 1.017 | 0.026 |
+| 1BNA | forward + backward | 8.750 | 1.970 | 0.435 |
 
-On the ten-sugar 4BYH fixture, graphing `sugar_bb` reduced full carbohydrate
-forward latency from 2.094 to 1.441 ms and forward plus backward from 4.778 to
-2.018 ms at batch 1. Capture took 0.172 seconds after normal scorer warmup;
-output and gradient maximum absolute differences were 1.6e-5 and 4.8e-7.
+At protein batch 64, which is compute-bound, the corresponding gains were only
+2.7% forward and 1.5% forward plus backward. Forward capture retained about 50
+MiB for the protein/PPI fixtures and 82 MiB for 1BNA; backward capture retained
+about 50 MiB and 178 MiB, respectively. Score and coordinate-gradient maximum
+absolute differences were at most 7.8e-3 and 7.7e-6 in this matrix. Capturing
+inside minimization remains rejected: the small numerical change can alter the
+LBFGS trajectory and final local minimum.
 
 For independent variants, batch packing is the safer high-throughput operation.
 Four protein--ligand or protein--DNA mutations packed about 3--4 times faster

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -37,6 +37,26 @@ member. Group similarly sized structures when practical, and use a score
 function built from the same parameter database as poses with custom residue or
 ligand types.
 
+## Understand first-use latency
+
+The wheel ships precompiled scoring extensions, but constructing databases,
+poses, and packing metadata still performs CPU setup. Importing ``tmol`` is now
+lazy at the public-API boundary: after importing Torch, the top-level import took
+9--14 ms instead of 1.89 s in the H200 test environment. The relevant modules
+load when their public objects are first requested, so benchmark complete
+workflows rather than treating import time as eliminated work.
+
+The same environment showed median default-database construction decreasing
+from 1.906 to 1.681 s after accelerating safe YAML and common angle parsing.
+Serialized scoring tables are memory-mapped while loading; a repeated Dunbrack
+table load decreased from 24.15 to 11.94 ms without changing the resulting
+objects. Removing first-call Numba compilation from residue and disulfide setup
+also decreased a cysteine-rich PPI pose load from about 0.89 to 0.49 s. These
+are one-time process costs. In an order-balanced protein-packing run, the first
+pack decreased from 4.83--5.39 to 2.18--2.23 s while warmed medians stayed at
+about 51 ms. Reuse databases, pose metadata, rendered scorers, and packers when
+the input chemistry and layout permit it.
+
 ## Accelerate repeated fixed-layout scoring
 
 For a fixed pose layout, opt into CUDA Graph capture when the scorer will be

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -116,10 +116,11 @@ FP32 Cartesian minimization can amplify sub-milliscale score differences into
 different local minima; compare final energies and constraints, and split cases
 when exact trajectory reproducibility is required.
 
-The block-pair interaction reduction now sums through a broadcast mask instead
-of materializing expanded boolean-index results. On an eight-complex PPI batch,
-this changed median interface-score latency from 18.798 to 16.313 ms and peak
-allocated memory from 5.20 to 2.72 GiB, without changing the scoring kernels.
+The block-pair interaction reduction now uses a broadcast mask for ordinary
+inputs and a contraction when its score tensor exceeds the measured 512 MiB
+workspace crossover. On an eight-complex PPI batch, this changed median
+interface-score latency from 18.798 to 16.087 ms and peak allocated memory from
+5.20 to 2.47 GiB, without changing the scoring kernels.
 
 ## Time CUDA work correctly
 

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -46,16 +46,16 @@ lazy at the public-API boundary: after importing Torch, the top-level import too
 load when their public objects are first requested, so benchmark complete
 workflows rather than treating import time as eliminated work.
 
-The same environment showed median default-database construction decreasing
-from 1.906 to 1.681 s after accelerating safe YAML and common angle parsing.
-Serialized scoring tables are memory-mapped while loading; a repeated Dunbrack
-table load decreased from 24.15 to 11.94 ms without changing the resulting
-objects. Removing first-call Numba compilation from residue and disulfide setup
-also decreased a cysteine-rich PPI pose load from about 0.89 to 0.49 s. These
-are one-time process costs. In an order-balanced protein-packing run, the first
-pack decreased from 4.83--5.39 to 2.18--2.23 s while warmed medians stayed at
-about 51 ms. Reuse databases, pose metadata, rendered scorers, and packers when
-the input chemistry and layout permit it.
+Across eight order-balanced processes in the same environment, median default
+database construction decreased from 1.950 to 0.710 s, a cysteine-rich PPI pose
+load from 6.653 to 1.446 s, and scorer rendering from 1.824 to 0.766 s. Peak host
+RSS decreased from about 1.48 to 1.35 GiB; GPU peak memory was unchanged.
+Serialized scoring tables are memory-mapped while loading; an isolated repeated
+Dunbrack table load decreased from 24.15 to 11.94 ms without changing the
+resulting objects. In an order-balanced protein-packing run, the first pack
+decreased from 4.66--4.75 to 2.28--2.55 s while warmed medians stayed at about
+51--53 ms. These are one-time process costs. Reuse databases, pose metadata,
+rendered scorers, and packers when the input chemistry and layout permit it.
 
 ## Accelerate repeated fixed-layout scoring
 

--- a/tmol/__init__.py
+++ b/tmol/__init__.py
@@ -4,6 +4,7 @@
 # This must happen early so that torch.ops.tmol_* namespaces are available
 # before any compiled module is imported.
 import contextlib
+from importlib import import_module as _import_module
 from importlib.metadata import PackageNotFoundError, version
 
 
@@ -25,63 +26,6 @@ from tmol._load_ext import ensure_compiled_or_jit as _ensure_compiled_or_jit
 # Individual compiled.py modules will raise a clear error if needed.
 with contextlib.suppress(Exception):
     _ensure_compiled_or_jit()
-
-from tmol.chemical import one2three, three2one
-from tmol.database import ParameterDatabase
-from tmol.io import (
-    pose_stack_from_pdb,
-    pose_stack_to_pdb_string,
-    selection_gallery,
-    switchable_view,
-    view,
-    CanonicalOrdering,
-    canonical_form_from_pdb,
-    default_canonical_ordering,
-    default_packed_block_types,
-    pose_stack_from_canonical_form,
-    canonical_form_from_openfold,
-    canonical_ordering_for_openfold,
-    packed_block_types_for_openfold,
-    pose_stack_from_openfold,
-    canonical_form_from_rosettafold2,
-    canonical_ordering_for_rosettafold2,
-    packed_block_types_for_rosettafold2,
-    pose_stack_from_rosettafold2,
-    atom_records_from_pose_stack,
-    write_pose_stack_pdb,
-    extended_pose_stack_from_sequences,
-)
-from tmol.kinematics import (
-    KinematicModuleData,
-    EdgeType,
-    FoldForest,
-    CartesianMoveMap,
-    MoveMap,
-    set_named_torsions,
-)
-from tmol.optimization import (
-    build_kinforest_network,
-    run_cart_min,
-    run_kin_min,
-    run_min,
-)
-from tmol.pose import (
-    PackedBlockTypes,
-    PoseStack,
-    ConstraintSet,
-    get_named_torsions,
-    get_torsion_names,
-)
-from tmol.score import (
-    beta2016_score_function,
-    ScoreFunction,
-    ScoreType,
-)
-from tmol.score.constraint import (
-    ConstraintEnergyTerm,
-    create_mainchain_coordinate_constraints,
-)
-from tmol.relax import fast_relax
 
 try:
     __version__ = version("tmol")
@@ -136,3 +80,85 @@ __all__ = [
     "view",
     "write_pose_stack_pdb",
 ]
+
+
+_LAZY_ATTRS = {}
+for _module, _names in (
+    ("tmol.chemical", ("one2three", "three2one")),
+    ("tmol.database", ("ParameterDatabase",)),
+    (
+        "tmol.io",
+        (
+            "CanonicalOrdering",
+            "atom_records_from_pose_stack",
+            "canonical_form_from_openfold",
+            "canonical_form_from_pdb",
+            "canonical_form_from_rosettafold2",
+            "canonical_ordering_for_openfold",
+            "canonical_ordering_for_rosettafold2",
+            "default_canonical_ordering",
+            "default_packed_block_types",
+            "extended_pose_stack_from_sequences",
+            "packed_block_types_for_openfold",
+            "packed_block_types_for_rosettafold2",
+            "pose_stack_from_canonical_form",
+            "pose_stack_from_openfold",
+            "pose_stack_from_pdb",
+            "pose_stack_from_rosettafold2",
+            "pose_stack_to_pdb_string",
+            "selection_gallery",
+            "switchable_view",
+            "view",
+            "write_pose_stack_pdb",
+        ),
+    ),
+    (
+        "tmol.kinematics",
+        (
+            "CartesianMoveMap",
+            "EdgeType",
+            "FoldForest",
+            "KinematicModuleData",
+            "MoveMap",
+            "set_named_torsions",
+        ),
+    ),
+    (
+        "tmol.optimization",
+        ("build_kinforest_network", "run_cart_min", "run_kin_min", "run_min"),
+    ),
+    (
+        "tmol.pose",
+        (
+            "ConstraintSet",
+            "PackedBlockTypes",
+            "PoseStack",
+            "get_named_torsions",
+            "get_torsion_names",
+        ),
+    ),
+    (
+        "tmol.score",
+        ("ScoreFunction", "ScoreType", "beta2016_score_function"),
+    ),
+    (
+        "tmol.score.constraint",
+        ("ConstraintEnergyTerm", "create_mainchain_coordinate_constraints"),
+    ),
+    ("tmol.relax", ("fast_relax",)),
+):
+    _LAZY_ATTRS.update(dict.fromkeys(_names, _module))
+del _module, _names
+
+
+def __getattr__(name):
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(_import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/tmol/chemical/_all_bonds.py
+++ b/tmol/chemical/_all_bonds.py
@@ -1,11 +1,9 @@
 import numpy
-import numba
 
 from typing import Tuple
 from tmol.types import NDArray
 
 
-@numba.jit(nopython=True)
 def bonds_and_bond_ranges(
     n_atoms: int,
     intra_res_bonds: NDArray[numpy.int32][:, 2],

--- a/tmol/chemical/_ideal_coords.py
+++ b/tmol/chemical/_ideal_coords.py
@@ -1,8 +1,6 @@
 import numpy
-import numba
 
 
-@numba.jit(nopython=True)
 def eye4():
     """Create the identity homogeneous transform
     Only necessary because numpy.eye(4, dtype=numpy.float32)
@@ -18,12 +16,10 @@ def eye4():
     # return m
 
 
-@numba.jit(nopython=True)
 def normalize(v):
     return v / numpy.linalg.norm(v)
 
 
-@numba.jit(nopython=True)
 def frame_from_coords(p1, p2, p3):
     ht = eye4()
     z = normalize(p3 - p2)
@@ -38,7 +34,6 @@ def frame_from_coords(p1, p2, p3):
     return ht
 
 
-@numba.jit(nopython=True)
 def rot_x(rot):
     ht = eye4()
     crot = numpy.cos(rot)
@@ -51,7 +46,6 @@ def rot_x(rot):
     return ht
 
 
-@numba.jit(nopython=True)
 def rot_z(rot):
     ht = eye4()
     crot = numpy.cos(rot)
@@ -64,14 +58,12 @@ def rot_z(rot):
     return ht
 
 
-@numba.jit(nopython=True)
 def trans_z(trans):
     ht = eye4()
     ht[2, 3] = trans
     return ht
 
 
-@numba.jit(nopython=True)
 def build_coords_from_icoors(icoors_ancestors, icoors_geom):
     # start with atom 1 at the origin
     # place atom 2 along the x axis

--- a/tmol/database/_yaml.py
+++ b/tmol/database/_yaml.py
@@ -1,0 +1,8 @@
+import yaml
+
+
+_SAFE_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
+
+def safe_load(stream):
+    return yaml.load(stream, Loader=_SAFE_LOADER)

--- a/tmol/database/chemical/__init__.py
+++ b/tmol/database/chemical/__init__.py
@@ -5,7 +5,7 @@ import attr
 import cattr
 
 import os
-import yaml
+from tmol.database._yaml import safe_load
 
 AcceptorHybridization = NewType("AcceptorHybridization", str)
 _acceptor_hybridizations = {"sp2", "sp3", "ring"}
@@ -275,7 +275,7 @@ class ChemicalDatabase:
     def from_file(cls, path):
         path = os.path.join(path, "chemical.yaml")
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         raw = normalize_bond_tuples(raw)
 
         return cattr.structure(raw, cls)

--- a/tmol/database/scoring/_cartbonded.py
+++ b/tmol/database/scoring/_cartbonded.py
@@ -1,6 +1,6 @@
 import attr
 import cattr
-import yaml
+from tmol.database._yaml import safe_load
 import json
 import hashlib
 
@@ -68,7 +68,7 @@ class CartBondedDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            resparam_dict = yaml.safe_load(infile)
+            resparam_dict = safe_load(infile)
             resparam_dict["hash"] = cls._generate_hash(resparam_dict)
 
         return cattr.structure(resparam_dict, cls)

--- a/tmol/database/scoring/_disulfide.py
+++ b/tmol/database/scoring/_disulfide.py
@@ -1,4 +1,4 @@
-import yaml
+from tmol.database._yaml import safe_load
 
 import attr
 import cattr
@@ -45,5 +45,5 @@ class DisulfideDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)

--- a/tmol/database/scoring/_dunbrack_libraries.py
+++ b/tmol/database/scoring/_dunbrack_libraries.py
@@ -89,4 +89,4 @@ class DunbrackRotamerLibrary:
                 (RotamericDataForAA, f"{_OLD}.RotamericDataForAA"),
             ]
         ):
-            return torch.load(fname)
+            return torch.load(fname, mmap=True)

--- a/tmol/database/scoring/_elec.py
+++ b/tmol/database/scoring/_elec.py
@@ -1,6 +1,6 @@
 import attr
 import cattr
-import yaml
+from tmol.database._yaml import safe_load
 
 from typing import Tuple
 
@@ -37,5 +37,5 @@ class ElecDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)

--- a/tmol/database/scoring/_genbonded.py
+++ b/tmol/database/scoring/_genbonded.py
@@ -1,5 +1,5 @@
 import attr
-import yaml
+from tmol.database._yaml import safe_load
 
 from itertools import permutations
 from typing import Dict, List, Optional, Tuple
@@ -157,7 +157,7 @@ class GenBondedDatabase:
     @classmethod
     def from_file(cls, path: str) -> "GenBondedDatabase":
         with open(path, "r") as fh:
-            raw = yaml.safe_load(fh)
+            raw = safe_load(fh)
 
         # --- atom hierarchy -------------------------------------------
         atom_hierarchy: Dict[str, List[str]] = {}

--- a/tmol/database/scoring/_hbond.py
+++ b/tmol/database/scoring/_hbond.py
@@ -1,6 +1,6 @@
 import attr
 import cattr
-import yaml
+from tmol.database._yaml import safe_load
 import pandas
 
 from typing import Tuple
@@ -87,7 +87,7 @@ class HBondDatabaseRaw:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)
 
 

--- a/tmol/database/scoring/_ljlk.py
+++ b/tmol/database/scoring/_ljlk.py
@@ -1,4 +1,4 @@
-import yaml
+from tmol.database._yaml import safe_load
 
 import attr
 import cattr
@@ -44,5 +44,5 @@ class LJLKDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)

--- a/tmol/database/scoring/_na_torsion.py
+++ b/tmol/database/scoring/_na_torsion.py
@@ -1,6 +1,6 @@
 from typing import Dict, Tuple
 
-import yaml
+from tmol.database._yaml import safe_load
 import attr
 import cattr
 
@@ -47,5 +47,5 @@ class NaTorsionDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)

--- a/tmol/database/scoring/_omega_bbdep.py
+++ b/tmol/database/scoring/_omega_bbdep.py
@@ -43,4 +43,4 @@ class OmegaBBDepDatabase:
                 (OmegaBBDepTables, f"{_OLD}.OmegaBBDepTables"),
             ]
         ):
-            return torch.load(fname)
+            return torch.load(fname, mmap=True)

--- a/tmol/database/scoring/_rama.py
+++ b/tmol/database/scoring/_rama.py
@@ -42,4 +42,4 @@ class RamaDatabase:
                 (RamaMappingParams, f"{_OLD}.RamaMappingParams"),
             ]
         ):
-            return torch.load(fname)
+            return torch.load(fname, mmap=True)

--- a/tmol/database/scoring/_ref.py
+++ b/tmol/database/scoring/_ref.py
@@ -1,4 +1,4 @@
-import yaml
+from tmol.database._yaml import safe_load
 
 import attr
 import cattr
@@ -11,5 +11,5 @@ class RefDatabase:
     @classmethod
     def from_file(cls, path):
         with open(path, "r") as infile:
-            raw = yaml.safe_load(infile)
+            raw = safe_load(infile)
         return cattr.structure(raw, cls)

--- a/tmol/io/_canonical_ordering.py
+++ b/tmol/io/_canonical_ordering.py
@@ -536,8 +536,8 @@ def canonical_form_from_atom_records(  # noqa: C901
     uniq_res_ind = {}
     uniq_res_list = []
     count_uniq = -1
-    for i, row in atom_records.iterrows():
-        resid = (row["chain"], row["resi"], row["insert"])
+    for row in atom_records.itertuples(index=False):
+        resid = (row.chain, row.resi, row.insert)
         if resid not in uniq_res_ind:
             count_uniq += 1
             uniq_res_ind[resid] = count_uniq
@@ -558,17 +558,17 @@ def canonical_form_from_atom_records(  # noqa: C901
     chains_seen = {}
     chain_id_to_label = {}
     chain_id_counter = 0  # TO DO: determine if this is wholly redundant w/ "chaini"
-    for i, row in atom_records.iterrows():
-        resid = (row["chain"], row["resi"], row["insert"])
+    for row in atom_records.itertuples(index=False):
+        resid = (row.chain, row.resi, row.insert)
         res_ind = uniq_res_ind[resid]
-        if row["chaini"] not in chains_seen:
-            chains_seen[row["chaini"]] = chain_id_counter
-            chain_id_to_label[chain_id_counter] = row["chain"]
+        if row.chaini not in chains_seen:
+            chains_seen[row.chaini] = chain_id_counter
+            chain_id_to_label[chain_id_counter] = row.chain
             chain_id_counter += 1
-        chain_id[0, res_ind] = chains_seen[row["chaini"]]
+        chain_id[0, res_ind] = chains_seen[row.chaini]
         if res_types[0, res_ind] == -2:
             try:
-                aa_ind = canonical_ordering.restype_io_equiv_classes.index(row["resn"])
+                aa_ind = canonical_ordering.restype_io_equiv_classes.index(row.resn)
                 res_types[0, res_ind] = aa_ind
                 chain_labels[0, res_ind] = chain_id_to_label[chain_id[0, res_ind]]
                 res_labels[0, res_ind] = uniq_res_list[res_ind][1]
@@ -579,16 +579,16 @@ def canonical_form_from_atom_records(  # noqa: C901
                 res_labels[0, res_ind] = ""
                 res_ins_codes[0, res_ind] = ""
         if res_types[0, res_ind] >= 0:
-            res_at_mapping = canonical_ordering.restypes_atom_index_mapping[row["resn"]]
+            res_at_mapping = canonical_ordering.restypes_atom_index_mapping[row.resn]
 
-            atname = row["atomn"].strip()
+            atname = row.atomn.strip()
             try:
                 atind = res_at_mapping[atname]
-                coords[0, res_ind, atind, 0] = row["x"]
-                coords[0, res_ind, atind, 1] = row["y"]
-                coords[0, res_ind, atind, 2] = row["z"]
-                atom_occupancy[0, res_ind, atind] = row["occupancy"]
-                atom_b_factor[0, res_ind, atind] = row["b"]
+                coords[0, res_ind, atind, 0] = row.x
+                coords[0, res_ind, atind, 1] = row.y
+                coords[0, res_ind, atind, 2] = row.z
+                atom_occupancy[0, res_ind, atind] = row.occupancy
+                atom_b_factor[0, res_ind, atind] = row.b
             except KeyError:
                 # ignore atoms that are not in the canonical form
                 # TO DO: warn the user that some atoms are not being processed?

--- a/tmol/io/details/_disulfide_search.py
+++ b/tmol/io/details/_disulfide_search.py
@@ -1,6 +1,5 @@
 import numpy
 import torch
-import numba
 
 from typing import Optional
 from tmol.types import (
@@ -90,7 +89,6 @@ def find_disulfides(
     )
 
 
-@numba.jit(nopython=True)
 def find_disulf_numba(
     coords: NDArray[numpy.float32][:, :, :, 3],
     n_input_dslf: int,
@@ -101,7 +99,7 @@ def find_disulf_numba(
     cutoff_dis: float,
     restype_variants: NDArray[numpy.int32][:, :],
 ):
-    # TEMP: Implement this in numpy/numba on the CPU to start
+    # Keep this small greedy matching pass on the CPU.
 
     # algorithm for CYD matching:
     # greedy

--- a/tmol/kinematics/_scan_ordering.py
+++ b/tmol/kinematics/_scan_ordering.py
@@ -4,7 +4,6 @@ import torch
 
 from collections import defaultdict
 
-from numba import jit
 import scipy.sparse as sparse
 import scipy.sparse.csgraph as csgraph
 
@@ -26,7 +25,6 @@ from ._datatypes import (
 )
 
 
-@jit(nopython=True)
 def get_children(parents):
     nelts = parents.shape[0]
 
@@ -64,7 +62,7 @@ def get_children(parents):
     return n_descendents, child_list_span, child_list
 
 
-# jitted scan operation
+# CPU scan operation
 # inputs:
 #    parents - the "parents" array from the kinematic tree
 #              assumes proper ordering: child index > parent index
@@ -76,7 +74,6 @@ def get_children(parents):
 #    genStarts - an N x 2 array giving indices where each gen begins
 #         genStarts[:,0] indexes nodes
 #         genStarts[:,1] indexes scanStarts
-@jit(nopython=True)
 def get_scans(parents, roots):
     """Partitioning of a tree into linear subpaths.
 

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -7,12 +7,25 @@ from tmol.pack.rotamer.dunbrack import create_dunbrack_sampler_from_database
 from tmol.optimization import run_cart_min
 
 
+_EINSUM_MIN_BYTES = 512 * 1024 * 1024
+
+
 def _sum_cross_block_scores(block_pair_scores, mask, other_mask):
     """Sum both orientations of block-pair scores selected by two masks."""
     cross_mask = (mask.unsqueeze(2) & other_mask.unsqueeze(1)) | (
         other_mask.unsqueeze(2) & mask.unsqueeze(1)
     )
-    return block_pair_scores.masked_fill(~cross_mask.unsqueeze(0), 0).sum(dim=(2, 3))
+    # At large batch/block counts, contraction avoids materializing a
+    # term-expanded masked tensor. Below this measured crossover its workspace
+    # is larger than the masked reduction.
+    score_bytes = block_pair_scores.numel() * block_pair_scores.element_size()
+    if score_bytes >= _EINSUM_MIN_BYTES:
+        return torch.einsum(
+            "tpij,pij->tp", block_pair_scores, cross_mask.to(block_pair_scores.dtype)
+        )
+    return block_pair_scores.masked_fill(~cross_mask.unsqueeze(0), 0).sum(
+        dim=(2, 3)
+    )
 
 
 def calculate_block_pair_ddg(

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -7,6 +7,14 @@ from tmol.pack.rotamer.dunbrack import create_dunbrack_sampler_from_database
 from tmol.optimization import run_cart_min
 
 
+def _sum_cross_block_scores(block_pair_scores, mask, other_mask):
+    """Sum both orientations of block-pair scores selected by two masks."""
+    cross_mask = (mask.unsqueeze(2) & other_mask.unsqueeze(1)) | (
+        other_mask.unsqueeze(2) & mask.unsqueeze(1)
+    )
+    return block_pair_scores.masked_fill(~cross_mask.unsqueeze(0), 0).sum(dim=(2, 3))
+
+
 def calculate_block_pair_ddg(
     pose_stack,
     mask,
@@ -93,32 +101,10 @@ def calculate_block_pair_ddg(
     scorer = sfxn.render_block_pair_scoring_module(pose_stack)
     block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
 
-    # block_pair_scores shape: [n_terms, n_poses, n_blocks, n_blocks]
-    n_terms, n_poses, n_blocks, _ = block_pair_scores.shape
-
     # mask shape: [n_poses, n_blocks]
     # Use mask2 if provided, otherwise use ~mask for the second set of indices
     other_mask = mask2 if mask2 is not None else ~mask
-
-    # Create masks for both sides of the diagonal for each pose
-    # Side 1: i is in mask, j is in other_mask
-    mask_i = mask.unsqueeze(2)  # Shape: [n_poses, n_blocks, 1]
-    other_j = other_mask.unsqueeze(1)  # Shape: [n_poses, 1, n_blocks]
-    cross_mask_1 = mask_i & other_j
-
-    # Side 2: i is in other_mask, j is in mask
-    other_i = other_mask.unsqueeze(2)  # Shape: [n_poses, n_blocks, 1]
-    mask_j = mask.unsqueeze(1)  # Shape: [n_poses, 1, n_blocks]
-    cross_mask_2 = other_i & mask_j
-
-    # Combine both sides
-    cross_mask = cross_mask_1 | cross_mask_2  # Shape: [n_poses, n_blocks, n_blocks]
-
-    # Expand mask to cover each score term
-    cross_mask = cross_mask.unsqueeze(0).expand(n_terms, -1, -1, -1)
-
-    # Apply mask and sum all of the block pair energies
-    ddg_scores = block_pair_scores[cross_mask].view(n_terms, n_poses, -1).sum(dim=2)
+    ddg_scores = _sum_cross_block_scores(block_pair_scores, mask, other_mask)
 
     if sum_terms:
         ddg_scores = ddg_scores.sum(dim=0)
@@ -375,7 +361,6 @@ def compute_block_centroids_and_furthest_dist(pose_stack):
 
 
 def build_coord_mask_for_mask_and_interacting_atoms(pose_stack, mask):
-
     # Build coord_mask: True for atoms in masked blocks and sidechain atoms within 5.0 Angstroms.
     n_poses, max_n_atoms, _ = pose_stack.coords.shape
     n_blocks = pose_stack.max_n_blocks

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -615,20 +615,23 @@ class LBFGS_Armijo(Optimizer):
             ctx.needs_reset |= failed & ~ctx.was_reset
 
     def _check_segment_convergence(self, ctx, n_iter):
-        """Freeze converged segments; return True once the run should stop.
+        """Freeze independently converged segments; stop when all are done.
 
-        Two tests per segment: max gradient component, then change in energy.
-
-        Only the gradient test freezes a segment.
+        A segmented run must stop each segment at the same iteration where an
+        equivalent one-segment run would stop. Otherwise an early-converged pose
+        keeps moving while another pose finishes, making batch minimization
+        depend on which other structures happen to share the stack.
         """
-        stationary = self._seg_amax(ctx.flat_grad.abs()) <= ctx.gradtol
-        ctx.converged |= stationary
-
-        done = self._inactive(ctx).clone()
+        newly_converged = self._seg_amax(ctx.flat_grad.abs()) <= ctx.gradtol
         if ctx.prev_loss_vec is not None:
             dE = (ctx.loss_vec - ctx.prev_loss_vec).abs()
             rdiff = 2 * dE / (ctx.loss_vec.abs() + ctx.prev_loss_vec.abs() + 1e-10)
-            done |= (dE <= ctx.atol) | (rdiff <= ctx.rtol)
+            energy_converged = (dE <= ctx.atol) | (rdiff <= ctx.rtol)
+            # A rejected zero step also has dE == 0, but it is not convergence:
+            # the next iteration must try the scheduled steepest-descent reset.
+            newly_converged |= energy_converged & ~ctx.needs_reset
+        ctx.converged |= newly_converged
+        done = self._inactive(ctx)
 
         n_done = int(done.sum().item())
         n_stalled = int(ctx.stalled.sum().item())

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -26,12 +26,10 @@ class CartesianSfxnNetwork(torch.nn.Module):
         # otherwise overwrite the caller's coordinates
         self.full_coords = pose_stack.coords.clone().detach()
         if coord_mask is None:
-            coord_mask = torch.full(
-                self.full_coords.shape[:-1],
-                True,
-                device=self.full_coords.device,
-                dtype=torch.bool,
-            )
+            # Padding coordinates never contribute to a pose's score. Excluding
+            # them keeps heterogeneous batches from allocating and updating
+            # meaningless optimizer degrees of freedom.
+            coord_mask = pose_stack.real_atoms
         self.coord_mask = coord_mask
 
         # Precompute flat integer indices for the boolean mask

--- a/tmol/pack/rotamer/_bfs_sidechain.py
+++ b/tmol/pack/rotamer/_bfs_sidechain.py
@@ -1,5 +1,4 @@
 import numpy
-import numba
 
 from typing import List
 
@@ -7,7 +6,6 @@ from tmol.types import validate_args
 from tmol.chemical import RefinedResidueType
 
 
-@numba.jit(nopython=True)
 def bfs_sidechain_atoms_jit(parents, sc_roots):
     n_atoms = parents.shape[0]
     n_children = numpy.zeros(n_atoms, dtype=numpy.int32)

--- a/tmol/pose/_pose_stack.py
+++ b/tmol/pose/_pose_stack.py
@@ -116,7 +116,6 @@ class PoseStack:
     #################### INIT #####################
 
     def __attrs_post_init__(self):
-
         n_poses = self.block_coord_offset.size(0)
         n_blocks = self.block_coord_offset.size(1)
 
@@ -308,7 +307,7 @@ class PoseStack:
         # now perform the actual copy
         expanded_coords = torch.zeros(
             (self.n_poses, self.max_n_blocks, self.max_n_block_atoms, 3),
-            dtype=torch.float32,
+            dtype=self.coords.dtype,
             device=self.device,
         )
         expanded_coords[real_expanded_pose_ats] = self.coords[self.real_atoms]

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1,8 +1,10 @@
+import logging
+from typing import Dict, Sequence
+import warnings
+
 import torch
 import yaml
-import logging
 
-from typing import Dict, Sequence
 from tmol.types import Tensor
 
 from tmol.database import ParameterDatabase
@@ -365,11 +367,16 @@ class WholePoseScoringModule:
             if name not in requested or name in captured:
                 continue
             sample = example_coords.detach().clone().requires_grad_(True)
-            with torch.enable_grad():
+            with torch.enable_grad(), warnings.catch_warnings():
+                # PyTorch's internal backward-capture warmup retains the sample
+                # leaf's default-stream AccumulateGrad node. Capture and replay
+                # are valid; suppress only that known internal warning.
+                warnings.filterwarnings(
+                    "ignore",
+                    message="The AccumulateGrad node's stream does not match",
+                )
                 self.term_modules[index] = torch.cuda.make_graphed_callables(
-                    term,
-                    (sample,),
-                    allow_unused_input=True,
+                    term, (sample,), allow_unused_input=True
                 )
             captured.add(name)
         self._cuda_graphed_terms = captured

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -148,7 +148,9 @@ class ScoreFunction:
 
         return self._multi_body_terms
 
-    def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
+    def render_whole_pose_scoring_module(
+        self, pose_stack: PoseStack, cuda_graph: bool = False
+    ):
         """Create an object designed to evaluate the score of a set of Poses
         repeatedly as the Poses change their conformation, e.g., as in
         minimization. This object will derive from torch.nn.Module and
@@ -161,7 +163,10 @@ class ScoreFunction:
         term_modules = [
             t.render_whole_pose_scoring_module(pose_stack) for t in self.all_terms()
         ]
-        return WholePoseScoringModule(self.weights_tensor(), term_modules)
+        scoring_module = WholePoseScoringModule(self.weights_tensor(), term_modules)
+        if cuda_graph:
+            scoring_module.enable_cuda_graphs(pose_stack.coords)
+        return scoring_module
 
     def render_block_pair_scoring_module(self, pose_stack: PoseStack):
         """Create an object designed to evaluate the score of a set of Poses
@@ -179,7 +184,9 @@ class ScoreFunction:
         return BlockPairScoringModule(self.weights_tensor(), term_modules)
 
     def render_rotamer_scoring_module(
-        self, pose_stack: PoseStack, rotamer_set: "RotamerSet"  # noqa: F405
+        self,
+        pose_stack: PoseStack,
+        rotamer_set: "RotamerSet",  # noqa: F405
     ):
         """Create an object designed to evaluate the score a RotamerSet
         repeatedly as the Poses change their conformation, e.g., as in
@@ -335,6 +342,38 @@ class WholePoseScoringModule:
 
     def unweighted_scores(self, coords):
         return torch.cat([term(coords) for term in self.term_modules], dim=0)
+
+    def enable_cuda_graphs(self, example_coords, terms=("NaTorsion", "SugarBB")):
+        """Capture launch-bound pure-Torch terms for a fixed coordinate shape.
+
+        The returned scorer accepts new coordinate values with the same shape,
+        dtype, and device and retains forward and backward support. Only terms
+        known to be CUDA-capture safe are enabled by default; TMol's C++ score
+        operators currently allocate ModernGPU scratch during each call and
+        therefore cannot be captured safely.
+
+        Capture has a one-time cost and is intended for a scorer that will be
+        reused. Calling this method again is a no-op for already captured terms.
+        """
+        if not example_coords.is_cuda:
+            raise ValueError("CUDA graphs require CUDA coordinates")
+
+        requested = set(terms)
+        captured = getattr(self, "_cuda_graphed_terms", set())
+        for index, term in enumerate(self.term_modules):
+            name = getattr(term, "classname", None)
+            if name not in requested or name in captured:
+                continue
+            sample = example_coords.detach().clone().requires_grad_(True)
+            with torch.enable_grad():
+                self.term_modules[index] = torch.cuda.make_graphed_callables(
+                    term,
+                    (sample,),
+                    allow_unused_input=True,
+                )
+            captured.add(name)
+        self._cuda_graphed_terms = captured
+        return self
 
 
 class BlockPairScoringModule:

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -349,6 +349,8 @@ class WholePoseScoringModule:
                 return self._cuda_graphed_autograd(coords)
             if not needs_grad and hasattr(self, "_cuda_graphed_forward"):
                 return self._cuda_graphed_forward(coords)
+        if not torch.is_grad_enabled() and coords.requires_grad:
+            coords = coords.detach()
         unweighted = self.unweighted_scores(coords)
         weighted = self.weights * unweighted if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
@@ -459,6 +461,8 @@ class BlockPairScoringModule:
         self.term_modules = term_modules
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
+        if not torch.is_grad_enabled() and coords.requires_grad:
+            coords = coords.detach()
         unweighted = self.unweighted_scores(coords)
         weighted = self.weights * unweighted if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
@@ -481,6 +485,8 @@ class RotamerScoringModule:
         self.term_modules = term_modules
 
     def __call__(self, coords):
+        if not torch.is_grad_enabled() and coords.requires_grad:
+            coords = coords.detach()
         # Accumulate weighted values and their indices across all terms at the
         # dense [nnz] level.  This avoids torch.stack on sparse tensors, which
         # previously created a [n_subterms, n_poses, n_rots, n_rots] 4D sparse

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -151,7 +151,7 @@ class ScoreFunction:
         return self._multi_body_terms
 
     def render_whole_pose_scoring_module(
-        self, pose_stack: PoseStack, cuda_graph: bool = False
+        self, pose_stack: PoseStack, cuda_graph=False
     ):
         """Create an object designed to evaluate the score of a set of Poses
         repeatedly as the Poses change their conformation, e.g., as in
@@ -160,6 +160,12 @@ class ScoreFunction:
         terms that themselves are derived from torch.nn.Module. This
         object's __call__ will return a tensor of weighted energies of
         shape (n_poses,).
+
+        Set ``cuda_graph`` to ``"forward"`` for repeated inference,
+        ``"forward_backward"`` for repeated scoring with coordinate gradients,
+        or ``True`` to capture both paths. Graph capture requires CUDA and a
+        fixed coordinate shape, dtype, and device. Forward-only replay reuses
+        its output buffer; clone an output that must survive the next call.
         """
         self.pre_work_initialization(pose_stack)
         term_modules = [
@@ -167,7 +173,8 @@ class ScoreFunction:
         ]
         scoring_module = WholePoseScoringModule(self.weights_tensor(), term_modules)
         if cuda_graph:
-            scoring_module.enable_cuda_graphs(pose_stack.coords)
+            mode = "both" if cuda_graph is True else cuda_graph
+            scoring_module.enable_cuda_graphs(pose_stack.coords, mode=mode)
         return scoring_module
 
     def render_block_pair_scoring_module(self, pose_stack: PoseStack):
@@ -336,6 +343,12 @@ class WholePoseScoringModule:
         self.term_modules = term_modules
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
+        if sum_terms and apply_weights:
+            needs_grad = torch.is_grad_enabled() and coords.requires_grad
+            if needs_grad and hasattr(self, "_cuda_graphed_autograd"):
+                return self._cuda_graphed_autograd(coords)
+            if not needs_grad and hasattr(self, "_cuda_graphed_forward"):
+                return self._cuda_graphed_forward(coords)
         unweighted = self.unweighted_scores(coords)
         weighted = self.weights * unweighted if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
@@ -345,42 +358,93 @@ class WholePoseScoringModule:
     def unweighted_scores(self, coords):
         return torch.cat([term(coords) for term in self.term_modules], dim=0)
 
-    def enable_cuda_graphs(self, example_coords, terms=("NaTorsion", "SugarBB")):
-        """Capture launch-bound pure-Torch terms for a fixed coordinate shape.
+    def enable_cuda_graphs(self, example_coords, mode="both"):
+        """Capture the default weighted score for a fixed coordinate shape.
 
         The returned scorer accepts new coordinate values with the same shape,
-        dtype, and device and retains forward and backward support. Only terms
-        known to be CUDA-capture safe are enabled by default; TMol's C++ score
-        operators currently allocate ModernGPU scratch during each call and
-        therefore cannot be captured safely.
+        dtype, and device and retains forward and backward support. Calls that
+        request unweighted or unsummed terms continue to use the eager path.
+        Forward-only replay reuses its output buffer.
 
-        Capture has a one-time cost and is intended for a scorer that will be
-        reused. Calling this method again is a no-op for already captured terms.
+        ``mode`` may be ``"forward"``, ``"forward_backward"``, or ``"both"``.
+        Capture has a one-time cost and retains static buffers, so select only
+        the paths that will be reused. Calling this method again is a no-op for
+        paths that are already captured.
         """
         if not example_coords.is_cuda:
             raise ValueError("CUDA graphs require CUDA coordinates")
+        if mode not in ("forward", "forward_backward", "both"):
+            raise ValueError(f"unsupported CUDA graph mode: {mode!r}")
 
-        requested = set(terms)
-        captured = getattr(self, "_cuda_graphed_terms", set())
-        for index, term in enumerate(self.term_modules):
-            name = getattr(term, "classname", None)
-            if name not in requested or name in captured:
-                continue
+        if mode in ("forward", "both") and not hasattr(
+            self, "_cuda_graphed_forward"
+        ):
+            graph_module = _DefaultWholePoseScoringModule(
+                self.weights, self.term_modules
+            )
+            self._cuda_graphed_forward = _InferenceCUDAGraph(
+                graph_module, example_coords
+            )
+
+        if mode in ("forward_backward", "both") and not hasattr(
+            self, "_cuda_graphed_autograd"
+        ):
+            graph_module = _DefaultWholePoseScoringModule(
+                self.weights, self.term_modules
+            )
             sample = example_coords.detach().clone().requires_grad_(True)
-            with torch.enable_grad(), warnings.catch_warnings():
-                # PyTorch's internal backward-capture warmup retains the sample
-                # leaf's default-stream AccumulateGrad node. Capture and replay
-                # are valid; suppress only that known internal warning.
+            with (
+                torch.cuda.device(example_coords.device),
+                torch.enable_grad(),
+                warnings.catch_warnings(),
+            ):
+                # PyTorch's backward-capture warmup retains the sample leaf's
+                # default-stream AccumulateGrad node. Capture and replay are
+                # valid; suppress only that known internal warning.
                 warnings.filterwarnings(
                     "ignore",
                     message="The AccumulateGrad node's stream does not match",
                 )
-                self.term_modules[index] = torch.cuda.make_graphed_callables(
-                    term, (sample,), allow_unused_input=True
+                self._cuda_graphed_autograd = torch.cuda.make_graphed_callables(
+                    graph_module, (sample,), allow_unused_input=True
                 )
-            captured.add(name)
-        self._cuda_graphed_terms = captured
         return self
+
+
+class _DefaultWholePoseScoringModule(torch.nn.Module):
+    """Graph-capturable default reduction for a whole-pose scorer."""
+
+    def __init__(self, weights, term_modules):
+        super().__init__()
+        self.weights = weights
+        self.term_modules = torch.nn.ModuleList(term_modules)
+
+    def forward(self, coords):
+        unweighted = torch.cat([term(coords) for term in self.term_modules], dim=0)
+        return torch.sum(self.weights * unweighted, dim=0)
+
+
+class _InferenceCUDAGraph:
+    """Forward-only graph replay with a fixed-address input buffer."""
+
+    def __init__(self, module, example_coords):
+        self._coords = example_coords.detach().clone()
+        with torch.cuda.device(example_coords.device):
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream), torch.no_grad():
+                for _ in range(3):
+                    module(self._coords)
+            torch.cuda.current_stream().wait_stream(stream)
+
+            self._graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(self._graph, stream=stream), torch.no_grad():
+                self._output = module(self._coords)
+
+    def __call__(self, coords):
+        self._coords.copy_(coords)
+        self._graph.replay()
+        return self._output
 
 
 class BlockPairScoringModule:

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -248,7 +248,9 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // Allocate the tensors to which we will write our outputs
   int const n_V = output_block_pair_energies ? max_n_blocks : 1;
   auto V_t = TPack<Real, 4, D>::zeros({5, n_poses, n_V, n_V});
-  auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({5, n_atoms});
+  auto dV_dx_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, D>::zeros({5, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({5, n_atoms});
 
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;

--- a/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
+++ b/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
@@ -123,7 +123,9 @@ auto DisulfidePoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     n_V = 1;
   }
   TPack<Real, 4, D> V_t = TPack<Real, 4, D>::zeros({1, n_poses, n_V, n_V});
-  auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms});
+  auto dV_dx_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({1, n_atoms});
 
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -156,7 +156,9 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
   int n_V = output_block_pair_energies ? max_n_blocks : 1;
   TPack<Real, 4, D> V_t = TPack<Real, 4, D>::zeros({3, n_poses, n_V, n_V});
-  auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms});
+  auto dV_dx_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({3, n_atoms});
 
   auto dihedral_atom_inds_t =
       TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih});

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -503,7 +503,9 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   assert(block_type_intra_repr_path_distance.size(1) == max_n_block_atoms);
   assert(block_type_intra_repr_path_distance.size(2) == max_n_block_atoms);
 
-  auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms});
+  auto dV_dcoords_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -438,7 +438,9 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
   // One score type: gen_torsions (index 0).
   int const n_V = output_block_pair_energies ? max_n_blocks : 1;
   auto V_t = TPack<Real, 4, D>::zeros({1, n_poses, n_V, n_V});
-  auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms});
+  auto dV_dx_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({1, n_atoms});
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;
 

--- a/tmol/score/hbond/_hbond_dependent_term.py
+++ b/tmol/score/hbond/_hbond_dependent_term.py
@@ -1,6 +1,5 @@
 import attr
 import numpy
-import numba
 import torch
 import pandas
 
@@ -23,7 +22,6 @@ from tmol.types import (
 )
 
 
-@numba.jit(nopython=True)
 def attached_H_for_don(atom_is_hydrogen, D_idx, bonds, bond_spans):
     donH = numpy.full(atom_is_hydrogen.shape, -1, dtype=numpy.int32)
     heavy_at_don_for_H = numpy.full(atom_is_hydrogen.shape, -1, dtype=numpy.int32)

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -585,7 +585,9 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
   assert(max_n_interblock_bonds <= MAX_N_CONN);
 
-  auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms});
+  auto dV_dcoords_t =
+      compute_derivs ? TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, Dev>::empty({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -27,6 +27,7 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         super(LJLKEnergyTerm, self).__init__(param_db=param_db, device=device)
         self.type_params = ljlk_param_resolver.type_params
         self.global_params = ljlk_param_resolver.global_params
+        self._max_dis = float(param_db.scoring.ljlk.global_parameters.max_dis)
         self.tile_size = LJLKEnergyTerm.tile_size
         self.soft_repulsive = False
 
@@ -176,5 +177,5 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             type_params,
             global_params,
             # max_dis as host scalar for detect-neighbors call
-            float(self.global_params.max_dis.item()),
+            self._max_dis,
         ]

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -757,7 +757,9 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   assert(block_type_path_distance.size(1) == max_n_block_atoms);
   assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-  auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms});
+  auto dV_dcoords_t =
+      require_gradient ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
+                       : TPack<Vec<Real, 3>, 2, D>::empty({3, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =

--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -36,6 +36,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         # These depend only on static values from ljlk_param_resolver globals,
         #   so they can be built once rather than on every forward
         gp = self.ljlk_param_resolver.global_params
+        self._max_dis = float(param_db.scoring.ljlk.global_parameters.max_dis)
         self._lk_ball_global_params = torch.stack(
             tuple(
                 t.to(torch.float)
@@ -292,7 +293,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             pose_stack.packed_block_types.bond_separation,
             self._lk_ball_global_params,
             # max_dis as host scalar for detect-neighbors call
-            float(self.ljlk_param_resolver.global_params.max_dis.item()),
+            self._max_dis,
             water_coords,
             block_pair_scoring,
         ]
@@ -354,7 +355,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             pose_stack.packed_block_types.bond_separation,
             self._lk_ball_global_params,
             # max_dis as host scalar for detect-neighbors call
-            float(self.ljlk_param_resolver.global_params.max_dis.item()),
+            self._max_dis,
             water_coords,
             block_pair_scoring,
         ]

--- a/tmol/tests/nucleic/test_na_scoring.py
+++ b/tmol/tests/nucleic/test_na_scoring.py
@@ -123,3 +123,35 @@ def test_beta2016_protein_dna_is_more_than_parts(protein_dna_pdb, torch_device):
     complexed = total(protein_dna_pdb)
     separate = total(dna_only) + total(prot_only)
     assert complexed != pytest.approx(separate, abs=1.0)
+
+
+def test_cuda_graphed_na_score_matches_eager_forward_and_backward(
+    dna_pdb, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA graph test")
+
+    pose_stack = _pose_stack(dna_pdb, torch_device)
+    sfxn = beta2016_score_function(torch_device)
+
+    eager_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    eager_score = sfxn.render_whole_pose_scoring_module(pose_stack)(eager_coords)
+    eager_score.sum().backward()
+    expected_score = eager_score.detach().clone()
+    expected_grad = eager_coords.grad.detach().clone()
+    del eager_score, eager_coords
+
+    graphed = sfxn.render_whole_pose_scoring_module(pose_stack, cuda_graph=True)
+    graph_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    graph_score = graphed(graph_coords)
+    graph_score.sum().backward()
+
+    torch.testing.assert_close(graph_score, expected_score, rtol=1e-5, atol=1e-3)
+    torch.testing.assert_close(graph_coords.grad, expected_grad, rtol=1e-4, atol=1e-3)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            graphed(pose_stack.coords),
+            expected_score,
+            rtol=1e-5,
+            atol=1e-3,
+        )

--- a/tmol/tests/nucleic/test_na_scoring.py
+++ b/tmol/tests/nucleic/test_na_scoring.py
@@ -144,10 +144,10 @@ def test_cuda_graphed_na_score_matches_eager_forward_and_backward(
     graphed = sfxn.render_whole_pose_scoring_module(pose_stack, cuda_graph=True)
     graph_coords = pose_stack.coords.detach().clone().requires_grad_(True)
     graph_score = graphed(graph_coords)
-    graph_score.sum().backward()
+    (graph_grad,) = torch.autograd.grad(graph_score.sum(), graph_coords)
 
     torch.testing.assert_close(graph_score, expected_score, rtol=1e-5, atol=1e-3)
-    torch.testing.assert_close(graph_coords.grad, expected_grad, rtol=1e-4, atol=1e-3)
+    torch.testing.assert_close(graph_grad, expected_grad, rtol=1e-4, atol=1e-3)
     with torch.no_grad():
         torch.testing.assert_close(
             graphed(pose_stack.coords),

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 import biotite.structure as struc
 
@@ -7,11 +8,16 @@ from tmol.io import (
     biotite_from_pose_stack,
 )
 from tmol import run_cart_min, beta2016_score_function
-from tmol.ops._score_utils import _sum_cross_block_scores
+import tmol.ops._score_utils as score_utils
 
 
-def test_sum_cross_block_scores_handles_different_mask_sizes(torch_device):
+@pytest.mark.parametrize("einsum", [False, True])
+def test_sum_cross_block_scores_handles_different_mask_sizes(
+    torch_device, monkeypatch, einsum
+):
     """Each pose may select a different number of block pairs."""
+    threshold = 0 if einsum else float("inf")
+    monkeypatch.setattr(score_utils, "_EINSUM_MIN_BYTES", threshold)
     scores = torch.arange(
         2 * 2 * 4 * 4, dtype=torch.float32, device=torch_device
     ).reshape(2, 2, 4, 4)
@@ -25,7 +31,7 @@ def test_sum_cross_block_scores_handles_different_mask_sizes(torch_device):
         device=torch_device,
     )
 
-    actual = _sum_cross_block_scores(scores, mask, other)
+    actual = score_utils._sum_cross_block_scores(scores, mask, other)
     expected = torch.empty_like(actual)
     expected[:, 0] = scores[:, 0, 0, 1] + scores[:, 0, 1, 0]
     expected[:, 1] = scores[:, 1, :2, 2:].sum(dim=(1, 2)) + scores[:, 1, 2:, :2].sum(

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -7,6 +7,40 @@ from tmol.io import (
     biotite_from_pose_stack,
 )
 from tmol import run_cart_min, beta2016_score_function
+from tmol.ops._score_utils import _sum_cross_block_scores
+
+
+def test_sum_cross_block_scores_handles_different_mask_sizes(torch_device):
+    """Each pose may select a different number of block pairs."""
+    scores = torch.arange(
+        2 * 2 * 4 * 4, dtype=torch.float32, device=torch_device
+    ).reshape(2, 2, 4, 4)
+    scores.requires_grad_(True)
+    mask = torch.tensor(
+        [[True, False, False, False], [True, True, False, False]],
+        device=torch_device,
+    )
+    other = torch.tensor(
+        [[False, True, False, False], [False, False, True, True]],
+        device=torch_device,
+    )
+
+    actual = _sum_cross_block_scores(scores, mask, other)
+    expected = torch.empty_like(actual)
+    expected[:, 0] = scores[:, 0, 0, 1] + scores[:, 0, 1, 0]
+    expected[:, 1] = scores[:, 1, :2, 2:].sum(dim=(1, 2)) + scores[:, 1, 2:, :2].sum(
+        dim=(1, 2)
+    )
+    torch.testing.assert_close(actual, expected)
+
+    actual.sum().backward()
+    selected = (mask.unsqueeze(2) & other.unsqueeze(1)) | (
+        other.unsqueeze(2) & mask.unsqueeze(1)
+    )
+    torch.testing.assert_close(
+        scores.grad,
+        selected.unsqueeze(0).expand_as(scores).to(scores.dtype),
+    )
 
 
 def test_build_coord_mask_and_minimize_for_first_residue(

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -193,6 +193,26 @@ def test_constant_energy_offset_does_not_change_where_a_block_stops(torch_device
     assert _rosenbrock(offset[1]) < 1e-4, _rosenbrock(offset[1])
 
 
+def test_energy_converged_block_stops_where_it_would_alone(torch_device):
+    """A block must not keep moving while a slower stack-mate finishes."""
+    problem = BlockProblem(
+        blocks=[_quadratic(0.0, offset=1.0e8), _rosenbrock],
+        starts=[
+            torch.ones(8, dtype=torch.float64),
+            torch.full((10,), -1.2, dtype=torch.float64),
+        ],
+        device=torch_device,
+    )
+    kwargs = dict(lr=1.0, max_iter=50, gradtol=0.0)
+    together = problem.minimize_together(**kwargs)[2]
+    alone = problem.minimize_alone(**kwargs)
+
+    for i, (in_stack, by_itself) in enumerate(zip(together, alone)):
+        torch.testing.assert_close(
+            in_stack, by_itself, rtol=1e-8, atol=1e-9, msg=f"block {i}"
+        )
+
+
 def test_noise_floor_stops_before_grinding_on_noise(torch_device):
     """The floor scales with |f|, so a huge objective stops at a coarser dE."""
     coarse = BlockProblem(
@@ -216,8 +236,8 @@ def test_noise_floor_stops_before_grinding_on_noise(torch_device):
     assert coarse_opt.state[coarse_x]["n_iter"] <= fine_opt.state[fine_x]["n_iter"]
 
 
-def test_only_stationary_segments_are_frozen(torch_device):
-    """A segment with a large gradient stays active however flat its energy."""
+def test_gradtol_does_not_freeze_nonstationary_segment(torch_device):
+    """The gradient criterion alone must not freeze a large-gradient segment."""
     problem = BlockProblem(
         blocks=[_quadratic(0.0), _rosenbrock],
         starts=[
@@ -226,7 +246,15 @@ def test_only_stationary_segments_are_frozen(torch_device):
         ],
         device=torch_device,
     )
-    optimizer, x, _ = problem.minimize_together(lr=1.0, max_iter=20, gradtol=1e-8)
+    optimizer, x, _ = problem.minimize_together(
+        lr=1.0,
+        max_iter=20,
+        gradtol=1e-8,
+        # Isolate the gradient criterion tested here. Energy convergence is
+        # independently covered by test_energy_converged_block_stops_where_it_would_alone.
+        rtol=0.0,
+        atol=0.0,
+    )
 
     # the quadratic block reaches its minimum; the rosenbrock valley does not
     grads = torch.split(x.grad.detach(), problem.sizes)

--- a/tmol/tests/optimization/test_pose_stack_minimization.py
+++ b/tmol/tests/optimization/test_pose_stack_minimization.py
@@ -53,8 +53,8 @@ def _compare(label, poses, stack, sfxn, min_per_pose, tol=5.0):
 
     report = _report(label, start, one_by_one, stacked)
     assert torch.all(stacked < start), report
-    # loose: a stacked pose keeps stepping while its stack-mates are still
-    # active, and minimization trajectories are sensitive to the last bits
+    # FP32 reduction order differs between a heterogeneous stack and separate
+    # runs, so nonlinear line-search trajectories need a loose energy bound.
     assert torch.all(torch.abs(stacked - one_by_one) < tol), report
 
 
@@ -106,8 +106,15 @@ def test_cart_network_segment_ids(
     assert segment_ids.shape == (network.masked_coords.numel(),)
     counts = torch.bincount(segment_ids)
     assert len(counts) == len(distinct_pose_stacks)
-    # the default mask covers padding too, so every pose has the same count
-    assert torch.all(counts == 3 * stack_of_distinct_poses.coords.shape[1])
+    solo_counts = torch.tensor(
+        [
+            CartesianSfxnNetwork(sfxn, pose).masked_coords.numel()
+            for pose in distinct_pose_stacks
+        ],
+        device=counts.device,
+    )
+    # Padding in a heterogeneous stack must not create optimizer variables.
+    assert torch.all(counts == solo_counts), f"{counts} != {solo_counts}"
     # coords are laid out pose-major, so the labels come in contiguous runs
     assert torch.all(segment_ids[1:] >= segment_ids[:-1])
 

--- a/tmol/tests/pose/test_pose_stack.py
+++ b/tmol/tests/pose/test_pose_stack.py
@@ -1,5 +1,7 @@
 import numpy
+import pytest
 import torch
+import attrs
 from tmol.io import pose_stack_from_pdb
 from tmol.pose import PoseStackBuilder
 
@@ -62,11 +64,14 @@ def test_real_atoms(ubq_40_60_pose_stack):
     )
 
 
-def test_expand_coords(ubq_40_60_pose_stack, torch_device):
-    poses = ubq_40_60_pose_stack
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_expand_coords(ubq_40_60_pose_stack, torch_device, dtype):
+    poses = attrs.evolve(
+        ubq_40_60_pose_stack, coords=ubq_40_60_pose_stack.coords.to(dtype)
+    )
     expanded_coords_gold = torch.zeros(
         (2, poses.max_n_blocks, poses.max_n_block_atoms, 3),
-        dtype=torch.float32,
+        dtype=dtype,
         device=torch_device,
     )
     real_expanded_coords_gold = torch.zeros(

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -1,6 +1,7 @@
 import torch
 import numpy
 import os
+import pytest
 
 from tmol.score import (
     _non_memoized_beta2016,
@@ -36,6 +37,41 @@ def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
     scores = scorer(pose_stack100.coords)
 
     assert scores is not None
+
+
+def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA graph test")
+
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    sfxn = beta2016_score_function(torch_device)
+    eager = sfxn.render_whole_pose_scoring_module(pose_stack)
+
+    eager_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    expected_score = eager(eager_coords)
+    (expected_grad,) = torch.autograd.grad(expected_score.sum(), eager_coords)
+    expected_terms = eager(
+        pose_stack.coords, sum_terms=False, apply_weights=False
+    )
+
+    graphed = sfxn.render_whole_pose_scoring_module(pose_stack, cuda_graph=True)
+    graph_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    graph_score = graphed(graph_coords)
+    (graph_grad,) = torch.autograd.grad(graph_score.sum(), graph_coords)
+
+    torch.testing.assert_close(graph_score, expected_score, rtol=1e-5, atol=1e-3)
+    torch.testing.assert_close(graph_grad, expected_grad, rtol=1e-4, atol=1e-3)
+    # Non-default reductions intentionally retain their normal eager semantics.
+    torch.testing.assert_close(
+        graphed(pose_stack.coords, sum_terms=False, apply_weights=False),
+        expected_terms,
+    )
+
+    changed_coords = pose_stack.coords.detach().clone()
+    changed_coords[0, 0, 0] += 0.1
+    torch.testing.assert_close(
+        graphed(changed_coords), eager(changed_coords), rtol=1e-5, atol=1e-3
+    )
 
 
 def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -8,6 +8,7 @@ from tmol.score import (
     ScoreFunction,
     ScoreType,
 )
+from tmol.score._score_function import WholePoseScoringModule
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
     DEFAULT_ATOM_OCCUPANCY,
@@ -37,6 +38,24 @@ def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
     scores = scorer(pose_stack100.coords)
 
     assert scores is not None
+
+
+def test_no_grad_scoring_detaches_coordinates():
+    class RecordingTerm(torch.nn.Module):
+        def forward(self, coords):
+            self.input_requires_grad = coords.requires_grad
+            return coords.sum().reshape(1, 1)
+
+    term = RecordingTerm()
+    scorer = WholePoseScoringModule(torch.ones(1), [term])
+    coords = torch.ones(1, requires_grad=True)
+
+    scorer(coords)
+    assert term.input_requires_grad
+
+    with torch.no_grad():
+        scorer(coords)
+    assert not term.input_requires_grad
 
 
 def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):

--- a/tmol/utility/_units.py
+++ b/tmol/utility/_units.py
@@ -9,8 +9,8 @@ import cattr
 
 ureg = pint.UnitRegistry()
 u = ureg.parse_expression
-_BOND_ANGLE_LIMIT = (u("0 rad"), u("pi rad"))
-_DIHEDRAL_ANGLE_LIMIT = (u("-pi rad"), u("pi rad"))
+_BOND_ANGLE_LIMIT = (0.0, math.pi)
+_DIHEDRAL_ANGLE_LIMIT = (-math.pi, math.pi)
 
 
 def _simple_angle(angle: str):

--- a/tmol/utility/_units.py
+++ b/tmol/utility/_units.py
@@ -9,6 +9,19 @@ import cattr
 
 ureg = pint.UnitRegistry()
 u = ureg.parse_expression
+_BOND_ANGLE_LIMIT = (u("0 rad"), u("pi rad"))
+_DIHEDRAL_ANGLE_LIMIT = (u("-pi rad"), u("pi rad"))
+
+
+def _simple_angle(angle: str):
+    fields = angle.split()
+    if len(fields) != 2 or fields[1] not in ("deg", "rad"):
+        return None
+    try:
+        value = float(fields[0])
+    except ValueError:
+        return None
+    return math.radians(value) if fields[1] == "deg" else value
 
 
 def parse_angle(
@@ -26,7 +39,9 @@ def parse_angle(
     """
 
     if isinstance(angle, str):
-        val = ureg.parse_expression(angle)
+        val = _simple_angle(angle)
+        if val is None:
+            val = ureg.parse_expression(angle)
     else:
         val = angle
 
@@ -47,12 +62,12 @@ def parse_angle(
 
 def parse_bond_angle(v: Union[float, str]) -> float:
     """Parse a bond angle on the range [0, pi) via pint."""
-    return parse_angle(v, lim=(u("0 rad"), u("pi rad")))
+    return parse_angle(v, lim=_BOND_ANGLE_LIMIT)
 
 
 def parse_dihedral_angle(v) -> float:
     """Parse a dihedral angle on the range [-pi, pi) via pint."""
-    return parse_angle(v, lim=(u("-pi rad"), u("pi rad")))
+    return parse_angle(v, lim=_DIHEDRAL_ANGLE_LIMIT)
 
 
 Angle = NewType("Angle", float)


### PR DESCRIPTION
## Summary

This PR improves installed-wheel workflows in four places:

- reduces block-pair interaction memory, with a measured size crossover between masked reduction and contraction;
- makes heterogeneous Cartesian minimization and segmented LBFGS batch-correct while excluding padding DOFs;
- removes avoidable host synchronization and derivative-buffer initialization from repeated scoring, and adds opt-in whole-score CUDA Graph capture for fixed layouts; and
- makes top-level API loading lazy and removes several seconds of first-call database, pose, and packing setup without changing warmed algorithms.

The wheel still eagerly registers its shipped AOT extension. Runtime JIT is neither required nor used by these measurements.

## H200 methodology

Results compare installed prebuilt wheels for current `master` (`a3e0864bc`) and this branch using Torch 2.13.0, CUDA 13.2, one H200 per process, runtime JIT disabled, synchronized warmups, 30 timed repeats, and order-balanced base/candidate processes. Compile/capture and cold-start costs are reported separately from steady state. A separate isolated DNA check used 100 repeats.

## Steady-state results

| Workflow | Base | Candidate | Change |
| --- | ---: | ---: | ---: |
| Protein B1 forward | 0.740 ms | 0.598 ms | -19.2% |
| Protein B1 forward + backward | 1.335 ms | 1.175 ms | -12.0% |
| RNA B64 forward | 5.744 ms | 3.984 ms | -30.6% |
| RNA B64 forward + backward | 16.282 ms | 12.635 ms | -22.4% |
| Protein--DNA B16 forward | 5.389 ms | 4.022 ms | -25.4% |
| Protein--DNA B16 forward + backward | 13.906 ms | 10.910 ms | -21.5% |
| Protein--ligand B1 forward | 0.988 ms | 0.919 ms | -7.0% |
| Protein--ligand B1 forward + backward | 1.807 ms | 1.561 ms | -13.6% |

All isolated protein, PPI, DNA, RNA, protein--DNA, and protein--ligand batch points were neutral or faster. In the 100-repeat DNA check, forward/backward gains ranged from 2.4/0.5% at B1 to 15.3/12.4% at B64. Gains taper at large compute-bound protein/PPI batches, as expected.

For the large PPI B8 interaction tensor, the adaptive contraction changes full interface scoring from 19.04 to 15.91 ms and peak allocation from 5,048 to 2,587 MiB versus current master. Smaller tensors retain masked reduction because contraction workspace is larger below the measured 512 MiB crossover.

## CUDA Graph results

Capture is opt-in through `cuda_graph="forward"`, `"forward_backward"`, or `True` for both. It accepts new coordinate values at a fixed shape/device/dtype; forward replay reuses its output buffer. Non-default term reductions stay eager.

| Input | Path | Eager | Graphed | Capture |
| --- | --- | ---: | ---: | ---: |
| Protein B1 | forward | 0.610 ms | 0.490 ms | 0.010 s |
| Protein B1 | forward + backward | 1.155 ms | 0.736 ms | 0.552 s |
| DNA B1 | forward | 3.855 ms | 1.005 ms | 0.050 s |
| DNA B1 | forward + backward | 8.532 ms | 1.972 ms | 0.413 s |

At protein B64, capture is only a 2--3% result, so it should be enabled only after amortizing setup and retained graph buffers. Minimization deliberately remains eager: small reduction-order differences can change a nonlinear line-search trajectory and local minimum.

## First-use results

Across eight order-balanced fresh processes:

| Phase | Base | Candidate | Change |
| --- | ---: | ---: | ---: |
| Default database | 1.942 s | 0.676 s | -65.2% |
| Cysteine-rich PPI pose | 6.582 s | 0.957 s | -85.5% |
| Scorer render | 1.843 s | 0.770 s | -58.2% |
| Peak host RSS | 1.48 GiB | 1.35 GiB | -9.1% |

After Torch is imported, `import tmol` changes from 2.08--4.34 s to 8.8--13.1 ms; requesting the first heavyweight public symbol performs the deferred work. A first protein pack changes from 4.52--4.78 to 2.18--2.24 s while warmed medians remain about 51--54 ms. The broader NumPy rewrite that made cold packing still faster was rejected because it regressed warmed packing by about 2%.

## Validation

- Installed-wheel focused tests cover scoring/graphs, DNA/RNA, database loading, chemical refinement, disulfides, hydrogen setup, minimization, pose dtype, scan ordering, and packing on CPU and H200.
- The exact current-master wheel gate is 197 passed, 2 skipped, and 2 expected xpasses across the changed reduction, graph, minimization, pose, unit/database, chemical, canonical-I/O, disulfide, scan-ordering, and packing suites.
- Eager score/coordinate-gradient parity was checked at small and large batches for protein, PPI, DNA, RNA, protein--DNA, and protein--ligand. Maximum score and gradient deltas were 2.7e-3 and 1.6e-5; mean gradient deltas were at most 1.1e-7, consistent with normal GPU atomic ordering.
- Graphed protein/DNA outputs and coordinate gradients match eager within the documented tolerances; changed coordinate values were tested.
- The installed wheel contains the AOT `_C.so`, resolves all 46 top-level public names, and emits no runtime extension build artifacts.

## H200 decisions

- Kept 32-thread native launch boxes. Broad and term-specific 64-thread H200 variants regressed representative end-to-end workloads, in some cases by 20--30%.
- Kept the adaptive interface contraction only above its measured memory crossover; smaller cases use the lower-workspace masked path.
- Rejected bounded/per-term streaming defaults: they saved memory but cost 0.7--7.8% latency.
- Rejected whole-score `torch.compile`: TMol native operators do not yet provide the FakeTensor/meta registrations required for a clean full graph. CUDA Graph replay addresses the measured launch-bound cases today.
- Rejected custom persistent/L2-residency work: profiles did not show a bounded reusable state whose expected gain justified a new architecture-specific kernel.

## Follow-ups justified by the profiles

- Add FakeTensor/meta registrations and capture-safe scratch APIs for native score operators; this is the prerequisite for evaluating full-score `torch.compile` without graph breaks.
- Consider a versioned, database-hash-keyed serialized cache for patched/refined default chemistry. Patch-graph construction is now the largest avoidable CPU setup phase, but this needs explicit invalidation semantics and does not belong in a small kernel PR.
- Revisit an SM90-only CartBonded launch dispatch only with a dedicated template path: isolated 64-thread trials occasionally helped that term, but the broad change regressed complete workloads and is not safe as a default.
