### PR TITLE
Match Rosetta metal geometry constraints

### DIFF
--- a/docs/development/metal_coordination.md
+++ b/docs/development/metal_coordination.md
@@ -1,0 +1,60 @@
+# Programmatic metal coordination
+
+## Scope
+
+TMol recognizes explicit inter-component bonds to single-ion Mg, Ca, and Zn
+components by element, not by residue name. The deposited component and atom
+names are preserved while the importer generates an ion residue type, up to
+eight deterministic connections, and matching connection variants for donor
+residues. Coordinating waters are retained; unrelated crystallographic waters
+remain filtered.
+
+The implementation intentionally requires an explicit PDB/mmCIF bond table.
+It does not infer coordination from distance, so an absent or ambiguous bond
+cannot silently alter chemistry. Multi-atom cofactors such as heme and metals
+outside Mg/Ca/Zn are not yet supported.
+
+## Rosetta parity
+
+The generated ion parameters match Rosetta `fa_standard`:
+
+| element | atom type | charge | LJ radius | LJ well depth | LK dgfree | LK lambda | LK volume |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Mg | `Mg2p` | +2 | 1.185 | 0.015 | -5.0 | 3.5 | 7.0 |
+| Ca | `Ca2p` | +2 | 1.367 | 0.120 | 0.0 | 2.0 | 10.7 |
+| Zn | `Zn2p` | +2 | 1.090 | 0.250 | -5.0 | 3.5 | 5.4 |
+
+Like Rosetta's `SetupMetalsMover`, import adds chemical connections so
+ordinary nonbonded count-pair logic does not treat each donor as a clash. It
+also adds deposited-geometry constraints with Rosetta's functional forms:
+
+- virtual-to-donor, metal-to-virtual, and virtual-to-virtual harmonic distance
+  constraints with 0.1 Å standard deviation;
+- metal-donor-parent harmonic angle constraints with 0.05 radian standard
+  deviation wherever the donor has a distinct local parent atom (a
+  single-atom deposited water does not); and
+- distance and angle strength multipliers, both 1.0 by default.
+
+The constraints are zero at the deposited geometry. As in Rosetta, they only
+contribute when the constraint score term has nonzero weight. Set
+`ScoreType.constraint` to 1.0 for scoring or Cartesian minimization.
+
+The checked-in regressions use the four-coordinate Zn site from PDB 1CA2 and a
+seven-coordinate Ca site from PDB 1CLL. They verify topology, virtual proxy
+placement, Rosetta parameter values, zero deposited constraint energy,
+positive differentiable energy after a donor perturbation, and finite
+beta2016 scoring on CPU and CUDA.
+
+## Deliberate boundary
+
+This layer matches Rosetta's ion nonbonded parameters, explicit connectivity,
+and deposited-geometry constraint equations. It does not claim an inferred
+metal-binding residue catalog, charge-state mutation for multiply coordinated
+donors, or specialized quantum/ligand-field energetics. Those require an
+explicit chemistry policy and should not be hidden in generic import.
+
+## Rosetta references
+
+- [SetupMetalsMover documentation](https://docs.rosettacommons.org/docs/latest/scripting_documentation/RosettaScripts/Movers/movers_pages/SetupMetalsMover)
+- [Rosetta metal setup and scoring documentation](https://docs.rosettacommons.org/docs/latest/rosetta_basics/non_protein_residues/Metals)
+- [SetupMetalsMover implementation helpers](https://github.com/RosettaCommons/rosetta/blob/main/source/src/core/util/metalloproteins_util.cc)

--- a/docs/development/ptm_glycan_implementation.md
+++ b/docs/development/ptm_glycan_implementation.md
@@ -87,3 +87,6 @@ them would require a statistical carbohydrate model, which conflicts with the
 current requirement to generate arbitrary sugars without a sugar library.
 The clean extension point is a future optional topology-derived conformer
 sampler, not residue-name conditionals in import or scoring.
+
+The stacked [metal coordination implementation](metal_coordination.md) reuses
+the same explicit-connection machinery for programmatically generated ions.

--- a/docs/tutorial/10_metal_coordination.md
+++ b/docs/tutorial/10_metal_coordination.md
@@ -1,0 +1,55 @@
+# Score and minimize an explicitly bonded metal site
+
+Read a PDB or mmCIF with its explicit bond table, then build the pose normally:
+
+```python
+import torch
+from biotite.structure.io.pdbx import CIFFile, get_structure
+
+from tmol import ScoreType, beta2016_score_function, run_cart_min
+from tmol.io import pose_stack_from_biotite
+
+device = torch.device("cuda")
+structure = get_structure(
+    CIFFile.read("metal_site.cif"),
+    model=1,
+    include_bonds=True,
+)
+pose, context = pose_stack_from_biotite(
+    structure,
+    device,
+    no_optH=True,
+    return_context=True,
+)
+```
+
+Mg, Ca, and Zn single-ion components are generated from their element. Only
+explicitly bonded coordinating waters are retained. The pose contains the
+metal-donor connections and Rosetta-style deposited-geometry constraints.
+Distance constraints cover every donor. A donor-parent angle constraint is
+also generated when the donor component supplies a distinct local parent;
+single-atom deposited waters therefore have no angle constraint.
+
+Enable those constraints when scoring or minimizing, just as Rosetta requires
+the `metalbinding_constraint` term to be active:
+
+```python
+score_function = beta2016_score_function(
+    device,
+    param_db=context.parameter_database,
+)
+score_function.set_weight(ScoreType.constraint, 1.0)
+
+score = score_function.render_whole_pose_scoring_module(pose)(pose.coords).sum()
+minimized = run_cart_min(
+    pose.clone(),
+    score_function,
+    optimizer_kwargs={"max_iter": 200},
+)
+```
+
+Pass `metal_distance_constraint_multiplier=0.0` or
+`metal_angle_constraint_multiplier=0.0` to `pose_stack_from_biotite()` to omit
+one constraint family. Do not disable both for unconstrained minimization: the
+ion and donor geometry can distort even though their connection topology is
+still present.

--- a/tmol/io/_metal_bonds.py
+++ b/tmol/io/_metal_bonds.py
@@ -26,7 +26,8 @@ from tmol.io._covalent_bonds import (
     _template,
     _virtualize_leaving_hydrogens,
 )
-from tmol.pose import InterResidueConnection, connect_pose_blocks
+from tmol.pose import ConstraintSet, InterResidueConnection, connect_pose_blocks
+from tmol.score.constraint import ConstraintEnergyTerm
 
 MAX_COORDINATION_CONNECTIONS = 8
 
@@ -406,7 +407,119 @@ def augment_database_for_metal_bonds(structure, param_db):
     return attr.evolve(param_db, chemical=chemical), variant_names
 
 
-def apply_metal_bonds_from_biotite(pose_stack, structure, variant_names):
+def _add_metal_constraints(
+    pose_stack,
+    named_contacts,
+    endpoint_connections,
+    key_to_block,
+    distance_multiplier,
+    angle_multiplier,
+):
+    """Add Rosetta SetupMetalsMover-equivalent deposited-geometry constraints."""
+
+    if distance_multiplier < 0 or angle_multiplier < 0:
+        raise ValueError("metal constraint multipliers must be nonnegative")
+    if distance_multiplier == 0 and angle_multiplier == 0:
+        return pose_stack
+
+    device = pose_stack.device
+    distance_atoms = []
+    distance_params = []
+    angle_atoms = []
+    angle_params = []
+    proxies_by_metal = defaultdict(list)
+
+    def coord(pose_index, block, atom_index):
+        offset = int(pose_stack.block_coord_offset64[pose_index, block])
+        return pose_stack.coords[pose_index, offset + atom_index]
+
+    for pose_index in range(len(pose_stack)):
+        for metal_endpoint, metal_name, donor_endpoint, _donor_name in named_contacts:
+            metal_block = key_to_block[(pose_index, metal_endpoint[0][:3])]
+            donor_block = key_to_block[(pose_index, donor_endpoint[0][:3])]
+            metal_type = pose_stack.block_type(pose_index, metal_block)
+            donor_type = pose_stack.block_type(pose_index, donor_block)
+            metal_atom = metal_type.atom_to_idx[metal_endpoint[1]]
+            donor_atom = donor_type.atom_to_idx[donor_endpoint[1]]
+            signature = tuple(sorted(endpoint_connections[metal_endpoint[0]]))
+            virtual_number = signature.index((metal_endpoint[1], metal_name)) + 1
+            virtual_atom = metal_type.atom_to_idx[f"V{virtual_number}"]
+            metal_ref = (pose_index, metal_block, metal_atom)
+            virtual_ref = (pose_index, metal_block, virtual_atom)
+            donor_ref = (pose_index, donor_block, donor_atom)
+            proxies_by_metal[(pose_index, metal_endpoint[0])].append(
+                (virtual_ref, coord(pose_index, metal_block, virtual_atom))
+            )
+
+            if distance_multiplier > 0:
+                sd = 0.1 / math.sqrt(distance_multiplier)
+                distance_atoms.extend(
+                    ((virtual_ref, donor_ref), (metal_ref, virtual_ref))
+                )
+                metal_virtual_distance = torch.linalg.norm(
+                    coord(pose_index, metal_block, metal_atom)
+                    - coord(pose_index, metal_block, virtual_atom)
+                ).item()
+                distance_params.extend(((0.0, sd), (metal_virtual_distance, sd)))
+
+            if angle_multiplier > 0:
+                icoor = donor_type.icoors[donor_type.icoors_index[donor_endpoint[1]]]
+                if (
+                    icoor.parent in donor_type.atom_to_idx
+                    and icoor.parent != donor_endpoint[1]
+                ):
+                    parent_atom = donor_type.atom_to_idx[icoor.parent]
+                    parent_ref = (pose_index, donor_block, parent_atom)
+                    vector1 = coord(pose_index, metal_block, metal_atom) - coord(
+                        pose_index, donor_block, donor_atom
+                    )
+                    vector2 = coord(pose_index, donor_block, parent_atom) - coord(
+                        pose_index, donor_block, donor_atom
+                    )
+                    cosine = torch.dot(vector1, vector2) / (
+                        torch.linalg.norm(vector1) * torch.linalg.norm(vector2)
+                    )
+                    target = torch.acos(cosine.clamp(-1.0, 1.0)).item()
+                    angle_atoms.append((metal_ref, donor_ref, parent_ref))
+                    angle_params.append((target, 0.05 / math.sqrt(angle_multiplier)))
+
+    if distance_multiplier > 0:
+        sd = 0.1 / math.sqrt(distance_multiplier)
+        for proxies in proxies_by_metal.values():
+            for first in range(len(proxies)):
+                for second in range(first + 1, len(proxies)):
+                    first_ref, first_coord = proxies[first]
+                    second_ref, second_coord = proxies[second]
+                    distance_atoms.append((first_ref, second_ref))
+                    distance_params.append(
+                        (torch.linalg.norm(first_coord - second_coord).item(), sd)
+                    )
+
+    constraints = pose_stack.constraint_set or ConstraintSet.create_empty(
+        device=device, n_poses=len(pose_stack)
+    )
+    if distance_atoms:
+        constraints = constraints.add_constraints(
+            ConstraintEnergyTerm.harmonic,
+            torch.tensor(distance_atoms, dtype=torch.int32, device=device),
+            torch.tensor(distance_params, dtype=torch.float32, device=device),
+        )
+    if angle_atoms:
+        constraints = constraints.add_constraints(
+            ConstraintEnergyTerm.harmonic_angle,
+            torch.tensor(angle_atoms, dtype=torch.int32, device=device),
+            torch.tensor(angle_params, dtype=torch.float32, device=device),
+        )
+    return attr.evolve(pose_stack, constraint_set=constraints)
+
+
+def apply_metal_bonds_from_biotite(
+    pose_stack,
+    structure,
+    variant_names,
+    distance_constraint_multiplier=1.0,
+    angle_constraint_multiplier=1.0,
+):
     """Select coordination variants and install explicit metal bonds."""
 
     contacts = _metal_cross_residue_bonds(structure)
@@ -511,4 +624,12 @@ def apply_metal_bonds_from_biotite(pose_stack, structure, variant_names):
                     name2,
                 )
             )
-    return connect_pose_blocks(pose_stack, connections)
+    pose_stack = connect_pose_blocks(pose_stack, connections)
+    return _add_metal_constraints(
+        pose_stack,
+        named_contacts,
+        endpoint_connections,
+        key_to_block,
+        distance_constraint_multiplier,
+        angle_constraint_multiplier,
+    )

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -168,6 +168,8 @@ def pose_stack_from_biotite(  # noqa: C901
     strict_ligands: bool = True,
     ligand_params_files: list[str] | None = None,
     sample_proton_chi: bool = True,
+    metal_distance_constraint_multiplier: float = 1.0,
+    metal_angle_constraint_multiplier: float = 1.0,
     return_context: bool = False,
     context: PoseBuildContext | None = None,
     **kwargs: object,
@@ -215,6 +217,11 @@ def pose_stack_from_biotite(  # noqa: C901
             ``chi_samples`` so OptHSampler samples ligand polar-H rotamers
             (enabled by default; pass False to disable). Only used when
             prepare_ligands=True.
+        metal_distance_constraint_multiplier: Strength multiplier for deposited
+            metal coordination distances. Set to zero to omit these constraints.
+        metal_angle_constraint_multiplier: Strength multiplier for deposited
+            metal-donor-parent angles. Set to zero to omit these constraints.
+            Give ``ScoreType.constraint`` nonzero weight to score either kind.
         return_context: If True, return ``(pose_stack, PoseBuildContext)``.
         **kwargs: Additional arguments passed to pose_stack_from_canonical_form.
 
@@ -305,7 +312,11 @@ def pose_stack_from_biotite(  # noqa: C901
         from tmol.io._metal_bonds import apply_metal_bonds_from_biotite
 
         pose_stack = apply_metal_bonds_from_biotite(
-            pose_stack, biotite_structure, context.metal_variant_names
+            pose_stack,
+            biotite_structure,
+            context.metal_variant_names,
+            metal_distance_constraint_multiplier,
+            metal_angle_constraint_multiplier,
         )
     block_has_missing_atoms = opt_return_vals["block_has_missing_atoms"]
 

--- a/tmol/score/constraint/_constraint_energy_term.py
+++ b/tmol/score/constraint/_constraint_energy_term.py
@@ -60,6 +60,19 @@ class ConstraintEnergyTerm(EnergyTerm):
         return ((dist - params[:, 0]) / params[:, 1]) ** 2
 
     @classmethod
+    def harmonic_angle(cls, atoms, params):
+        """Harmonic angle constraint for three atoms, in radians."""
+
+        vector1 = atoms[:, 0] - atoms[:, 1]
+        vector2 = atoms[:, 2] - atoms[:, 1]
+        denominator = torch.linalg.norm(vector1, dim=-1) * torch.linalg.norm(
+            vector2, dim=-1
+        )
+        cosine = torch.sum(vector1 * vector2, dim=-1) / denominator.clamp_min(1e-12)
+        angle = torch.acos(cosine.clamp(-1.0, 1.0))
+        return ((angle - params[:, 0]) / params[:, 1]) ** 2
+
+    @classmethod
     def harmonic_coordinate(cls, atoms, params):
         # params[:, 0]   == distance to target coordinate
         # params[:, 1:4] == target coordinate

--- a/tmol/tests/io/test_metal_bonds.py
+++ b/tmol/tests/io/test_metal_bonds.py
@@ -2,6 +2,7 @@
 
 from io import StringIO
 
+import attr
 import biotite.structure as struc
 from biotite.structure.io.pdb import PDBFile, get_structure
 import numpy as np
@@ -14,7 +15,8 @@ from tmol.io._metal_bonds import (
     _metal_cross_residue_bonds,
     augment_database_for_metals,
 )
-from tmol.score import beta2016_score_function
+from tmol.score import ScoreFunction, ScoreType, beta2016_score_function
+from tmol import run_cart_min
 
 # Heavy atoms and deposited CONECT records from PDB 1CA2 (Zn carbonic anhydrase)
 # and 1CLL (a seven-coordinate Ca site in calmodulin).
@@ -172,10 +174,51 @@ def test_real_metal_sites_import_multicoordinate_topology(
     water_type = next(block for block in block_types if block.name3 == "HOH")
     assert {"H1", "H2"} <= set(water_type.properties.virtual)
     assert torch.isfinite(pose.coords).all()
+    expected_distance_constraints = 2 * n_contacts + n_contacts * (n_contacts - 1) // 2
+    assert pose.constraint_set is not None
+    assert pose.constraint_set.constraint_atoms.shape[0] == (
+        expected_distance_constraints + n_contacts - 1
+    )
+
+    constraint_score_function = ScoreFunction(context.parameter_database, torch_device)
+    constraint_score_function.set_weight(ScoreType.constraint, 1.0)
+    constraint_scorer = constraint_score_function.render_whole_pose_scoring_module(pose)
+    initial_constraint_score = constraint_scorer(pose.coords).sum()
+    torch.testing.assert_close(
+        initial_constraint_score,
+        torch.zeros_like(initial_constraint_score),
+        atol=1e-5,
+        rtol=0,
+    )
+    partner_block, partner_connection = pose.inter_residue_connections64[
+        0, metal_block, 0
+    ].tolist()
+    partner_type = block_types[partner_block]
+    partner_atom = partner_type.connections[partner_connection].atom
+    partner_coord = (
+        int(pose.block_coord_offset64[0, partner_block])
+        + partner_type.atom_to_idx[partner_atom]
+    )
+    perturbed = pose.coords.detach().clone()
+    perturbed[0, partner_coord, 0] += 0.2
+    perturbed.requires_grad_(True)
+    perturbed_constraint_score = constraint_scorer(perturbed).sum()
+    assert perturbed_constraint_score > 0
+    perturbed_constraint_score.backward()
+    assert torch.isfinite(perturbed.grad).all()
+    minimized = run_cart_min(
+        attr.evolve(pose, coords=perturbed.detach()),
+        constraint_score_function,
+        optimizer_kwargs={"max_iter": 20},
+    )
+    assert (
+        constraint_scorer(minimized.coords).sum() < perturbed_constraint_score.detach()
+    )
 
     score_function = beta2016_score_function(
         torch_device, param_db=context.parameter_database
     )
+    score_function.set_weight(ScoreType.constraint, 1.0)
     score = score_function.render_whole_pose_scoring_module(pose)(pose.coords).sum()
     assert torch.isfinite(score)
 


### PR DESCRIPTION
Stack 6/6; depends on #423.

## Summary
- add deposited-geometry constraints equivalent to Rosetta SetupMetalsMover: virtual-donor, metal-virtual, virtual-virtual, and metal-donor-parent geometry
- use Rosetta standard deviations (0.1 A distances, 0.05 rad angles) and equivalent distance/angle strength multipliers
- keep constraint scoring opt-in through ScoreType.constraint, matching Rosetta score-function behavior
- add a differentiable harmonic-angle constraint primitive
- verify positive finite gradients and Cartesian minimization recovery after donor perturbation
- document scoring/minimization usage, exact parity, and deliberate chemistry boundaries

A donor-parent angle is generated only when a distinct local parent exists; a single-atom deposited water still receives all applicable distance constraints but cannot define that angle.

## Validation
- real PDB 1CA2 Zn and 1CLL Ca sites on CPU and H200
- deposited constraint energy is zero; perturbation is positive/differentiable; constraint-only Cartesian minimization reduces it
- exact published tip: **5 passed, 2 warnings** on H200 (Slurm job 100658)
- parent PTM/glycan/covalent integration matrix: **31 passed** on H200 (Slurm job 100652)

## Rosetta boundary
This matches ion nonbonded parameters, explicit connectivity, and SetupMetalsMover deposited-geometry equations. It intentionally does not infer bonds, mutate donor protonation/charge states, or claim ligand-field/quantum energetics.