### PR TITLE
Support programmatic explicit metal coordination

### DIFF
--- a/tmol/io/_build_context.py
+++ b/tmol/io/_build_context.py
@@ -26,3 +26,5 @@ class PoseBuildContext:
     ligand_names: dict = field(default_factory=dict)
     # (base block-type name, attachment atoms) -> connection-capable clone.
     covalent_variant_names: dict = field(default_factory=dict)
+    # (base block-type name, coordination signature) -> metal-capable clone.
+    metal_variant_names: dict = field(default_factory=dict)

--- a/tmol/io/_covalent_bonds.py
+++ b/tmol/io/_covalent_bonds.py
@@ -52,6 +52,8 @@ def _is_standard_polymer_bond(keys, res1, atom1, res2, atom2):
 def _explicit_cross_residue_bonds(structure):
     """Return nonstandard cross-residue bonds from a Biotite bond table."""
 
+    from tmol.ligand._detect import _METAL_SYMBOLS
+
     array = _template(structure)
     if array.bonds is None:
         return ()
@@ -61,6 +63,11 @@ def _explicit_cross_residue_bonds(structure):
     for atom1, atom2, _bond_type in array.bonds.as_array():
         res1, res2 = int(atom_to_residue[atom1]), int(atom_to_residue[atom2])
         if res1 == res2:
