### PR TITLE
Make batched Cartesian minimization independent across poses

### DIFF
--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -615,20 +615,23 @@ class LBFGS_Armijo(Optimizer):
             ctx.needs_reset |= failed & ~ctx.was_reset
 
     def _check_segment_convergence(self, ctx, n_iter):
-        """Freeze converged segments; return True once the run should stop.
+        """Freeze independently converged segments; stop when all are done.
 
-        Two tests per segment: max gradient component, then change in energy.
-
-        Only the gradient test freezes a segment.
+        A segmented run must stop each segment at the same iteration where an
+        equivalent one-segment run would stop. Otherwise an early-converged pose
+        keeps moving while another pose finishes, making batch minimization
+        depend on which other structures happen to share the stack.
         """
-        stationary = self._seg_amax(ctx.flat_grad.abs()) <= ctx.gradtol
-        ctx.converged |= stationary
-
-        done = self._inactive(ctx).clone()
+        newly_converged = self._seg_amax(ctx.flat_grad.abs()) <= ctx.gradtol
         if ctx.prev_loss_vec is not None:
             dE = (ctx.loss_vec - ctx.prev_loss_vec).abs()
             rdiff = 2 * dE / (ctx.loss_vec.abs() + ctx.prev_loss_vec.abs() + 1e-10)
-            done |= (dE <= ctx.atol) | (rdiff <= ctx.rtol)
+            energy_converged = (dE <= ctx.atol) | (rdiff <= ctx.rtol)
+            # A rejected zero step also has dE == 0, but it is not convergence:
+            # the next iteration must try the scheduled steepest-descent reset.
+            newly_converged |= energy_converged & ~ctx.needs_reset
+        ctx.converged |= newly_converged
+        done = self._inactive(ctx)
 
         n_done = int(done.sum().item())
         n_stalled = int(ctx.stalled.sum().item())

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -557,7 +557,7 @@ class LBFGS_Armijo(Optimizer):
         ctx.d.mul_((~inactive).to(ctx.d.dtype)[self._segment_ids])
 
     def _directional_derivative(self, ctx, correct=True):
-        """Directional derivative g . d, per segment and in total."""
+        """Compute and cache the directional derivative g . d per segment."""
         flat_grad, d = ctx.flat_grad, ctx.d
         gtd_seg = self._seg_sum(flat_grad * d)
         if correct:
@@ -573,7 +573,6 @@ class LBFGS_Armijo(Optimizer):
                 d.copy_(torch.where(bad_elem, repaired, d))
                 gtd_seg = self._seg_sum(flat_grad * d)
         ctx.gtd_seg = gtd_seg
-        return gtd_seg.sum().item()
 
     def _segment_line_search(self, ctx, linefn_vec):
         """Line search with an independent step size per segment."""
@@ -634,8 +633,8 @@ class LBFGS_Armijo(Optimizer):
         done = self._inactive(ctx)
 
         n_done = int(done.sum().item())
-        n_stalled = int(ctx.stalled.sum().item())
         if self.verbose:
+            n_stalled = int(ctx.stalled.sum().item())
             print(
                 f"  iter {n_iter:4d}  E={ctx.loss:.6f}"
                 f"  evals={ctx.ls_evals}"

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -26,12 +26,10 @@ class CartesianSfxnNetwork(torch.nn.Module):
         # otherwise overwrite the caller's coordinates
         self.full_coords = pose_stack.coords.clone().detach()
         if coord_mask is None:
-            coord_mask = torch.full(
-                self.full_coords.shape[:-1],
-                True,
-                device=self.full_coords.device,
-                dtype=torch.bool,
-            )
+            # Padding coordinates never contribute to a pose's score. Excluding
+            # them keeps heterogeneous batches from allocating and updating
+            # meaningless optimizer degrees of freedom.
+            coord_mask = pose_stack.real_atoms
         self.coord_mask = coord_mask
 
         # Precompute flat integer indices for the boolean mask

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -39,16 +39,17 @@ class CartesianSfxnNetwork(torch.nn.Module):
             self.coord_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
         )
 
-        self.masked_coords = torch.nn.Parameter(self.full_coords[self.coord_mask])
+        self.masked_coords = torch.nn.Parameter(
+            self.full_coords.view(-1, self.full_coords.shape[-1])[self._coord_flat_idx]
+        )
 
         # pose each element of masked_coords belongs to, for per-pose minimization
-        pose_for_atom = torch.arange(
-            self.full_coords.shape[0], dtype=torch.int64, device=self.full_coords.device
-        ).unsqueeze(1)
-        pose_for_atom = pose_for_atom.expand(self.coord_mask.shape).reshape(-1)
-        self.segment_ids = pose_for_atom[self._coord_flat_idx].repeat_interleave(
-            self.full_coords.shape[-1]
+        pose_for_atom = torch.div(
+            self._coord_flat_idx,
+            self.full_coords.shape[1],
+            rounding_mode="floor",
         )
+        self.segment_ids = pose_for_atom.repeat_interleave(self.full_coords.shape[-1])
 
         self.count = 0
 

--- a/tmol/pose/_pose_stack.py
+++ b/tmol/pose/_pose_stack.py
@@ -116,7 +116,6 @@ class PoseStack:
     #################### INIT #####################
 
     def __attrs_post_init__(self):
-
         n_poses = self.block_coord_offset.size(0)
         n_blocks = self.block_coord_offset.size(1)
 
@@ -308,7 +307,7 @@ class PoseStack:
         # now perform the actual copy
         expanded_coords = torch.zeros(
             (self.n_poses, self.max_n_blocks, self.max_n_block_atoms, 3),
-            dtype=torch.float32,
+            dtype=self.coords.dtype,
             device=self.device,
         )
         expanded_coords[real_expanded_pose_ats] = self.coords[self.real_atoms]

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -193,6 +193,26 @@ def test_constant_energy_offset_does_not_change_where_a_block_stops(torch_device
     assert _rosenbrock(offset[1]) < 1e-4, _rosenbrock(offset[1])
 
 
+def test_energy_converged_block_stops_where_it_would_alone(torch_device):
+    """A block must not keep moving while a slower stack-mate finishes."""
+    problem = BlockProblem(
+        blocks=[_quadratic(0.0, offset=1.0e8), _rosenbrock],
+        starts=[
+            torch.ones(8, dtype=torch.float64),
+            torch.full((10,), -1.2, dtype=torch.float64),
+        ],
+        device=torch_device,
+    )
+    kwargs = dict(lr=1.0, max_iter=50, gradtol=0.0)
+    together = problem.minimize_together(**kwargs)[2]
+    alone = problem.minimize_alone(**kwargs)
+
+    for i, (in_stack, by_itself) in enumerate(zip(together, alone)):
+        torch.testing.assert_close(
+            in_stack, by_itself, rtol=1e-8, atol=1e-9, msg=f"block {i}"
+        )
+
+
 def test_noise_floor_stops_before_grinding_on_noise(torch_device):
     """The floor scales with |f|, so a huge objective stops at a coarser dE."""
     coarse = BlockProblem(
@@ -216,8 +236,8 @@ def test_noise_floor_stops_before_grinding_on_noise(torch_device):
     assert coarse_opt.state[coarse_x]["n_iter"] <= fine_opt.state[fine_x]["n_iter"]
 
 
-def test_only_stationary_segments_are_frozen(torch_device):
-    """A segment with a large gradient stays active however flat its energy."""
+def test_gradtol_does_not_freeze_nonstationary_segment(torch_device):
+    """The gradient criterion alone must not freeze a large-gradient segment."""
     problem = BlockProblem(
         blocks=[_quadratic(0.0), _rosenbrock],
         starts=[
@@ -226,7 +246,15 @@ def test_only_stationary_segments_are_frozen(torch_device):
         ],
         device=torch_device,
     )
-    optimizer, x, _ = problem.minimize_together(lr=1.0, max_iter=20, gradtol=1e-8)
+    optimizer, x, _ = problem.minimize_together(
+        lr=1.0,
+        max_iter=20,
+        gradtol=1e-8,
+        # Isolate the gradient criterion tested here. Energy convergence is
+        # independently covered by test_energy_converged_block_stops_where_it_would_alone.
+        rtol=0.0,
+        atol=0.0,
+    )
 
     # the quadratic block reaches its minimum; the rosenbrock valley does not
     grads = torch.split(x.grad.detach(), problem.sizes)

--- a/tmol/tests/optimization/test_pose_stack_minimization.py
+++ b/tmol/tests/optimization/test_pose_stack_minimization.py
@@ -53,8 +53,8 @@ def _compare(label, poses, stack, sfxn, min_per_pose, tol=5.0):
 
     report = _report(label, start, one_by_one, stacked)
     assert torch.all(stacked < start), report
-    # loose: a stacked pose keeps stepping while its stack-mates are still
-    # active, and minimization trajectories are sensitive to the last bits
+    # FP32 reduction order differs between a heterogeneous stack and separate
+    # runs, so nonlinear line-search trajectories need a loose energy bound.
     assert torch.all(torch.abs(stacked - one_by_one) < tol), report
 
 
@@ -106,8 +106,15 @@ def test_cart_network_segment_ids(
     assert segment_ids.shape == (network.masked_coords.numel(),)
     counts = torch.bincount(segment_ids)
     assert len(counts) == len(distinct_pose_stacks)
-    # the default mask covers padding too, so every pose has the same count
-    assert torch.all(counts == 3 * stack_of_distinct_poses.coords.shape[1])
+    solo_counts = torch.tensor(
+        [
+            CartesianSfxnNetwork(sfxn, pose).masked_coords.numel()
+            for pose in distinct_pose_stacks
+        ],
+        device=counts.device,
+    )
+    # Padding in a heterogeneous stack must not create optimizer variables.
+    assert torch.all(counts == solo_counts), f"{counts} != {solo_counts}"
     # coords are laid out pose-major, so the labels come in contiguous runs
     assert torch.all(segment_ids[1:] >= segment_ids[:-1])
 

--- a/tmol/tests/pose/test_pose_stack.py
+++ b/tmol/tests/pose/test_pose_stack.py
@@ -1,5 +1,7 @@
 import numpy
+import pytest
 import torch
+import attrs
 from tmol.io import pose_stack_from_pdb
 from tmol.pose import PoseStackBuilder
 
@@ -62,11 +64,14 @@ def test_real_atoms(ubq_40_60_pose_stack):
     )
 
 
-def test_expand_coords(ubq_40_60_pose_stack, torch_device):
-    poses = ubq_40_60_pose_stack
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_expand_coords(ubq_40_60_pose_stack, torch_device, dtype):
+    poses = attrs.evolve(
+        ubq_40_60_pose_stack, coords=ubq_40_60_pose_stack.coords.to(dtype)
+    )
     expanded_coords_gold = torch.zeros(
         (2, poses.max_n_blocks, poses.max_n_block_atoms, 3),
-        dtype=torch.float32,
+        dtype=dtype,
         device=torch_device,
     )
     real_expanded_coords_gold = torch.zeros(


### PR DESCRIPTION
## Summary

- freeze each independently converged LBFGS segment at the same iteration it would stop in a one-pose run;
- do not interpret a rejected zero step as energy convergence while a scheduled reset is still pending;
- exclude padding coordinates from the default Cartesian minimization degrees of freedom;
- preserve the input coordinate dtype when expanding a pose stack; and
- reuse flat coordinate indices for the minimizer gather and per-pose segment IDs instead of materializing a padded pose-label grid.

This is intentionally separate from #417 because it fixes heterogeneous-batch minimization behavior rather than providing a bitwise-preserving scoring optimization.

## Validation

- GitHub CI at correctness-complete SHA `85208eb2` completed the source build, benchmark lane, 1,498 CPU tests, and 834 CUDA tests with zero failures/errors (52 expected CPU skips); both result artifacts and coverage were published. Latest SHA `3ea60a786` additionally removes two redundant GPU-to-CPU synchronizations per LBFGS iteration: an unused total directional derivative and a stalled-segment count needed only in verbose mode; its full CI rerun is queued.
- CPU and CUDA tests compare batched segmented minimization with independent one-segment runs.
- Regression coverage verifies energy-converged segments freeze, failed steps still reset, default coordinate masks exclude padding, and float64 pose expansion retains float64.
- The preceding head passes 54 focused CPU/CUDA installed-wheel tests with 2 expected xpasses on Torch 2.13 / CUDA 13.2 / H200. A jagged 10/20/40/76-residue stack removes 52.0% of optimizer variables and reduces peak allocation from 278.9 to 227.8 MiB; five-iteration minimization latency is neutral because scoring dominates.
- `clang-format`, Black, and flake8 pass across the repository.

The final synchronization-only patch also passes all 12 standalone segmented-LBFGS invariant tests on CPU, plus Black, flake8, syntax, and diff checks.