### PR TITLE
Support explicit inter-residue covalent bonds

### DIFF
--- a/tmol/io/_build_context.py
+++ b/tmol/io/_build_context.py
@@ -24,3 +24,5 @@ class PoseBuildContext:
     fragment_definitions: tuple = ()
     # SMILES string -> residue type name, for ligands prepared from a sequence.
     ligand_names: dict = field(default_factory=dict)
+    # (base block-type name, attachment atoms) -> connection-capable clone.
+    covalent_variant_names: dict = field(default_factory=dict)

--- a/tmol/io/_covalent_bonds.py
+++ b/tmol/io/_covalent_bonds.py
@@ -1,0 +1,266 @@
+"""Import explicit, non-polymeric covalent bonds from Biotite structures."""
+
+from collections import defaultdict
+import math
+
+import attr
+import biotite.structure as struc
+import numpy as np
+import torch
+
+from tmol.database.chemical import Connection, Icoor
+from tmol.pose import InterResidueConnection, connect_pose_blocks
+
+
+def _template(structure):
+    return structure[0] if isinstance(structure, struc.AtomArrayStack) else structure
+
+
+def _residue_keys(array):
+    starts = struc.get_residue_starts(array)
+    ends = np.append(starts[1:], array.array_length())
+    ins_codes = (
+        array.ins_code if "ins_code" in array.get_annotation_categories() else None
+    )
+    keys = []
+    for start, end in zip(starts, ends):
+        keys.append(
+            (
+                str(array.chain_id[start]),
+                int(array.res_id[start]),
+                str(ins_codes[start]) if ins_codes is not None else "",
+                str(array.res_name[start]),
+            )
+        )
+    atom_to_residue = (
+        np.searchsorted(starts, np.arange(array.array_length()), side="right") - 1
+    )
+    return starts, ends, keys, atom_to_residue
+
+
+def _is_standard_polymer_bond(keys, res1, atom1, res2, atom2):
+    """Return whether a cross-residue bond is an adjacent polymer link."""
+
+    if abs(res1 - res2) != 1:
+        return False
+    if keys[res1][0] != keys[res2][0]:
+        return False
+    first_atom, second_atom = (atom1, atom2) if res1 < res2 else (atom2, atom1)
+    return (first_atom, second_atom) in (("C", "N"), ("O3'", "P"))
+
+
+def _explicit_cross_residue_bonds(structure):
+    """Return nonstandard cross-residue bonds from a Biotite bond table."""
+
+    array = _template(structure)
+    if array.bonds is None:
+        return ()
+    _, _, keys, atom_to_residue = _residue_keys(array)
+    result = []
+    occupied = set()
+    for atom1, atom2, _bond_type in array.bonds.as_array():
+        res1, res2 = int(atom_to_residue[atom1]), int(atom_to_residue[atom2])
+        if res1 == res2:
+            continue
+        name1, name2 = str(array.atom_name[atom1]), str(array.atom_name[atom2])
+        if _is_standard_polymer_bond(keys, res1, name1, res2, name2) or {
+            name1,
+            name2,
+        } == {"SG"}:
+            continue
+        endpoints = ((keys[res1], name1), (keys[res2], name2))
+        for endpoint in endpoints:
+            if endpoint in occupied:
+                raise ValueError(
+                    f"covalent attachment atom {endpoint[0]}:{endpoint[1]} "
+                    "has more than one inter-residue bond"
+                )
+            occupied.add(endpoint)
+        result.append(endpoints)
+    return tuple(result)
+
+
+def _angle(a, b, c):
+    ba, bc = a - b, c - b
+    denom = float(np.linalg.norm(ba) * np.linalg.norm(bc))
+    if denom < 1e-12:
+        return 0.0
+    return float(np.arccos(np.clip(np.dot(ba, bc) / denom, -1.0, 1.0)))
+
+
+def _dihedral(a, b, c, d):
+    b1, b2, b3 = b - a, c - b, d - c
+    n1, n2 = np.cross(b1, b2), np.cross(b2, b3)
+    norms = (
+        float(np.linalg.norm(n1)),
+        float(np.linalg.norm(n2)),
+        float(np.linalg.norm(b2)),
+    )
+    if min(norms) < 1e-12:
+        return 0.0
+    n1, n2 = n1 / norms[0], n2 / norms[1]
+    return float(np.arctan2(np.dot(np.cross(n1, b2 / norms[2]), n2), np.dot(n1, n2)))
+
+
+def _connection_icoor(raw, atom, local_coords, remote_coord):
+    adjacency = defaultdict(list)
+    for name1, name2, *_ in raw.bonds:
+        adjacency[name1].append(name2)
+        adjacency[name2].append(name1)
+    gp_candidates = [name for name in adjacency[atom] if name in local_coords]
+    if not gp_candidates:
+        raise ValueError(f"connection atom {raw.name}:{atom} has no local frame")
+    gp = sorted(gp_candidates)[0]
+    ggp_candidates = [
+        name for name in adjacency[gp] if name != atom and name in local_coords
+    ]
+    if not ggp_candidates:
+        ggp_candidates = [name for name in local_coords if name not in (atom, gp)]
+    if not ggp_candidates:
+        raise ValueError(f"connection atom {raw.name}:{atom} lacks a third frame atom")
+    ggp = sorted(ggp_candidates)[0]
+    return Icoor(
+        name=f"covalent_{atom}",
+        phi=-_dihedral(
+            remote_coord, local_coords[atom], local_coords[gp], local_coords[ggp]
+        ),
+        theta=math.pi - _angle(remote_coord, local_coords[atom], local_coords[gp]),
+        d=float(np.linalg.norm(remote_coord - local_coords[atom])),
+        parent=atom,
+        grand_parent=gp,
+        great_grand_parent=ggp,
+    )
+
+
+def augment_database_for_covalent_bonds(structure, param_db):
+    """Add same-atom-layout residue variants needed by explicit input bonds."""
+
+    bonds = _explicit_cross_residue_bonds(structure)
+    if not bonds:
+        return param_db, {}
+
+    array = _template(structure)
+    starts, ends, keys, _ = _residue_keys(array)
+    key_to_residue = {key: i for i, key in enumerate(keys)}
+    attachment_atoms = defaultdict(set)
+    partner_coord = {}
+    for (key1, atom1), (key2, atom2) in bonds:
+        attachment_atoms[key1].add(atom1)
+        attachment_atoms[key2].add(atom2)
+        res1, res2 = key_to_residue[key1], key_to_residue[key2]
+        inds1 = range(starts[res1], ends[res1])
+        inds2 = range(starts[res2], ends[res2])
+        idx1 = next(i for i in inds1 if array.atom_name[i] == atom1)
+        idx2 = next(i for i in inds2 if array.atom_name[i] == atom2)
+        partner_coord[(key1, atom1)] = np.asarray(array.coord[idx2], dtype=np.float64)
+        partner_coord[(key2, atom2)] = np.asarray(array.coord[idx1], dtype=np.float64)
+
+    patterns = set()
+    geometry = {}
+    for key, atoms in attachment_atoms.items():
+        res_ind = key_to_residue[key]
+        local = {
+            str(array.atom_name[i]): np.asarray(array.coord[i], dtype=np.float64)
+            for i in range(starts[res_ind], ends[res_ind])
+        }
+        pattern = (key[3], tuple(sorted(atoms)))
+        patterns.add(pattern)
+        geometry.setdefault(
+            pattern, (local, {a: partner_coord[(key, a)] for a in atoms})
+        )
+
+    clones = []
+    variant_names = {}
+    supported_patterns = set()
+    for raw in param_db.chemical.residues:
+        for res_name, atoms in sorted(patterns):
+            if raw.name3 != res_name or not set(atoms) <= {a.name for a in raw.atoms}:
+                continue
+            local, remotes = geometry[(res_name, atoms)]
+            suffix = ",".join(atoms)
+            clone_name = f"{raw.name}:covalent_{suffix}"
+            added_connections = tuple(
+                Connection(name=f"covalent_{atom}", atom=atom, type="SINGLE")
+                for atom in atoms
+            )
+            added_icoors = tuple(
+                _connection_icoor(raw, atom, local, remotes[atom]) for atom in atoms
+            )
+            clone = attr.evolve(
+                raw,
+                name=clone_name,
+                connections=(*raw.connections, *added_connections),
+                icoors=(*raw.icoors, *added_icoors),
+            )
+            clones.append(clone)
+            variant_names[(raw.name, atoms)] = clone_name
+            supported_patterns.add((res_name, atoms))
+
+    missing = sorted(set(patterns) - supported_patterns)
+    if missing:
+        raise ValueError(
+            f"no residue type supports covalent attachment pattern(s): {missing}"
+        )
+    chemical = attr.evolve(
+        param_db.chemical, residues=(*param_db.chemical.residues, *clones)
+    )
+    return attr.evolve(param_db, chemical=chemical), variant_names
+
+
+def apply_covalent_bonds_from_biotite(pose_stack, structure, variant_names):
+    """Select connection-capable variants and install explicit input bonds."""
+
+    bonds = _explicit_cross_residue_bonds(structure)
+    if not bonds:
+        return pose_stack
+    attachment_atoms = defaultdict(set)
+    for endpoint1, endpoint2 in bonds:
+        attachment_atoms[endpoint1[0]].add(endpoint1[1])
+        attachment_atoms[endpoint2[0]].add(endpoint2[1])
+
+    pbt = pose_stack.packed_block_types
+    name_to_ind = {bt.name: i for i, bt in enumerate(pbt.active_block_types)}
+    type64 = pose_stack.block_type_ind64.clone()
+    key_to_block = {}
+    for pose_index in range(len(pose_stack)):
+        for block in range(pose_stack.max_n_blocks):
+            if type64[pose_index, block] < 0:
+                continue
+            key = (
+                str(pose_stack.pdb_info.chain_labels[pose_index, block]),
+                int(pose_stack.pdb_info.residue_labels[pose_index, block]),
+                str(pose_stack.pdb_info.residue_insertion_codes[pose_index, block]),
+            )
+            key_to_block[(pose_index, key)] = block
+
+    for pose_index in range(len(pose_stack)):
+        for input_key, atoms in attachment_atoms.items():
+            block = key_to_block[(pose_index, input_key[:3])]
+            original = pbt.active_block_types[int(type64[pose_index, block])]
+            clone_name = variant_names[(original.name, tuple(sorted(atoms)))]
+            clone = pbt.active_block_types[name_to_ind[clone_name]]
+            if tuple(a.name for a in clone.atoms) != tuple(
+                a.name for a in original.atoms
+            ):
+                raise ValueError("covalent variants must preserve atom layout")
+            type64[pose_index, block] = name_to_ind[clone_name]
+
+    pose_stack = attr.evolve(
+        pose_stack,
+        coords=pose_stack.coords.clone(),
+        block_type_ind64=type64,
+        block_type_ind=type64.to(torch.int32),
+    )
+    connections = []
+    for pose_index in range(len(pose_stack)):
+        for (key1, atom1), (key2, atom2) in bonds:
+            connections.append(
+                InterResidueConnection(
+                    pose_index,
+                    key_to_block[(pose_index, key1[:3])],
+                    f"covalent_{atom1}",
+                    key_to_block[(pose_index, key2[:3])],
+                    f"covalent_{atom2}",
+                )
+            )
+    return connect_pose_blocks(pose_stack, connections)