+            continue
+        elements = {
+            str(array.element[index]).strip().capitalize() for index in (atom1, atom2)
+        }
+        if elements & _METAL_SYMBOLS:
             continue
         name1, name2 = str(array.atom_name[atom1]), str(array.atom_name[atom2])
         if _is_standard_polymer_bond(keys, res1, name1, res2, name2) or {

--- a/tmol/io/_metal_bonds.py
+++ b/tmol/io/_metal_bonds.py
@@ -1,0 +1,514 @@
+"""Import explicit metal coordination bonds from Biotite structures."""
+
+from collections import Counter, defaultdict
+import math
+
+import attr
+import numpy as np
+import torch
+
+from tmol.database import ParameterDatabase, inject_residue_params
+from tmol.database.chemical import (
+    Atom,
+    AtomType,
+    ChemicalProperties,
+    Connection,
+    Element,
+    Icoor,
+    PolymerProperties,
+    ProtonationProperties,
+    RawResidueType,
+)
+from tmol.database.scoring._ljlk import LJLKAtomTypeParameters
+from tmol.io._covalent_bonds import (
+    _connection_icoor,
+    _residue_keys,
+    _template,
+    _virtualize_leaving_hydrogens,
+)
+from tmol.pose import InterResidueConnection, connect_pose_blocks
+
+MAX_COORDINATION_CONNECTIONS = 8
+
+# Rosetta fa_standard ion physics.  This is an element-level force-field table,
+# not a residue-name catalog: deposited component and atom names are preserved
+# when residue types are generated below.
+_METAL_PARAMETERS = {
+    "Mg": (12, "Mg2p", 2.0, (1.185, 0.015, -5.0, 3.5, 7.0)),
+    "Ca": (20, "Ca2p", 2.0, (1.367, 0.120, 0.0, 2.0, 10.7)),
+    "Zn": (30, "Zn2p", 2.0, (1.090, 0.250, -5.0, 3.5, 5.4)),
+}
+
+
+def _element(value):
+    value = str(value).strip()
+    return value[:1].upper() + value[1:].lower()
+
+
+def _metal_residues(structure):
+    """Return supported single-ion components keyed by deposited name."""
+
+    array = _template(structure)
+    starts, ends, keys, _ = _residue_keys(array)
+    result = {}
+    for start, end, key in zip(starts, ends, keys):
+        supported = [
+            index
+            for index in range(start, end)
+            if _element(array.element[index]) in _METAL_PARAMETERS
+        ]
+        if not supported:
+            continue
+        if len(supported) != 1 or end - start != 1:
+            raise ValueError(
+                f"{key}: supported metal components must contain one ion atom"
+            )
+        index = supported[0]
+        value = (_element(array.element[index]), str(array.atom_name[index]))
+        previous = result.setdefault(key[3], value)
+        if previous != value:
+            raise ValueError(
+                f"metal component name {key[3]!r} denotes inconsistent ions"
+            )
+    return result
+
+
+def _metal_residue_type(name, atom_name, atom_type):
+    virtuals = tuple(f"V{index}" for index in range(1, 9))
+    atoms = (Atom(atom_name, atom_type), *(Atom(name, "Vrt") for name in virtuals))
+    bonds = tuple((atom_name, name, "SINGLE", False) for name in virtuals)
+    icoors = (
+        Icoor(atom_name, 0.0, 0.0, 0.0, atom_name, "V1", "V2"),
+        Icoor("V1", 0.0, math.pi, 1.0, atom_name, "V1", "V2"),
+        Icoor("V2", 0.0, math.pi / 2, 1.0, atom_name, "V1", "V2"),
+        Icoor("V3", math.pi / 2, math.pi / 2, 1.0, atom_name, "V2", "V1"),
+        Icoor("V4", math.pi, math.pi / 2, 1.0, atom_name, "V2", "V1"),
+        Icoor("V5", math.pi, math.pi / 2, 1.0, atom_name, "V1", "V2"),
+        Icoor("V6", -math.pi / 2, math.pi / 2, 1.0, atom_name, "V2", "V1"),
+        Icoor("V7", math.pi / 4, math.pi / 2, 1.0, atom_name, "V1", "V2"),
+        Icoor("V8", -math.pi / 4, math.pi / 2, 1.0, atom_name, "V1", "V2"),
+    )
+    properties = ChemicalProperties(
+        is_canonical=False,
+        polymer=PolymerProperties(False, None, None, (), "NA", ()),
+        chemical_modifications=("generated_metal",),
+        connectivity=(),
+        protonation=ProtonationProperties((), "positively_charged", 7.0),
+        virtual=virtuals,
+    )
+    return RawResidueType(
+        name=name,
+        base_name=name,
+        name3=name,
+        io_equiv_class=name,
+        atoms=atoms,
+        atom_aliases=(),
+        bonds=bonds,
+        connections=(),
+        torsions=(),
+        icoors=icoors,
+        properties=properties,
+        chi_samples=(),
+        default_jump_connection_atom=atom_name,
+    )
+
+
+def augment_database_for_metals(structure, param_db: ParameterDatabase):
+    """Generate deposited Mg/Ca/Zn components and Rosetta ion parameters."""
+
+    components = _metal_residues(structure)
+    existing = {residue.name for residue in param_db.chemical.residues}
+    additions = []
+    charges = {}
+    added_elements = set()
+    for name, (element, atom_name) in components.items():
+        if name in existing:
+            continue
+        _atomic_number, atom_type, charge, _ljlk = _METAL_PARAMETERS[element]
+        additions.append(_metal_residue_type(name, atom_name, atom_type))
+        charges[name] = {atom_name: charge, **{f"V{i}": 0.0 for i in range(1, 9)}}
+        added_elements.add(element)
+    if not additions:
+        return param_db
+
+    result = inject_residue_params(
+        param_db,
+        additions,
+        atom_types=[
+            AtomType(_METAL_PARAMETERS[element][1], element)
+            for element in sorted(added_elements)
+        ],
+        partial_charges=charges,
+    )
+    existing_elements = {element.name for element in result.chemical.element_types}
+    elements = tuple(
+        Element(element, _METAL_PARAMETERS[element][0])
+        for element in sorted(added_elements)
+        if element not in existing_elements
+    )
+    existing_ljlk = {
+        parameter.name for parameter in result.scoring.ljlk.atom_type_parameters
+    }
+    ljlk = tuple(
+        LJLKAtomTypeParameters(atom_type, *values)
+        for element in sorted(set(value[0] for value in components.values()))
+        for _atomic_number, atom_type, _charge, values in [_METAL_PARAMETERS[element]]
+        if atom_type not in existing_ljlk
+    )
+    chemical = attr.evolve(
+        result.chemical,
+        element_types=(*result.chemical.element_types, *elements),
+    )
+    scoring = attr.evolve(
+        result.scoring,
+        ljlk=attr.evolve(
+            result.scoring.ljlk,
+            atom_type_parameters=(*result.scoring.ljlk.atom_type_parameters, *ljlk),
+        ),
+    )
+    return attr.evolve(result, chemical=chemical, scoring=scoring)
+
+
+def _metal_cross_residue_bonds(structure):
+    """Return sorted metal--donor contacts from an explicit bond table."""
+
+    array = _template(structure)
+    if array.bonds is None:
+        return ()
+    _, _, keys, atom_to_residue = _residue_keys(array)
+    contacts = []
+    for atom1, atom2, _bond_type in array.bonds.as_array():
+        res1, res2 = int(atom_to_residue[atom1]), int(atom_to_residue[atom2])
+        if res1 == res2:
+            continue
+        is_metal1 = _element(array.element[atom1]) in _METAL_PARAMETERS
+        is_metal2 = _element(array.element[atom2]) in _METAL_PARAMETERS
+        if is_metal1 == is_metal2:
+            continue
+        metal_i, donor_i = (atom1, atom2) if is_metal1 else (atom2, atom1)
+        metal_res = int(atom_to_residue[metal_i])
+        donor_res = int(atom_to_residue[donor_i])
+        contacts.append(
+            (
+                (keys[metal_res], str(array.atom_name[metal_i])),
+                (keys[donor_res], str(array.atom_name[donor_i])),
+            )
+        )
+    return tuple(sorted(contacts))
+
+
+def _connection_names(contacts):
+    """Assign deterministic unique names, including bridging donors."""
+
+    totals = Counter(endpoint for contact in contacts for endpoint in contact)
+    seen = Counter()
+    named = []
+    for contact in contacts:
+        names = []
+        for key, atom in contact:
+            endpoint = (key, atom)
+            seen[endpoint] += 1
+            suffix = f"_{seen[endpoint]}" if totals[endpoint] > 1 else ""
+            names.append(f"metal_{atom}{suffix}")
+        named.append((contact[0], names[0], contact[1], names[1]))
+    return tuple(named)
+
+
+def _metal_connection_icoor(raw, connection_name, atom, distance):
+    """Create an ion connection frame using its built-in virtual geometry."""
+
+    virtuals = tuple(raw.properties.virtual)
+    if len(virtuals) < 2:
+        raise ValueError(f"metal residue {raw.name} lacks two virtual frame atoms")
+    return Icoor(
+        name=connection_name,
+        phi=0.0,
+        theta=math.pi / 2,
+        d=distance,
+        parent=atom,
+        grand_parent=virtuals[0],
+        great_grand_parent=virtuals[1],
+    )
+
+
+def _fallback_connection_icoor(raw, connection_name, atom, distance):
+    """Return a topology-only frame when deposited local frame atoms are absent."""
+
+    adjacency = defaultdict(list)
+    for atom1, atom2, *_ in raw.bonds:
+        adjacency[atom1].append(atom2)
+        adjacency[atom2].append(atom1)
+    if not adjacency[atom]:
+        raise ValueError(f"connection atom {raw.name}:{atom} has no local frame")
+    grand_parent = sorted(adjacency[atom])[0]
+    great_grandparents = sorted(
+        name for name in adjacency[grand_parent] if name != atom
+    )
+    if not great_grandparents:
+        great_grandparents = sorted(
+            atom_info.name
+            for atom_info in raw.atoms
+            if atom_info.name not in (atom, grand_parent)
+        )
+    if not great_grandparents:
+        raise ValueError(f"connection atom {raw.name}:{atom} lacks a third frame atom")
+    return Icoor(
+        name=connection_name,
+        phi=0.0,
+        theta=math.pi / 2,
+        d=distance,
+        parent=atom,
+        grand_parent=grand_parent,
+        great_grand_parent=great_grandparents[0],
+    )
+
+
+def augment_database_for_metal_bonds(structure, param_db):
+    """Add same-layout residue variants for explicit metal coordination."""
+
+    contacts = _metal_cross_residue_bonds(structure)
+    if not contacts:
+        return param_db, {}
+
+    array = _template(structure)
+    starts, ends, keys, _ = _residue_keys(array)
+    key_to_residue = {key: i for i, key in enumerate(keys)}
+    named_contacts = _connection_names(contacts)
+    endpoint_connections = defaultdict(list)
+    remote_coords = {}
+    for endpoint1, name1, endpoint2, name2 in named_contacts:
+        endpoint_connections[endpoint1[0]].append((endpoint1[1], name1))
+        endpoint_connections[endpoint2[0]].append((endpoint2[1], name2))
+        res1, res2 = key_to_residue[endpoint1[0]], key_to_residue[endpoint2[0]]
+        idx1 = next(
+            i
+            for i in range(starts[res1], ends[res1])
+            if array.atom_name[i] == endpoint1[1]
+        )
+        idx2 = next(
+            i
+            for i in range(starts[res2], ends[res2])
+            if array.atom_name[i] == endpoint2[1]
+        )
+        remote_coords[(endpoint1[0], name1)] = np.asarray(
+            array.coord[idx2], dtype=np.float64
+        )
+        remote_coords[(endpoint2[0], name2)] = np.asarray(
+            array.coord[idx1], dtype=np.float64
+        )
+
+    patterns = {}
+    for key, connections in endpoint_connections.items():
+        signature = tuple(sorted(connections))
+        res_ind = key_to_residue[key]
+        local = {
+            str(array.atom_name[i]): np.asarray(array.coord[i], dtype=np.float64)
+            for i in range(starts[res_ind], ends[res_ind])
+        }
+        patterns.setdefault((key[3], signature), (key, local))
+
+    atom_type_elements = {
+        atom_type.name: atom_type.element for atom_type in param_db.chemical.atom_types
+    }
+    metal_residue_names = set(_metal_residues(structure))
+    clones = []
+    variant_names = {}
+    supported = set()
+    for raw in param_db.chemical.residues:
+        raw_atom_names = {atom.name for atom in raw.atoms}
+        for pattern, (input_key, local) in sorted(patterns.items()):
+            res_name, signature = pattern
+            attachment_atoms = tuple(atom for atom, _ in signature)
+            if raw.name3 != res_name or not set(attachment_atoms) <= raw_atom_names:
+                continue
+            if len(raw.connections) + len(signature) > MAX_COORDINATION_CONNECTIONS:
+                raise ValueError(
+                    f"residue {raw.name} would require "
+                    f"{len(raw.connections) + len(signature)} connections; "
+                    f"the scoring kernels support {MAX_COORDINATION_CONNECTIONS}"
+                )
+            clone_name = f"{raw.name}:" + ",".join(name for _, name in signature)
+            added_connections = tuple(
+                Connection(name=name, atom=atom, type="SINGLE")
+                for atom, name in signature
+            )
+            if raw.name in metal_residue_names:
+                added_icoors = tuple(
+                    _metal_connection_icoor(
+                        raw,
+                        name,
+                        atom,
+                        float(
+                            np.linalg.norm(
+                                remote_coords[(input_key, name)] - local[atom]
+                            )
+                        ),
+                    )
+                    for atom, name in signature
+                )
+            else:
+                added_icoors = []
+                for atom, name in signature:
+                    remote = remote_coords[(input_key, name)]
+                    distance = float(np.linalg.norm(remote - local[atom]))
+                    try:
+                        icoor = _connection_icoor(raw, name, atom, local, remote)
+                    except ValueError:
+                        icoor = _fallback_connection_icoor(raw, name, atom, distance)
+                    added_icoors.append(icoor)
+                added_icoors = tuple(added_icoors)
+            clone_atoms, clone_properties = _virtualize_leaving_hydrogens(
+                raw, attachment_atoms, atom_type_elements
+            )
+            if raw.name3 == "HOH":
+                # Deposited crystallographic waters normally contain oxygen only.
+                # Keep the coordinating oxygen and make absent hydrogens inert.
+                water_hydrogens = tuple(
+                    atom.name
+                    for atom in clone_atoms
+                    if atom_type_elements[atom.atom_type] == "H"
+                )
+                clone_atoms = tuple(
+                    (
+                        attr.evolve(atom, atom_type="Vrt")
+                        if atom.name in water_hydrogens
+                        else atom
+                    )
+                    for atom in clone_atoms
+                )
+                clone_properties = attr.evolve(
+                    clone_properties,
+                    virtual=tuple(
+                        dict.fromkeys((*clone_properties.virtual, *water_hydrogens))
+                    ),
+                )
+            clones.append(
+                attr.evolve(
+                    raw,
+                    name=clone_name,
+                    atoms=clone_atoms,
+                    connections=(*raw.connections, *added_connections),
+                    icoors=(*raw.icoors, *added_icoors),
+                    properties=clone_properties,
+                )
+            )
+            variant_names[(raw.name, signature)] = clone_name
+            supported.add(pattern)
+
+    missing = sorted(set(patterns) - supported)
+    if missing:
+        raise ValueError(
+            f"no residue type supports metal attachment pattern(s): {missing}"
+        )
+    chemical = attr.evolve(
+        param_db.chemical, residues=(*param_db.chemical.residues, *clones)
+    )
+    return attr.evolve(param_db, chemical=chemical), variant_names
+
+
+def apply_metal_bonds_from_biotite(pose_stack, structure, variant_names):
+    """Select coordination variants and install explicit metal bonds."""
+
+    contacts = _metal_cross_residue_bonds(structure)
+    if not contacts:
+        return pose_stack
+    named_contacts = _connection_names(contacts)
+    endpoint_connections = defaultdict(list)
+    for endpoint1, name1, endpoint2, name2 in named_contacts:
+        endpoint_connections[endpoint1[0]].append((endpoint1[1], name1))
+        endpoint_connections[endpoint2[0]].append((endpoint2[1], name2))
+
+    pbt = pose_stack.packed_block_types
+    name_to_ind = {bt.name: i for i, bt in enumerate(pbt.active_block_types)}
+    type64 = pose_stack.block_type_ind64.clone()
+    coords = pose_stack.coords.clone()
+    key_to_block = {}
+    for pose_index in range(len(pose_stack)):
+        for block in range(pose_stack.max_n_blocks):
+            if type64[pose_index, block] < 0:
+                continue
+            key = (
+                str(pose_stack.pdb_info.chain_labels[pose_index, block]),
+                int(pose_stack.pdb_info.residue_labels[pose_index, block]),
+                str(pose_stack.pdb_info.residue_insertion_codes[pose_index, block]),
+            )
+            key_to_block[(pose_index, key)] = block
+
+    for pose_index in range(len(pose_stack)):
+        for input_key, connections in endpoint_connections.items():
+            block = key_to_block[(pose_index, input_key[:3])]
+            original = pbt.active_block_types[int(type64[pose_index, block])]
+            signature = tuple(sorted(connections))
+            clone_name = variant_names[(original.name, signature)]
+            clone = pbt.active_block_types[name_to_ind[clone_name]]
+            if tuple(a.name for a in clone.atoms) != tuple(
+                a.name for a in original.atoms
+            ):
+                raise ValueError("metal variants must preserve atom layout")
+            type64[pose_index, block] = name_to_ind[clone_name]
+            atom_start = int(pose_stack.block_coord_offset[pose_index, block])
+            block_coords = coords[
+                pose_index, atom_start : atom_start + len(clone.atoms)
+            ]
+            missing = torch.isnan(block_coords).any(dim=-1)
+            if torch.any(missing):
+                virtual_inds = [
+                    clone.atom_to_idx[name] for name in clone.properties.virtual
+                ]
+                anchor_candidates = [
+                    i
+                    for i in range(len(clone.atoms))
+                    if i not in virtual_inds and not bool(missing[i])
+                ]
+                if anchor_candidates:
+                    anchor = anchor_candidates[0]
+                    ideal = torch.as_tensor(
+                        clone.ideal_coords,
+                        dtype=coords.dtype,
+                        device=coords.device,
+                    )
+                    placed = ideal + (block_coords[anchor] - ideal[anchor])
+                    for atom_ind in virtual_inds:
+                        if bool(missing[atom_ind]):
+                            block_coords[atom_ind] = placed[atom_ind]
+
+    # Rosetta places each metal virtual proxy exactly on its deposited donor.
+    # Copy from each pose independently so AtomArrayStack models retain their
+    # own coordination geometry.
+    for pose_index in range(len(pose_stack)):
+        for metal_endpoint, metal_name, donor_endpoint, _donor_name in named_contacts:
+            metal_block = key_to_block[(pose_index, metal_endpoint[0][:3])]
+            donor_block = key_to_block[(pose_index, donor_endpoint[0][:3])]
+            metal_type = pbt.active_block_types[int(type64[pose_index, metal_block])]
+            donor_type = pbt.active_block_types[int(type64[pose_index, donor_block])]
+            signature = tuple(sorted(endpoint_connections[metal_endpoint[0]]))
+            virtual_index = signature.index((metal_endpoint[1], metal_name)) + 1
+            metal_offset = int(pose_stack.block_coord_offset[pose_index, metal_block])
+            donor_offset = int(pose_stack.block_coord_offset[pose_index, donor_block])
+            coords[
+                pose_index,
+                metal_offset + metal_type.atom_to_idx[f"V{virtual_index}"],
+            ] = coords[
+                pose_index,
+                donor_offset + donor_type.atom_to_idx[donor_endpoint[1]],
+            ]
+
+    pose_stack = attr.evolve(
+        pose_stack,
+        coords=coords,
+        block_type_ind64=type64,
+        block_type_ind=type64.to(torch.int32),
+    )
+    connections = []
+    for pose_index in range(len(pose_stack)):
+        for endpoint1, name1, endpoint2, name2 in named_contacts:
+            connections.append(
+                InterResidueConnection(
+                    pose_index,
+                    key_to_block[(pose_index, endpoint1[0][:3])],
+                    name1,
+                    key_to_block[(pose_index, endpoint2[0][:3])],
+                    name2,
+                )
+            )
+    return connect_pose_blocks(pose_stack, connections)

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -81,12 +81,17 @@ def build_context_from_biotite(
     """
     torch_device = resolve_device(torch_device)
     from tmol.io._covalent_bonds import augment_database_for_covalent_bonds
+    from tmol.io._metal_bonds import (
+        augment_database_for_metal_bonds,
+        augment_database_for_metals,
+    )
 
     if prepare_ligands:
         from tmol.ligand import prepare_ligands as _prepare_ligands
 
         if param_db is None:
             param_db = ParameterDatabase.get_default()
+        param_db = augment_database_for_metals(biotite_structure, param_db)
 
         param_db, co, fragment_definitions = _prepare_ligands(
             biotite_structure,
@@ -101,6 +106,9 @@ def build_context_from_biotite(
         param_db, covalent_variant_names = augment_database_for_covalent_bonds(
             biotite_structure, param_db
         )
+        param_db, metal_variant_names = augment_database_for_metal_bonds(
+            biotite_structure, param_db
+        )
         co = CanonicalOrdering.from_chemdb(param_db.chemical)
         rts = ResidueTypeSet.from_database(param_db.chemical)
         pbt = PackedBlockTypes.from_restype_list(
@@ -113,33 +121,37 @@ def build_context_from_biotite(
             restype_set=rts,
             fragment_definitions=fragment_definitions,
             covalent_variant_names=covalent_variant_names,
+            metal_variant_names=metal_variant_names,
         )
 
     if param_db is None:
-        co = canonical_ordering_for_biotite()
-        pbt = packed_block_types_for_biotite(torch_device)
         db = _paramdb_for_biotite()
-        rts = _restype_set_for_biotite()
-    else:
-        db, covalent_variant_names = augment_database_for_covalent_bonds(
-            biotite_structure, param_db
-        )
-        co, rts, pbt = _derived_types_for_param_db(db, torch_device)
-    if param_db is None:
-        # The cached default types are valid only when no custom bonds require
-        # connection-capable clones.
-        db2, covalent_variant_names = augment_database_for_covalent_bonds(
-            biotite_structure, db
-        )
-        if covalent_variant_names:
-            db = db2
+        db_with_metals = augment_database_for_metals(biotite_structure, db)
+        if db_with_metals is db:
+            co = canonical_ordering_for_biotite()
+            pbt = packed_block_types_for_biotite(torch_device)
+            rts = _restype_set_for_biotite()
+        else:
+            db = db_with_metals
             co, rts, pbt = _derived_types_for_param_db(db, torch_device)
+    else:
+        db = augment_database_for_metals(biotite_structure, param_db)
+        co, rts, pbt = _derived_types_for_param_db(db, torch_device)
+    # Cached default types remain usable only if neither topology augmenter
+    # creates a connection-capable residue clone.
+    db, covalent_variant_names = augment_database_for_covalent_bonds(
+        biotite_structure, db
+    )
+    db, metal_variant_names = augment_database_for_metal_bonds(biotite_structure, db)
+    if covalent_variant_names or metal_variant_names:
+        co, rts, pbt = _derived_types_for_param_db(db, torch_device)
     return PoseBuildContext(
         canonical_ordering=co,
         packed_block_types=pbt,
         parameter_database=db,
         restype_set=rts,
         covalent_variant_names=covalent_variant_names,
+        metal_variant_names=metal_variant_names,
     )
 
 
@@ -289,6 +301,12 @@ def pose_stack_from_biotite(  # noqa: C901
         pose_stack = apply_covalent_bonds_from_biotite(
             pose_stack, biotite_structure, context.covalent_variant_names
         )
+    if context.metal_variant_names:
+        from tmol.io._metal_bonds import apply_metal_bonds_from_biotite
+
+        pose_stack = apply_metal_bonds_from_biotite(
+            pose_stack, biotite_structure, context.metal_variant_names
+        )
     block_has_missing_atoms = opt_return_vals["block_has_missing_atoms"]
 
     if block_has_missing_atoms is not None and torch.any(block_has_missing_atoms):
@@ -366,6 +384,8 @@ def _assert_no_ligand_with_missing_atoms(
         atom_start = int(block_coord_offset[pi, bi].item())
         block_coords = coords[pi, atom_start : atom_start + n_ats]
         missing_mask = torch.isnan(block_coords).any(dim=-1)
+        if not torch.any(missing_mask):
+            continue
         missing_names = [
             bt.atoms[ai].name
             for ai in torch.nonzero(missing_mask, as_tuple=False).flatten().tolist()
@@ -567,7 +587,7 @@ def _filter_supported_atoms_and_connectivity(  # noqa: C901
     co: CanonicalOrdering,
 ):
     biotite_residues = biotite.structure.get_residues(biotite_structure)[1]
-    to_remove = {"HOH"}
+    to_remove = set()
     known_residue_names = set(co.restype_io_equiv_classes)
     for i_3lc in biotite_residues:
         if i_3lc in to_remove:
@@ -581,6 +601,29 @@ def _filter_supported_atoms_and_connectivity(  # noqa: C901
     valid_res = numpy.array([name not in to_remove for name in res_names])[
         biotite_residue_starts
     ]
+    # Retain only crystallographic waters that participate in an explicit
+    # supported metal-coordination bond; bulk solvent remains filtered.
+    from tmol.io._metal_bonds import _metal_cross_residue_bonds
+
+    coordinating_waters = {
+        donor[0][:3]
+        for _metal, donor in _metal_cross_residue_bonds(biotite_structure)
+        if donor[0][3] == "HOH"
+    }
+    insertion_codes = (
+        biotite_structure.ins_code
+        if "ins_code" in biotite_structure.get_annotation_categories()
+        else None
+    )
+    for residue_index, start in enumerate(biotite_residue_starts):
+        if res_names[start] != "HOH":
+            continue
+        key = (
+            str(biotite_structure.chain_id[start]),
+            int(biotite_structure.res_id[start]),
+            str(insertion_codes[start]) if insertion_codes is not None else "",
+        )
+        valid_res[residue_index] = key in coordinating_waters
 
     # Filter residues missing mainchain atoms required for rotamer building.
     # Only atoms present in every variant count as required, so an atom a terminus

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -211,7 +211,9 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         lengths, angles, torsions, improper = self.find_subgraphs(
             block_type.bond_indices, block_type
         )
-        cart_subgraphs = numpy.asarray(lengths + angles + torsions + improper)
+        cart_subgraphs = numpy.asarray(
+            lengths + angles + torsions + improper, dtype=numpy.int32
+        ).reshape((-1, 4))
         cart_subgraph_type_counts = numpy.array(
             [len(lengths), len(angles), len(torsions) + len(improper)]
         )

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -32,7 +32,7 @@
 #include <chrono>
 
 // The maximum number of inter-residue chemical bonds
-#define MAX_N_CONN 4
+#define MAX_N_CONN 8
 #define TILE_SIZE 32
 
 namespace tmol {

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -32,7 +32,7 @@
 #include <chrono>
 
 // The maximum number of inter-residue chemical bonds
-#define MAX_N_CONN 4
+#define MAX_N_CONN 8
 #define TILE_SIZE 32
 
 namespace tmol {

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -33,7 +33,7 @@
 #include <chrono>
 
 // The maximum number of inter-residue chemical bonds
-#define MAX_N_CONN 4
+#define MAX_N_CONN 8
 #define TILE_SIZE 32
 
 namespace tmol {

--- a/tmol/score/lk_ball/potentials/constants.hh
+++ b/tmol/score/lk_ball/potentials/constants.hh
@@ -2,4 +2,4 @@
 
 #define TILE_SIZE 32
 #define MAX_N_WATER 4
-#define MAX_N_CONN 4
+#define MAX_N_CONN 8

--- a/tmol/tests/io/test_metal_bonds.py
+++ b/tmol/tests/io/test_metal_bonds.py
@@ -1,0 +1,218 @@
+"""Real deposited-site regression tests for explicit metal coordination."""
+
+from io import StringIO
+
+import biotite.structure as struc
+from biotite.structure.io.pdb import PDBFile, get_structure
+import numpy as np
+import pytest
+import torch
+
+from tmol.database import ParameterDatabase
+from tmol.io import pose_stack_from_biotite
+from tmol.io._metal_bonds import (
+    _metal_cross_residue_bonds,
+    augment_database_for_metals,
+)
+from tmol.score import beta2016_score_function
+
+# Heavy atoms and deposited CONECT records from PDB 1CA2 (Zn carbonic anhydrase)
+# and 1CLL (a seven-coordinate Ca site in calmodulin).
+_ZN_SITE = """\
+ATOM      1  N   HIS A  94     -11.224  -0.437  10.993  1.00  0.00           N
+ATOM      2  CA  HIS A  94     -10.286  -1.397  10.390  1.00  0.00           C
+ATOM      3  C   HIS A  94     -10.332  -2.694  11.250  1.00  0.00           C
+ATOM      4  O   HIS A  94     -11.009  -2.721  12.306  1.00  0.00           O
+ATOM      5  CB  HIS A  94      -8.804  -0.880  10.319  1.00  0.00           C
+ATOM      6  CG  HIS A  94      -8.360  -0.482  11.734  1.00  0.00           C
+ATOM      7  ND1 HIS A  94      -8.477   0.648  12.357  1.00  0.00           N
+ATOM      8  CD2 HIS A  94      -7.755  -1.329  12.614  1.00  0.00           C
+ATOM      9  CE1 HIS A  94      -7.986   0.567  13.611  1.00  0.00           C
+ATOM     10  NE2 HIS A  94      -7.528  -0.707  13.770  1.00  0.00           N
+ATOM     11  N   HIS A  96      -8.072  -6.530  12.430  1.00  0.00           N
+ATOM     12  CA  HIS A  96      -6.846  -7.256  12.722  1.00  0.00           C
+ATOM     13  C   HIS A  96      -7.309  -8.744  12.547  1.00  0.00           C
+ATOM     14  O   HIS A  96      -8.430  -9.033  13.024  1.00  0.00           O
+ATOM     15  CB  HIS A  96      -6.188  -7.093  14.129  1.00  0.00           C
+ATOM     16  CG  HIS A  96      -5.970  -5.603  14.353  1.00  0.00           C
+ATOM     17  ND1 HIS A  96      -4.786  -5.048  14.101  1.00  0.00           N
+ATOM     18  CD2 HIS A  96      -6.823  -4.621  14.782  1.00  0.00           C
+ATOM     19  CE1 HIS A  96      -4.844  -3.734  14.356  1.00  0.00           C
+ATOM     20  NE2 HIS A  96      -6.001  -3.468  14.754  1.00  0.00           N
+ATOM     21  N   HIS A 119     -12.039  -2.559  14.939  1.00  0.00           N
+ATOM     22  CA  HIS A 119     -11.835  -1.368  15.750  1.00  0.00           C
+ATOM     23  C   HIS A 119     -12.500  -0.136  15.066  1.00  0.00           C
+ATOM     24  O   HIS A 119     -12.086   0.160  13.911  1.00  0.00           O
+ATOM     25  CB  HIS A 119     -10.343  -1.014  15.977  1.00  0.00           C
+ATOM     26  CG  HIS A 119      -9.511  -1.987  16.739  1.00  0.00           C
+ATOM     27  ND1 HIS A 119      -8.127  -2.175  16.625  1.00  0.00           N
+ATOM     28  CD2 HIS A 119      -9.934  -2.873  17.699  1.00  0.00           C
+ATOM     29  CE1 HIS A 119      -7.768  -3.117  17.429  1.00  0.00           C
+ATOM     30  NE2 HIS A 119      -8.867  -3.564  18.160  1.00  0.00           N
+HETATM   31 ZN    ZN A 262      -6.788  -1.621  15.381  1.00  0.00          ZN
+HETATM   32  O   HOH A 263      -5.366  -0.357  16.238  1.00  0.00           O
+CONECT   10   31
+CONECT   20   31
+CONECT   27   31
+CONECT   31   10   20   27   32
+CONECT   32   31
+END
+"""
+
+_CA_SITE = """\
+ATOM      1  N   ASP A  20       4.266  43.121  25.376  1.00  0.00           N
+ATOM      2  CA  ASP A  20       3.304  44.245  25.573  1.00  0.00           C
+ATOM      3  C   ASP A  20       3.670  44.929  26.900  1.00  0.00           C
+ATOM      4  O   ASP A  20       2.889  44.743  27.823  1.00  0.00           O
+ATOM      5  CB  ASP A  20       1.892  43.688  25.483  1.00  0.00           C
+ATOM      6  CG  ASP A  20       0.838  44.766  25.732  1.00  0.00           C
+ATOM      7  OD1 ASP A  20       1.362  45.900  25.680  1.00  0.00           O
+ATOM      8  OD2 ASP A  20      -0.327  44.468  26.038  1.00  0.00           O
+ATOM      9  N   ASP A  22       3.444  47.960  28.072  1.00  0.00           N
+ATOM     10  CA  ASP A  22       2.467  48.811  28.776  1.00  0.00           C
+ATOM     11  C   ASP A  22       1.114  48.178  28.881  1.00  0.00           C
+ATOM     12  O   ASP A  22       0.189  48.826  29.396  1.00  0.00           O
+ATOM     13  CB  ASP A  22       2.549  50.211  28.151  1.00  0.00           C
+ATOM     14  CG  ASP A  22       1.791  50.191  26.830  1.00  0.00           C
+ATOM     15  OD1 ASP A  22       1.480  49.126  26.287  1.00  0.00           O
+ATOM     16  OD2 ASP A  22       1.487  51.294  26.337  1.00  0.00           O
+ATOM     17  N   ASP A  24      -1.454  47.546  26.710  1.00  0.00           N
+ATOM     18  CA  ASP A  24      -2.616  48.079  25.966  1.00  0.00           C
+ATOM     19  C   ASP A  24      -3.219  47.054  25.040  1.00  0.00           C
+ATOM     20  O   ASP A  24      -4.213  47.333  24.351  1.00  0.00           O
+ATOM     21  CB  ASP A  24      -2.213  49.407  25.299  1.00  0.00           C
+ATOM     22  CG  ASP A  24      -1.522  49.054  23.983  1.00  0.00           C
+ATOM     23  OD1 ASP A  24      -0.647  48.198  24.144  1.00  0.00           O
+ATOM     24  OD2 ASP A  24      -1.796  49.554  22.920  1.00  0.00           O
+ATOM     25  N   THR A  26      -1.468  45.522  22.517  1.00  0.00           N
+ATOM     26  CA  THR A  26      -0.742  45.570  21.225  1.00  0.00           C
+ATOM     27  C   THR A  26       0.732  45.703  21.494  1.00  0.00           C
+ATOM     28  O   THR A  26       1.230  46.259  22.472  1.00  0.00           O
+ATOM     29  CB  THR A  26      -1.250  46.702  20.252  1.00  0.00           C
+ATOM     30  OG1 THR A  26      -0.824  47.960  20.889  1.00  0.00           O
+ATOM     31  CG2 THR A  26      -2.752  46.752  19.973  1.00  0.00           C
+ATOM     32  N   GLU A  31       8.220  48.516  21.601  1.00  0.00           N
+ATOM     33  CA  GLU A  31       8.160  47.434  22.629  1.00  0.00           C
+ATOM     34  C   GLU A  31       8.991  46.269  22.136  1.00  0.00           C
+ATOM     35  O   GLU A  31       9.814  45.682  22.880  1.00  0.00           O
+ATOM     36  CB  GLU A  31       6.723  47.039  22.947  1.00  0.00           C
+ATOM     37  CG  GLU A  31       5.971  48.075  23.781  1.00  0.00           C
+ATOM     38  CD  GLU A  31       4.517  47.919  23.975  1.00  0.00           C
+ATOM     39  OE1 GLU A  31       3.830  47.450  23.067  1.00  0.00           O
+ATOM     40  OE2 GLU A  31       3.900  48.247  24.996  1.00  0.00           O
+HETATM   41 CA    CA A 149       1.708  47.776  24.197  1.00  0.00          CA
+HETATM   42  O   HOH A 181       1.728  50.102  22.982  1.00  0.00           O
+CONECT    7   41
+CONECT   15   41
+CONECT   23   41
+CONECT   28   41
+CONECT   39   41
+CONECT   40   41
+CONECT   41    7   15   23   28
+CONECT   41   39   40   42
+CONECT   42   41
+END
+"""
+
+
+def _structure(pdb_text):
+    return get_structure(PDBFile.read(StringIO(pdb_text)), model=1, include_bonds=True)
+
+
+def _block_types(pose):
+    return [
+        pose.packed_block_types.active_block_types[int(index)]
+        for index in pose.block_type_ind64[0]
+        if index >= 0
+    ]
+
+
+@pytest.mark.parametrize(
+    "site,metal,n_contacts,donor_atoms",
+    [
+        pytest.param(_ZN_SITE, "ZN", 4, {"NE2", "ND1", "O"}, id="1CA2-zinc"),
+        pytest.param(_CA_SITE, "CA", 7, {"OD1", "O", "OE1", "OE2"}, id="1CLL-calcium"),
+    ],
+)
+def test_real_metal_sites_import_multicoordinate_topology(
+    torch_device, site, metal, n_contacts, donor_atoms
+):
+    structure = _structure(site)
+    contacts = _metal_cross_residue_bonds(structure)
+    assert len(contacts) == n_contacts
+    assert {donor[1] for _metal_endpoint, donor in contacts} == donor_atoms
+
+    pose, context = pose_stack_from_biotite(
+        structure, torch_device, no_optH=True, return_context=True
+    )
+    block_types = _block_types(pose)
+    metal_block = next(i for i, block in enumerate(block_types) if block.name3 == metal)
+    metal_type = block_types[metal_block]
+    assert len(metal_type.connections) == n_contacts
+    assert (
+        torch.count_nonzero(pose.inter_residue_connections64[0, metal_block, :, 0] >= 0)
+        == n_contacts
+    )
+    metal_offset = int(pose.block_coord_offset64[0, metal_block])
+    for connection_index in range(n_contacts):
+        partner_block, partner_connection = pose.inter_residue_connections64[
+            0, metal_block, connection_index
+        ].tolist()
+        partner_type = block_types[partner_block]
+        donor_atom = partner_type.connections[partner_connection].atom
+        donor_coord = pose.coords[
+            0,
+            int(pose.block_coord_offset64[0, partner_block])
+            + partner_type.atom_to_idx[donor_atom],
+        ]
+        proxy_coord = pose.coords[
+            0, metal_offset + metal_type.atom_to_idx[f"V{connection_index + 1}"]
+        ]
+        torch.testing.assert_close(proxy_coord, donor_coord)
+    water_type = next(block for block in block_types if block.name3 == "HOH")
+    assert {"H1", "H2"} <= set(water_type.properties.virtual)
+    assert torch.isfinite(pose.coords).all()
+
+    score_function = beta2016_score_function(
+        torch_device, param_db=context.parameter_database
+    )
+    score = score_function.render_whole_pose_scoring_module(pose)(pose.coords).sum()
+    assert torch.isfinite(score)
+
+
+def test_generated_metal_parameters_match_rosetta_defaults():
+    structure = struc.AtomArray(3)
+    structure.atom_name = np.asarray(("MG", "CA", "ZN"))
+    structure.element = np.asarray(("Mg", "Ca", "Zn"))
+    structure.res_name = np.asarray(("MG", "CAL", "ZINC"))
+    structure.chain_id[:] = "A"
+    structure.res_id = np.arange(1, 4)
+    structure.coord = np.zeros((3, 3))
+    database = augment_database_for_metals(structure, ParameterDatabase.get_default())
+    ljlk = {entry.name: entry for entry in database.scoring.ljlk.atom_type_parameters}
+    expected = {
+        "Zn2p": (1.09, 0.25, -5.0, 3.5, 5.4),
+        "Mg2p": (1.185, 0.015, -5.0, 3.5, 7.0),
+        "Ca2p": (1.367, 0.12, 0.0, 2.0, 10.7),
+    }
+    for name, values in expected.items():
+        actual = ljlk[name]
+        assert (
+            actual.lj_radius,
+            actual.lj_wdepth,
+            actual.lk_dgfree,
+            actual.lk_lambda,
+            actual.lk_volume,
+        ) == pytest.approx(values)
+    assert {residue.name for residue in database.chemical.residues} >= {
+        "MG",
+        "CAL",
+        "ZINC",
+    }
+    charges = {
+        (parameter.res, parameter.atom): parameter.charge
+        for parameter in database.scoring.elec.atom_charge_parameters
+    }
+    assert charges[("MG", "MG")] == 2.0
+    assert charges[("CAL", "CA")] == 2.0
+    assert charges[("ZINC", "ZN")] == 2.0


### PR DESCRIPTION
Stack 5/6; depends on #422.

## Summary
- recognize explicitly bonded single-ion Mg, Ca, and Zn components by element rather than residue-name catalogs
- generate deposited-name-preserving ion residue types with Rosetta fa_standard charges and LJ/LK parameters
- convert explicit metal-donor records into up to eight deterministic pose connections and donor variants
- retain explicitly coordinating waters while leaving unrelated crystallographic-water filtering unchanged
- place inert ion virtual proxies at deposited donor coordinates and keep connected pairs out of ordinary nonbonded clash handling
- raise the affected scoring-kernel connection capacity from four to eight for seven-coordinate sites

## Validation
- real deposited four-coordinate Zn site from PDB 1CA2
- real deposited seven-coordinate Ca site from PDB 1CLL
- asserts topology, per-donor proxy placement, finite beta2016 score, coordinating-water handling, exact Rosetta LJ/LK values, and +2 ion charges on CPU and CUDA
- exact published tip on H200: **5 passed** (Slurm jobs 100657 and independent confirmation 100659)
- affected H200 score suites: **148 passed, 2 xfailed** (electrostatics, hbond, LJ/LK, LK-ball, and constraints; Slurm job 100646)

## Deliberate boundary
This layer requires an explicit PDB/mmCIF bond table and never infers coordination from distance. It supports single-ion Mg/Ca/Zn, not multi-atom cofactors such as heme.

Next: #424 adds Rosetta-equivalent deposited-geometry constraints.