--- a/tmol/io/_covalent_bonds.py
+++ b/tmol/io/_covalent_bonds.py
@@ -132,6 +132,37 @@ def _connection_icoor(raw, atom, local_coords, remote_coord):
     )
 
 
+def _virtualize_leaving_hydrogens(raw, attachment_atoms, atom_type_elements):
+    """Turn one bonded hydrogen per new attachment into an inert virtual atom."""
+
+    adjacency = defaultdict(list)
+    for atom1, atom2, *_ in raw.bonds:
+        adjacency[atom1].append(atom2)
+        adjacency[atom2].append(atom1)
+    atom_by_name = {atom.name: atom for atom in raw.atoms}
+    leaving = []
+    for attachment in attachment_atoms:
+        candidates = sorted(
+            neighbor
+            for neighbor in adjacency[attachment]
+            if atom_type_elements[atom_by_name[neighbor].atom_type] == "H"
+            and neighbor not in leaving
+        )
+        if candidates:
+            leaving.append(candidates[0])
+    if not leaving:
+        return raw.atoms, raw.properties
+    atoms = tuple(
+        attr.evolve(atom, atom_type="Vrt") if atom.name in leaving else atom
+        for atom in raw.atoms
+    )
+    properties = attr.evolve(
+        raw.properties,
+        virtual=tuple(dict.fromkeys((*raw.properties.virtual, *leaving))),
+    )
+    return atoms, properties
+
+
 def augment_database_for_covalent_bonds(structure, param_db):
     """Add same-atom-layout residue variants needed by explicit input bonds."""
 
@@ -172,6 +203,9 @@ def augment_database_for_covalent_bonds(structure, param_db):
     clones = []
     variant_names = {}
     supported_patterns = set()
+    atom_type_elements = {
+        atom_type.name: atom_type.element for atom_type in param_db.chemical.atom_types
+    }
     for raw in param_db.chemical.residues:
         for res_name, atoms in sorted(patterns):
             if raw.name3 != res_name or not set(atoms) <= {a.name for a in raw.atoms}:
@@ -186,11 +220,16 @@ def augment_database_for_covalent_bonds(structure, param_db):
             added_icoors = tuple(
                 _connection_icoor(raw, atom, local, remotes[atom]) for atom in atoms
             )
+            clone_atoms, clone_properties = _virtualize_leaving_hydrogens(
+                raw, atoms, atom_type_elements
+            )
             clone = attr.evolve(
                 raw,
                 name=clone_name,
+                atoms=clone_atoms,
                 connections=(*raw.connections, *added_connections),
                 icoors=(*raw.icoors, *added_icoors),
+                properties=clone_properties,
             )
             clones.append(clone)
             variant_names[(raw.name, atoms)] = clone_name

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -80,6 +80,8 @@ def build_context_from_biotite(
         types, parameter database, and residue type set.
     """
     torch_device = resolve_device(torch_device)
+    from tmol.io._covalent_bonds import augment_database_for_covalent_bonds
+
     if prepare_ligands:
         from tmol.ligand import prepare_ligands as _prepare_ligands
 
@@ -96,6 +98,10 @@ def build_context_from_biotite(
             strict_ligands=strict_ligands,
             return_fragment_definitions=True,
         )
+        param_db, covalent_variant_names = augment_database_for_covalent_bonds(
+            biotite_structure, param_db
+        )
+        co = CanonicalOrdering.from_chemdb(param_db.chemical)
         rts = ResidueTypeSet.from_database(param_db.chemical)
         pbt = PackedBlockTypes.from_restype_list(
             rts.chem_db, rts, rts.residue_types, torch_device
@@ -106,6 +112,7 @@ def build_context_from_biotite(
             parameter_database=param_db,
             restype_set=rts,
             fragment_definitions=fragment_definitions,
+            covalent_variant_names=covalent_variant_names,
         )
 
     if param_db is None:
@@ -114,13 +121,25 @@ def build_context_from_biotite(
         db = _paramdb_for_biotite()
         rts = _restype_set_for_biotite()
     else:
-        db = param_db
+        db, covalent_variant_names = augment_database_for_covalent_bonds(
+            biotite_structure, param_db
+        )
         co, rts, pbt = _derived_types_for_param_db(db, torch_device)
+    if param_db is None:
+        # The cached default types are valid only when no custom bonds require
+        # connection-capable clones.
+        db2, covalent_variant_names = augment_database_for_covalent_bonds(
+            biotite_structure, db
+        )
+        if covalent_variant_names:
+            db = db2
+            co, rts, pbt = _derived_types_for_param_db(db, torch_device)
     return PoseBuildContext(
         canonical_ordering=co,
         packed_block_types=pbt,
         parameter_database=db,
         restype_set=rts,
+        covalent_variant_names=covalent_variant_names,
     )
 
 
@@ -264,6 +283,12 @@ def pose_stack_from_biotite(  # noqa: C901
 
         pose_stack = apply_fragment_connections(pose_stack, fragment_mapping)
         fragment_mapping = pose_stack.split_block_mapping
+    if context.covalent_variant_names:
+        from tmol.io._covalent_bonds import apply_covalent_bonds_from_biotite
+
+        pose_stack = apply_covalent_bonds_from_biotite(
+            pose_stack, biotite_structure, context.covalent_variant_names
+        )
     block_has_missing_atoms = opt_return_vals["block_has_missing_atoms"]
 
     if block_has_missing_atoms is not None and torch.any(block_has_missing_atoms):
@@ -441,12 +466,56 @@ def biotite_from_pose_stack(
         co = canonical_ordering_for_biotite()
     cf = canonical_form_from_pose_stack(co, pose_stack)
     structure = biotite_from_canonical_form(cf, co=co)
+    residue_starts = biotite.structure.get_residue_starts(structure)
+    residue_ends = numpy.append(residue_starts[1:], structure.array_length())
+    _add_pose_inter_residue_bonds(structure, pose_stack, residue_starts, residue_ends)
     sbm = getattr(pose_stack, "split_block_mapping", None)
     if merge_fragments and sbm is not None and sbm.entries:
         from tmol.ligand import recombine_fragmented_ligands
 
         structure = recombine_fragmented_ligands(structure, pose_stack)
     return structure
+
+
+def _add_pose_inter_residue_bonds(structure, pose_stack, residue_starts, residue_ends):
+    """Restore PoseStack connection bonds in a Biotite bond table."""
+
+    import biotite.structure as struc
+
+    bond_rows = [] if structure.bonds is None else structure.bonds.as_array().tolist()
+    existing = {tuple(sorted(row[:2])) for row in bond_rows}
+    pbt = pose_stack.packed_block_types
+    for block1, (start1, end1) in enumerate(zip(residue_starts, residue_ends)):
+        type1 = int(pose_stack.block_type_ind64[0, block1])
+        if type1 < 0:
+            continue
+        bt1 = pbt.active_block_types[type1]
+        for conn1, (block2, conn2) in enumerate(
+            pose_stack.inter_residue_connections64[0, block1].cpu().tolist()
+        ):
+            if block2 < block1:
+                continue
+            if block2 < 0:
+                continue
+            bt2 = pbt.active_block_types[int(pose_stack.block_type_ind64[0, block2])]
+            name1 = bt1.connections[conn1].atom
+            name2 = bt2.connections[conn2].atom
+            atom1 = next(
+                i for i in range(start1, end1) if structure.atom_name[i] == name1
+            )
+            atom2 = next(
+                i
+                for i in range(residue_starts[block2], residue_ends[block2])
+                if structure.atom_name[i] == name2
+            )
+            pair = tuple(sorted((atom1, atom2)))
+            if pair not in existing:
+                bond_rows.append((atom1, atom2, int(struc.BondType.SINGLE)))
+                existing.add(pair)
+    if bond_rows:
+        structure.bonds = struc.BondList(
+            structure.array_length(), numpy.asarray(bond_rows, dtype=numpy.int32)
+        )
 
 
 def _map_atoms_to_canonical(co, atom_res_inds, res_names, atom_names):

--- a/tmol/ligand/_fragmentation.py
+++ b/tmol/ligand/_fragmentation.py
@@ -806,67 +806,20 @@ def apply_fragment_connections(pose_stack, mapping: FragmentedLigandPoseMapping)
 
         return _attr.evolve(pose_stack, split_block_mapping=sbm)
 
-    import attr
-    import torch
+    from tmol.pose import InterResidueConnection, connect_pose_blocks
 
-    from tmol.pose import PoseStackBuilder
-
-    pbt = pose_stack.packed_block_types
-    inter_residue_connections64 = pose_stack.inter_residue_connections64.clone()
-    for pose_index in range(len(pose_stack)):
-        for block_a, name_a, block_b, name_b in mapping.connection_pairs:
-            type_a = int(pose_stack.block_type_ind64[pose_index, block_a].item())
-            type_b = int(pose_stack.block_type_ind64[pose_index, block_b].item())
-            restype_a = pbt.active_block_types[type_a]
-            restype_b = pbt.active_block_types[type_b]
-            conn_a = int(restype_a.connection_to_cidx[name_a])
-            conn_b = int(restype_b.connection_to_cidx[name_b])
-            if torch.any(
-                inter_residue_connections64[pose_index, block_a, conn_a] != -1
-            ):
-                raise ValueError(
-                    f"fragment connection {block_a}:{name_a} is already occupied"
-                )
-            if torch.any(
-                inter_residue_connections64[pose_index, block_b, conn_b] != -1
-            ):
-                raise ValueError(
-                    f"fragment connection {block_b}:{name_b} is already occupied"
-                )
-            inter_residue_connections64[pose_index, block_a, conn_a] = torch.tensor(
-                (block_b, conn_b), dtype=torch.int64, device=pose_stack.device
-            )
-            inter_residue_connections64[pose_index, block_b, conn_b] = torch.tensor(
-                (block_a, conn_a), dtype=torch.int64, device=pose_stack.device
-            )
-
-    real_res = pose_stack.block_type_ind64 >= 0
-    (
-        pconn_matrix,
-        pconn_offsets,
-        block_n_conn,
-        pose_n_pconn,
-    ) = PoseStackBuilder._take_real_conn_conn_intrablock_pairs(
-        pbt, pose_stack.block_type_ind64, real_res
-    )
-    PoseStackBuilder._incorporate_inter_residue_connections_into_connectivity_graph(
-        inter_residue_connections64, pconn_offsets, pconn_matrix
-    )
-    inter_block_bondsep64 = (
-        PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph(
-            pbt, block_n_conn, pose_n_pconn, pconn_matrix
-        )
-    )
-    result = attr.evolve(
+    result = connect_pose_blocks(
         pose_stack,
-        coords=pose_stack.coords.clone(),
-        inter_residue_connections=inter_residue_connections64.to(torch.int32),
-        inter_residue_connections64=inter_residue_connections64,
-        inter_block_bondsep=inter_block_bondsep64.to(torch.int32),
-        inter_block_bondsep64=inter_block_bondsep64,
+        (
+            InterResidueConnection(pose_index, block_a, name_a, block_b, name_b)
+            for pose_index in range(len(pose_stack))
+            for block_a, name_a, block_b, name_b in mapping.connection_pairs
+        ),
     )
     result, sbm = build_split_block_mapping(result, mapping)
-    return attr.evolve(result, split_block_mapping=sbm)
+    import attr as _attr
+
+    return _attr.evolve(result, split_block_mapping=sbm)
 
 
 def build_split_block_mapping(

--- a/tmol/ligand/_preparation.py
+++ b/tmol/ligand/_preparation.py
@@ -379,11 +379,6 @@ def _ligand_unsupported_reason(
             "types for them"
         )
 
-    if lig.covalently_linked:
-        return (
-            f"{lig.res_name}: ligand is covalently linked to another residue "
-            "(e.g. glycan attached to protein) — not supported"
-        )
     return None
 
 

--- a/tmol/pose/__init__.py
+++ b/tmol/pose/__init__.py
@@ -8,6 +8,10 @@ from ._pdb_info import (  # noqa: F401
 )  # noqa: F401
 from ._pose_stack import PoseStack  # noqa: F401
 from ._pose_stack_builder import PoseStackBuilder  # noqa: F401
+from ._inter_residue_connection import (  # noqa: F401
+    InterResidueConnection,
+    connect_pose_blocks,
+)
 from ._sequence import (  # noqa: F401
     SeqToken,
     resolve_block_type_names,
@@ -23,6 +27,7 @@ __all__ = [
     "PackedBlockTypes",
     "PoseStack",
     "PoseStackBuilder",
+    "InterResidueConnection",
     "SeqToken",
     "SplitBlockEntry",
     "SplitBlockMapping",
@@ -31,4 +36,5 @@ __all__ = [
     "resolve_block_type_names",
     "smiles_in_tokens",
     "tokenize_sequences",
+    "connect_pose_blocks",
 ]

--- a/tmol/pose/_inter_residue_connection.py
+++ b/tmol/pose/_inter_residue_connection.py
@@ -1,0 +1,101 @@
+"""Utilities for installing explicit covalent bonds between pose blocks."""
+
+from dataclasses import dataclass
+
+import attr
+import torch
+
+from tmol.pose._pose_stack_builder import PoseStackBuilder
+
+
+@dataclass(frozen=True)
+class InterResidueConnection:
+    """A reciprocal bond between named connection sites on two blocks."""
+
+    pose_index: int
+    block1: int
+    connection1: str
+    block2: int
+    connection2: str
+
+
+def connect_pose_blocks(pose_stack, connections):
+    """Install explicit inter-residue bonds and rebuild bonded distances.
+
+    Both block types must already expose the named connection sites.  This
+    keeps chemistry declaration (residue types and variants) separate from
+    topology declaration (which residues are actually bonded), as in Rosetta.
+    The input pose is not modified.
+    """
+
+    connections = tuple(connections)
+    if not connections:
+        return pose_stack
+
+    pbt = pose_stack.packed_block_types
+    inter64 = pose_stack.inter_residue_connections64.clone()
+
+    for bond in connections:
+        if not 0 <= bond.pose_index < len(pose_stack):
+            raise IndexError(f"pose index {bond.pose_index} is out of range")
+        if bond.block1 == bond.block2:
+            raise ValueError("an inter-residue connection requires two blocks")
+
+        endpoints = (
+            (bond.block1, bond.connection1),
+            (bond.block2, bond.connection2),
+        )
+        resolved = []
+        for block, connection in endpoints:
+            if not 0 <= block < pose_stack.max_n_blocks:
+                raise IndexError(f"block index {block} is out of range")
+            bt_ind = int(pose_stack.block_type_ind64[bond.pose_index, block].item())
+            if bt_ind < 0:
+                raise ValueError(f"pose {bond.pose_index} block {block} is empty")
+            bt = pbt.active_block_types[bt_ind]
+            try:
+                conn_ind = int(bt.connection_to_cidx[connection])
+            except KeyError as exc:
+                raise ValueError(
+                    f"block {block} ({bt.name}) has no connection named "
+                    f"'{connection}'"
+                ) from exc
+            if torch.any(inter64[bond.pose_index, block, conn_ind] != -1):
+                raise ValueError(f"connection {block}:{connection} is already occupied")
+            resolved.append((block, conn_ind, bt))
+
+        (block1, conn1, bt1), (block2, conn2, bt2) = resolved
+        type1 = bt1.connections[conn1].type
+        type2 = bt2.connections[conn2].type
+        if type1 != type2:
+            raise ValueError(
+                f"connection bond types disagree: {block1}:{bond.connection1} "
+                f"is {type1}, {block2}:{bond.connection2} is {type2}"
+            )
+        inter64[bond.pose_index, block1, conn1] = torch.tensor(
+            (block2, conn2), dtype=torch.int64, device=pose_stack.device
+        )
+        inter64[bond.pose_index, block2, conn2] = torch.tensor(
+            (block1, conn1), dtype=torch.int64, device=pose_stack.device
+        )
+
+    real_res = pose_stack.block_type_ind64 >= 0
+    pconn, offsets, block_n_conn, pose_n_pconn = (
+        PoseStackBuilder._take_real_conn_conn_intrablock_pairs(
+            pbt, pose_stack.block_type_ind64, real_res
+        )
+    )
+    PoseStackBuilder._incorporate_inter_residue_connections_into_connectivity_graph(
+        inter64, offsets, pconn
+    )
+    bondsep64 = PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph(
+        pbt, block_n_conn, pose_n_pconn, pconn
+    )
+    return attr.evolve(
+        pose_stack,
+        coords=pose_stack.coords.clone(),
+        inter_residue_connections=inter64.to(torch.int32),
+        inter_residue_connections64=inter64,
+        inter_block_bondsep=bondsep64.to(torch.int32),
+        inter_block_bondsep64=bondsep64,
+    )

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -124,11 +124,20 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
                     for atom1, atom2, atom4 in comb:
                         improper.append((atom1, atom2, atom3, atom4))
 
-        return (
-            lengths,
-            angles,
-            torsions,
-            improper,
+        virtual = {
+            block_type.atom_to_idx[name] for name in block_type.properties.virtual
+        }
+
+        def without_virtual(subgraphs):
+            return [
+                graph
+                for graph in subgraphs
+                if virtual.isdisjoint(atom for atom in graph if atom >= 0)
+            ]
+
+        return tuple(
+            without_virtual(subgraphs)
+            for subgraphs in (lengths, angles, torsions, improper)
         )
 
     def get_raw_params_for_res(self, res: str):
@@ -326,7 +335,6 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         # Fill the hash table
         cur_val = 0
         for bt in packed_block_types.active_block_types:
-
             bt_params = bt.cartbonded_annotations[self.hash]
             for key_w_str, value in bt_params.cartbonded_params.items():
                 key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -54,6 +54,8 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         # fd let's try not to grab data members from the param resolver ...
 
         partial_charge = self.param_resolver.get_partial_charges_for_block(block_type)
+        for atom_name in block_type.properties.virtual:
+            partial_charge[block_type.atom_to_idx[atom_name]] = 0.0
 
         # count pair representative logic:
         # decide whether or not two atoms i and j should have their interaction counted
@@ -72,6 +74,12 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         representative_mapping = (
             self.param_resolver.get_bonded_path_length_mapping_for_block(block_type)
         )
+        virtual_indices = {
+            block_type.atom_to_idx[name] for name in block_type.properties.virtual
+        }
+        for atom_index, representative in enumerate(representative_mapping):
+            if representative in virtual_indices:
+                representative_mapping[atom_index] = atom_index
 
         inter_rep_path_dist = block_type.path_distance[:, representative_mapping]
         intra_rep_path_dist = inter_rep_path_dist[representative_mapping, :]

--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -8,7 +8,7 @@ from ..hbond._hbond_dependent_term import HBondDependentTerm
 from ..ljlk._params import LJLKGlobalParams, LJLKParamResolver
 from tmol.database import ParameterDatabase
 
-from tmol.chemical import RefinedResidueType
+from tmol.chemical import RefinedResidueType, bonds_and_bond_ranges
 from tmol.pose import (
     PackedBlockTypes,
     PoseStack,
@@ -114,10 +114,11 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         tiled_polars = numpy.full((n_tiles, tile_size), -1, dtype=numpy.int32)
         tiled_polars[is_tiled_polar] = polar_inds
 
-        # ASSUMPTION! either h or hvy; change when VRTS are added!
-        # Grace: lk parameters for VRTs should not affect score even if included,
-        # it would just be slightly inefficient
         atom_is_heavy = numpy.invert(hbbt_params.is_hydrogen == 1)
+        virtual = [
+            block_type.atom_to_idx[name] for name in block_type.properties.virtual
+        ]
+        atom_is_heavy[virtual] = False
 
         # "apolar" here means "does not build waters"; e.g. proline's N would be
         # considered apolar.
@@ -228,6 +229,22 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             tile_pol_occ_inds[i, :i_n_tiles] = i_lkbp.tile_pol_occ_inds
             tile_lk_ball_params[i, :i_n_tiles] = i_lkbp.tile_lk_ball_params
 
+        water_gen_bonds = []
+        for bt in packed_block_types.active_block_types:
+            virtual = numpy.zeros(bt.n_atoms, dtype=bool)
+            virtual[[bt.atom_to_idx[name] for name in bt.properties.virtual]] = True
+            bonds = bt.bond_indices[
+                numpy.logical_not(
+                    numpy.logical_or(
+                        virtual[bt.bond_indices[:, 0]],
+                        virtual[bt.bond_indices[:, 1]],
+                    )
+                )
+            ]
+            water_gen_bonds.append(
+                bonds_and_bond_ranges(bt.n_atoms, bonds, bt.ordered_connection_atoms)
+            )
+
         def _t(t):
             return torch.tensor(t, device=packed_block_types.device)
 
@@ -238,6 +255,34 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             tile_lk_ball_params=_t(tile_lk_ball_params),
         )
         setattr(packed_block_types, "lk_ball_params", lk_ball_params)
+        max_n_bonds = max(bonds.shape[0] for bonds, _ranges in water_gen_bonds)
+        packed_bonds = torch.full(
+            (n_types, max_n_bonds, 3),
+            -1,
+            dtype=torch.int32,
+            device=packed_block_types.device,
+        )
+        packed_ranges = torch.full(
+            (n_types, packed_block_types.max_n_atoms, 2),
+            -1,
+            dtype=torch.int32,
+            device=packed_block_types.device,
+        )
+        for i, (bonds, ranges) in enumerate(water_gen_bonds):
+            packed_bonds[i, : bonds.shape[0]] = _t(bonds)
+            packed_ranges[i, : ranges.shape[0]] = _t(ranges)
+        setattr(
+            packed_block_types,
+            "lk_ball_n_all_bonds",
+            _t(
+                numpy.array(
+                    [bonds.shape[0] for bonds, _ranges in water_gen_bonds],
+                    dtype=numpy.int32,
+                )
+            ),
+        )
+        setattr(packed_block_types, "lk_ball_all_bonds", packed_bonds)
+        setattr(packed_block_types, "lk_ball_atom_all_bond_ranges", packed_ranges)
 
     def setup_poses(self, pose_stack: PoseStack):
         super(LKBallEnergyTerm, self).setup_poses(pose_stack)
@@ -258,9 +303,9 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             pose_stack.packed_block_types.n_atoms,
             pose_stack.packed_block_types.n_conn,
             pose_stack.packed_block_types.conn_atom,
-            pose_stack.packed_block_types.n_all_bonds,
-            pose_stack.packed_block_types.all_bonds,
-            pose_stack.packed_block_types.atom_all_bond_ranges,
+            pose_stack.packed_block_types.lk_ball_n_all_bonds,
+            pose_stack.packed_block_types.lk_ball_all_bonds,
+            pose_stack.packed_block_types.lk_ball_atom_all_bond_ranges,
             pose_stack.packed_block_types.hbpbt_params.tile_n_donH,
             pose_stack.packed_block_types.hbpbt_params.tile_n_acc,
             pose_stack.packed_block_types.hbpbt_params.tile_donH_inds,
@@ -320,9 +365,9 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             pose_stack.packed_block_types.n_atoms,
             pose_stack.packed_block_types.n_conn,
             pose_stack.packed_block_types.conn_atom,
-            pose_stack.packed_block_types.n_all_bonds,
-            pose_stack.packed_block_types.all_bonds,
-            pose_stack.packed_block_types.atom_all_bond_ranges,
+            pose_stack.packed_block_types.lk_ball_n_all_bonds,
+            pose_stack.packed_block_types.lk_ball_all_bonds,
+            pose_stack.packed_block_types.lk_ball_atom_all_bond_ranges,
             pose_stack.packed_block_types.hbpbt_params.tile_n_donH,
             pose_stack.packed_block_types.hbpbt_params.tile_n_acc,
             pose_stack.packed_block_types.hbpbt_params.tile_donH_inds,

--- a/tmol/tests/io/test_explicit_covalent_bonds.py
+++ b/tmol/tests/io/test_explicit_covalent_bonds.py
@@ -3,8 +3,12 @@ import numpy as np
 import pytest
 import torch
 
+from tmol.database import ParameterDatabase
 from tmol.io import biotite_from_pose_stack, pose_stack_from_biotite
-from tmol.io._covalent_bonds import _explicit_cross_residue_bonds
+from tmol.io._covalent_bonds import (
+    _explicit_cross_residue_bonds,
+    augment_database_for_covalent_bonds,
+)
 
 
 def _crosslinked_protein(biotite_1ubq):
@@ -130,3 +134,41 @@ def test_only_adjacent_c_n_bonds_are_treated_as_polymer(biotite_1ubq):
     bonds = _explicit_cross_residue_bonds(structure)
     assert len(bonds) == 1
     assert {endpoint[1] for endpoint in bonds[0]} == {"C", "N"}
+
+
+def test_attachment_virtualizes_a_leaving_hydrogen(biotite_1ubq):
+    """Adding an explicit bond does not leave an over-valent hydroxyl."""
+
+    structure = biotite_1ubq.copy()
+    starts = struc.get_residue_starts(structure)
+    ser_residue = next(
+        i for i, start in enumerate(starts) if structure.res_name[start] == "SER"
+    )
+    other_residue = ser_residue + 2
+    ends = np.append(starts[1:], structure.array_length())
+    atom1 = next(
+        i
+        for i in range(starts[ser_residue], ends[ser_residue])
+        if structure.atom_name[i] == "OG"
+    )
+    atom2 = next(
+        i
+        for i in range(starts[other_residue], ends[other_residue])
+        if structure.atom_name[i] == "O"
+    )
+    structure.bonds = struc.BondList(
+        structure.array_length(),
+        np.asarray([(atom1, atom2, int(struc.BondType.SINGLE))], dtype=np.int32),
+    )
+
+    database, variants = augment_database_for_covalent_bonds(
+        structure, ParameterDatabase.get_default()
+    )
+    variant = next(
+        residue
+        for residue in database.chemical.residues
+        if residue.name == variants[("SER", ("OG",))]
+    )
+    hg = next(atom for atom in variant.atoms if atom.name == "HG")
+    assert hg.atom_type == "Vrt"
+    assert "HG" in variant.properties.virtual

--- a/tmol/tests/io/test_explicit_covalent_bonds.py
+++ b/tmol/tests/io/test_explicit_covalent_bonds.py
@@ -1,0 +1,132 @@
+import biotite.structure as struc
+import numpy as np
+import pytest
+import torch
+
+from tmol.io import biotite_from_pose_stack, pose_stack_from_biotite
+from tmol.io._covalent_bonds import _explicit_cross_residue_bonds
+
+
+def _crosslinked_protein(biotite_1ubq):
+    structure = biotite_1ubq.copy()
+    starts = struc.get_residue_starts(structure)
+    structure = structure[: starts[3]].copy()
+    starts = struc.get_residue_starts(structure)
+    ends = np.append(starts[1:], structure.array_length())
+    atom1 = next(i for i in range(starts[0], ends[0]) if structure.atom_name[i] == "O")
+    atom2 = next(i for i in range(starts[2], ends[2]) if structure.atom_name[i] == "O")
+    rows = [] if structure.bonds is None else structure.bonds.as_array().tolist()
+    rows.append((atom1, atom2, int(struc.BondType.SINGLE)))
+    structure.bonds = struc.BondList(
+        structure.array_length(), np.asarray(rows, dtype=np.int32)
+    )
+    return structure, atom1, atom2
+
+
+def test_explicit_nonpolymeric_bond_round_trip_and_score(biotite_1ubq, torch_device):
+    structure, _, _ = _crosslinked_protein(biotite_1ubq)
+    pose, context = pose_stack_from_biotite(
+        structure, torch_device, no_optH=True, return_context=True
+    )
+
+    block_types = [
+        pose.packed_block_types.active_block_types[int(ind)]
+        for ind in pose.block_type_ind64[0]
+        if ind >= 0
+    ]
+    assert block_types[0].name.endswith(":covalent_O")
+    assert block_types[2].name.endswith(":covalent_O")
+    conn1 = block_types[0].connection_to_cidx["covalent_O"]
+    conn2 = block_types[2].connection_to_cidx["covalent_O"]
+    assert tuple(pose.inter_residue_connections64[0, 0, conn1].tolist()) == (
+        2,
+        conn2,
+    )
+    assert tuple(pose.inter_residue_connections64[0, 2, conn2].tolist()) == (
+        0,
+        conn1,
+    )
+    assert int(pose.inter_block_bondsep64[0, 0, 2, conn1, conn2]) == 1
+
+    from tmol import beta2016_score_function
+
+    coords = pose.coords.detach().clone().requires_grad_(True)
+    score = (
+        beta2016_score_function(torch_device, param_db=context.parameter_database)
+        .render_whole_pose_scoring_module(pose)(coords)
+        .sum()
+    )
+    score.backward()
+    assert torch.isfinite(score)
+    assert torch.all(torch.isfinite(coords.grad))
+
+    exported = biotite_from_pose_stack(pose, co=context.canonical_ordering)
+    starts = struc.get_residue_starts(exported)
+    atom_res = (
+        np.searchsorted(starts, np.arange(exported.array_length()), side="right") - 1
+    )
+    cross = {
+        (
+            int(atom_res[a]),
+            str(exported.atom_name[a]),
+            int(atom_res[b]),
+            str(exported.atom_name[b]),
+        )
+        for a, b, _ in exported.bonds.as_array()
+        if atom_res[a] != atom_res[b]
+    }
+    assert (0, "O", 2, "O") in cross or (2, "O", 0, "O") in cross
+
+
+def test_reusing_context_preserves_explicit_topology(biotite_1ubq, torch_device):
+    structure, _, _ = _crosslinked_protein(biotite_1ubq)
+    first, context = pose_stack_from_biotite(
+        structure, torch_device, no_optH=True, return_context=True
+    )
+    moved = structure.copy()
+    moved.coord += np.float32(0.25)
+    second = pose_stack_from_biotite(moved, torch_device, no_optH=True, context=context)
+    assert torch.equal(
+        first.inter_residue_connections, second.inter_residue_connections
+    )
+
+
+def test_attachment_atom_cannot_have_two_partners(biotite_1ubq, torch_device):
+    structure, atom1, _ = _crosslinked_protein(biotite_1ubq)
+    starts = struc.get_residue_starts(structure)
+    atom3 = next(
+        i for i in range(starts[1], starts[2]) if structure.atom_name[i] == "O"
+    )
+    rows = structure.bonds.as_array().tolist()
+    rows.append((atom1, atom3, int(struc.BondType.SINGLE)))
+    structure.bonds = struc.BondList(
+        structure.array_length(), np.asarray(rows, dtype=np.int32)
+    )
+    with pytest.raises(ValueError, match="more than one inter-residue bond"):
+        pose_stack_from_biotite(structure, torch_device, no_optH=True)
+
+
+def test_only_adjacent_c_n_bonds_are_treated_as_polymer(biotite_1ubq):
+    structure = biotite_1ubq.copy()
+    starts = struc.get_residue_starts(structure)
+    structure = structure[: starts[3]].copy()
+    starts = struc.get_residue_starts(structure)
+    ends = np.append(starts[1:], structure.array_length())
+    carbon = next(i for i in range(starts[0], ends[0]) if structure.atom_name[i] == "C")
+    adjacent_nitrogen = next(
+        i for i in range(starts[1], ends[1]) if structure.atom_name[i] == "N"
+    )
+    distant_nitrogen = next(
+        i for i in range(starts[2], ends[2]) if structure.atom_name[i] == "N"
+    )
+    rows = [
+        (carbon, adjacent_nitrogen, int(struc.BondType.SINGLE)),
+        (carbon, distant_nitrogen, int(struc.BondType.SINGLE)),
+    ]
+    structure.bonds = struc.BondList(
+        structure.array_length(), np.asarray(rows, dtype=np.int32)
+    )
+
+    bonds = _explicit_cross_residue_bonds(structure)
+    assert len(bonds) == 1
+    assert {endpoint[1] for endpoint in bonds[0]} == {"C", "N"}

--- a/tmol/tests/io/test_explicit_covalent_bonds.py
+++ b/tmol/tests/io/test_explicit_covalent_bonds.py
@@ -136,7 +136,7 @@ def test_only_adjacent_c_n_bonds_are_treated_as_polymer(biotite_1ubq):
     assert {endpoint[1] for endpoint in bonds[0]} == {"C", "N"}
 
 
-def test_attachment_virtualizes_a_leaving_hydrogen(biotite_1ubq):
+def test_attachment_virtualizes_a_leaving_hydrogen(biotite_1ubq, torch_device):
     """Adding an explicit bond does not leave an over-valent hydroxyl."""
 
     structure = biotite_1ubq.copy()
@@ -146,16 +146,11 @@ def test_attachment_virtualizes_a_leaving_hydrogen(biotite_1ubq):
     )
     other_residue = ser_residue + 2
     ends = np.append(starts[1:], structure.array_length())
-    atom1 = next(
-        i
-        for i in range(starts[ser_residue], ends[ser_residue])
-        if structure.atom_name[i] == "OG"
-    )
-    atom2 = next(
-        i
-        for i in range(starts[other_residue], ends[other_residue])
-        if structure.atom_name[i] == "O"
-    )
+    structure = structure[starts[ser_residue] : ends[other_residue]].copy()
+    starts = struc.get_residue_starts(structure)
+    ends = np.append(starts[1:], structure.array_length())
+    atom1 = next(i for i in range(starts[0], ends[0]) if structure.atom_name[i] == "OG")
+    atom2 = next(i for i in range(starts[2], ends[2]) if structure.atom_name[i] == "O")
     structure.bonds = struc.BondList(
         structure.array_length(),
         np.asarray([(atom1, atom2, int(struc.BondType.SINGLE))], dtype=np.int32),
@@ -172,3 +167,20 @@ def test_attachment_virtualizes_a_leaving_hydrogen(biotite_1ubq):
     hg = next(atom for atom in variant.atoms if atom.name == "HG")
     assert hg.atom_type == "Vrt"
     assert "HG" in variant.properties.virtual
+
+    pose, context = pose_stack_from_biotite(
+        structure, torch_device, no_optH=True, return_context=True
+    )
+    block_type = pose.packed_block_types.active_block_types[
+        int(pose.block_type_ind64[0, 0])
+    ]
+    virtual_index = int(pose.block_coord_offset64[0, 0]) + block_type.atom_to_idx["HG"]
+    from tmol import beta2016_score_function
+
+    scorer = beta2016_score_function(
+        torch_device, param_db=context.parameter_database
+    ).render_whole_pose_scoring_module(pose)
+    reference = scorer(pose.coords)
+    moved = pose.coords.clone()
+    moved[0, virtual_index] += 50.0
+    torch.testing.assert_close(scorer(moved), reference, atol=0, rtol=0)


### PR DESCRIPTION
Stack 1/6: generic covalent-topology foundation.

## Summary
- import explicit noncanonical inter-residue bonds from Biotite bond tables
- add a reusable pose-block connection primitive
- generate same-layout connection variants and virtualize displaced attachment hydrogens
- exclude virtual leaving atoms from cartbonded, electrostatics, and LK-ball scoring
- preserve standard peptide, nucleotide, and disulfide handling

## Validation
- focused CPU/CUDA covalent and virtual-atom tests: **9 passed**
- cartbonded, electrostatics, and LK-ball regression suites: **58 passed**
- rebased onto current master (including #425)

Next: #420 adds programmatic modified-polymer specialization.