### PR TITLE
Accelerate CUDA scoring, minimization, and FastRelax

### DIFF
--- a/tmol/numeric/bspline_compiled/bspline.hh
+++ b/tmol/numeric/bspline_compiled/bspline.hh
@@ -348,6 +348,45 @@ struct ndspline {
     return {Vs_t, dV_dIs_t};
   }
 
+  static auto EIGEN_DEVICE_FUNC interpolate_V(
+      TensorAccessor<Real, NDIM, D> coeffs, Eigen::Matrix<Real, NDIM, 1> X)
+      -> Real {
+    typedef Eigen::Matrix<Real, NDIM, 1> RealN;
+    typedef Eigen::Matrix<Int, NDIM, 1> IntN;
+
+    Int nprods = 1;
+    IntN idx;
+    RealN frac;
+
+    for (int dim = 0; dim < NDIM; ++dim) {
+      idx[dim] = (Int)std::floor(X[dim]);
+      frac[dim] = X[dim] - idx[dim];
+      idx[dim] -= (DEGREE / 2);
+      nprods *= (DEGREE + 1);
+    }
+
+    Eigen::Matrix<Real, NDIM, DEGREE + 1> wts = _get_weights(frac);
+    Real interp = 0;
+    for (int pt = 0; pt < nprods; ++pt) {
+      Real weight = 1;
+      Int stride = 1;
+      Int pt_indexer = pt;
+      Int idx_ij = 0;
+
+      for (int dim = NDIM - 1; dim >= 0; --dim) {
+        Int idx_box_i = pt_indexer % (DEGREE + 1);
+        Int idx_i = (idx[dim] + idx_box_i) % coeffs.size(dim);
+        if (idx_i < 0) idx_i += coeffs.size(dim);
+        idx_ij += stride * idx_i;
+        stride *= coeffs.size(dim);
+        weight *= wts(dim, idx_box_i);
+        pt_indexer /= (DEGREE + 1);
+      }
+      interp += weight * coeffs.data()[idx_ij];
+    }
+    return interp;
+  }
+
   static auto EIGEN_DEVICE_FUNC interpolate(
       TensorAccessor<Real, NDIM, D> coeffs, Eigen::Matrix<Real, NDIM, 1> X)
       -> tmol::score::common::tuple<Real, Eigen::Matrix<Real, NDIM, 1> > {

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -285,9 +285,15 @@ class LBFGS_Armijo(Optimizer):
         self._n_segments = n_segments
         self._segment_size = segment_size
         self._pad_index = segment_ids * segment_size + rank
+        # The common Cartesian-minimization layout has equally sized segments
+        # stored consecutively. In that case padding is just a view/copy; keep
+        # the indexed path for heterogeneous or interleaved segment layouts.
+        self._segments_are_dense = bool(torch.equal(self._pad_index, arange))
 
     def _seg_sum(self, values):
         """Sum a parameter-shaped vector within each segment."""
+        if self._segments_are_dense:
+            return values.view(self._n_segments, self._segment_size).sum(-1)
         if self._sum_scratch is None or self._sum_scratch.dtype != values.dtype:
             self._sum_scratch = torch.zeros(
                 self._n_segments * self._segment_size,
@@ -298,6 +304,8 @@ class LBFGS_Armijo(Optimizer):
 
     def _seg_amax(self, values):
         """Maximum of a parameter-shaped vector within each segment."""
+        if self._segments_are_dense:
+            return values.view(self._n_segments, self._segment_size).amax(-1)
         out = torch.empty(self._n_segments, dtype=values.dtype, device=values.device)
         return out.scatter_reduce_(
             0, self._segment_ids, values, "amax", include_self=False
@@ -305,6 +313,12 @@ class LBFGS_Armijo(Optimizer):
 
     def _pad(self, values, out=None):
         """Scatter a parameter-shaped vector to (n_segments, segment_size)."""
+        if self._segments_are_dense:
+            padded = values.view(self._n_segments, self._segment_size)
+            if out is not None:
+                out.copy_(padded)
+                return out.view(self._n_segments, self._segment_size)
+            return padded
         if out is None:
             out = torch.zeros(
                 self._n_segments * self._segment_size,
@@ -319,6 +333,8 @@ class LBFGS_Armijo(Optimizer):
 
     def _unpad(self, padded):
         """Gather a (n_segments, segment_size) tensor back to parameter shape."""
+        if self._segments_are_dense:
+            return padded.reshape(-1)
         return padded.reshape(-1)[self._pad_index]
 
     def _wrap_closure(self, closure):

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -38,6 +38,9 @@ class CartesianSfxnNetwork(torch.nn.Module):
         self._coord_flat_idx = (
             self.coord_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
         )
+        self._all_coords_movable = (
+            self._coord_flat_idx.numel() == self.full_coords.numel()
+        )
 
         self.masked_coords = torch.nn.Parameter(
             self.full_coords.view(-1, self.full_coords.shape[-1])[self._coord_flat_idx]
@@ -55,14 +58,19 @@ class CartesianSfxnNetwork(torch.nn.Module):
 
     def forward(self):
         self.count += 1
-        self.full_coords = self.full_coords.detach()
-        # self.full_coords[self.coord_mask] = self.masked_coords
-        self.full_coords.view(-1, self.full_coords.shape[-1])[
-            self._coord_flat_idx
-        ] = self.masked_coords
+        if self._all_coords_movable:
+            self.full_coords = self.masked_coords.view_as(self.full_coords)
+        else:
+            self.full_coords = self.full_coords.detach()
+            self.full_coords.view(-1, self.full_coords.shape[-1])[
+                self._coord_flat_idx
+            ] = self.masked_coords
         return self.whole_pose_scoring_module(self.full_coords)
 
     def pose_stack_from_dofs(self):
+        if self._all_coords_movable:
+            full_coords = self.masked_coords.detach().view_as(self.full_coords).clone()
+            return attrs.evolve(self.pose_stack, coords=full_coords)
         full_coords = self.full_coords.detach().clone()
         full_coords.view(-1, full_coords.shape[-1])[
             self._coord_flat_idx

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -39,7 +39,7 @@ class CartesianSfxnNetwork(torch.nn.Module):
             self.coord_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
         )
         self._all_coords_movable = (
-            self._coord_flat_idx.numel() == self.full_coords.numel()
+            self._coord_flat_idx.numel() == self.coord_mask.numel()
         )
 
         self.masked_coords = torch.nn.Parameter(

--- a/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.hh
+++ b/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.hh
@@ -86,7 +86,8 @@ class BackboneTorsionPoseScoreDispatch {
       // Omega (backbone-dependent) potential parameters
       TView<Real, 4, Dev> omega_tables,
       TView<RamaTableParams<Real>, 1, Dev> omega_table_params,
-      bool output_block_pair_energies)
+      bool output_block_pair_energies,
+      bool compute_derivs)
       -> std::tuple<TPack<Real, 4, Dev>, TPack<Vec<Real, 3>, 2, Dev>>;
 
   static auto backward(

--- a/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
+++ b/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
@@ -76,7 +76,8 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     TView<RamaTableParams<Real>, 1, Dev> rama_table_params,
     TView<Real, 4, Dev> omega_tables,
     TView<RamaTableParams<Real>, 1, Dev> omega_table_params,
-    bool output_block_pair_energies)
+    bool output_block_pair_energies,
+    bool compute_derivs)
     -> std::tuple<TPack<Real, 4, Dev>, TPack<Vec<Real, 3>, 2, Dev>> {
   using tmol::score::common::accumulate;
   using Real3 = Vec<Real, 3>;
@@ -139,7 +140,9 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   } else {
     V_t = TPack<Real, 4, Dev>::zeros({2, n_poses, 1, 1});
   }
-  auto dV_dxyz_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({2, n_atoms});
+  auto dV_dxyz_t = compute_derivs
+                       ? TPack<Vec<Real, 3>, 2, Dev>::zeros({2, n_atoms})
+                       : TPack<Vec<Real, 3>, 2, Dev>::empty({2, n_atoms});
 
   auto V = V_t.view;
   auto dV_dxyz = dV_dxyz_t.view;
@@ -233,19 +236,34 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
     // accumulate rama
     if (valid_phipsi && rama_table_ind >= 0) {
-      auto rama = rama_V_dV<Dev, Real, Int>(
-          phi_coords,
-          psi_coords,
-          rama_tables[rama_table_ind],
-          Eigen::Map<Vec<Real, 2>>(rama_table_params[rama_table_ind].bbstarts),
-          Eigen::Map<Vec<Real, 2>>(rama_table_params[rama_table_ind].bbsteps));
-      accumulate<Dev, Real>::add(
-          V[0][pose_ind][V_ind1][V_ind2], common::get<0>(rama));
-      for (int j = 0; j < 4; ++j) {
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[0][phi_ats[j]], common::get<1>(rama).row(j));
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[0][psi_ats[j]], common::get<2>(rama).row(j));
+      if (compute_derivs) {
+        auto rama = rama_V_dV<Dev, Real, Int>(
+            phi_coords,
+            psi_coords,
+            rama_tables[rama_table_ind],
+            Eigen::Map<Vec<Real, 2>>(
+                rama_table_params[rama_table_ind].bbstarts),
+            Eigen::Map<Vec<Real, 2>>(
+                rama_table_params[rama_table_ind].bbsteps));
+        accumulate<Dev, Real>::add(
+            V[0][pose_ind][V_ind1][V_ind2], common::get<0>(rama));
+        for (int j = 0; j < 4; ++j) {
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[0][phi_ats[j]], common::get<1>(rama).row(j));
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[0][psi_ats[j]], common::get<2>(rama).row(j));
+        }
+      } else {
+        accumulate<Dev, Real>::add(
+            V[0][pose_ind][V_ind1][V_ind2],
+            rama_V<Dev, Real, Int>(
+                phi_coords,
+                psi_coords,
+                rama_tables[rama_table_ind],
+                Eigen::Map<Vec<Real, 2>>(
+                    rama_table_params[rama_table_ind].bbstarts),
+                Eigen::Map<Vec<Real, 2>>(
+                    rama_table_params[rama_table_ind].bbsteps)));
       }
     }
 
@@ -289,36 +307,59 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     }
 
     if (valid_phipsi && omega_table_ind >= 0) {
-      auto omega = omega_bbdep_V_dV<Dev, Real, Int>(
-          phi_coords,
-          psi_coords,
-          omega_coords,
-          omega_tables[omega_table_ind][0],
-          omega_tables[omega_table_ind][1],
-          Eigen::Map<Vec<Real, 2>>(
-              omega_table_params[omega_table_ind].bbstarts),
-          Eigen::Map<Vec<Real, 2>>(omega_table_params[omega_table_ind].bbsteps),
-          32.8);
-      accumulate<Dev, Real>::add(
-          V[1][pose_ind][V_ind1][V_ind2], common::get<0>(omega));
-      for (int j = 0; j < 4; ++j) {
-        // omega : [V, dVdphi, dVdpsi, dVdomega]
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[1][phi_ats[j]], common::get<1>(omega).row(j));
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[1][psi_ats[j]], common::get<2>(omega).row(j));
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[1][omega_ats[j]], common::get<3>(omega).row(j));
+      if (compute_derivs) {
+        auto omega = omega_bbdep_V_dV<Dev, Real, Int>(
+            phi_coords,
+            psi_coords,
+            omega_coords,
+            omega_tables[omega_table_ind][0],
+            omega_tables[omega_table_ind][1],
+            Eigen::Map<Vec<Real, 2>>(
+                omega_table_params[omega_table_ind].bbstarts),
+            Eigen::Map<Vec<Real, 2>>(
+                omega_table_params[omega_table_ind].bbsteps),
+            32.8);
+        accumulate<Dev, Real>::add(
+            V[1][pose_ind][V_ind1][V_ind2], common::get<0>(omega));
+        for (int j = 0; j < 4; ++j) {
+          // omega : [V, dVdphi, dVdpsi, dVdomega]
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[1][phi_ats[j]], common::get<1>(omega).row(j));
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[1][psi_ats[j]], common::get<2>(omega).row(j));
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[1][omega_ats[j]], common::get<3>(omega).row(j));
+        }
+      } else {
+        accumulate<Dev, Real>::add(
+            V[1][pose_ind][V_ind1][V_ind2],
+            omega_bbdep_V<Dev, Real, Int>(
+                phi_coords,
+                psi_coords,
+                omega_coords,
+                omega_tables[omega_table_ind][0],
+                omega_tables[omega_table_ind][1],
+                Eigen::Map<Vec<Real, 2>>(
+                    omega_table_params[omega_table_ind].bbstarts),
+                Eigen::Map<Vec<Real, 2>>(
+                    omega_table_params[omega_table_ind].bbsteps),
+                32.8));
       }
     } else {
       // if rama is undefined, fall back to old version
-      auto omega = omega_V_dV<Dev, Real, Int>(omega_coords, 32.8);
-      accumulate<Dev, Real>::add(
-          V[1][pose_ind][V_ind1][V_ind2], common::get<0>(omega));
-      for (int j = 0; j < 4; ++j) {
-        // omega : [V, dVdomega]
-        accumulate<Dev, Vec<Real, 3>>::add(
-            dV_dxyz[1][omega_ats[j]], common::get<1>(omega).row(j));
+      if (compute_derivs) {
+        auto omega = omega_V_dV<Dev, Real, Int>(omega_coords, 32.8);
+        accumulate<Dev, Real>::add(
+            V[1][pose_ind][V_ind1][V_ind2], common::get<0>(omega));
+        for (int j = 0; j < 4; ++j) {
+          // omega : [V, dVdomega]
+          accumulate<Dev, Vec<Real, 3>>::add(
+              dV_dxyz[1][omega_ats[j]], common::get<1>(omega).row(j));
+        }
+      } else {
+        accumulate<Dev, Real>::add(
+            V[1][pose_ind][V_ind1][V_ind2],
+            omega_V<Real>(omega_coords, Real(32.8)));
       }
     }
   });

--- a/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
+++ b/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
@@ -108,7 +108,8 @@ class BackboneTorsionPoseScoreOp
                       TCAST(rama_table_params),
                       TCAST(omega_tables),
                       TCAST(omega_table_params),
-                      output_block_pair_energies);
+                      output_block_pair_energies,
+                      rot_coords.requires_grad());
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;

--- a/tmol/score/backbone_torsion/potentials/potentials.hh
+++ b/tmol/score/backbone_torsion/potentials/potentials.hh
@@ -67,6 +67,26 @@ def rama_V_dV(
 }
 
 template <tmol::Device D, typename Real, typename Int>
+def rama_V(
+    CoordQuad phi,
+    CoordQuad psi,
+    TensorAccessor<Real, 2, D> coeffs,
+    Real2 bbstart,
+    Real2 bbstep) -> Real {
+  Real2 phipsi_idx;
+  phipsi_idx[0] =
+      (dihedral_angle<Real>::V(phi.row(0), phi.row(1), phi.row(2), phi.row(3))
+       - bbstart[0])
+      / bbstep[0];
+  phipsi_idx[1] =
+      (dihedral_angle<Real>::V(psi.row(0), psi.row(1), psi.row(2), psi.row(3))
+       - bbstart[1])
+      / bbstep[1];
+  return tmol::numeric::bspline::ndspline<2, 3, D, Real, Int>::interpolate_V(
+      coeffs, phipsi_idx);
+}
+
+template <tmol::Device D, typename Real, typename Int>
 def omega_V_dV(CoordQuad omega, Real K) -> tuple<Real, CoordQuad> {
   Real V;
   Real dVdomega;
@@ -92,6 +112,18 @@ def omega_V_dV(CoordQuad omega, Real K) -> tuple<Real, CoordQuad> {
   dV_domegaatm.row(3) = omegaang.dV_dL;
 
   return {V, dVdomega * dV_domegaatm};
+}
+
+template <typename Real>
+def omega_V(CoordQuad omega, Real K) -> Real {
+  Real omega_offset = dihedral_angle<Real>::V(
+      omega.row(0), omega.row(1), omega.row(2), omega.row(3));
+  if (omega_offset > 0.5 * EIGEN_PI) {
+    omega_offset -= EIGEN_PI;
+  } else if (omega_offset < -0.5 * EIGEN_PI) {
+    omega_offset += EIGEN_PI;
+  }
+  return K * omega_offset * omega_offset;
 }
 
 // bb-dep version of omega
@@ -175,6 +207,47 @@ def omega_bbdep_V_dV(
   }
 
   return {V, dV_dphiatm, dV_dpsiatm, dV_domegaatm};
+}
+
+template <tmol::Device D, typename Real, typename Int>
+def omega_bbdep_V(
+    CoordQuad phi,
+    CoordQuad psi,
+    CoordQuad omega,
+    TensorAccessor<Real, 2, D> coeffs_mu,
+    TensorAccessor<Real, 2, D> coeffs_sig,
+    Real2 bbstart,
+    Real2 bbstep,
+    Real K) -> Real {
+  const Real pi = EIGEN_PI;
+  Real omegaang = dihedral_angle<Real>::V(
+      omega.row(0), omega.row(1), omega.row(2), omega.row(3));
+  if (omegaang > -0.5 * EIGEN_PI && omegaang < 0.5 * EIGEN_PI) {
+    return omega_V(omega, K);
+  }
+
+  Real2 phipsi_idx;
+  phipsi_idx[0] =
+      (dihedral_angle<Real>::V(phi.row(0), phi.row(1), phi.row(2), phi.row(3))
+       - bbstart[0])
+      / bbstep[0];
+  phipsi_idx[1] =
+      (dihedral_angle<Real>::V(psi.row(0), psi.row(1), psi.row(2), psi.row(3))
+       - bbstart[1])
+      / bbstep[1];
+
+  Real mu = tmol::numeric::bspline::ndspline<2, 3, D, Real, Int>::interpolate_V(
+      coeffs_mu, phipsi_idx);
+  Real sig =
+      tmol::numeric::bspline::ndspline<2, 3, D, Real, Int>::interpolate_V(
+          coeffs_sig, phipsi_idx);
+  Real baseline = std::log(1. / (6. * sqrt(2. * pi)))
+                  - std::log(1. / (sig * sqrt(2. * pi)));
+  Real offset = omegaang * 180.0 / pi - mu;
+  if (offset < -180.0) {
+    offset += 360.0;
+  }
+  return baseline + offset * offset / (2 * sig * sig);
 }
 
 #undef Real2

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -286,74 +286,85 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     Real improper_torsion_score = 0.0;
     Real hxyl_torsion_score = 0.0;
 
-    auto score_subgraph =
-        ([&] TMOL_DEVICE_FUNC(Vec<Int, 4> atoms, Int param_index) {
-          Vec<Real, 7> params = hash_values[param_index];
+    auto score_subgraph = ([&] TMOL_DEVICE_FUNC(
+                               Vec<Int, 4> atoms, Int param_index) {
+      Vec<Real, 7> params = hash_values[param_index];
 
-          Vec<Real, 3> atom1 = rot_coords[atoms[0]];
-          Vec<Real, 3> atom2 = rot_coords[atoms[1]];
+      Vec<Real, 3> atom1 = rot_coords[atoms[0]];
+      Vec<Real, 3> atom2 = rot_coords[atoms[1]];
 
-          subgraph_type type = get_subgraph_type(atoms);
+      subgraph_type type = get_subgraph_type(atoms);
 
-          int score_type = params[0];
+      int score_type = params[0];
 
-          // Real score;
-          switch (type) {
-            case subgraph_type::length: {
-              auto eval = cblength_V_dV(atom1, atom2, params[2], params[1]);
-              accumulate_result<Real, Int, 2, D>(
-                  length_score,
-                  eval,
-                  atoms.head(2),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
-            case subgraph_type::angle: {
-              Vec<Real, 3> atom3 = rot_coords[atoms[2]];
-              auto eval =
-                  cbangle_V_dV(atom1, atom2, atom3, params[2], params[1]);
-              accumulate_result<Real, Int, 3, D>(
-                  angle_score,
-                  eval,
-                  atoms.head(3),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
-            case subgraph_type::torsion: {
-              Vec<Real, 3> atom3 = rot_coords[atoms[2]];
-              Vec<Real, 3> atom4 = rot_coords[atoms[3]];
-              auto eval = cbtorsion_V_dV(
-                  atom1,
-                  atom2,
-                  atom3,
-                  atom4,
-                  params[1],
-                  params[2],
-                  params[3],
-                  params[4],
-                  params[5],
-                  params[6]);
-              Real& tor_score = (score_type == 3)   ? improper_torsion_score
-                                : (score_type == 4) ? hxyl_torsion_score
-                                                    : torsion_score;
-              accumulate_result<Real, Int, 4, D>(
-                  tor_score,
-                  eval,
-                  atoms.head(4),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
+      // Real score;
+      switch (type) {
+        case subgraph_type::length: {
+          if (compute_derivs) {
+            auto eval = cblength_V_dV(atom1, atom2, params[2], params[1]);
+            accumulate_result<Real, Int, 2, D>(
+                length_score,
+                eval,
+                atoms.head(2),
+                true,
+                dV_dx[score_type],
+                1.0);
+          } else {
+            length_score += cblength_V(atom1, atom2, params[2], params[1]);
           }
-        });
+
+          break;
+        }
+        case subgraph_type::angle: {
+          Vec<Real, 3> atom3 = rot_coords[atoms[2]];
+          if (compute_derivs) {
+            auto eval = cbangle_V_dV(atom1, atom2, atom3, params[2], params[1]);
+            accumulate_result<Real, Int, 3, D>(
+                angle_score, eval, atoms.head(3), true, dV_dx[score_type], 1.0);
+          } else {
+            angle_score += cbangle_V(atom1, atom2, atom3, params[2], params[1]);
+          }
+
+          break;
+        }
+        case subgraph_type::torsion: {
+          Vec<Real, 3> atom3 = rot_coords[atoms[2]];
+          Vec<Real, 3> atom4 = rot_coords[atoms[3]];
+          Real& tor_score = (score_type == 3)   ? improper_torsion_score
+                            : (score_type == 4) ? hxyl_torsion_score
+                                                : torsion_score;
+          if (compute_derivs) {
+            auto eval = cbtorsion_V_dV(
+                atom1,
+                atom2,
+                atom3,
+                atom4,
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+                params[6]);
+            accumulate_result<Real, Int, 4, D>(
+                tor_score, eval, atoms.head(4), true, dV_dx[score_type], 1.0);
+          } else {
+            tor_score += cbtorsion_V(
+                atom1,
+                atom2,
+                atom3,
+                atom4,
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+                params[6]);
+          }
+
+          break;
+        }
+      }
+    });
 
     int block_ind2 = -1;
     if (conn_ind1 == max_n_conns) {
@@ -1167,7 +1178,9 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // Allocate the tensors to which we will write our outputs
   int const n_V = output_block_pair_energies ? n_output_intxns_total : n_poses;
   auto V_t = TPack<Real, 2, D>::zeros({5, n_V});
-  auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({5, n_atoms});
+  auto dV_dx_t = compute_derivs
+                     ? TPack<Vec<Real, 3>, 2, D>::zeros({5, n_atoms})
+                     : TPack<Vec<Real, 3>, 2, D>::empty({5, n_atoms});
   auto dispatch_indices_t = TPack<Int, 2, D>::zeros({3, n_output_intxns_total});
 
   auto V = V_t.view;
@@ -1231,74 +1244,85 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     Real improper_torsion_score = 0.0;
     Real hxyl_torsion_score = 0.0;
 
-    auto score_subgraph =
-        ([&] TMOL_DEVICE_FUNC(Vec<Int, 4> atoms, Int param_index) {
-          Vec<Real, 7> params = hash_values[param_index];
+    auto score_subgraph = ([&] TMOL_DEVICE_FUNC(
+                               Vec<Int, 4> atoms, Int param_index) {
+      Vec<Real, 7> params = hash_values[param_index];
 
-          Vec<Real, 3> atom1 = rot_coords[atoms[0]];
-          Vec<Real, 3> atom2 = rot_coords[atoms[1]];
+      Vec<Real, 3> atom1 = rot_coords[atoms[0]];
+      Vec<Real, 3> atom2 = rot_coords[atoms[1]];
 
-          subgraph_type type = get_subgraph_type(atoms);
+      subgraph_type type = get_subgraph_type(atoms);
 
-          int score_type = params[0];
+      int score_type = params[0];
 
-          // Real score;
-          switch (type) {
-            case subgraph_type::length: {
-              auto eval = cblength_V_dV(atom1, atom2, params[2], params[1]);
-              accumulate_result<Real, Int, 2, D>(
-                  length_score,
-                  eval,
-                  atoms.head(2),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
-            case subgraph_type::angle: {
-              Vec<Real, 3> atom3 = rot_coords[atoms[2]];
-              auto eval =
-                  cbangle_V_dV(atom1, atom2, atom3, params[2], params[1]);
-              accumulate_result<Real, Int, 3, D>(
-                  angle_score,
-                  eval,
-                  atoms.head(3),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
-            case subgraph_type::torsion: {
-              Vec<Real, 3> atom3 = rot_coords[atoms[2]];
-              Vec<Real, 3> atom4 = rot_coords[atoms[3]];
-              auto eval = cbtorsion_V_dV(
-                  atom1,
-                  atom2,
-                  atom3,
-                  atom4,
-                  params[1],
-                  params[2],
-                  params[3],
-                  params[4],
-                  params[5],
-                  params[6]);
-              Real& tor_score = (score_type == 3)   ? improper_torsion_score
-                                : (score_type == 4) ? hxyl_torsion_score
-                                                    : torsion_score;
-              accumulate_result<Real, Int, 4, D>(
-                  tor_score,
-                  eval,
-                  atoms.head(4),
-                  compute_derivs,
-                  dV_dx[score_type],
-                  1.0);
-
-              break;
-            }
+      // Real score;
+      switch (type) {
+        case subgraph_type::length: {
+          if (compute_derivs) {
+            auto eval = cblength_V_dV(atom1, atom2, params[2], params[1]);
+            accumulate_result<Real, Int, 2, D>(
+                length_score,
+                eval,
+                atoms.head(2),
+                true,
+                dV_dx[score_type],
+                1.0);
+          } else {
+            length_score += cblength_V(atom1, atom2, params[2], params[1]);
           }
-        });
+
+          break;
+        }
+        case subgraph_type::angle: {
+          Vec<Real, 3> atom3 = rot_coords[atoms[2]];
+          if (compute_derivs) {
+            auto eval = cbangle_V_dV(atom1, atom2, atom3, params[2], params[1]);
+            accumulate_result<Real, Int, 3, D>(
+                angle_score, eval, atoms.head(3), true, dV_dx[score_type], 1.0);
+          } else {
+            angle_score += cbangle_V(atom1, atom2, atom3, params[2], params[1]);
+          }
+
+          break;
+        }
+        case subgraph_type::torsion: {
+          Vec<Real, 3> atom3 = rot_coords[atoms[2]];
+          Vec<Real, 3> atom4 = rot_coords[atoms[3]];
+          Real& tor_score = (score_type == 3)   ? improper_torsion_score
+                            : (score_type == 4) ? hxyl_torsion_score
+                                                : torsion_score;
+          if (compute_derivs) {
+            auto eval = cbtorsion_V_dV(
+                atom1,
+                atom2,
+                atom3,
+                atom4,
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+                params[6]);
+            accumulate_result<Real, Int, 4, D>(
+                tor_score, eval, atoms.head(4), true, dV_dx[score_type], 1.0);
+          } else {
+            tor_score += cbtorsion_V(
+                atom1,
+                atom2,
+                atom3,
+                atom4,
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+                params[6]);
+          }
+
+          break;
+        }
+      }
+    });
 
     if (conn_ind1 == max_n_conns) {
       // intra-residue!

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -238,8 +238,9 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // then performs a reduction so that thread-0 can write the results to global
   // memory.
 
-  // Optimal launch box on v100 and a100 is nt=32, vt=1
-  LAUNCH_BOX_32;
+  // This interaction kernel benefits from a 64-register budget on modern GPUs,
+  // which leaves enough resident warps to hide its dependency latency.
+  LAUNCH_BOX_32_OCC(32);
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
 

--- a/tmol/score/cartbonded/potentials/potentials.hh
+++ b/tmol/score/cartbonded/potentials/potentials.hh
@@ -30,6 +30,12 @@ static def square(Real v) -> Real {
 }
 
 template <typename Real>
+def cblength_V(Real3 atm1, Real3 atm2, Real K, Real x0) -> Real {
+  Real dist = distance<Real>::V(atm1, atm2);
+  return 0.5 * K * square(dist - x0);
+}
+
+template <typename Real>
 def cblength_V_dV_old(Real3 atm1, Real3 atm2, Real K, Real x0)
     -> tuple<Real, Real3, Real3> {
   auto dist = distance<Real>::V_dV(atm1, atm2);
@@ -65,6 +71,12 @@ def cbangle_V_dV(Real3 atm1, Real3 atm2, Real3 atm3, Real K, Real x0)
   return {E, dEout};
 }
 
+template <typename Real>
+def cbangle_V(Real3 atm1, Real3 atm2, Real3 atm3, Real K, Real x0) -> Real {
+  Real angle = pt_interior_angle<Real>::V(atm1, atm2, atm3);
+  return 0.5 * K * square(angle - x0);
+}
+
 // torsions use a sum of three sin funcs
 //   sum_n K*(cos(n*x-x0)+1) for n=1,2,3
 template <typename Real>
@@ -94,6 +106,24 @@ def cbtorsion_V_dV(
   dEout[2] = dE * torsion.dV_dK;
   dEout[3] = dE * torsion.dV_dL;
   return {E, dEout};
+}
+
+template <typename Real>
+def cbtorsion_V(
+    Real3 atm1,
+    Real3 atm2,
+    Real3 atm3,
+    Real3 atm4,
+    Real K1,
+    Real K2,
+    Real K3,
+    Real phi1,
+    Real phi2,
+    Real phi3) -> Real {
+  Real torsion = dihedral_angle<Real>::V(atm1, atm2, atm3, atm4);
+  return K1 * (std::cos(torsion - phi1) + 1.0)
+         + K2 * (std::cos(2.0 * torsion - phi2) + 1.0)
+         + K3 * (std::cos(3.0 * torsion - phi3) + 1.0);
 }
 
 template <typename Real>

--- a/tmol/score/common/launch_box_macros.hh
+++ b/tmol/score/common/launch_box_macros.hh
@@ -28,10 +28,27 @@ struct launch_t_cpu {
       arch_75_cta<32, 1>> \
       launch_t;
 
+// Create a one-warp launch box with a requested minimum number of resident
+// blocks per SM on Volta and newer. This lets register-heavy kernels trade
+// registers for latency hiding without changing their warp-cooperative
+// algorithm or imposing modern occupancy targets on legacy architectures.
+#define LAUNCH_BOX_32_OCC_AS(name, occ) \
+  using namespace mgpu;                 \
+  typedef launch_box_t<                 \
+      arch_20_cta<32, 1>,               \
+      arch_35_cta<32, 1>,               \
+      arch_52_cta<32, 1>,               \
+      arch_70_cta<32, 1, 1, occ>,       \
+      arch_75_cta<32, 1, 1, occ>>       \
+      name;
+#define LAUNCH_BOX_32_OCC(occ) LAUNCH_BOX_32_OCC_AS(launch_t, occ)
+
 #else
 // On the CPU, an "ntreads" of 1 is faster because there
 // is only one set of threads
 #define LAUNCH_BOX_32 typedef launch_t_cpu<1, 1> launch_t;
+#define LAUNCH_BOX_32_OCC_AS(name, occ) typedef launch_t_cpu<1, 1> name;
+#define LAUNCH_BOX_32_OCC(occ) typedef launch_t_cpu<1, 1> launch_t;
 #endif
 
 #ifdef __NVCC__

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -166,8 +166,10 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dihedral_values_t = TPack<Real, 2, D>::zeros({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
   auto dihedral_deriv_t =
-      TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
-          {n_rots, max_n_dih});
+      compute_derivs ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
+                           {n_rots, max_n_dih})
+                     : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
+                           {n_rots, max_n_dih});
   auto dihedral_deriv = dihedral_deriv_t.view;
 
   auto rotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
@@ -177,14 +179,19 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto semirotameric_rottable_assignment =
       semirotameric_rottable_assignment_t.view;
 
-  auto dneglnprob_rot_dbb_xyz_t = TPack<CoordQuad, 2, D>::zeros({n_rots, 2});
+  auto dneglnprob_rot_dbb_xyz_t =
+      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
+                     : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
   auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
 
-  auto drotchi_devpen_dtor_xyz_t = TPack<CoordQuad, 2, D>::zeros({n_rots, 3});
+  auto drotchi_devpen_dtor_xyz_t =
+      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                     : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
 
   auto dneglnprob_nonrot_dtor_xyz_t =
-      TPack<CoordQuad, 2, D>::zeros({n_rots, 3});
+      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                     : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
 
   auto V = V_t.view;
@@ -254,12 +261,20 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                          : (ii == 1) ? PSI_DEFAULT
                                      : 0.0;
 
-      measure_dihedral_V_dV(
-          TensorAccessor<Vec<Real, 3>, 1, D>(rot_coords),
-          dihedral_atom_inds[rotamer_index][ii],
-          dih_default,
-          dihedral_values[rotamer_index][ii],
-          dihedral_deriv[rotamer_index][ii]);
+      if (compute_derivs) {
+        measure_dihedral_V_dV(
+            TensorAccessor<Vec<Real, 3>, 1, D>(rot_coords),
+            dihedral_atom_inds[rotamer_index][ii],
+            dih_default,
+            dihedral_values[rotamer_index][ii],
+            dihedral_deriv[rotamer_index][ii]);
+      } else {
+        measure_dihedral_V(
+            TensorAccessor<Vec<Real, 3>, 1, D>(rot_coords),
+            dihedral_atom_inds[rotamer_index][ii],
+            dih_default,
+            dihedral_values[rotamer_index][ii]);
+      }
     }
 
     // Templated on there being 2 backbone dihedrals for canonical aas.
@@ -285,7 +300,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           dihedral_values[rotamer_index],
           rotameric_rottable_assignment[rotamer_index],
           dneglnprob_rot_dbb_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index]);
+          dihedral_deriv[rotamer_index],
+          compute_derivs);
 
       if (output_block_pair_energies) {
         V[0][pose_index][block_index][block_index] = prob;
@@ -335,7 +351,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           rotameric_rottable_assignment[rotamer_index],
           // Out
           drotchi_devpen_dtor_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index]);
+          dihedral_deriv[rotamer_index],
+          compute_derivs);
       rotameric_chi_dev_penalty += Erotdev;
 
       if (compute_derivs) {
@@ -387,7 +404,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           semirotameric_rottable_assignment[rotamer_index],
 
           dneglnprob_nonrot_dtor_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index]);
+          dihedral_deriv[rotamer_index],
+          compute_derivs);
 
       if (output_block_pair_energies) {
         V[2][pose_index][block_index][block_index] = Esemi;

--- a/tmol/score/dunbrack/potentials/potentials.hh
+++ b/tmol/score/dunbrack/potentials/potentials.hh
@@ -58,6 +58,24 @@ def measure_dihedral_V_dV(
 }
 
 template <typename Real, typename Int, tmol::Device D>
+def measure_dihedral_V(
+    TensorAccessor<Eigen::Matrix<Real, 3, 1>, 1, D> coordinates,
+    const Vec<Int, 4>& dihedral_atom_inds,
+    Real dih_default,
+    Real& dihedral) -> void {
+  Int at1 = dihedral_atom_inds[0];
+  if (at1 >= 0) {
+    dihedral = dihedral_angle<Real>::V(
+        coordinates[at1],
+        coordinates[dihedral_atom_inds[1]],
+        coordinates[dihedral_atom_inds[2]],
+        coordinates[dihedral_atom_inds[3]]);
+  } else if (at1 == -1) {
+    dihedral = dih_default;
+  }
+}
+
+template <typename Real, typename Int, tmol::Device D>
 def measure_dihedrals_V_dV(
     TensorAccessor<Eigen::Matrix<Real, 3, 1>, 1, D> coordinates,
     int i,
@@ -535,7 +553,8 @@ def block_deviation_penalty_for_chi(
     Int rotameric_rottable_assignment,
     // Out
     TensorAccessor<CoordQuad, 1, D> drotchi_devpen_dtor_xyz,
-    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz) -> Real {
+    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz,
+    bool compute_derivs = true) -> Real {
   Real devpen, dpen_dchi;
   Eigen::Matrix<Real, 2, 1> dpen_dbb;
 
@@ -556,13 +575,15 @@ def block_deviation_penalty_for_chi(
       chi_ind,
       rotameric_rottable_assignment);
 
-  for (int ii = 0; ii < NbbP1 - 1 + 1; ++ii) {
-    int tor_ind = (ii == NbbP1 - 1 ? (NbbP1 - 1 + chi_ind) : ii);
-    Real dpen_dtor = ii == NbbP1 - 1 ? dpen_dchi : dpen_dbb(ii);
-    for (int jj = 0; jj < 4; ++jj) {
-      for (int kk = 0; kk < 3; ++kk) {
-        drotchi_devpen_dtor_xyz[ii](jj, kk) =
-            dpen_dtor * ddihe_dxyz[tor_ind](jj, kk);
+  if (compute_derivs) {
+    for (int ii = 0; ii < NbbP1 - 1 + 1; ++ii) {
+      int tor_ind = (ii == NbbP1 - 1 ? (NbbP1 - 1 + chi_ind) : ii);
+      Real dpen_dtor = ii == NbbP1 - 1 ? dpen_dchi : dpen_dbb(ii);
+      for (int jj = 0; jj < 4; ++jj) {
+        for (int kk = 0; kk < 3; ++kk) {
+          drotchi_devpen_dtor_xyz[ii](jj, kk) =
+              dpen_dtor * ddihe_dxyz[tor_ind](jj, kk);
+        }
       }
     }
   }
@@ -748,7 +769,8 @@ def rotameric_chi_probability_for_block(
     TensorAccessor<Real, 1, D> dihedrals,
     Int rotameric_rottable_assignment,
     TensorAccessor<CoordQuad, 1, D> dneglnprob_rot_dbb_xyz,
-    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz) -> Real {
+    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz,
+    bool compute_derivs = true) -> Real {
   Real neglnprobE = 0.0;
   Eigen::Matrix<Real, NbbP1 - 1, 1> dneglnprob_ddihe;
   tie(neglnprobE, dneglnprob_ddihe) = block_rotameric_chi_probability(
@@ -763,11 +785,13 @@ def rotameric_chi_probability_for_block(
       block_rotamer_table_set,
       rotameric_rottable_assignment);
 
-  for (int ii = 0; ii < 2; ++ii) {
-    for (int jj = 0; jj < 4; ++jj) {
-      for (int kk = 0; kk < 3; ++kk) {
-        dneglnprob_rot_dbb_xyz[ii](jj, kk) =
-            dneglnprob_ddihe(ii) * ddihe_dxyz[ii](jj, kk);
+  if (compute_derivs) {
+    for (int ii = 0; ii < 2; ++ii) {
+      for (int jj = 0; jj < 4; ++jj) {
+        for (int kk = 0; kk < 3; ++kk) {
+          dneglnprob_rot_dbb_xyz[ii](jj, kk) =
+              dneglnprob_ddihe(ii) * ddihe_dxyz[ii](jj, kk);
+        }
       }
     }
   }
@@ -839,7 +863,8 @@ def block_semirotameric_energy(
     TensorAccessor<Real, 1, D> dihedrals,
     Int semirotameric_rottable_assignment,
     TensorAccessor<CoordQuad, 1, D> dneglnprob_nonrot_dtor_xyz,
-    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz) -> Real {
+    TensorAccessor<CoordQuad, 1, D> ddihe_dxyz,
+    bool compute_derivs = true) -> Real {
   Eigen::Matrix<Real, NbbP2 - 1, 1> dihe;
   Eigen::Matrix<Real, NbbP2 - 1, 1> temp_dihe_deg;
   Eigen::Matrix<Real, NbbP2 - 1, 1> temp_orig_dihe_deg;
@@ -889,11 +914,13 @@ def block_semirotameric_energy(
     dnlp_ddihe[ii] /= dihe_step[ii];
   }
 
-  for (int ii = 0; ii < 3; ++ii) {
-    int tor_ind = ii == 2 ? block_semirot_dihedral_index : ii;
-    for (int jj = 0; jj < 4; ++jj) {
-      dneglnprob_nonrot_dtor_xyz[ii].row(jj) =
-          dnlp_ddihe(ii) * ddihe_dxyz[tor_ind].row(jj);
+  if (compute_derivs) {
+    for (int ii = 0; ii < 3; ++ii) {
+      int tor_ind = ii == 2 ? block_semirot_dihedral_index : ii;
+      for (int jj = 0; jj < 4; ++jj) {
+        dneglnprob_nonrot_dtor_xyz[ii].row(jj) =
+            dnlp_ddihe(ii) * ddihe_dxyz[tor_ind].row(jj);
+      }
     }
   }
 

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -165,20 +165,52 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         D = self.global_params.elec_sigmoidal_die_D
         D0 = self.global_params.elec_sigmoidal_die_D0
         S = self.global_params.elec_sigmoidal_die_S
+        min_dis = self.global_params.elec_min_dis
         max_dis = self.global_params.elec_max_dis
-        eps_at_cutoff = D - 0.5 * (D - D0) * (
-            2 + 2 * max_dis * S + max_dis * max_dis * S * S
-        ) * math.exp(-max_dis * S)
+
+        def eps(dist):
+            return D - 0.5 * (D - D0) * (
+                2 + 2 * dist * S + dist * dist * S * S
+            ) * math.exp(-dist * S)
+
+        def deps(dist):
+            return 0.5 * (D - D0) * dist * dist * S * S * S * math.exp(-dist * S)
+
+        eps_at_cutoff = eps(max_dis)
         cutoff_offset = 322.0637 / (max_dis * eps_at_cutoff)
+        min_score = 322.0637 / (min_dis * eps(min_dis)) - cutoff_offset
+
+        low_end = min_dis + 0.25
+        low_eps = eps(low_end)
+        low_score = 322.0637 / (low_end * low_eps) - cutoff_offset
+        low_deriv = (
+            -322.0637
+            * (low_eps + low_end * deps(low_end))
+            / (low_end * low_end * low_eps * low_eps)
+        )
+
+        high_start = max_dis - 1.0
+        high_eps = eps(high_start)
+        high_score = 322.0637 / (high_start * high_eps) - cutoff_offset
+        high_deriv = (
+            -322.0637
+            * (high_eps + high_start * deps(high_start))
+            / (high_start * high_start * high_eps * high_eps)
+        )
 
         global_params = torch.tensor(
             [
                 D,
                 D0,
                 S,
-                self.global_params.elec_min_dis,
+                min_dis,
                 max_dis,
                 cutoff_offset,
+                min_score,
+                low_score,
+                low_deriv,
+                high_score,
+                high_deriv,
             ],
             dtype=torch.float32,
             device=pose_stack.device,

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 
 from .._atom_type_dependent_term import AtomTypeDependentTerm
@@ -160,13 +162,23 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         def _t(ts):
             return tuple(map(lambda t: t.to(torch.float), ts))
 
+        D = self.global_params.elec_sigmoidal_die_D
+        D0 = self.global_params.elec_sigmoidal_die_D0
+        S = self.global_params.elec_sigmoidal_die_S
+        max_dis = self.global_params.elec_max_dis
+        eps_at_cutoff = D - 0.5 * (D - D0) * (
+            2 + 2 * max_dis * S + max_dis * max_dis * S * S
+        ) * math.exp(-max_dis * S)
+        cutoff_offset = 322.0637 / (max_dis * eps_at_cutoff)
+
         global_params = torch.tensor(
             [
-                self.global_params.elec_sigmoidal_die_D,
-                self.global_params.elec_sigmoidal_die_D0,
-                self.global_params.elec_sigmoidal_die_S,
+                D,
+                D0,
+                S,
                 self.global_params.elec_min_dis,
-                self.global_params.elec_max_dis,
+                max_dis,
+                cutoff_offset,
             ],
             dtype=torch.float32,
             device=pose_stack.device,

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -416,17 +416,8 @@ TMOL_DEVICE_FUNC Real elec_atom_energy(
   Real const q1 = score_dat.r1.charges[atom_tile_ind1];
   Real const q2 = score_dat.r2.charges[atom_tile_ind2];
   Real const dist = distance<Real>::V(coord1, coord2);
-  Real const result = elec(
-      dist,
-      q1,
-      q2,
-      Real(cp_separation),
-      score_dat.global_params.D,
-      score_dat.global_params.D0,
-      score_dat.global_params.S,
-      score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis,
-      score_dat.global_params.cutoff_offset);
+  Real const result =
+      elec(dist, q1, q2, Real(cp_separation), score_dat.global_params);
   return result;
 }
 
@@ -454,12 +445,7 @@ TMOL_DEVICE_FUNC void elec_atom_derivs(
       score_dat.r1.charges[atom_tile_ind1],
       score_dat.r2.charges[atom_tile_ind2],
       Real(cp_separation),
-      score_dat.global_params.D,
-      score_dat.global_params.D0,
-      score_dat.global_params.S,
-      score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis,
-      score_dat.global_params.cutoff_offset);
+      score_dat.global_params);
 
   // all threads accumulate derivatives for atom 1 to global memory
   // Remove "0.5 *" as the energy is no longer split between the i,j and j,i
@@ -511,12 +497,7 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
       score_dat.r1.charges[atom_tile_ind1],
       score_dat.r2.charges[atom_tile_ind2],
       Real(cp_separation),
-      score_dat.global_params.D,
-      score_dat.global_params.D0,
-      score_dat.global_params.S,
-      score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis,
-      score_dat.global_params.cutoff_offset);
+      score_dat.global_params);
 
   // all threads accumulate derivatives for atom 1 to global memory
   Vec<Real, 3> elec_dxyz_at1 = dV_ddist * ddist_dat1;

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -447,7 +447,6 @@ TMOL_DEVICE_FUNC void elec_atom_derivs(
   auto dist_r = distance<Real>::V_dV(coord1, coord2);
   auto& dist = dist_r.V;
   auto& ddist_dat1 = dist_r.dV_dA;
-  auto& ddist_dat2 = dist_r.dV_dB;
   Real V(0.0), dV_ddist(0.0);
   tie(V, dV_ddist) = elec_delec_ddist(
       dist,
@@ -475,7 +474,7 @@ TMOL_DEVICE_FUNC void elec_atom_derivs(
   }
 
   // all threads accumulate derivatives for atom 2 to global memory
-  Vec<Real, 3> elec_dxyz_at2 = dTdV * dV_ddist * ddist_dat2;
+  Vec<Real, 3> elec_dxyz_at2 = -elec_dxyz_at1;
   for (int j = 0; j < 3; ++j) {
     if (elec_dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(
@@ -504,7 +503,6 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
   auto dist_r = distance<Real>::V_dV(coord1, coord2);
   auto& dist = dist_r.V;
   auto& ddist_dat1 = dist_r.dV_dA;
-  auto& ddist_dat2 = dist_r.dV_dB;
   Real V(0.0), dV_ddist(0.0);
   tie(V, dV_ddist) = elec_delec_ddist(
       dist,
@@ -530,7 +528,7 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
   }
 
   // all threads accumulate derivatives for atom 2 to global memory
-  Vec<Real, 3> elec_dxyz_at2 = dV_ddist * ddist_dat2;
+  Vec<Real, 3> elec_dxyz_at2 = -elec_dxyz_at1;
   for (int j = 0; j < 3; ++j) {
     if (elec_dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(

--- a/tmol/score/elec/potentials/elec.hh
+++ b/tmol/score/elec/potentials/elec.hh
@@ -425,7 +425,8 @@ TMOL_DEVICE_FUNC Real elec_atom_energy(
       score_dat.global_params.D0,
       score_dat.global_params.S,
       score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis);
+      score_dat.global_params.max_dis,
+      score_dat.global_params.cutoff_offset);
   return result;
 }
 
@@ -457,7 +458,8 @@ TMOL_DEVICE_FUNC void elec_atom_derivs(
       score_dat.global_params.D0,
       score_dat.global_params.S,
       score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis);
+      score_dat.global_params.max_dis,
+      score_dat.global_params.cutoff_offset);
 
   // all threads accumulate derivatives for atom 1 to global memory
   // Remove "0.5 *" as the energy is no longer split between the i,j and j,i
@@ -513,7 +515,8 @@ TMOL_DEVICE_FUNC Real elec_atom_energy_and_derivs_full(
       score_dat.global_params.D0,
       score_dat.global_params.S,
       score_dat.global_params.min_dis,
-      score_dat.global_params.max_dis);
+      score_dat.global_params.max_dis,
+      score_dat.global_params.cutoff_offset);
 
   // all threads accumulate derivatives for atom 1 to global memory
   Vec<Real, 3> elec_dxyz_at1 = dV_ddist * ddist_dat1;

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -701,20 +701,14 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
              int start_atom2,
              ElecScoringData<Real> const& score_dat,
              int cp_separation) {
-          if (compute_derivs) {
-            auto val = elec_atom_energy_and_derivs_full(
-                atom_tile_ind1,
-                atom_tile_ind2,
-                start_atom1,
-                start_atom2,
-                score_dat,
-                cp_separation,
-                dV_dcoords);
-            return val;
-          } else {
-            return elec_atom_energy(
-                atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
-          }
+          return elec_atom_energy_and_derivs_full(
+              atom_tile_ind1,
+              atom_tile_ind2,
+              start_atom1,
+              start_atom2,
+              score_dat,
+              cp_separation,
+              dV_dcoords);
         });
 
     auto score_inter_elec_atom_pair = ([=] SCORE_INTER_ELEC_ATOM_PAIR);
@@ -847,7 +841,7 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // mgpu::standard_context_t context(wrapped_stream.stream());
 
   // 3
-  if (output_block_pair_energies) {
+  if (output_block_pair_energies || !compute_derivs) {
     DeviceDispatch<D>::template foreach_workgroup<launch_t>(
         mgr, n_poses * max_n_upper_triangle_inds, eval_energies_by_block);
   } else {

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -544,8 +544,9 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   }
   auto output = output_t.view;
 
-  // Optimal launch box on v100 and a100 is nt=32, vt=1
-  LAUNCH_BOX_32;
+  // This atom-pair kernel benefits from a 64-register budget on modern GPUs,
+  // which leaves enough resident warps to hide its dependency latency.
+  LAUNCH_BOX_32_OCC(32);
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
 

--- a/tmol/score/elec/potentials/params.hh
+++ b/tmol/score/elec/potentials/params.hh
@@ -16,6 +16,11 @@ struct ElecGlobalParams {
   Real min_dis;
   Real max_dis;
   Real cutoff_offset;
+  Real min_score;
+  Real low_score;
+  Real low_deriv;
+  Real high_score;
+  Real high_deriv;
 };
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/params.hh
+++ b/tmol/score/elec/potentials/params.hh
@@ -15,6 +15,7 @@ struct ElecGlobalParams {
   Real S;
   Real min_dis;
   Real max_dis;
+  Real cutoff_offset;
 };
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -60,7 +60,8 @@ def elec_delec_ddist(
     float D0,
     float S,
     float min_dis,
-    float max_dis) -> tuple<Real, Real> {
+    float max_dis,
+    Real C2) -> tuple<Real, Real> {
   Real low_poly_start = min_dis - 0.25;
   Real low_poly_end = min_dis + 0.25;
   Real hi_poly_start = max_dis - 1.0;
@@ -69,8 +70,6 @@ def elec_delec_ddist(
   Real weight = connectivity_weight<Real>(bonded_path_length);
 
   Real C1 = 322.0637;  // electrostatic energy constant (matches Rosetta C0_)
-  Real C2 = C1 / (max_dis * eps(max_dis, D, D0, S));
-
   Real eiej = e_i * e_j;
 
   Real elecE = 0, delec_ddist = 0;
@@ -140,7 +139,8 @@ def elec(
     float D0,
     float S,
     float min_dis,
-    float max_dis) -> Real {
+    float max_dis,
+    Real C2) -> Real {
   Real low_poly_start = min_dis - 0.25;
   Real low_poly_end = min_dis + 0.25;
   Real hi_poly_start = max_dis - 1.0;
@@ -149,8 +149,6 @@ def elec(
   Real weight = connectivity_weight<Real>(bonded_path_length);
 
   Real C1 = 322.0637;  // electrostatic energy constant (matches Rosetta C0_)
-  Real C2 = C1 / (max_dis * eps(max_dis, D, D0, S));
-
   Real eiej = e_i * e_j;
   if (eiej == 0) {
     // Early exit for virtual atoms / atoms with a charge of 0

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -11,6 +11,8 @@
 #include <tmol/score/common/tuple.hh>
 #include <tmol/score/common/tuple_operators.hh>
 
+#include "params.hh"
+
 #undef B0
 
 namespace tmol {
@@ -56,20 +58,14 @@ def elec_delec_ddist(
     Real e_i,
     Real e_j,
     Real bonded_path_length,
-    float D,
-    float D0,
-    float S,
-    float min_dis,
-    float max_dis,
-    Real C2) -> tuple<Real, Real> {
-  Real low_poly_start = min_dis - 0.25;
-  Real low_poly_end = min_dis + 0.25;
-  Real hi_poly_start = max_dis - 1.0;
-  Real hi_poly_end = max_dis;
+    ElecGlobalParams<Real> const& params) -> tuple<Real, Real> {
+  Real low_poly_start = params.min_dis - 0.25;
+  Real low_poly_end = params.min_dis + 0.25;
+  Real hi_poly_start = params.max_dis - 1.0;
+  Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);
 
-  Real C1 = 322.0637;  // electrostatic energy constant (matches Rosetta C0_)
   Real eiej = e_i * e_j;
 
   Real elecE = 0, delec_ddist = 0;
@@ -80,51 +76,39 @@ def elec_delec_ddist(
 
   if (dist < low_poly_start) {
     // flat part
-    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
-    elecE = eiej * min_dis_score;
+    elecE = eiej * params.min_score;
     delec_ddist = 0;
   } else if (dist < low_poly_end) {
     // short range fade
     // Interesting thing to note here: If eiej is 0, you might
     // expect that interpolating between 0 and 0 would give you 0
     // everywhere, but it does NOT!
-    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
-    Real eps_elec = eps(low_poly_end, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(low_poly_end, D, D0, S);
-    Real dmax_elec = eiej * (C1 / (low_poly_end * eps_elec) - C2);
-    Real dmax_elec_d_dist =
-        -C1 * eiej * (eps_elec + low_poly_end * deps_elec_d_dist)
-        / (low_poly_end * low_poly_end * eps_elec * eps_elec);
-
     tie(elecE, delec_ddist) = interpolate_V_dV<Real>(
         dist,
         low_poly_start,
-        eiej * min_dis_score,
+        eiej * params.min_score,
         0.0,
         low_poly_end,
-        dmax_elec,
-        dmax_elec_d_dist);
+        eiej * params.low_score,
+        eiej * params.low_deriv);
 
   } else if (dist < hi_poly_start) {
     // Coulombic part
-    Real eps_elec = eps(dist, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(dist, D, D0, S);
+    Real eps_elec = eps(dist, params.D, params.D0, params.S);
+    Real deps_elec_d_dist = deps_ddist(dist, params.D, params.D0, params.S);
 
-    elecE = eiej * (C1 / (dist * eps_elec) - C2);
-    delec_ddist = -C1 * eiej * (eps_elec + dist * deps_elec_d_dist)
+    elecE = eiej * (Real(322.0637) / (dist * eps_elec) - params.cutoff_offset);
+    delec_ddist = -Real(322.0637) * eiej * (eps_elec + dist * deps_elec_d_dist)
                   / (dist * dist * eps_elec * eps_elec);
 
   } else if (dist < hi_poly_end) {
     // long range fade
-    Real eps_elec = eps(hi_poly_start, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(hi_poly_start, D, D0, S);
-    Real dmin_elec = eiej * (C1 / (hi_poly_start * eps_elec) - C2);
-    Real dmin_elec_d_dist =
-        -C1 * eiej * (eps_elec + hi_poly_start * deps_elec_d_dist)
-        / (hi_poly_start * hi_poly_start * eps_elec * eps_elec);
-
     tie(elecE, delec_ddist) = interpolate_to_zero_V_dV(
-        dist, hi_poly_start, dmin_elec, dmin_elec_d_dist, hi_poly_end);
+        dist,
+        hi_poly_start,
+        eiej * params.high_score,
+        eiej * params.high_deriv,
+        hi_poly_end);
   }
 
   return {weight * elecE, weight * delec_ddist};
@@ -135,20 +119,14 @@ def elec(
     Real e_i,
     Real e_j,
     Real bonded_path_length,
-    float D,
-    float D0,
-    float S,
-    float min_dis,
-    float max_dis,
-    Real C2) -> Real {
-  Real low_poly_start = min_dis - 0.25;
-  Real low_poly_end = min_dis + 0.25;
-  Real hi_poly_start = max_dis - 1.0;
-  Real hi_poly_end = max_dis;
+    ElecGlobalParams<Real> const& params) -> Real {
+  Real low_poly_start = params.min_dis - 0.25;
+  Real low_poly_end = params.min_dis + 0.25;
+  Real hi_poly_start = params.max_dis - 1.0;
+  Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);
 
-  Real C1 = 322.0637;  // electrostatic energy constant (matches Rosetta C0_)
   Real eiej = e_i * e_j;
   if (eiej == 0) {
     // Early exit for virtual atoms / atoms with a charge of 0
@@ -158,48 +136,36 @@ def elec(
   Real elecE = 0;
   if (dist < low_poly_start) {
     // flat part
-    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
-    elecE = eiej * min_dis_score;
+    elecE = eiej * params.min_score;
   } else if (dist < low_poly_end) {
     // short range fade
     // Interesting thing to note here: If eiej is 0, you might
     // expect that interpolating between 0 and 0 would give you 0
     // everywhere, but it does NOT!
-    Real min_dis_score = C1 / (min_dis * eps(min_dis, D, D0, S)) - C2;
-    Real eps_elec = eps(low_poly_end, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(low_poly_end, D, D0, S);
-    Real dmax_elec = eiej * (C1 / (low_poly_end * eps_elec) - C2);
-    Real dmax_elec_d_dist =
-        -C1 * eiej * (eps_elec + low_poly_end * deps_elec_d_dist)
-        / (low_poly_end * low_poly_end * eps_elec * eps_elec);
-
     elecE = interpolate<Real>(
         dist,
         low_poly_start,
-        eiej * min_dis_score,
+        eiej * params.min_score,
         0.0,
         low_poly_end,
-        dmax_elec,
-        dmax_elec_d_dist);
+        eiej * params.low_score,
+        eiej * params.low_deriv);
 
   } else if (dist < hi_poly_start) {
     // Coulombic part
-    Real eps_elec = eps(dist, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(dist, D, D0, S);
+    Real eps_elec = eps(dist, params.D, params.D0, params.S);
+    Real deps_elec_d_dist = deps_ddist(dist, params.D, params.D0, params.S);
 
-    elecE = eiej * (C1 / (dist * eps_elec) - C2);
+    elecE = eiej * (Real(322.0637) / (dist * eps_elec) - params.cutoff_offset);
 
   } else if (dist < hi_poly_end) {
     // long range fade
-    Real eps_elec = eps(hi_poly_start, D, D0, S);
-    Real deps_elec_d_dist = deps_ddist(hi_poly_start, D, D0, S);
-    Real dmin_elec = eiej * (C1 / (hi_poly_start * eps_elec) - C2);
-    Real dmin_elec_d_dist =
-        -C1 * eiej * (eps_elec + hi_poly_start * deps_elec_d_dist)
-        / (hi_poly_start * hi_poly_start * eps_elec * eps_elec);
-
     elecE = interpolate_to_zero(
-        dist, hi_poly_start, dmin_elec, dmin_elec_d_dist, hi_poly_end);
+        dist,
+        hi_poly_start,
+        eiej * params.high_score,
+        eiej * params.high_deriv,
+        hi_poly_end);
   }
 
   return weight * elecE;

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -143,6 +143,7 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
                     self.type_params.is_polarh,
                     self.type_params.is_acceptor,
                     self.type_params.is_carbon_lk,
+                    self.type_params.is_hydrogen,
                     -self.type_params.lk_dgfree
                     / (2 * 5.56832799683 * self.type_params.lk_lambda),
                     1 / (self.type_params.lk_lambda * self.type_params.lk_lambda),

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -134,7 +134,7 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             _t(
                 [
                     self.type_params.lj_radius,
-                    self.type_params.lj_wdepth,
+                    torch.sqrt(self.type_params.lj_wdepth),
                     self.type_params.lk_dgfree,
                     self.type_params.lk_lambda,
                     self.type_params.lk_volume,

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -143,6 +143,9 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
                     self.type_params.is_polarh,
                     self.type_params.is_acceptor,
                     self.type_params.is_carbon_lk,
+                    -self.type_params.lk_dgfree
+                    / (2 * 5.56832799683 * self.type_params.lk_lambda),
+                    1 / (self.type_params.lk_lambda * self.type_params.lk_lambda),
                 ]
             ),
             dim=1,

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -119,6 +119,10 @@ struct lj_score {
       LJTypeParams<Real> i,
       LJTypeParams<Real> j,
       LJGlobalParams<Real> global) -> V_dV_t {
+    if (dist >= global.max_dis) {
+      return {0.0, 0.0, 0.0, 0.0};
+    }
+
     Real sigma = lj_sigma<Real>(i, j, global);
     Real weight = connectivity_weight<Real, Real>(bonded_path_length);
     Real epsilon = i.lj_sqrt_wdepth * j.lj_sqrt_wdepth;
@@ -146,7 +150,7 @@ struct lj_score {
       lj = vdw_at_dist.V;
       d_lj_d_dist = vdw_at_dist.dV_ddist;
 
-    } else if (dist < cpoly_dmax) {
+    } else {
       auto vdw_at_cpoly_dmin = vdw<Real>::V_dV(cpoly_dmin, sigma, epsilon);
       tie(lj, d_lj_d_dist) = interpolate_to_zero_V_dV(
           dist,
@@ -154,10 +158,6 @@ struct lj_score {
           vdw_at_cpoly_dmin.V,
           vdw_at_cpoly_dmin.dV_ddist,
           cpoly_dmax);
-
-    } else {
-      lj = 0.0;
-      d_lj_d_dist = 0.0;
     }
 
     Real Vatr, Vrep, d_Vatr_dd, d_Vrep_dd;

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -36,14 +36,15 @@ struct vdw {
   }
 
   static def V_dV(Real dist, Real sigma, Real epsilon) -> dV_t {
-    Real sd = (sigma / dist);
+    Real const inv_dist = 1 / dist;
+    Real sd = sigma * inv_dist;
     Real sd2 = sd * sd;
     Real sd6 = sd2 * sd2 * sd2;
     Real sd12 = sd6 * sd6;
 
     return {
         epsilon * (sd12 - Real(2.0) * sd6),
-        Real(12.0) * epsilon * (sd6 - sd12) / dist};
+        Real(12.0) * epsilon * (sd6 - sd12) * inv_dist};
   }
 };
 

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -72,43 +72,40 @@ struct lj_score {
     Real cpoly_dmax = global.max_dis;
     Real spline_start = global.max_dis - Real(1.5);
 
-    Real weight;
-    Real Vatr, Vrep;
     if (dist > cpoly_dmax) {
-      Vatr = 0.0;
-      Vrep = 0.0;
-      weight = 0.0;
+      return {0.0, 0.0};
+    }
+
+    Real sigma = lj_sigma<Real>(i, j, global);
+    Real epsilon = i.lj_sqrt_wdepth * j.lj_sqrt_wdepth;
+    Real d_lin = sigma * global.lj_dlin_sigma_factor;
+    Real cpoly_dmin =
+        sigma > spline_start
+            ? (sigma > cpoly_dmax - Real(0.1) ? cpoly_dmax - Real(0.1) : sigma)
+            : spline_start;
+
+    Real weight = connectivity_weight<Real, Real>(bonded_path_length);
+    Real Vatr, Vrep;
+    if (dist > cpoly_dmin) {
+      auto vdw_at_cpoly_dmin = vdw<Real>::V_dV(cpoly_dmin, sigma, epsilon);
+      Vatr = interpolate_to_zero(
+          dist,
+          cpoly_dmin,
+          vdw_at_cpoly_dmin.V,
+          vdw_at_cpoly_dmin.dV_ddist,
+          cpoly_dmax);
+    } else if (dist > d_lin) {
+      Vatr = vdw<Real>::V(dist, sigma, epsilon);
     } else {
-      Real sigma = lj_sigma<Real>(i, j, global);
-      Real epsilon = i.lj_sqrt_wdepth * j.lj_sqrt_wdepth;
-      Real d_lin = sigma * global.lj_dlin_sigma_factor;
-      Real cpoly_dmin = sigma > spline_start ? (sigma > cpoly_dmax - Real(0.1)
-                                                    ? cpoly_dmax - Real(0.1)
-                                                    : sigma)
-                                             : spline_start;
+      auto vdw_at_d_lin = vdw<Real>::V_dV(d_lin, sigma, epsilon);
+      Vatr = (vdw_at_d_lin.V + vdw_at_d_lin.dV_ddist * (dist - d_lin));
+    }
 
-      weight = connectivity_weight<Real, Real>(bonded_path_length);
-      if (dist > cpoly_dmin) {
-        auto vdw_at_cpoly_dmin = vdw<Real>::V_dV(cpoly_dmin, sigma, epsilon);
-        Vatr = interpolate_to_zero(
-            dist,
-            cpoly_dmin,
-            vdw_at_cpoly_dmin.V,
-            vdw_at_cpoly_dmin.dV_ddist,
-            cpoly_dmax);
-      } else if (dist > d_lin) {
-        Vatr = vdw<Real>::V(dist, sigma, epsilon);
-      } else {
-        auto vdw_at_d_lin = vdw<Real>::V_dV(d_lin, sigma, epsilon);
-        Vatr = (vdw_at_d_lin.V + vdw_at_d_lin.dV_ddist * (dist - d_lin));
-      }
-
-      if (dist < sigma) {
-        Vrep = Vatr + epsilon;
-        Vatr = -epsilon;
-      } else {
-        Vrep = 0.0;
-      }
+    if (dist < sigma) {
+      Vrep = Vatr + epsilon;
+      Vatr = -epsilon;
+    } else {
+      Vrep = 0.0;
     }
     return {weight * Vatr, weight * Vrep};
   }

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -79,7 +79,7 @@ struct lj_score {
       weight = 0.0;
     } else {
       Real sigma = lj_sigma<Real>(i, j, global);
-      Real epsilon = std::sqrt(i.lj_wdepth * j.lj_wdepth);
+      Real epsilon = i.lj_sqrt_wdepth * j.lj_sqrt_wdepth;
       Real d_lin = sigma * global.lj_dlin_sigma_factor;
       Real cpoly_dmin = sigma > spline_start ? (sigma > cpoly_dmax - Real(0.1)
                                                     ? cpoly_dmax - Real(0.1)
@@ -120,7 +120,7 @@ struct lj_score {
       LJGlobalParams<Real> global) -> V_dV_t {
     Real sigma = lj_sigma<Real>(i, j, global);
     Real weight = connectivity_weight<Real, Real>(bonded_path_length);
-    Real epsilon = std::sqrt(i.lj_wdepth * j.lj_wdepth);
+    Real epsilon = i.lj_sqrt_wdepth * j.lj_sqrt_wdepth;
 
     // Real d_lin = sigma * 0.6;
     Real d_lin = sigma * global.lj_dlin_sigma_factor;

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -43,7 +43,7 @@ struct vdw {
 
     return {
         epsilon * (sd12 - Real(2.0) * sd6),
-        epsilon * ((Real(-12.0) * sd12 / dist) - (Real(-12.0) * sd6 / dist))};
+        Real(12.0) * epsilon * (sd6 - sd12) / dist};
   }
 };
 

--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -841,7 +841,6 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
 #pragma unroll
   for (int score_type = 0; score_type < 3; ++score_type) {
     Real3 const dxyz_at1 = radial_derivs[score_type] * dist_r.dV_dA;
-    Real3 const dxyz_at2 = radial_derivs[score_type] * dist_r.dV_dB;
 #pragma unroll
     for (int j = 0; j < 3; ++j) {
       if (dxyz_at1[j] != 0) {
@@ -851,12 +850,12 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
                        + start_atom1][j],
             dxyz_at1[j]);
       }
-      if (dxyz_at2[j] != 0) {
+      if (dxyz_at1[j] != 0) {
         accumulate<D, Real>::add(
             dV_dcoords[score_type]
                       [score_dat.r2.rot_coord_offset + atom_tile_ind2
                        + start_atom2][j],
-            dxyz_at2[j]);
+            -dxyz_at1[j]);
       }
     }
   }

--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -557,42 +557,29 @@ TMOL_DEVICE_FUNC void lj_atom_derivs(
       score_dat.r2.params[atom_tile_ind2].lj_params(),
       score_dat.global_params);
 
-  // all threads accumulate derivatives for atom 1 to global memory
-  Real dTdVatr_block = (dTdV_atr);
-  Real dTdVrep_block = (dTdV_rep);
-  Vec<Real, 3> ljatr_dxyz_at1 = dTdVatr_block * lj.dVatr_ddist * ddist_dat1;
-  Vec<Real, 3> ljrep_dxyz_at1 = dTdVrep_block * lj.dVrep_ddist * ddist_dat1;
+  Real const weighted_dV_ddist =
+      dTdV_atr * lj.dVatr_ddist + dTdV_rep * lj.dVrep_ddist;
+
+  // Combine attractive and repulsive derivatives before the global update so
+  // each coordinate needs only one atomic addition.
+  Vec<Real, 3> dxyz_at1 = weighted_dV_ddist * ddist_dat1;
 
   for (int j = 0; j < 3; ++j) {
-    if (ljatr_dxyz_at1[j] != 0) {
+    if (dxyz_at1[j] != 0) {
       accumulate<D, Real>::add(
           dV_dcoords
               [score_dat.r1.rot_coord_offset + atom_tile_ind1 + start_atom1][j],
-          ljatr_dxyz_at1[j]);
-    }
-    if (ljrep_dxyz_at1[j] != 0) {
-      accumulate<D, Real>::add(
-          dV_dcoords
-              [score_dat.r1.rot_coord_offset + atom_tile_ind1 + start_atom1][j],
-          ljrep_dxyz_at1[j]);
+          dxyz_at1[j]);
     }
   }
 
-  // all threads accumulate derivatives for atom 2 to global memory
-  Vec<Real, 3> ljatr_dxyz_at2 = dTdVatr_block * lj.dVatr_ddist * ddist_dat2;
-  Vec<Real, 3> ljrep_dxyz_at2 = dTdVrep_block * lj.dVrep_ddist * ddist_dat2;
+  Vec<Real, 3> dxyz_at2 = weighted_dV_ddist * ddist_dat2;
   for (int j = 0; j < 3; ++j) {
-    if (ljatr_dxyz_at2[j] != 0) {
+    if (dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(
           dV_dcoords
               [score_dat.r2.rot_coord_offset + atom_tile_ind2 + start_atom2][j],
-          ljatr_dxyz_at2[j]);
-    }
-    if (ljrep_dxyz_at2[j] != 0) {
-      accumulate<D, Real>::add(
-          dV_dcoords
-              [score_dat.r2.rot_coord_offset + atom_tile_ind2 + start_atom2][j],
-          ljrep_dxyz_at2[j]);
+          dxyz_at2[j]);
     }
   }
 }

--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -540,7 +540,13 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy(
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
   Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
-  Real const dist = distance<Real>::V(coord1, coord2);
+  Real3 const delta = coord1 - coord2;
+  Real const dist2 = delta.squaredNorm();
+  Real const max_dis = score_dat.global_params.max_dis;
+  if (dist2 > max_dis * max_dis) {
+    return {0.0, 0.0, 0.0};
+  }
+  Real const dist = std::sqrt(dist2);
   auto const& p1 = score_dat.r1.params[atom_tile_ind1];
   auto const& p2 = score_dat.r2.params[atom_tile_ind2];
 
@@ -817,12 +823,22 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
   Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
-  auto const dist_r = distance<Real>::V_dV(coord1, coord2);
+  Real3 const delta = coord1 - coord2;
+  Real const dist2 = delta.squaredNorm();
+  Real const max_dis = score_dat.global_params.max_dis;
+  if (dist2 >= max_dis * max_dis) {
+    return {0.0, 0.0, 0.0};
+  }
+  Real const dist = std::sqrt(dist2);
+  Real3 ddist_dat1({0.0, 0.0, 0.0});
+  if (dist != 0) {
+    ddist_dat1 = delta / dist;
+  }
   auto const& p1 = score_dat.r1.params[atom_tile_ind1];
   auto const& p2 = score_dat.r2.params[atom_tile_ind2];
 
   auto const lj = lj_score<Real>::V_dV(
-      dist_r.V,
+      dist,
       cp_separation,
       p1.lj_params(),
       p2.lj_params(),
@@ -830,7 +846,7 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
   typename lk_isotropic_score<Real>::V_dV_t lk{0.0, 0.0};
   if (!p1.is_hydrogen && !p2.is_hydrogen) {
     lk = lk_isotropic_score<Real>::V_dV(
-        dist_r.V,
+        dist,
         cp_separation,
         p1.lk_params(),
         p2.lk_params(),
@@ -840,7 +856,7 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
   Real const radial_derivs[3] = {lj.dVatr_ddist, lj.dVrep_ddist, lk.dV_ddist};
 #pragma unroll
   for (int score_type = 0; score_type < 3; ++score_type) {
-    Real3 const dxyz_at1 = radial_derivs[score_type] * dist_r.dV_dA;
+    Real3 const dxyz_at1 = radial_derivs[score_type] * ddist_dat1;
 #pragma unroll
     for (int j = 0; j < 3; ++j) {
       if (dxyz_at1[j] != 0) {

--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -528,6 +528,39 @@ TMOL_DEVICE_FUNC std::array<Real, 2> lj_atom_energy(
       score_dat.global_params);
 }
 
+// Fused LJ/LK energy for pose scoring. Heavy-atom pairs reuse the coordinate
+// loads, distance, and count-pair separation for both potentials.
+template <typename Real>
+TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy(
+    int atom_tile_ind1,
+    int atom_tile_ind2,
+    LJLKScoringData<Real> const& score_dat,
+    int cp_separation) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
+  Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
+  Real const dist = distance<Real>::V(coord1, coord2);
+  auto const& p1 = score_dat.r1.params[atom_tile_ind1];
+  auto const& p2 = score_dat.r2.params[atom_tile_ind2];
+
+  auto const lj = lj_score<Real>::V(
+      dist,
+      cp_separation,
+      p1.lj_params(),
+      p2.lj_params(),
+      score_dat.global_params);
+  Real const lk = (!p1.is_hydrogen && !p2.is_hydrogen)
+                      ? lk_isotropic_score<Real>::V(
+                            dist,
+                            cp_separation,
+                            p1.lk_params(),
+                            p2.lk_params(),
+                            score_dat.global_params)
+                      : Real(0);
+  return {lj[0], lj[1], lk};
+}
+
 // LJ deriv only
 template <typename Real, tmol::Device D>
 TMOL_DEVICE_FUNC void lj_atom_derivs(
@@ -769,6 +802,66 @@ TMOL_DEVICE_FUNC Real lk_atom_energy_and_derivs_full(
     }
   }
   return lk.V;
+}
+
+template <typename Real, tmol::Device D>
+TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
+    int atom_tile_ind1,
+    int atom_tile_ind2,
+    int start_atom1,
+    int start_atom2,
+    LJLKScoringData<Real> const& score_dat,
+    int cp_separation,
+    TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords) {
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
+  Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
+  auto const dist_r = distance<Real>::V_dV(coord1, coord2);
+  auto const& p1 = score_dat.r1.params[atom_tile_ind1];
+  auto const& p2 = score_dat.r2.params[atom_tile_ind2];
+
+  auto const lj = lj_score<Real>::V_dV(
+      dist_r.V,
+      cp_separation,
+      p1.lj_params(),
+      p2.lj_params(),
+      score_dat.global_params);
+  typename lk_isotropic_score<Real>::V_dV_t lk{0.0, 0.0};
+  if (!p1.is_hydrogen && !p2.is_hydrogen) {
+    lk = lk_isotropic_score<Real>::V_dV(
+        dist_r.V,
+        cp_separation,
+        p1.lk_params(),
+        p2.lk_params(),
+        score_dat.global_params);
+  }
+
+  Real const radial_derivs[3] = {lj.dVatr_ddist, lj.dVrep_ddist, lk.dV_ddist};
+#pragma unroll
+  for (int score_type = 0; score_type < 3; ++score_type) {
+    Real3 const dxyz_at1 = radial_derivs[score_type] * dist_r.dV_dA;
+    Real3 const dxyz_at2 = radial_derivs[score_type] * dist_r.dV_dB;
+#pragma unroll
+    for (int j = 0; j < 3; ++j) {
+      if (dxyz_at1[j] != 0) {
+        accumulate<D, Real>::add(
+            dV_dcoords[score_type]
+                      [score_dat.r1.rot_coord_offset + atom_tile_ind1
+                       + start_atom1][j],
+            dxyz_at1[j]);
+      }
+      if (dxyz_at2[j] != 0) {
+        accumulate<D, Real>::add(
+            dV_dcoords[score_type]
+                      [score_dat.r2.rot_coord_offset + atom_tile_ind2
+                       + start_atom2][j],
+            dxyz_at2[j]);
+      }
+    }
+  }
+
+  return {lj.Vatr, lj.Vrep, lk.V};
 }
 
 }  // namespace potentials

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -118,8 +118,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
       int start_atom2,                                                       \
       int atom_tile_ind1,                                                    \
       int atom_tile_ind2,                                                    \
-      LJLKScoringData<Real> const& intra_dat)                                \
-      ->std::array<Real, 2> {                                                \
+      LJLKScoringData<Real> const& intra_dat) {                              \
     int const atom_ind1 = start_atom1 + atom_tile_ind1;                      \
     int const atom_ind2 = start_atom2 + atom_tile_ind2;                      \
     int const separation = block_type_path_distance[intra_dat.r1.block_type] \
@@ -416,6 +415,36 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         eval_scores_for_atom_pairs);                                        \
   }
 
+// Fused pose-scoring traversal: LJ is evaluated for every atom pair and LK
+// for the heavy subset inside the pair function, reusing geometry and count
+// pair work.
+#define EVAL_INTERRES_ATOM_PAIR_SCORES_FUSED                                \
+  TMOL_DEVICE_FUNC(                                                         \
+      LJLKScoringData<Real>& inter_dat, int start_atom1, int start_atom2) { \
+    auto eval_scores_for_atom_pairs = ([&](int tid) {                       \
+      auto LJLK = tmol::score::common::InterResBlockEvaluation<             \
+          LJLKScoringData,                                                  \
+          AllAtomPairSelector,                                              \
+          D,                                                                \
+          TILE_SIZE,                                                        \
+          nt,                                                               \
+          3,                                                                \
+          Real,                                                             \
+          Int>::                                                            \
+          eval_interres_atom_pair(                                          \
+              tid,                                                          \
+              start_atom1,                                                  \
+              start_atom2,                                                  \
+              score_inter_ljlk_atom_pair,                                   \
+              inter_dat);                                                   \
+      inter_dat.total_ljatr += std::get<0>(LJLK);                           \
+      inter_dat.total_ljrep += std::get<1>(LJLK);                           \
+      inter_dat.total_lk += std::get<2>(LJLK);                              \
+    });                                                                     \
+    DeviceOperations<D>::template for_each_in_workgroup<nt>(                \
+        eval_scores_for_atom_pairs);                                        \
+  }
+
 // STORE_CALCULATED_ENERGIES
 //    store energies if we are NOT computing per-blockpair
 // captures:
@@ -623,6 +652,33 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
     DeviceOperations<D>::template for_each_in_workgroup<nt>(                \
         eval_scores_for_atom_pairs);                                        \
   }
+
+#define EVAL_INTRARES_ATOM_PAIR_SCORES_FUSED                                \
+  TMOL_DEVICE_FUNC(                                                         \
+      LJLKScoringData<Real>& intra_dat, int start_atom1, int start_atom2) { \
+    auto eval_scores_for_atom_pairs = ([&](int tid) {                       \
+      auto LJLK = tmol::score::common::IntraResBlockEvaluation<             \
+          LJLKScoringData,                                                  \
+          AllAtomPairSelector,                                              \
+          D,                                                                \
+          TILE_SIZE,                                                        \
+          nt,                                                               \
+          3,                                                                \
+          Real,                                                             \
+          Int>::                                                            \
+          eval_intrares_atom_pairs(                                         \
+              tid,                                                          \
+              start_atom1,                                                  \
+              start_atom2,                                                  \
+              score_intra_ljlk_atom_pair,                                   \
+              intra_dat);                                                   \
+      intra_dat.total_ljatr += std::get<0>(LJLK);                           \
+      intra_dat.total_ljrep += std::get<1>(LJLK);                           \
+      intra_dat.total_lk += std::get<2>(LJLK);                              \
+    });                                                                     \
+    DeviceOperations<D>::template for_each_in_workgroup<nt>(                \
+        eval_scores_for_atom_pairs);                                        \
+  }
 // end of macro definitions
 
 template <
@@ -807,39 +863,21 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // handles whole-pose calls that do not require gradients, avoiding the
   // register footprint and runtime branches of the derivative-capable kernel.
   auto eval_energies_by_block = ([=] TMOL_DEVICE_FUNC(int cta) {
-    auto atom_pair_lj_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int,
-                                int,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lj_atom_energy(
+    auto atom_pair_ljlk_fn = ([=] TMOL_DEVICE_FUNC(
+                                  int atom_tile_ind1,
+                                  int atom_tile_ind2,
+                                  int,
+                                  int,
+                                  LJLKScoringData<Real> const& score_dat,
+                                  int cp_separation) {
+      return ljlk_atom_energy(
           atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
     });
 
-    auto atom_pair_lk_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int,
-                                int,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lk_atom_energy(
-          atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
-    });
-
-    auto score_inter_lj_atom_pair =
-        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_intra_lj_atom_pair =
-        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_inter_lk_atom_pair =
-        ([=] SCORE_INTER_LK_ATOM_PAIR(atom_pair_lk_fn));
-
-    auto score_intra_lk_atom_pair =
-        ([=] SCORE_INTRA_LK_ATOM_PAIR(atom_pair_lk_fn));
+    auto score_inter_ljlk_atom_pair =
+        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
+    auto score_intra_ljlk_atom_pair =
+        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
 
     auto load_block_coords_and_params_into_shared =
         ([=] LOAD_BLOCK_COORDS_AND_PARAMS_INTO_SHARED);
@@ -905,7 +943,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     // Evaluate both the LJ and LK scores in separate dispatches
     // over all atoms in the tile and the subset of heavy atoms in
     // the tile
-    auto eval_interres_atom_pair_scores = ([=] EVAL_INTERRES_ATOM_PAIR_SCORES);
+    auto eval_interres_atom_pair_scores =
+        ([=] EVAL_INTERRES_ATOM_PAIR_SCORES_FUSED);
 
     auto store_calculated_energies = ([=] STORE_POSE_CALCULATED_ENERGIES);
 
@@ -923,7 +962,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     // Evaluate both the LJ and LK scores in separate dispatches
     // over all atoms in the tile and the subset of heavy atoms in
     // the tile
-    auto eval_intrares_atom_pair_scores = ([=] EVAL_INTRARES_ATOM_PAIR_SCORES);
+    auto eval_intrares_atom_pair_scores =
+        ([=] EVAL_INTRARES_ATOM_PAIR_SCORES_FUSED);
 
     tmol::score::common::tile_evaluate_rot_pair<
         DeviceOperations,
@@ -957,14 +997,14 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   });
 
   auto eval_energies = ([=] TMOL_DEVICE_FUNC(int cta) {
-    auto atom_pair_lj_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int start_atom1,
-                                int start_atom2,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lj_atom_energy_and_derivs_full(
+    auto atom_pair_ljlk_fn = ([=] TMOL_DEVICE_FUNC(
+                                  int atom_tile_ind1,
+                                  int atom_tile_ind2,
+                                  int start_atom1,
+                                  int start_atom2,
+                                  LJLKScoringData<Real> const& score_dat,
+                                  int cp_separation) {
+      return ljlk_atom_energy_and_derivs_full(
           atom_tile_ind1,
           atom_tile_ind2,
           start_atom1,
@@ -975,35 +1015,10 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       );
     });
 
-    auto atom_pair_lk_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int start_atom1,
-                                int start_atom2,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lk_atom_energy_and_derivs_full(
-          atom_tile_ind1,
-          atom_tile_ind2,
-          start_atom1,
-          start_atom2,
-          score_dat,
-          cp_separation,
-          dV_dcoords  // captured
-      );
-    });
-
-    auto score_inter_lj_atom_pair =
-        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_intra_lj_atom_pair =
-        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_inter_lk_atom_pair =
-        ([=] SCORE_INTER_LK_ATOM_PAIR(atom_pair_lk_fn));
-
-    auto score_intra_lk_atom_pair =
-        ([=] SCORE_INTRA_LK_ATOM_PAIR(atom_pair_lk_fn));
+    auto score_inter_ljlk_atom_pair =
+        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
+    auto score_intra_ljlk_atom_pair =
+        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
 
     auto load_block_coords_and_params_into_shared =
         ([=] LOAD_BLOCK_COORDS_AND_PARAMS_INTO_SHARED);
@@ -1066,7 +1081,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     auto load_interres_data_from_shared = ([=] LOAD_INTERRES_DATA_FROM_SHARED);
 
-    auto eval_interres_atom_pair_scores = ([=] EVAL_INTERRES_ATOM_PAIR_SCORES);
+    auto eval_interres_atom_pair_scores =
+        ([=] EVAL_INTERRES_ATOM_PAIR_SCORES_FUSED);
 
     auto store_calculated_energies = ([=] STORE_POSE_CALCULATED_ENERGIES);
 
@@ -1081,7 +1097,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     auto load_intrares_data_from_shared = ([=] LOAD_INTRARES_DATA_FROM_SHARED);
 
-    auto eval_intrares_atom_pair_scores = ([=] EVAL_INTRARES_ATOM_PAIR_SCORES);
+    auto eval_intrares_atom_pair_scores =
+        ([=] EVAL_INTRARES_ATOM_PAIR_SCORES_FUSED);
 
     tmol::score::common::tile_evaluate_rot_pair<
         DeviceOperations,
@@ -1675,39 +1692,21 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   auto eval_energies_by_block = ([=] TMOL_DEVICE_FUNC(int cta) {
-    auto atom_pair_lj_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int,
-                                int,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lj_atom_energy(
+    auto atom_pair_ljlk_fn = ([=] TMOL_DEVICE_FUNC(
+                                  int atom_tile_ind1,
+                                  int atom_tile_ind2,
+                                  int,
+                                  int,
+                                  LJLKScoringData<Real> const& score_dat,
+                                  int cp_separation) {
+      return ljlk_atom_energy(
           atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
     });
 
-    auto atom_pair_lk_fn = ([=] TMOL_DEVICE_FUNC(
-                                int atom_tile_ind1,
-                                int atom_tile_ind2,
-                                int,
-                                int,
-                                LJLKScoringData<Real> const& score_dat,
-                                int cp_separation) {
-      return lk_atom_energy(
-          atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
-    });
-
-    auto score_inter_lj_atom_pair =
-        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_intra_lj_atom_pair =
-        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_lj_fn));
-
-    auto score_inter_lk_atom_pair =
-        ([=] SCORE_INTER_LK_ATOM_PAIR(atom_pair_lk_fn));
-
-    auto score_intra_lk_atom_pair =
-        ([=] SCORE_INTRA_LK_ATOM_PAIR(atom_pair_lk_fn));
+    auto score_inter_ljlk_atom_pair =
+        ([=] SCORE_INTER_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
+    auto score_intra_ljlk_atom_pair =
+        ([=] SCORE_INTRA_LJ_ATOM_PAIR(atom_pair_ljlk_fn));
 
     auto load_block_coords_and_params_into_shared =
         ([=] LOAD_BLOCK_COORDS_AND_PARAMS_INTO_SHARED);
@@ -1755,10 +1754,8 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     auto load_interres_data_from_shared = ([=] LOAD_INTERRES_DATA_FROM_SHARED);
 
-    // Evaluate both the LJ and LK scores in separate dispatches
-    // over all atoms in the tile and the subset of heavy atoms in
-    // the tile
-    auto eval_interres_atom_pair_scores = ([=] EVAL_INTERRES_ATOM_PAIR_SCORES);
+    auto eval_interres_atom_pair_scores =
+        ([=] EVAL_INTERRES_ATOM_PAIR_SCORES_FUSED);
 
     auto store_calculated_energies = ([=] STORE_ROTAMER_CALCULATED_ENERGIES);
 
@@ -1773,10 +1770,8 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     auto load_intrares_data_from_shared = ([=] LOAD_INTRARES_DATA_FROM_SHARED);
 
-    // Evaluate both the LJ and LK scores in separate dispatches
-    // over all atoms in the tile and the subset of heavy atoms in
-    // the tile
-    auto eval_intrares_atom_pair_scores = ([=] EVAL_INTRARES_ATOM_PAIR_SCORES);
+    auto eval_intrares_atom_pair_scores =
+        ([=] EVAL_INTRARES_ATOM_PAIR_SCORES_FUSED);
 
     tmol::score::common::tile_evaluate_rot_pair<
         DeviceOperations,

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -890,10 +890,6 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       CTA_REAL_REDUCE_T_VARIABLE;
     } shared;
 
-    Real total_ljatr = 0;
-    Real total_ljrep = 0;
-    Real total_lk = 0;
-
     int const max_important_bond_separation = 4;
 
     int const pose_ind = cta / (max_n_upper_triangle_inds);
@@ -1031,9 +1027,6 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       CTA_REAL_REDUCE_T_VARIABLE;
 
     } shared;
-
-    Real total_lj = 0;
-    Real total_lk = 0;
 
     int const max_important_bond_separation = 4;
 
@@ -1393,9 +1386,6 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::backward(
 
     } shared;
 
-    Real total_lj = 0;
-    Real total_lk = 0;
-
     int const max_important_bond_separation = 4;
 
     int const pose_ind = cta / (max_n_upper_triangle_inds);
@@ -1719,10 +1709,6 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       CTA_REAL_REDUCE_T_VARIABLE;
     } shared;
 
-    Real total_ljatr = 0;
-    Real total_ljrep = 0;
-    Real total_lk = 0;
-
     int const max_important_bond_separation = 4;
 
     int const pose_ind = dispatch_indices[0][cta];
@@ -2026,9 +2012,6 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::backward(
       CTA_REAL_REDUCE_T_VARIABLE;
 
     } shared;
-
-    Real total_lj = 0;
-    Real total_lk = 0;
 
     int const max_important_bond_separation = 4;
 

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -779,8 +779,13 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   }
   auto output = output_t.view;
 
-  // Optimal launch box on v100 and a100 is nt=32, vt=1
   LAUNCH_BOX_32;
+  // Large workloads benefit from a second kernel variant whose register budget
+  // exposes a full 32 resident warps per SM. Keep the unconstrained variant for
+  // small workloads, where register pressure is less important than avoiding
+  // spills.
+  LAUNCH_BOX_32_OCC_AS(launch_t_high_occupancy, 32);
+  constexpr int min_high_occupancy_workgroups = 1 << 14;
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
@@ -791,17 +796,16 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // n-blocks tensor, and whole-pose scoring, where the output is
   // atomic-incremented into an n-pose x 1 x 1 tensor. In the whole-pose scoring
   // case, we compute the atomic derivatives in the forward pass and then weight
-  // them by whatever weights are applied to the terms; in a very mininmal
+  // them by whatever weights are applied to the terms; in a very minimal
   // backward pass (see compiled_ops.cpp). Thread 0 in each CTA atomic- adds the
   // block-pair energy for the block pair it is assigned to. In the block-pair
   // scoring case, we are unable to compute the atomic derivatives in the
   // forward pass, because how the block-pair outputs will be weighted is not
   // known until the backward pass and the memory to store atom-pair derivatives
   // for each interacting block pair would be prohibitive. So we do not compute
-  // derivatives at all in the forward pass. It is slightly more efficient to
-  // have a separate kernel that bypasses the derivative calculations but the
-  // actual performance difference for having a second kernel has not been
-  // measured. (TO DO, go ahead and measure it!)
+  // derivatives at all in the forward pass. The same energy-only kernel also
+  // handles whole-pose calls that do not require gradients, avoiding the
+  // register footprint and runtime branches of the derivative-capable kernel.
   auto eval_energies_by_block = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto atom_pair_lj_fn = ([=] TMOL_DEVICE_FUNC(
                                 int atom_tile_ind1,
@@ -1152,8 +1156,20 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     DeviceOperations<D>::template foreach_workgroup<launch_t>(
         mgr, n_poses * max_n_upper_triangle_inds, eval_energies_by_block);
   } else {
-    DeviceOperations<D>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_energies);
+    int const n_workgroups = n_poses * max_n_upper_triangle_inds;
+    if (!require_gradient && n_workgroups >= min_high_occupancy_workgroups) {
+      DeviceOperations<D>::template foreach_workgroup<launch_t_high_occupancy>(
+          mgr, n_workgroups, eval_energies_by_block);
+    } else if (!require_gradient) {
+      DeviceOperations<D>::template foreach_workgroup<launch_t>(
+          mgr, n_workgroups, eval_energies_by_block);
+    } else if (n_workgroups >= min_high_occupancy_workgroups) {
+      DeviceOperations<D>::template foreach_workgroup<launch_t_high_occupancy>(
+          mgr, n_workgroups, eval_energies);
+    } else {
+      DeviceOperations<D>::template foreach_workgroup<launch_t>(
+          mgr, n_workgroups, eval_energies);
+    }
   }
 
   return {output_t, dV_dcoords_t, scratch_rot_neighbors_t};

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -964,20 +964,15 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
                                 int start_atom2,
                                 LJLKScoringData<Real> const& score_dat,
                                 int cp_separation) {
-      if (require_gradient) {  // captured
-        return lj_atom_energy_and_derivs_full(
-            atom_tile_ind1,
-            atom_tile_ind2,
-            start_atom1,
-            start_atom2,
-            score_dat,
-            cp_separation,
-            dV_dcoords  // captured
-        );
-      } else {
-        return lj_atom_energy(
-            atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
-      }
+      return lj_atom_energy_and_derivs_full(
+          atom_tile_ind1,
+          atom_tile_ind2,
+          start_atom1,
+          start_atom2,
+          score_dat,
+          cp_separation,
+          dV_dcoords  // captured
+      );
     });
 
     auto atom_pair_lk_fn = ([=] TMOL_DEVICE_FUNC(
@@ -987,20 +982,15 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
                                 int start_atom2,
                                 LJLKScoringData<Real> const& score_dat,
                                 int cp_separation) {
-      if (require_gradient) {  // captured
-        return lk_atom_energy_and_derivs_full(
-            atom_tile_ind1,
-            atom_tile_ind2,
-            start_atom1,
-            start_atom2,
-            score_dat,
-            cp_separation,
-            dV_dcoords  // captured
-        );
-      } else {
-        return lk_atom_energy(
-            atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
-      }
+      return lk_atom_energy_and_derivs_full(
+          atom_tile_ind1,
+          atom_tile_ind2,
+          start_atom1,
+          start_atom2,
+          score_dat,
+          cp_separation,
+          dV_dcoords  // captured
+      );
     });
 
     auto score_inter_lj_atom_pair =

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -922,12 +922,12 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     int const block_type1 = block_type_ind_for_rot[rot_ind1];
     int const block_type2 = block_type_ind_for_rot[rot_ind2];
 
-    int const n_atoms1 = block_type_n_atoms[block_type1];
-    int const n_atoms2 = block_type_n_atoms[block_type2];
-
     if (block_type1 < 0 || block_type2 < 0) {
       return;
     }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
 
     auto load_tile_invariant_interres_data =
         ([=] LOAD_TILE_INVARIANT_INTERRES_DATA);
@@ -1736,12 +1736,12 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     int const block_type1 = block_type_ind_for_rot[rot_ind1];
     int const block_type2 = block_type_ind_for_rot[rot_ind2];
 
-    int const n_atoms1 = block_type_n_atoms[block_type1];
-    int const n_atoms2 = block_type_n_atoms[block_type2];
-
     if (block_type1 < 0 || block_type2 < 0) {
       return;
     }
+
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
 
     auto load_tile_invariant_interres_data =
         ([=] LOAD_TILE_INVARIANT_INTERRES_DATA);

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -28,26 +28,44 @@ struct f_desolv {
     def astuple() { return tmol::score::common::make_tuple(V, dV_ddist); }
   };
 
+  static def V_precomputed(
+      Real dist,
+      Real lj_radius_i,
+      Real lk_coeff_i,
+      Real lk_inv_lambda2_i,
+      Real lk_volume_j) -> Real {
+    Real const delta = dist - lj_radius_i;
+    return lk_volume_j * lk_coeff_i / (dist * dist)
+           * std::exp(-delta * delta * lk_inv_lambda2_i);
+  }
+
+  static def V_dV_precomputed(
+      Real dist,
+      Real lj_radius_i,
+      Real lk_coeff_i,
+      Real lk_inv_lambda2_i,
+      Real lk_volume_j) -> V_dV_t {
+    Real const delta = dist - lj_radius_i;
+    Real const desolv = lk_volume_j * lk_coeff_i / (dist * dist)
+                        * std::exp(-delta * delta * lk_inv_lambda2_i);
+    Real const d_desolv_d_dist =
+        desolv * (-2 / dist - 2 * delta * lk_inv_lambda2_i);
+    return {desolv, d_desolv_d_dist};
+  }
+
   static def V(
       Real dist,
       Real lj_radius_i,
       Real lk_dgfree_i,
       Real lk_lambda_i,
       Real lk_volume_j) -> Real {
-    using std::exp;
-    using std::pow;
-    const Real pi = EIGEN_PI;
     static const Real pi_pow1p5 = 5.56832799683f;
-
-    // clang-format off
-    return (
-      -lk_volume_j
-      * lk_dgfree_i
-      / (2 * pi_pow1p5 * lk_lambda_i)
-      / (dist * dist)
-      * exp(-(dist - lj_radius_i)*(dist - lj_radius_i) / (lk_lambda_i*lk_lambda_i))
-    );
-    // clang-format on
+    return V_precomputed(
+        dist,
+        lj_radius_i,
+        -lk_dgfree_i / (2 * pi_pow1p5 * lk_lambda_i),
+        1 / (lk_lambda_i * lk_lambda_i),
+        lk_volume_j);
   }
 
   static def V_dV(
@@ -56,30 +74,13 @@ struct f_desolv {
       Real lk_dgfree_i,
       Real lk_lambda_i,
       Real lk_volume_j) -> V_dV_t {
-    using std::exp;
-    using std::pow;
-    const Real pi = EIGEN_PI;
     static const Real pi_pow1p5 = 5.56832799683f;
-
-    Real const exp_val =
-        exp(-(dist - lj_radius_i) * (dist - lj_radius_i)
-            / (lk_lambda_i * lk_lambda_i));
-    // clang-format off
-    Real desolv = (
-      -lk_volume_j
-      * lk_dgfree_i
-      / (2 * pi_pow1p5 * lk_lambda_i)
-      / (dist * dist)
-      * exp_val
-    );
-
-    Real d_desolv_d_dist =
-        desolv
-        * (-2 / dist
-           - (2 * dist - 2 * lj_radius_i) / (lk_lambda_i * lk_lambda_i));
-    // clang-format on
-
-    return {desolv, d_desolv_d_dist};
+    return V_dV_precomputed(
+        dist,
+        lj_radius_i,
+        -lk_dgfree_i / (2 * pi_pow1p5 * lk_lambda_i),
+        1 / (lk_lambda_i * lk_lambda_i),
+        lk_volume_j);
   }
 };
 
@@ -97,9 +98,9 @@ struct lk_isotropic_pair {
       Real bonded_path_length,
       Real lj_sigma_ij,
       Real lj_radius_i,
-      Real lk_dgfree_i,
-      Real lk_lambda_i,
       Real lk_volume_j,
+      Real lk_coeff_i,
+      Real lk_inv_lambda2_i,
       Real max_dis,
       bool is_cc_pair) -> Real {
     Real d_min = lj_sigma_ij * .89;
@@ -121,8 +122,12 @@ struct lk_isotropic_pair {
     if (dist > cpoly_far_dmax) {
       lk = 0.0;
     } else if (dist > cpoly_far_dmin) {
-      auto f_desolv_at_dmin = f_desolv<Real>::V_dV(
-          cpoly_far_dmin, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      auto f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
+          cpoly_far_dmin,
+          lj_radius_i,
+          lk_coeff_i,
+          lk_inv_lambda2_i,
+          lk_volume_j);
 
       lk = interpolate_to_zero(
           dist,
@@ -131,24 +136,28 @@ struct lk_isotropic_pair {
           f_desolv_at_dmin.dV_ddist,
           cpoly_far_dmax);
     } else if (dist > cpoly_close_dmax) {
-      lk = f_desolv<Real>::V(
-          dist, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      lk = f_desolv<Real>::V_precomputed(
+          dist, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j);
     } else if (dist > cpoly_close_dmin) {
-      auto f_desolv_at_dmax = f_desolv<Real>::V_dV(
-          cpoly_close_dmax, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      auto f_desolv_at_dmax = f_desolv<Real>::V_dV_precomputed(
+          cpoly_close_dmax,
+          lj_radius_i,
+          lk_coeff_i,
+          lk_inv_lambda2_i,
+          lk_volume_j);
 
       lk = interpolate<Real>(
           dist,
           cpoly_close_dmin,
-          f_desolv<Real>::V(
-              d_min, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j),
+          f_desolv<Real>::V_precomputed(
+              d_min, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j),
           0.0,
           cpoly_close_dmax,
           f_desolv_at_dmax.V,
           f_desolv_at_dmax.dV_ddist);
     } else {
-      lk = f_desolv<Real>::V(
-          d_min, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      lk = f_desolv<Real>::V_precomputed(
+          d_min, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j);
     }
 
     return weight * lk;
@@ -159,9 +168,9 @@ struct lk_isotropic_pair {
       Real bonded_path_length,
       Real lj_sigma_ij,
       Real lj_radius_i,
-      Real lk_dgfree_i,
-      Real lk_lambda_i,
       Real lk_volume_j,
+      Real lk_coeff_i,
+      Real lk_inv_lambda2_i,
       Real max_dis,
       bool is_cc_pair) -> V_dV_t {
     Real d_min = lj_sigma_ij * .89;
@@ -181,33 +190,41 @@ struct lk_isotropic_pair {
     Real lk, d_lk_d_dist;
 
     if (dist < cpoly_close_dmin) {
-      lk = f_desolv<Real>::V(
-          d_min, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      lk = f_desolv<Real>::V_precomputed(
+          d_min, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j);
       d_lk_d_dist = 0;
 
     } else if (dist < cpoly_close_dmax) {
-      auto f_desolv_at_dmax = f_desolv<Real>::V_dV(
-          cpoly_close_dmax, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      auto f_desolv_at_dmax = f_desolv<Real>::V_dV_precomputed(
+          cpoly_close_dmax,
+          lj_radius_i,
+          lk_coeff_i,
+          lk_inv_lambda2_i,
+          lk_volume_j);
 
       tie(lk, d_lk_d_dist) = interpolate_V_dV<Real>(
           dist,
           cpoly_close_dmin,
-          f_desolv<Real>::V(
-              d_min, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j),
+          f_desolv<Real>::V_precomputed(
+              d_min, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j),
           0.0,
           cpoly_close_dmax,
           f_desolv_at_dmax.V,
           f_desolv_at_dmax.dV_ddist);
 
     } else if (dist < cpoly_far_dmin) {
-      auto f_desolv_at_dist = f_desolv<Real>::V_dV(
-          dist, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      auto f_desolv_at_dist = f_desolv<Real>::V_dV_precomputed(
+          dist, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j);
 
       lk = f_desolv_at_dist.V;
       d_lk_d_dist = f_desolv_at_dist.dV_ddist;
     } else if (dist < cpoly_far_dmax) {
-      auto f_desolv_at_dmin = f_desolv<Real>::V_dV(
-          cpoly_far_dmin, lj_radius_i, lk_dgfree_i, lk_lambda_i, lk_volume_j);
+      auto f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
+          cpoly_far_dmin,
+          lj_radius_i,
+          lk_coeff_i,
+          lk_inv_lambda2_i,
+          lk_volume_j);
 
       tie(lk, d_lk_d_dist) = interpolate_to_zero_V_dV(
           dist,
@@ -261,16 +278,24 @@ struct lk_isotropic_score {
     if (dist > cpoly_far_dmax) {
       lk = 0.0;
     } else if (dist > cpoly_far_dmin) {
-      auto f_desolv_at_dmin = f_desolv<Real>::V_dV(
-          cpoly_far_dmin, i.lj_radius, i.lk_dgfree, i.lk_lambda, j.lk_volume);
+      auto f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
+          cpoly_far_dmin,
+          i.lj_radius,
+          i.lk_coeff,
+          i.lk_inv_lambda2,
+          j.lk_volume);
       lk = interpolate_to_zero(
           dist,
           cpoly_far_dmin,
           f_desolv_at_dmin.V,
           f_desolv_at_dmin.dV_ddist,
           cpoly_far_dmax);
-      f_desolv_at_dmin = f_desolv<Real>::V_dV(
-          cpoly_far_dmin, j.lj_radius, j.lk_dgfree, j.lk_lambda, i.lk_volume);
+      f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
+          cpoly_far_dmin,
+          j.lj_radius,
+          j.lk_coeff,
+          j.lk_inv_lambda2,
+          i.lk_volume);
       lk += interpolate_to_zero(
           dist,
           cpoly_far_dmin,
@@ -278,39 +303,47 @@ struct lk_isotropic_score {
           f_desolv_at_dmin.dV_ddist,
           cpoly_far_dmax);
     } else if (dist > cpoly_close_dmax) {
-      lk = f_desolv<Real>::V(
-               dist, i.lj_radius, i.lk_dgfree, i.lk_lambda, j.lk_volume)
-           + f_desolv<Real>::V(
-               dist, j.lj_radius, j.lk_dgfree, j.lk_lambda, i.lk_volume);
+      lk = f_desolv<Real>::V_precomputed(
+               dist, i.lj_radius, i.lk_coeff, i.lk_inv_lambda2, j.lk_volume)
+           + f_desolv<Real>::V_precomputed(
+               dist, j.lj_radius, j.lk_coeff, j.lk_inv_lambda2, i.lk_volume);
     } else if (dist > cpoly_close_dmin) {
-      auto f_desolv_at_dmax = f_desolv<Real>::V_dV(
-          cpoly_close_dmax, i.lj_radius, i.lk_dgfree, i.lk_lambda, j.lk_volume);
+      auto f_desolv_at_dmax = f_desolv<Real>::V_dV_precomputed(
+          cpoly_close_dmax,
+          i.lj_radius,
+          i.lk_coeff,
+          i.lk_inv_lambda2,
+          j.lk_volume);
       lk = interpolate<Real>(
           dist,
           cpoly_close_dmin,
-          f_desolv<Real>::V(
-              d_min, i.lj_radius, i.lk_dgfree, i.lk_lambda, j.lk_volume),
+          f_desolv<Real>::V_precomputed(
+              d_min, i.lj_radius, i.lk_coeff, i.lk_inv_lambda2, j.lk_volume),
           0.0,
           cpoly_close_dmax,
           f_desolv_at_dmax.V,
           f_desolv_at_dmax.dV_ddist);
-      f_desolv_at_dmax = f_desolv<Real>::V_dV(
-          cpoly_close_dmax, j.lj_radius, j.lk_dgfree, j.lk_lambda, i.lk_volume);
+      f_desolv_at_dmax = f_desolv<Real>::V_dV_precomputed(
+          cpoly_close_dmax,
+          j.lj_radius,
+          j.lk_coeff,
+          j.lk_inv_lambda2,
+          i.lk_volume);
       lk += interpolate<Real>(
           dist,
           cpoly_close_dmin,
-          f_desolv<Real>::V(
-              d_min, j.lj_radius, j.lk_dgfree, j.lk_lambda, i.lk_volume),
+          f_desolv<Real>::V_precomputed(
+              d_min, j.lj_radius, j.lk_coeff, j.lk_inv_lambda2, i.lk_volume),
           0.0,
           cpoly_close_dmax,
           f_desolv_at_dmax.V,
           f_desolv_at_dmax.dV_ddist);
 
     } else {
-      lk = f_desolv<Real>::V(
-               d_min, i.lj_radius, i.lk_dgfree, i.lk_lambda, j.lk_volume)
-           + f_desolv<Real>::V(
-               d_min, j.lj_radius, j.lk_dgfree, j.lk_lambda, i.lk_volume);
+      lk = f_desolv<Real>::V_precomputed(
+               d_min, i.lj_radius, i.lk_coeff, i.lk_inv_lambda2, j.lk_volume)
+           + f_desolv<Real>::V_precomputed(
+               d_min, j.lj_radius, j.lk_coeff, j.lk_inv_lambda2, i.lk_volume);
     }
     return weight * lk;
   }
@@ -329,9 +362,9 @@ struct lk_isotropic_score {
         bonded_path_length,
         sigma,
         i.lj_radius,
-        i.lk_dgfree,
-        i.lk_lambda,
         j.lk_volume,
+        i.lk_coeff,
+        i.lk_inv_lambda2,
         global.max_dis,
         is_cc_pair);
 
@@ -340,9 +373,9 @@ struct lk_isotropic_score {
         bonded_path_length,
         sigma,
         j.lj_radius,
-        j.lk_dgfree,
-        j.lk_lambda,
         i.lk_volume,
+        j.lk_coeff,
+        j.lk_inv_lambda2,
         global.max_dis,
         is_cc_pair);
 

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -73,20 +73,10 @@ struct f_desolv {
       * exp_val
     );
 
-    Real d_desolv_d_dist = (
-      -lk_volume_j
-      * lk_dgfree_i
-      / (2 * pi_pow1p5 * lk_lambda_i)
-      * exp_val
-      * ((  // (f * exp(g))' = f' * exp(g) + f g' exp(g)
-          -2 / (dist * dist * dist)
-        ) + (
-          1 / (dist * dist)
-          * -(2 * dist - 2 * lj_radius_i)
-          / (lk_lambda_i * lk_lambda_i)
-        )
-      )
-    );
+    Real d_desolv_d_dist =
+        desolv
+        * (-2 / dist
+           - (2 * dist - 2 * lj_radius_i) / (lk_lambda_i * lk_lambda_i));
     // clang-format on
 
     return {desolv, d_desolv_d_dist};

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -35,7 +35,8 @@ struct f_desolv {
       Real lk_inv_lambda2_i,
       Real lk_volume_j) -> Real {
     Real const delta = dist - lj_radius_i;
-    return lk_volume_j * lk_coeff_i / (dist * dist)
+    Real const inv_dist = 1 / dist;
+    return lk_volume_j * lk_coeff_i * inv_dist * inv_dist
            * std::exp(-delta * delta * lk_inv_lambda2_i);
   }
 
@@ -46,10 +47,11 @@ struct f_desolv {
       Real lk_inv_lambda2_i,
       Real lk_volume_j) -> V_dV_t {
     Real const delta = dist - lj_radius_i;
-    Real const desolv = lk_volume_j * lk_coeff_i / (dist * dist)
+    Real const inv_dist = 1 / dist;
+    Real const desolv = lk_volume_j * lk_coeff_i * inv_dist * inv_dist
                         * std::exp(-delta * delta * lk_inv_lambda2_i);
     Real const d_desolv_d_dist =
-        desolv * (-2 / dist - 2 * delta * lk_inv_lambda2_i);
+        desolv * (-2 * inv_dist - 2 * delta * lk_inv_lambda2_i);
     return {desolv, d_desolv_d_dist};
   }
 

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -259,6 +259,10 @@ struct lk_isotropic_score {
       LKTypeParams<Real> i,
       LKTypeParams<Real> j,
       LJGlobalParams<Real> global) -> Real {
+    if (dist > global.max_dis) {
+      return 0.0;
+    }
+
     Real lj_sigma_ij = lj_sigma<Real>(i, j, global);
 
     bool is_cc_pair = i.is_carbon_lk && j.is_carbon_lk;
@@ -277,9 +281,7 @@ struct lk_isotropic_score {
     Real weight = connectivity_weight<Real>(bonded_path_length);
 
     Real lk;
-    if (dist > cpoly_far_dmax) {
-      lk = 0.0;
-    } else if (dist > cpoly_far_dmin) {
+    if (dist > cpoly_far_dmin) {
       auto f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
           cpoly_far_dmin,
           i.lj_radius,

--- a/tmol/score/ljlk/potentials/params.hh
+++ b/tmol/score/ljlk/potentials/params.hh
@@ -47,10 +47,11 @@ struct LJLKTypeParams {
   Real is_polarh;
   Real is_acceptor;
   Real is_carbon_lk;
+  Real is_hydrogen;
   Real lk_coeff;
   Real lk_inv_lambda2;
 
-  LJTypeParams<Real> EIGEN_DEVICE_FUNC lj_params() {
+  LJTypeParams<Real> EIGEN_DEVICE_FUNC lj_params() const {
     return LJTypeParams<Real>(
         {lj_radius,
          lj_sqrt_wdepth,
@@ -60,7 +61,7 @@ struct LJLKTypeParams {
          is_acceptor});
   }
 
-  LKTypeParams<Real> EIGEN_DEVICE_FUNC lk_params() {
+  LKTypeParams<Real> EIGEN_DEVICE_FUNC lk_params() const {
     return LKTypeParams<Real>(
         {lj_radius,
          lk_dgfree,

--- a/tmol/score/ljlk/potentials/params.hh
+++ b/tmol/score/ljlk/potentials/params.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 #include <tmol/utility/tensor/TensorAccessor.h>
 #include <tmol/utility/tensor/TensorUtil.h>
 
@@ -11,7 +13,7 @@ namespace potentials {
 template <typename Real>
 struct LJTypeParams {
   Real lj_radius;
-  Real lj_wdepth;
+  Real lj_sqrt_wdepth;
   Real is_donor;
   Real is_hydroxyl;
   Real is_polarh;
@@ -36,7 +38,7 @@ struct LKTypeParams {
 template <typename Real>
 struct LJLKTypeParams {
   Real lj_radius;
-  Real lj_wdepth;
+  Real lj_sqrt_wdepth;
   Real lk_dgfree;
   Real lk_lambda;
   Real lk_volume;
@@ -50,7 +52,12 @@ struct LJLKTypeParams {
 
   LJTypeParams<Real> EIGEN_DEVICE_FUNC lj_params() {
     return LJTypeParams<Real>(
-        {lj_radius, lj_wdepth, is_donor, is_hydroxyl, is_polarh, is_acceptor});
+        {lj_radius,
+         lj_sqrt_wdepth,
+         is_donor,
+         is_hydroxyl,
+         is_polarh,
+         is_acceptor});
   }
 
   LKTypeParams<Real> EIGEN_DEVICE_FUNC lk_params() {
@@ -91,7 +98,7 @@ struct LJTypeParamTensors {
   auto operator[](Idx i) const {
     return LJTypeParams<Real>{
         lj_radius[i],
-        lj_wdepth[i],
+        std::sqrt(lj_wdepth[i]),
         is_donor[i],
         is_hydroxyl[i],
         is_polarh[i],

--- a/tmol/score/ljlk/potentials/params.hh
+++ b/tmol/score/ljlk/potentials/params.hh
@@ -29,6 +29,8 @@ struct LKTypeParams {
   Real is_polarh;
   Real is_acceptor;
   Real is_carbon_lk;
+  Real lk_coeff;
+  Real lk_inv_lambda2;
 };
 
 template <typename Real>
@@ -43,6 +45,8 @@ struct LJLKTypeParams {
   Real is_polarh;
   Real is_acceptor;
   Real is_carbon_lk;
+  Real lk_coeff;
+  Real lk_inv_lambda2;
 
   LJTypeParams<Real> EIGEN_DEVICE_FUNC lj_params() {
     return LJTypeParams<Real>(
@@ -59,7 +63,9 @@ struct LJLKTypeParams {
          is_hydroxyl,
          is_polarh,
          is_acceptor,
-         is_carbon_lk});
+         is_carbon_lk,
+         lk_coeff,
+         lk_inv_lambda2});
   }
 };
 
@@ -116,7 +122,9 @@ struct LKTypeParamTensors {
         is_hydroxyl[i],
         is_polarh[i],
         is_acceptor[i],
-        is_carbon_lk[i]};
+        is_carbon_lk[i],
+        -lk_dgfree[i] / (Real(2) * Real(5.56832799683) * lk_lambda[i]),
+        Real(1) / (lk_lambda[i] * lk_lambda[i])};
   }
 };
 

--- a/tmol/score/ljlk/potentials/params.pybind.hh
+++ b/tmol/score/ljlk/potentials/params.pybind.hh
@@ -77,6 +77,9 @@ struct type_caster<tmol::score::ljlk::potentials::LKTypeParams<Real>> {
     CAST_ATTR(src, value, is_hydroxyl);
     CAST_ATTR(src, value, is_polarh);
     CAST_ATTR(src, value, is_carbon_lk);
+    value.lk_coeff =
+        -value.lk_dgfree / (Real(2) * Real(5.56832799683) * value.lk_lambda);
+    value.lk_inv_lambda2 = Real(1) / (value.lk_lambda * value.lk_lambda);
 
     return true;
   }

--- a/tmol/score/ljlk/potentials/params.pybind.hh
+++ b/tmol/score/ljlk/potentials/params.pybind.hh
@@ -27,7 +27,13 @@ struct type_caster<tmol::score::ljlk::potentials::LJTypeParams<Real>> {
     nvtx_range_function();
 
     CAST_ATTR(src, value, lj_radius);
-    CAST_ATTR(src, value, lj_wdepth);
+    try {
+      value.lj_sqrt_wdepth = std::sqrt(
+          src.attr("lj_wdepth").cast<decltype(value.lj_sqrt_wdepth)>());
+    } catch (pybind11::cast_error) {
+      pybind11::print("Error casting: lj_wdepth");
+      return false;
+    }
     CAST_ATTR(src, value, is_donor);
     CAST_ATTR(src, value, is_acceptor);
     CAST_ATTR(src, value, is_hydroxyl);

--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -153,6 +153,8 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         bt_lj_radius = type_params.lj_radius[at].numpy()
         bt_lk_dgfree = type_params.lk_dgfree[at].numpy()
         bt_lk_lambda = type_params.lk_lambda[at].numpy()
+        bt_lk_coeff = -bt_lk_dgfree / (2 * 5.56832799683 * bt_lk_lambda)
+        bt_lk_inv_lambda2 = 1 / (bt_lk_lambda * bt_lk_lambda)
         bt_lk_volume = type_params.lk_volume[at].numpy()
         bt_is_donor = type_params.is_donor[at].numpy()
         bt_is_hydroxyl = type_params.is_hydroxyl[at].numpy()
@@ -163,8 +165,8 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         bt_lk_ball_at_params = numpy.stack(
             (
                 bt_lj_radius,
-                bt_lk_dgfree,
-                bt_lk_lambda,
+                bt_lk_coeff,
+                bt_lk_inv_lambda2,
                 bt_lk_volume,
                 bt_is_donor,
                 bt_is_hydroxyl,

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -727,8 +727,6 @@ class LKBallRotamerScoreOp
          water_coords,
          dispatch_indices});
 
-    ctx->saved_data["block_pair_scoring"] = output_block_pair_energies;
-
     return {score, dispatch_indices};
   }
 
@@ -774,8 +772,6 @@ class LKBallRotamerScoreOp
 
     auto dTdV = grad_outputs[0];
 
-    bool block_pair_scoring = ctx->saved_data["block_pair_scoring"].toBool();
-
     TMOL_DISPATCH_FLOATING_DEVICE(
         rot_coords.options(), "lk_ball_rotamer_score_backward", ([&] {
           using Real = scalar_t;
@@ -818,8 +814,7 @@ class LKBallRotamerScoreOp
 
                   TCAST(global_params),
                   TCAST(dispatch_indices),
-                  TCAST(dTdV),
-                  block_pair_scoring);
+                  TCAST(dTdV));
 
           dV_d_pose_coords = std::get<0>(result).tensor;
           dV_d_water_coords = std::get<1>(result).tensor;

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -581,11 +581,10 @@ struct lk_ball_score {
     Real const bridge_scale =
         weights[w_lk_bridge] * lk_iso.V + weights[w_lk_bridge_uncpl] * 0.5;
     Real3 const d_iso_dI = lk_iso.dV_ddist * dist.dV_dA;
-    Real3 const d_iso_dJ = lk_iso.dV_ddist * dist.dV_dB;
 
     return lk_ball_weighted_dVt<Real, MAX_WATER>{
         d_iso_dI * iso_scale + frac_bridge.dV.dI * bridge_scale,
-        d_iso_dJ * iso_scale
+        -d_iso_dI * iso_scale
             + frac_desolv.dV.dJ * (weights[w_lk_ball] * lk_iso.V)
             + frac_bridge.dV.dJ * bridge_scale,
         frac_desolv.dV.dWI * (weights[w_lk_ball] * lk_iso.V)

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -107,11 +107,7 @@ struct lk_fraction {
       }
     }
 
-    if (wted_d2_delta != 0) {
-      d_wted_d2_delta_d_J /= wted_d2_delta;
-      d_wted_d2_delta_d_WI /= wted_d2_delta;
-    }
-
+    Real const exp_sum = wted_d2_delta;
     wted_d2_delta = -std::log(wted_d2_delta);
 
     Real frac = 0;
@@ -127,12 +123,13 @@ struct lk_fraction {
       }
     }
 
-    // TODO nan @ 0
+    Real const derivative_scale =
+        exp_sum != 0 ? dfrac_dwted_d2 / exp_sum : Real(0);
     return V_dV_t{
         frac,
         dV_t{
-            d_wted_d2_delta_d_WI * dfrac_dwted_d2,
-            d_wted_d2_delta_d_J * dfrac_dwted_d2}};
+            d_wted_d2_delta_d_WI * derivative_scale,
+            d_wted_d2_delta_d_J * derivative_scale}};
   }
 
   static def dV(WatersMat WI, Real3 J, Real lj_radius_j) -> dV_t {
@@ -241,11 +238,7 @@ struct lk_bridge_fraction {
       }
     }
 
-    if (wted_d2_delta != 0) {
-      d_wted_d2_delta_d_WI /= wted_d2_delta;
-      d_wted_d2_delta_d_WJ /= wted_d2_delta;
-    }
-
+    Real const exp_sum = wted_d2_delta;
     wted_d2_delta = -std::log(wted_d2_delta);
 
     Real overlapfrac;
@@ -288,14 +281,15 @@ struct lk_bridge_fraction {
       d_anglefrac_d_base_delta = 0.0;
     }
 
-    // final scaling
+    Real const water_derivative_scale =
+        exp_sum != 0 ? anglefrac * d_overlapfrac_d_wted_d2 / exp_sum : Real(0);
     return V_dV_t{
         overlapfrac * anglefrac,
         dV_t{
             overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_I,
             overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_J,
-            anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WI,
-            anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WJ}};
+            water_derivative_scale * d_wted_d2_delta_d_WI,
+            water_derivative_scale * d_wted_d2_delta_d_WJ}};
   }
 
   static def dV(

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1330,8 +1330,18 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
   accum_derivs(
       occluder_block_dat, occluder_start + occluder_atom_tile_ind, dV.dJ);
   for (int i = 0; i < MAX_N_WATER; ++i) {
+    if (std::isnan(
+            polar_block_dat
+                .water_coords[3 * (MAX_N_WATER * polar_atom_tile_ind + i)]))
+      break;
     water_accum_derivs(
         polar_block_dat, polar_start + polar_atom_tile_ind, i, dV.dWI);
+  }
+  for (int i = 0; i < MAX_N_WATER; ++i) {
+    if (std::isnan(
+            occluder_block_dat
+                .water_coords[3 * (MAX_N_WATER * occluder_atom_tile_ind + i)]))
+      break;
     water_accum_derivs(
         occluder_block_dat, occluder_start + occluder_atom_tile_ind, i, dV.dWJ);
   }

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -67,11 +67,12 @@ struct lk_fraction {
     if (d2_low < 0.0) d2_low = 0.0;
 
     Real wted_d2_delta = 0;
+    // Water generation writes valid waters first and leaves the remaining
+    // slots as contiguous NaN padding.
     for (int w = 0; w < MAX_WATER; ++w) {
+      if (std::isnan(WI(w, 0))) break;
       Real d2_delta = (J - WI.row(w).transpose()).squaredNorm() - d2_low;
-      if (!std::isnan(d2_delta)) {
-        wted_d2_delta += std::exp(-d2_delta);
-      }
+      wted_d2_delta += std::exp(-d2_delta);
     }
 
     wted_d2_delta = -std::log(wted_d2_delta);
@@ -94,17 +95,16 @@ struct lk_fraction {
     Real3 d_wted_d2_delta_d_J = Real3::Zero();
     WatersMat d_wted_d2_delta_d_WI = WatersMat::Zero();
 
+    // Generated water rows are valid-first, followed by NaN padding.
     for (int w = 0; w < MAX_WATER; ++w) {
+      if (std::isnan(WI(w, 0))) break;
       Real3 delta_Jw = J - WI.row(w).transpose();
       Real d2_delta = delta_Jw.squaredNorm() - d2_low;
+      Real exp_d2_delta = std::exp(-d2_delta);
 
-      if (!std::isnan(d2_delta)) {
-        Real exp_d2_delta = std::exp(-d2_delta);
-
-        wted_d2_delta += exp_d2_delta;
-        d_wted_d2_delta_d_J += exp_d2_delta * delta_Jw;
-        d_wted_d2_delta_d_WI.row(w).transpose() = -exp_d2_delta * delta_Jw;
-      }
+      wted_d2_delta += exp_d2_delta;
+      d_wted_d2_delta_d_J += exp_d2_delta * delta_Jw;
+      d_wted_d2_delta_d_WI.row(w).transpose() = -exp_d2_delta * delta_Jw;
     }
 
     Real const exp_sum = wted_d2_delta;
@@ -175,13 +175,14 @@ struct lk_bridge_fraction {
       -> Real {
     // water overlap
     Real wted_d2_delta = 0.0;
+    // Generated water rows are valid-first, followed by NaN padding.
     for (int wi = 0; wi < MAX_WATER; wi++) {
+      if (std::isnan(WI(wi, 0))) break;
       for (int wj = 0; wj < MAX_WATER; wj++) {
+        if (std::isnan(WJ(wj, 0))) break;
         Real d2_delta =
             (WI.row(wi) - WJ.row(wj)).squaredNorm() - overlap_gap_A2;
-        if (!std::isnan(d2_delta)) {
-          wted_d2_delta += std::exp(-d2_delta);
-        }
+        wted_d2_delta += std::exp(-d2_delta);
       }
     }
     wted_d2_delta = -std::log(wted_d2_delta);
@@ -220,19 +221,19 @@ struct lk_bridge_fraction {
     WatersMat d_wted_d2_delta_d_WI = WatersMat::Zero();
     WatersMat d_wted_d2_delta_d_WJ = WatersMat::Zero();
 
+    // Generated water rows are valid-first, followed by NaN padding.
     for (int wi = 0; wi < MAX_WATER; wi++) {
+      if (std::isnan(WI(wi, 0))) break;
       for (int wj = 0; wj < MAX_WATER; wj++) {
+        if (std::isnan(WJ(wj, 0))) break;
         Real3 delta_ij = WI.row(wi) - WJ.row(wj);
         Real d2_delta = delta_ij.squaredNorm() - overlap_gap_A2;
+        Real exp_d2_delta = std::exp(-d2_delta);
 
-        if (!std::isnan(d2_delta)) {
-          Real exp_d2_delta = std::exp(-d2_delta);
+        d_wted_d2_delta_d_WI.row(wi).transpose() += exp_d2_delta * delta_ij;
+        d_wted_d2_delta_d_WJ.row(wj).transpose() -= exp_d2_delta * delta_ij;
 
-          d_wted_d2_delta_d_WI.row(wi).transpose() += exp_d2_delta * delta_ij;
-          d_wted_d2_delta_d_WJ.row(wj).transpose() -= exp_d2_delta * delta_ij;
-
-          wted_d2_delta += exp_d2_delta;
-        }
+        wted_d2_delta += exp_d2_delta;
       }
     }
 

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1160,11 +1160,8 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
     LKBallResPairData<Real> const& block_pair_dat,
     int cp_separation,
     Vec<Real, 4> dTdV,
-    int cta,
     TView<Eigen::Matrix<Real, 3, 1>, 1, Dev> dV_d_pose_coords,
-    TView<Eigen::Matrix<Real, 3, 1>, 2, Dev> dV_d_water_coords,
-    bool block_pair_scoring) {
-  using WatersMat = Eigen::Matrix<Real, MAX_N_WATER, 3>;
+    TView<Eigen::Matrix<Real, 3, 1>, 2, Dev> dV_d_water_coords) {
   using Real3 = Eigen::Matrix<Real, 3, 1>;
   using tmol::score::common::accumulate;
   using tmol::score::common::coord_from_shared;
@@ -1203,71 +1200,52 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
       occluder_block_dat.lk_ball_params[occluder_ind],
       block_pair_dat.global_params);
 
-  auto accum_derivs1 = ([&] TMOL_DEVICE_FUNC(
-                            LKBallSingleResData<Real> const& block_dat,
-                            int atom_ind,
-                            Real3 dV,
-                            lk_ball_score_type st) {
-    auto dTdV_val = dTdV[st];
+  auto accum_derivs = ([&] TMOL_DEVICE_FUNC(
+                           LKBallSingleResData<Real> const& block_dat,
+                           int atom_ind,
+                           lk_ball_dV_dReal3<Real> const& derivs) {
     for (int j = 0; j < 3; ++j) {
-      if (dV[j] != 0) {
+      Real const weighted_deriv =
+          dTdV[w_lk_ball_iso] * derivs.d_lkball_iso[j]
+          + dTdV[w_lk_ball] * derivs.d_lkball[j]
+          + dTdV[w_lk_bridge] * derivs.d_lkbridge[j]
+          + dTdV[w_lk_bridge_uncpl] * derivs.d_lkbridge_uncpl[j];
+      if (weighted_deriv != 0) {
         accumulate<Dev, Real>::add(
             dV_d_pose_coords[block_dat.rot_coord_offset + atom_ind][j],
-            dTdV_val * dV[j]);
+            weighted_deriv);
       }
     }
   });
 
-  auto accum_derivs4 = ([&] TMOL_DEVICE_FUNC(
-                            LKBallSingleResData<Real> const& block_dat,
-                            int atom_ind,
-                            lk_ball_dV_dReal3<Real> const& dV) {
-    accum_derivs1(block_dat, atom_ind, dV.d_lkball_iso, w_lk_ball_iso);
-    accum_derivs1(block_dat, atom_ind, dV.d_lkball, w_lk_ball);
-    accum_derivs1(block_dat, atom_ind, dV.d_lkbridge, w_lk_bridge);
-    accum_derivs1(block_dat, atom_ind, dV.d_lkbridge_uncpl, w_lk_bridge_uncpl);
-  });
+  auto water_accum_derivs =
+      ([&] TMOL_DEVICE_FUNC(
+           LKBallSingleResData<Real> const& block_dat,
+           int atom_ind,
+           int water_ind,
+           lk_ball_dV_dWater<Real, MAX_N_WATER> const& derivs) {
+        for (int j = 0; j < 3; ++j) {
+          Real const weighted_deriv =
+              dTdV[w_lk_ball_iso] * derivs.d_lkball_iso(water_ind, j)
+              + dTdV[w_lk_ball] * derivs.d_lkball(water_ind, j)
+              + dTdV[w_lk_bridge] * derivs.d_lkbridge(water_ind, j)
+              + dTdV[w_lk_bridge_uncpl] * derivs.d_lkbridge_uncpl(water_ind, j);
+          if (weighted_deriv != 0) {
+            accumulate<Dev, Real>::add(
+                dV_d_water_coords[block_dat.rot_coord_offset + atom_ind]
+                                 [water_ind][j],
+                weighted_deriv);
+          }
+        }
+      });
 
-  auto water_accum_derivs1 = ([&] TMOL_DEVICE_FUNC(
-                                  LKBallSingleResData<Real> const& block_dat,
-                                  int atom_ind,
-                                  int water_ind,
-                                  WatersMat dV,
-                                  lk_ball_score_type st) {
-    auto dTdV_val = dTdV[st];
-
-    for (int j = 0; j < 3; ++j) {
-      if (dV(water_ind, j) != 0) {
-        accumulate<Dev, Real>::add(
-            dV_d_water_coords[block_dat.rot_coord_offset + atom_ind][water_ind]
-                             [j],
-            dTdV_val * dV(water_ind, j));
-      }
-    }
-  });
-
-  auto water_accum_derivs4 = ([&] TMOL_DEVICE_FUNC(
-                                  LKBallSingleResData<Real> const& block_dat,
-                                  int atom_ind,
-                                  int water_ind,
-                                  lk_ball_dV_dWater<Real, MAX_N_WATER> const&
-                                      dV) {
-    water_accum_derivs1(
-        block_dat, atom_ind, water_ind, dV.d_lkball_iso, w_lk_ball_iso);
-    water_accum_derivs1(block_dat, atom_ind, water_ind, dV.d_lkball, w_lk_ball);
-    water_accum_derivs1(
-        block_dat, atom_ind, water_ind, dV.d_lkbridge, w_lk_bridge);
-    water_accum_derivs1(
-        block_dat, atom_ind, water_ind, dV.d_lkbridge_uncpl, w_lk_bridge_uncpl);
-  });
-
-  accum_derivs4(polar_block_dat, polar_start + polar_atom_tile_ind, dV.dI);
-  accum_derivs4(
+  accum_derivs(polar_block_dat, polar_start + polar_atom_tile_ind, dV.dI);
+  accum_derivs(
       occluder_block_dat, occluder_start + occluder_atom_tile_ind, dV.dJ);
   for (int i = 0; i < MAX_N_WATER; ++i) {
-    water_accum_derivs4(
+    water_accum_derivs(
         polar_block_dat, polar_start + polar_atom_tile_ind, i, dV.dWI);
-    water_accum_derivs4(
+    water_accum_derivs(
         occluder_block_dat, occluder_start + occluder_atom_tile_ind, i, dV.dWJ);
   }
 }

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -53,6 +53,11 @@ struct lk_fraction {
     static def Zero() -> dV_t { return {WatersMat::Zero(), Real3::Zero()}; }
   };
 
+  struct V_dV_t {
+    Real V;
+    dV_t dV;
+  };
+
   static constexpr Real ramp_width_A2 = lkball_globals<Real>::ramp_width_A2;
 
   static def square(Real v) -> Real { return v * v; }
@@ -81,7 +86,7 @@ struct lk_fraction {
     return frac;
   }
 
-  static def dV(WatersMat WI, Real3 J, Real lj_radius_j) -> dV_t {
+  static def V_dV(WatersMat WI, Real3 J, Real lj_radius_j) -> V_dV_t {
     Real d2_low = square(1.4 + lj_radius_j) - ramp_width_A2;
     if (d2_low < 0.0) d2_low = 0.0;
 
@@ -109,17 +114,29 @@ struct lk_fraction {
 
     wted_d2_delta = -std::log(wted_d2_delta);
 
+    Real frac = 0;
     Real dfrac_dwted_d2 = 0;
-    if (wted_d2_delta > 0 && wted_d2_delta < ramp_width_A2) {
-      dfrac_dwted_d2 = -4.0 * wted_d2_delta
-                       * (square(ramp_width_A2) - square(wted_d2_delta))
-                       / square(square(ramp_width_A2));
+    if (wted_d2_delta < 0) {
+      frac = 1;
+    } else if (wted_d2_delta < ramp_width_A2) {
+      frac = square(1 - square(wted_d2_delta / ramp_width_A2));
+      if (wted_d2_delta > 0) {
+        dfrac_dwted_d2 = -4.0 * wted_d2_delta
+                         * (square(ramp_width_A2) - square(wted_d2_delta))
+                         / square(square(ramp_width_A2));
+      }
     }
 
     // TODO nan @ 0
-    return dV_t{
-        d_wted_d2_delta_d_WI * dfrac_dwted_d2,
-        d_wted_d2_delta_d_J * dfrac_dwted_d2};
+    return V_dV_t{
+        frac,
+        dV_t{
+            d_wted_d2_delta_d_WI * dfrac_dwted_d2,
+            d_wted_d2_delta_d_J * dfrac_dwted_d2}};
+  }
+
+  static def dV(WatersMat WI, Real3 J, Real lj_radius_j) -> dV_t {
+    return V_dV(WI, J, lj_radius_j).dV;
   }
 };
 
@@ -140,6 +157,11 @@ struct lk_bridge_fraction {
       return dV_t{
           Real3::Zero(), Real3::Zero(), WatersMat::Zero(), WatersMat::Zero()};
     }
+  };
+
+  struct V_dV_t {
+    Real V;
+    dV_t dV;
   };
 
   static constexpr Real ramp_width_A2 = lkball_globals<Real>::ramp_width_A2;
@@ -193,9 +215,9 @@ struct lk_bridge_fraction {
     return overlapfrac * anglefrac;
   }
 
-  static def dV(
+  static def V_dV(
       Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
-      -> dV_t {
+      -> V_dV_t {
     Real wted_d2_delta = 0.0;
 
     WatersMat d_wted_d2_delta_d_WI = WatersMat::Zero();
@@ -267,12 +289,19 @@ struct lk_bridge_fraction {
     }
 
     // final scaling
-    return dV_t{
-        overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_I,
-        overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_J,
-        anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WI,
-        anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WJ,
-    };
+    return V_dV_t{
+        overlapfrac * anglefrac,
+        dV_t{
+            overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_I,
+            overlapfrac * d_anglefrac_d_base_delta * d_wted_d2_delta_d_J,
+            anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WI,
+            anglefrac * d_overlapfrac_d_wted_d2 * d_wted_d2_delta_d_WJ}};
+  }
+
+  static def dV(
+      Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
+      -> dV_t {
+    return V_dV(I, J, WI, WJ, lkb_water_dist).dV;
   }
 };
 
@@ -329,6 +358,21 @@ struct lk_ball_dVt {
         lk_ball_dV_dReal3<Real>::Zero(),
         lk_ball_dV_dWater<Real, MAX_WATER>::Zero(),
         lk_ball_dV_dWater<Real, MAX_WATER>::Zero()};
+  }
+};
+
+template <typename Real, int MAX_WATER>
+struct lk_ball_weighted_dVt {
+  typedef Eigen::Matrix<Real, 3, 1> Real3;
+  typedef Eigen::Matrix<Real, MAX_WATER, 3> WatersMat;
+
+  Real3 dI;
+  Real3 dJ;
+  WatersMat dWI;
+  WatersMat dWJ;
+
+  static def Zero() -> lk_ball_weighted_dVt {
+    return {Real3::Zero(), Real3::Zero(), WatersMat::Zero(), WatersMat::Zero()};
   }
 };
 
@@ -424,20 +468,15 @@ struct lk_ball_score {
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 
-    Real frac_IJ_desolv = lk_fraction<Real, MAX_WATER>::V(WI, J, j.lj_radius);
-    auto d_frac_IJ_desolv =
-        lk_fraction<Real, MAX_WATER>::dV(WI, J, j.lj_radius);
+    auto const frac_IJ_desolv =
+        lk_fraction<Real, MAX_WATER>::V_dV(WI, J, j.lj_radius);
 
-    Real frac_IJ_water_overlap;
-    typename lk_bridge_fraction<Real, MAX_WATER>::dV_t d_frac_IJ_water_overlap;
+    typename lk_bridge_fraction<Real, MAX_WATER>::V_dV_t frac_IJ_water_overlap;
     if (j.is_donor || j.is_acceptor) {
-      frac_IJ_water_overlap = lk_bridge_fraction<Real, MAX_WATER>::V(
-          I, J, WI, WJ, global.lkb_water_dist);
-      d_frac_IJ_water_overlap = lk_bridge_fraction<Real, MAX_WATER>::dV(
+      frac_IJ_water_overlap = lk_bridge_fraction<Real, MAX_WATER>::V_dV(
           I, J, WI, WJ, global.lkb_water_dist);
     } else {
-      frac_IJ_water_overlap = 0.0;
-      d_frac_IJ_water_overlap = decltype(d_frac_IJ_water_overlap)::Zero();
+      frac_IJ_water_overlap = {0.0, decltype(frac_IJ_water_overlap.dV)::Zero()};
     }
 
     Real3 d_lk_iso_IJ_dI = lk_iso_IJ.dV_ddist * d_dist_dI;
@@ -449,24 +488,25 @@ struct lk_ball_score {
             d_lk_iso_IJ_dI,
             // d(lk_iso_IJ.V * frac_IJ_desolv)
             // d(frac_IJ_desolv)/dI == 0
-            d_lk_iso_IJ_dI * frac_IJ_desolv,
+            d_lk_iso_IJ_dI * frac_IJ_desolv.V,
             // d(lk_iso_IJ.V * frac_IJ_water_overlap)
-            d_lk_iso_IJ_dI * frac_IJ_water_overlap
-                + lk_iso_IJ.V * d_frac_IJ_water_overlap.dI,
+            d_lk_iso_IJ_dI * frac_IJ_water_overlap.V
+                + lk_iso_IJ.V * frac_IJ_water_overlap.dV.dI,
             // d(frac_IJ_water_overlap / 2)
-            d_frac_IJ_water_overlap.dI / 2,
+            frac_IJ_water_overlap.dV.dI / 2,
         },
         // dJ
         lk_ball_dV_dReal3<Real>{
             // d(lk_iso_IJ.V)
             d_lk_iso_IJ_dJ,
             // d(lk_iso_IJ.V * frac_IJ_desolv)
-            d_lk_iso_IJ_dJ * frac_IJ_desolv + lk_iso_IJ.V * d_frac_IJ_desolv.dJ,
+            d_lk_iso_IJ_dJ * frac_IJ_desolv.V
+                + lk_iso_IJ.V * frac_IJ_desolv.dV.dJ,
             // d(lk_iso_IJ.V * frac_IJ_water_overlap)
-            d_lk_iso_IJ_dJ * frac_IJ_water_overlap
-                + lk_iso_IJ.V * d_frac_IJ_water_overlap.dJ,
+            d_lk_iso_IJ_dJ * frac_IJ_water_overlap.V
+                + lk_iso_IJ.V * frac_IJ_water_overlap.dV.dJ,
             // d(frac_IJ_water_overlap / 2)
-            d_frac_IJ_water_overlap.dJ / 2,
+            frac_IJ_water_overlap.dV.dJ / 2,
         },
         // dWI
         lk_ball_dV_dWater<Real, MAX_WATER>{
@@ -475,14 +515,14 @@ struct lk_ball_score {
 
             // d(lk_iso_IJ.V * frac_IJ_desolv)
             // d(lk_iso_IJ.V)/dWI == 0
-            lk_iso_IJ.V * d_frac_IJ_desolv.dWI,
+            lk_iso_IJ.V * frac_IJ_desolv.dV.dWI,
 
             // d(lk_iso_IJ.V * frac_IJ_water_overlap)
             // d(lk_iso_IJ.V)/dWI == 0
-            lk_iso_IJ.V * d_frac_IJ_water_overlap.dWI,
+            lk_iso_IJ.V * frac_IJ_water_overlap.dV.dWI,
 
             // d(frac_IJ_water_overlap / 2)
-            d_frac_IJ_water_overlap.dWI / 2},
+            frac_IJ_water_overlap.dV.dWI / 2},
         // dWJ
         lk_ball_dV_dWater<Real, MAX_WATER>{
             // d(lk_iso_IJ.V)
@@ -493,10 +533,70 @@ struct lk_ball_score {
 
             // d(lk_iso_IJ.V * frac_IJ_water_overlap)
             // d(lk_iso_IJ.V)/dWJ == 0
-            lk_iso_IJ.V * d_frac_IJ_water_overlap.dWJ,
+            lk_iso_IJ.V * frac_IJ_water_overlap.dV.dWJ,
 
             // d(frac_IJ_water_overlap / 2)
-            d_frac_IJ_water_overlap.dWJ / 2}};
+            frac_IJ_water_overlap.dV.dWJ / 2}};
+  }
+
+  static def weighted_dV(
+      Real3 I,
+      Real3 J,
+      WatersMat WI,
+      WatersMat WJ,
+      Real bonded_path_length,
+      LKBallTypeParams<Real> i,
+      LKBallTypeParams<Real> j,
+      LKBallGlobalParams<Real> global,
+      Vec<Real, 4> weights) -> lk_ball_weighted_dVt<Real, MAX_WATER> {
+    using tmol::score::common::distance;
+    using tmol::score::ljlk::potentials::lj_sigma;
+    using tmol::score::ljlk::potentials::lk_isotropic_pair;
+
+    if (std::isnan(WI(0, 0))) {
+      return lk_ball_weighted_dVt<Real, MAX_WATER>::Zero();
+    }
+
+    Real const sigma = lj_sigma<Real>(i, j, global);
+    auto const dist = distance<Real>::V_dV(I, J);
+    auto const lk_iso = lk_isotropic_pair<Real>::V_dV(
+        dist.V,
+        bonded_path_length,
+        sigma,
+        i.lj_radius,
+        i.lk_dgfree,
+        i.lk_lambda,
+        j.lk_volume,
+        global.distance_threshold,
+        i.is_carbon_lk && j.is_carbon_lk);
+
+    auto const frac_desolv =
+        lk_fraction<Real, MAX_WATER>::V_dV(WI, J, j.lj_radius);
+
+    typename lk_bridge_fraction<Real, MAX_WATER>::V_dV_t frac_bridge;
+    if (j.is_donor || j.is_acceptor) {
+      frac_bridge = lk_bridge_fraction<Real, MAX_WATER>::V_dV(
+          I, J, WI, WJ, global.lkb_water_dist);
+    } else {
+      frac_bridge = {0.0, decltype(frac_bridge.dV)::Zero()};
+    }
+
+    Real const iso_scale = weights[w_lk_ball_iso]
+                           + weights[w_lk_ball] * frac_desolv.V
+                           + weights[w_lk_bridge] * frac_bridge.V;
+    Real const bridge_scale =
+        weights[w_lk_bridge] * lk_iso.V + weights[w_lk_bridge_uncpl] * 0.5;
+    Real3 const d_iso_dI = lk_iso.dV_ddist * dist.dV_dA;
+    Real3 const d_iso_dJ = lk_iso.dV_ddist * dist.dV_dB;
+
+    return lk_ball_weighted_dVt<Real, MAX_WATER>{
+        d_iso_dI * iso_scale + frac_bridge.dV.dI * bridge_scale,
+        d_iso_dJ * iso_scale
+            + frac_desolv.dV.dJ * (weights[w_lk_ball] * lk_iso.V)
+            + frac_bridge.dV.dJ * bridge_scale,
+        frac_desolv.dV.dWI * (weights[w_lk_ball] * lk_iso.V)
+            + frac_bridge.dV.dWI * bridge_scale,
+        frac_bridge.dV.dWJ * bridge_scale};
   }
 };
 
@@ -1190,7 +1290,7 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
         MAX_N_WATER * occluder_atom_tile_ind + wi);
   }
 
-  auto dV = lk_ball_score<Real, 4>::dV(
+  auto dV = lk_ball_score<Real, 4>::weighted_dV(
       polar_xyz,
       occluder_xyz,
       wmat_polar,
@@ -1198,22 +1298,18 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
       cp_separation,
       polar_block_dat.lk_ball_params[polar_ind],
       occluder_block_dat.lk_ball_params[occluder_ind],
-      block_pair_dat.global_params);
+      block_pair_dat.global_params,
+      dTdV);
 
   auto accum_derivs = ([&] TMOL_DEVICE_FUNC(
                            LKBallSingleResData<Real> const& block_dat,
                            int atom_ind,
-                           lk_ball_dV_dReal3<Real> const& derivs) {
+                           Real3 const& derivs) {
     for (int j = 0; j < 3; ++j) {
-      Real const weighted_deriv =
-          dTdV[w_lk_ball_iso] * derivs.d_lkball_iso[j]
-          + dTdV[w_lk_ball] * derivs.d_lkball[j]
-          + dTdV[w_lk_bridge] * derivs.d_lkbridge[j]
-          + dTdV[w_lk_bridge_uncpl] * derivs.d_lkbridge_uncpl[j];
-      if (weighted_deriv != 0) {
+      if (derivs[j] != 0) {
         accumulate<Dev, Real>::add(
             dV_d_pose_coords[block_dat.rot_coord_offset + atom_ind][j],
-            weighted_deriv);
+            derivs[j]);
       }
     }
   });
@@ -1223,18 +1319,13 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
            LKBallSingleResData<Real> const& block_dat,
            int atom_ind,
            int water_ind,
-           lk_ball_dV_dWater<Real, MAX_N_WATER> const& derivs) {
+           Eigen::Matrix<Real, MAX_N_WATER, 3> const& derivs) {
         for (int j = 0; j < 3; ++j) {
-          Real const weighted_deriv =
-              dTdV[w_lk_ball_iso] * derivs.d_lkball_iso(water_ind, j)
-              + dTdV[w_lk_ball] * derivs.d_lkball(water_ind, j)
-              + dTdV[w_lk_bridge] * derivs.d_lkbridge(water_ind, j)
-              + dTdV[w_lk_bridge_uncpl] * derivs.d_lkbridge_uncpl(water_ind, j);
-          if (weighted_deriv != 0) {
+          if (derivs(water_ind, j) != 0) {
             accumulate<Dev, Real>::add(
                 dV_d_water_coords[block_dat.rot_coord_offset + atom_ind]
                                  [water_ind][j],
-                weighted_deriv);
+                derivs(water_ind, j));
           }
         }
       });

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -408,9 +408,9 @@ struct lk_ball_score {
         bonded_path_length,
         sigma,
         i.lj_radius,
-        i.lk_dgfree,
-        i.lk_lambda,
         j.lk_volume,
+        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
+        Real(1) / (i.lk_lambda * i.lk_lambda),
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
     Real frac_IJ_desolv = lk_fraction<Real, MAX_WATER>::V(WI, J, j.lj_radius);
@@ -462,9 +462,9 @@ struct lk_ball_score {
         bonded_path_length,
         sigma,
         i.lj_radius,
-        i.lk_dgfree,
-        i.lk_lambda,
         j.lk_volume,
+        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
+        Real(1) / (i.lk_lambda * i.lk_lambda),
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 
@@ -564,9 +564,9 @@ struct lk_ball_score {
         bonded_path_length,
         sigma,
         i.lj_radius,
-        i.lk_dgfree,
-        i.lk_lambda,
         j.lk_volume,
+        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
+        Real(1) / (i.lk_lambda * i.lk_lambda),
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1205,7 +1205,6 @@ TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
     LKBallResPairData<Real> const& block_pair_dat,
     int cp_separation) {
   using tmol::score::common::coord_from_shared;
-  using tmol::score::common::distance;
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   if (cp_separation <= 3) {
@@ -1217,9 +1216,10 @@ TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
   Real3 occluder_xyz =
       coord_from_shared(occluder_block_dat.pose_coords, occluder_atom_tile_ind);
 
-  Real const dist = distance<Real>::V(polar_xyz, occluder_xyz);
-
-  if (dist >= block_pair_dat.global_params.distance_threshold) {
+  Real const distance_threshold =
+      block_pair_dat.global_params.distance_threshold;
+  if ((polar_xyz - occluder_xyz).squaredNorm()
+      >= distance_threshold * distance_threshold) {
     return {0, 0, 0, 0};
   }
 
@@ -1265,7 +1265,6 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
   using Real3 = Eigen::Matrix<Real, 3, 1>;
   using tmol::score::common::accumulate;
   using tmol::score::common::coord_from_shared;
-  using tmol::score::common::distance;
 
   if (cp_separation <= 3) {
     return;
@@ -1276,8 +1275,11 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
   Real3 occluder_xyz =
       coord_from_shared(occluder_block_dat.pose_coords, occluder_atom_tile_ind);
 
-  auto const dist_r = distance<Real>::V_dV(polar_xyz, occluder_xyz);
-  if (dist_r.V >= block_pair_dat.global_params.distance_threshold) return;
+  Real const distance_threshold =
+      block_pair_dat.global_params.distance_threshold;
+  if ((polar_xyz - occluder_xyz).squaredNorm()
+      >= distance_threshold * distance_threshold)
+    return;
 
   Eigen::Matrix<Real, MAX_N_WATER, 3> wmat_polar;
   Eigen::Matrix<Real, MAX_N_WATER, 3> wmat_occluder;

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -402,8 +402,8 @@ struct lk_ball_score {
         sigma,
         i.lj_radius,
         j.lk_volume,
-        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
-        Real(1) / (i.lk_lambda * i.lk_lambda),
+        i.lk_coeff,
+        i.lk_inv_lambda2,
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
     Real frac_IJ_desolv = lk_fraction<Real, MAX_WATER>::V(WI, J, j.lj_radius);
@@ -456,8 +456,8 @@ struct lk_ball_score {
         sigma,
         i.lj_radius,
         j.lk_volume,
-        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
-        Real(1) / (i.lk_lambda * i.lk_lambda),
+        i.lk_coeff,
+        i.lk_inv_lambda2,
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 
@@ -558,8 +558,8 @@ struct lk_ball_score {
         sigma,
         i.lj_radius,
         j.lk_volume,
-        -i.lk_dgfree / (Real(2) * Real(5.56832799683) * i.lk_lambda),
-        Real(1) / (i.lk_lambda * i.lk_lambda),
+        i.lk_coeff,
+        i.lk_inv_lambda2,
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -102,8 +102,8 @@ struct lk_fraction {
         Real exp_d2_delta = std::exp(-d2_delta);
 
         wted_d2_delta += exp_d2_delta;
-        d_wted_d2_delta_d_J += 2 * exp_d2_delta * delta_Jw;
-        d_wted_d2_delta_d_WI.row(w).transpose() = -2 * exp_d2_delta * delta_Jw;
+        d_wted_d2_delta_d_J += exp_d2_delta * delta_Jw;
+        d_wted_d2_delta_d_WI.row(w).transpose() = -exp_d2_delta * delta_Jw;
       }
     }
 
@@ -124,7 +124,7 @@ struct lk_fraction {
     }
 
     Real const derivative_scale =
-        exp_sum != 0 ? dfrac_dwted_d2 / exp_sum : Real(0);
+        exp_sum != 0 ? 2 * dfrac_dwted_d2 / exp_sum : Real(0);
     return V_dV_t{
         frac,
         dV_t{
@@ -228,10 +228,8 @@ struct lk_bridge_fraction {
         if (!std::isnan(d2_delta)) {
           Real exp_d2_delta = std::exp(-d2_delta);
 
-          d_wted_d2_delta_d_WI.row(wi).transpose() +=
-              2 * exp_d2_delta * delta_ij;
-          d_wted_d2_delta_d_WJ.row(wj).transpose() -=
-              2 * exp_d2_delta * delta_ij;
+          d_wted_d2_delta_d_WI.row(wi).transpose() += exp_d2_delta * delta_ij;
+          d_wted_d2_delta_d_WJ.row(wj).transpose() -= exp_d2_delta * delta_ij;
 
           wted_d2_delta += exp_d2_delta;
         }
@@ -282,7 +280,8 @@ struct lk_bridge_fraction {
     }
 
     Real const water_derivative_scale =
-        exp_sum != 0 ? anglefrac * d_overlapfrac_d_wted_d2 / exp_sum : Real(0);
+        exp_sum != 0 ? 2 * anglefrac * d_overlapfrac_d_wted_d2 / exp_sum
+                     : Real(0);
     return V_dV_t{
         overlapfrac * anglefrac,
         dV_t{

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -184,6 +184,14 @@ struct lk_bridge_fraction {
   static def V(
       Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
       -> Real {
+    // The bridge score has compact support in the base-atom separation. Test
+    // that inexpensive condition before evaluating any water-pair exponentials.
+    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real overlap_len2 = (I - J).squaredNorm();
+    Real base_delta = fabs(overlap_len2 - overlap_target_len2);
+    if (base_delta > angle_overlap_A2) return Real(0);
+    Real anglefrac = square(1 - square(base_delta / angle_overlap_A2));
+
     // water overlap
     Real wted_d2_delta = 0.0;
     // Generated water rows are valid-first, followed by NaN padding.
@@ -206,25 +214,30 @@ struct lk_bridge_fraction {
       // square-square -> 1 as x -> 0
       overlapfrac = square(1 - square(wted_d2_delta / overlap_width_A2));
     }
-    // base angle
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
-    Real overlap_len2 = (I - J).squaredNorm();
-    Real base_delta = fabs(overlap_len2 - overlap_target_len2);
-
-    Real anglefrac;
-    if (base_delta > angle_overlap_A2) {
-      anglefrac = 0;
-    } else {
-      // square-square -> 1 as x -> 0
-      anglefrac = square(1 - square(base_delta / angle_overlap_A2));
-    }
-
     return overlapfrac * anglefrac;
   }
 
   static def V_dV(
       Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
       -> V_dV_t {
+    // Reject geometrically impossible bridges before the water-overlap loop.
+    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real3 delta_ij = I - J;
+    Real overlap_len2 = delta_ij.squaredNorm();
+    Real base_delta = overlap_len2 - overlap_target_len2;
+    if (std::abs(base_delta) > angle_overlap_A2) {
+      return V_dV_t{Real(0), dV_t::Zero()};
+    }
+    Real3 d_wted_d2_delta_d_I = 2.0 * delta_ij;
+    Real3 d_wted_d2_delta_d_J = -2.0 * delta_ij;
+    Real anglefrac = square(1 - square(base_delta / angle_overlap_A2));
+    Real d_anglefrac_d_base_delta =
+        std::abs(base_delta) > 0.0
+            ? -4.0 * base_delta
+                  * (square(angle_overlap_A2) - square(base_delta))
+                  / square(square(angle_overlap_A2))
+            : Real(0);
+
     Real wted_d2_delta = 0.0;
 
     WatersMat d_wted_d2_delta_d_WI = WatersMat::Zero();
@@ -263,29 +276,6 @@ struct lk_bridge_fraction {
           -4.0 * wted_d2_delta
           * (square(overlap_width_A2) - square(wted_d2_delta))
           / square(square(overlap_width_A2));
-    }
-
-    // base angle
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
-    Real3 delta_ij = I - J;
-    Real overlap_len2 = delta_ij.squaredNorm();
-    Real base_delta = overlap_len2 - overlap_target_len2;
-    Real3 d_wted_d2_delta_d_I = 2.0 * delta_ij;
-    Real3 d_wted_d2_delta_d_J = -2.0 * delta_ij;
-
-    Real anglefrac;
-    Real d_anglefrac_d_base_delta;
-    if (std::abs(base_delta) > angle_overlap_A2) {
-      anglefrac = 0.0;
-      d_anglefrac_d_base_delta = 0.0;
-    } else if (std::abs(base_delta) > 0.0) {
-      anglefrac = square(1 - square(base_delta / angle_overlap_A2));
-      d_anglefrac_d_base_delta =
-          -4.0 * base_delta * (square(angle_overlap_A2) - square(base_delta))
-          / square(square(angle_overlap_A2));
-    } else {
-      anglefrac = 1.0;
-      d_anglefrac_d_base_delta = 0.0;
     }
 
     Real const water_derivative_scale =

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -75,6 +75,11 @@ struct lk_fraction {
       wted_d2_delta += std::exp(-d2_delta);
     }
 
+    // The piecewise ramp is already clamped when the exponential sum lies
+    // outside (exp(-ramp_width_A2), 1). Avoid a logarithm in those common
+    // cases.
+    if (wted_d2_delta >= Real(1)) return Real(1);
+    if (wted_d2_delta <= std::exp(-ramp_width_A2)) return Real(0);
     wted_d2_delta = -std::log(wted_d2_delta);
 
     Real frac = 0;
@@ -108,6 +113,12 @@ struct lk_fraction {
     }
 
     Real const exp_sum = wted_d2_delta;
+    if (exp_sum >= Real(1)) {
+      return V_dV_t{Real(1), dV_t::Zero()};
+    }
+    if (exp_sum <= std::exp(-ramp_width_A2)) {
+      return V_dV_t{Real(0), dV_t::Zero()};
+    }
     wted_d2_delta = -std::log(wted_d2_delta);
 
     Real frac = 0;
@@ -185,17 +196,15 @@ struct lk_bridge_fraction {
         wted_d2_delta += std::exp(-d2_delta);
       }
     }
-    wted_d2_delta = -std::log(wted_d2_delta);
-
     Real overlapfrac;
-    if (wted_d2_delta > overlap_width_A2) {
+    if (wted_d2_delta <= std::exp(-overlap_width_A2)) {
       overlapfrac = 0;
-    } else if (wted_d2_delta > 0) {
+    } else if (wted_d2_delta >= Real(1)) {
+      overlapfrac = 1;
+    } else {
+      wted_d2_delta = -std::log(wted_d2_delta);
       // square-square -> 1 as x -> 0
       overlapfrac = square(1 - square(wted_d2_delta / overlap_width_A2));
-    } else {
-      // clamp the fraction to 1.
-      overlapfrac = 1;
     }
     // base angle
     Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
@@ -238,23 +247,22 @@ struct lk_bridge_fraction {
     }
 
     Real const exp_sum = wted_d2_delta;
-    wted_d2_delta = -std::log(wted_d2_delta);
 
     Real overlapfrac;
     Real d_overlapfrac_d_wted_d2;
 
-    if (wted_d2_delta > overlap_width_A2) {
-      overlapfrac = 0.0;
-      d_overlapfrac_d_wted_d2 = 0.0;
-    } else if (wted_d2_delta > 0) {
+    if (exp_sum <= std::exp(-overlap_width_A2)) {
+      return V_dV_t{Real(0), dV_t::Zero()};
+    } else if (exp_sum >= Real(1)) {
+      overlapfrac = 1;
+      d_overlapfrac_d_wted_d2 = 0;
+    } else {
+      wted_d2_delta = -std::log(wted_d2_delta);
       overlapfrac = square(1 - square(wted_d2_delta / overlap_width_A2));
       d_overlapfrac_d_wted_d2 =
           -4.0 * wted_d2_delta
           * (square(overlap_width_A2) - square(wted_d2_delta))
           / square(square(overlap_width_A2));
-    } else {
-      overlapfrac = 1.0;
-      d_overlapfrac_d_wted_d2 = 0.0;
     }
 
     // base angle

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -236,7 +236,7 @@ struct lk_bridge_fraction {
           d_wted_d2_delta_d_WJ.row(wj).transpose() -=
               2 * exp_d2_delta * delta_ij;
 
-          wted_d2_delta += std::exp(-d2_delta);
+          wted_d2_delta += exp_d2_delta;
         }
       }
     }

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -306,8 +306,7 @@ struct LKBallRotamerScoreDispatch {
       // LKBall potential parameters
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       TView<Int, 2, Dev> dispatch_indices,  // from forward pass
-      TView<Real, 2, Dev> dTdV,
-      bool block_pair_scoring)
+      TView<Real, 2, Dev> dTdV)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>>;
 };
 

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -458,8 +458,9 @@ class LKBallPoseScoreDispatch {
     }
     auto output = output_t.view;
 
-    // Optimal launch box on v100 and a100 is nt=32, vt=1
-    LAUNCH_BOX_32;
+    // This kernel is latency- and register-bound. A 16-warp occupancy target
+    // reduces its register footprint without introducing local-memory spills.
+    LAUNCH_BOX_32_OCC(16);
     // Define nt and reduce_t
     CTA_REAL_REDUCE_T_TYPEDEF;
 
@@ -768,14 +769,49 @@ class LKBallPoseScoreDispatch {
         TPack<Vec<Real, 3>, 2, Dev>::zeros({n_atoms, MAX_N_WATER});
     auto dV_d_water_coords = dV_d_water_coords_t.view;
 
-    // Optimal launch box on v100 and a100 is nt=32, vt=1
-    LAUNCH_BOX_32;
+    // This derivative kernel is latency- and register-bound. Requiring more
+    // resident warps gives the compiler a register budget that exposes enough
+    // parallelism to hide its long dependency chains.
+    LAUNCH_BOX_32_OCC(16);
     // Define nt and reduce_t
     CTA_REAL_REDUCE_T_TYPEDEF;
     int const max_n_upper_triangle_inds =
         (max_n_blocks * (max_n_blocks + 1)) / 2;
 
     auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
+      int const pose_ind = cta / max_n_upper_triangle_inds;
+      int const block_ind_pair = cta % max_n_upper_triangle_inds;
+
+      auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
+          block_ind_pair, max_n_blocks + 1);
+      int const block_ind1 = common::get<0>(upper_triangle_ind);
+      int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
+
+      // Reject empty work before setting up the derivative machinery below.
+      if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+        return;
+      }
+      int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
+      int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
+      if (rot_ind1 < 0 || rot_ind2 < 0) {
+        return;
+      }
+
+      int const block_type1 = block_type_ind_for_rot[rot_ind1];
+      int const block_type2 = block_type_ind_for_rot[rot_ind2];
+      int const n_atoms1 = block_type_n_atoms[block_type1];
+      int const n_atoms2 = block_type_n_atoms[block_type2];
+
+      // The upstream weights are invariant for every atom pair handled by this
+      // CTA. Loading them once avoids repeated global loads and a scoring-mode
+      // branch in the hottest inner loop.
+      Vec<Real, 4> local_dTdV;
+      int const weight_block1 = block_pair_scoring ? block_ind1 : 0;
+      int const weight_block2 = block_pair_scoring ? block_ind2 : 0;
+      for (int i = 0; i < 4; ++i) {
+        local_dTdV[i] = dTdV[i][pose_ind][weight_block1][weight_block2];
+      }
+
       auto lk_ball_atom_derivs =
           ([=] TMOL_DEVICE_FUNC(
                int pol_ind,
@@ -788,28 +824,6 @@ class LKBallPoseScoreDispatch {
                LKBallSingleResData<Real> const& occ_dat,
                LKBallResPairData<Real> const& respair_dat,
                int cp_separation) {
-            // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
-            Vec<Real, 4> local_dTdV;
-            // printf("nabbing dTdV for pose %d block pair %d %d\n",
-            //        respair_dat.pose_ind,
-            //        pol_dat.block_ind,
-            //        occ_dat.block_ind);
-            if (block_pair_scoring) {
-              int const p = respair_dat.pose_ind;
-              int a_ind = pol_dat.block_ind;
-              int b_ind = occ_dat.block_ind;
-              int const b1 = a_ind < b_ind ? a_ind : b_ind;
-              int const b2 = a_ind < b_ind ? b_ind : a_ind;
-              for (int i = 0; i < 4; i++) {
-                local_dTdV[i] = dTdV[i][p][b1][b2];
-              }
-            } else {
-              int const p = respair_dat.pose_ind;
-              for (int i = 0; i < 4; i++) {
-                local_dTdV[i] = dTdV[i][p][0][0];
-              }
-            }
-            // printf("...done\n");
             lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
                 pol_ind,
                 occ_ind,
@@ -822,10 +836,8 @@ class LKBallPoseScoreDispatch {
                 respair_dat,
                 cp_separation,
                 local_dTdV,
-                cta,
                 dV_d_pose_coords,
-                dV_d_water_coords,
-                block_pair_scoring);
+                dV_d_water_coords);
           });
 
       auto dscore_inter_lk_ball_atom_pair =
@@ -896,36 +908,6 @@ class LKBallPoseScoreDispatch {
       } shared;
 
       int const max_important_bond_separation = 4;
-
-      int const pose_ind = cta / (max_n_upper_triangle_inds);
-      int const block_ind_pair = cta % (max_n_upper_triangle_inds);
-
-      // We do not have to kill half of our thread blocks simply because they
-      // represent the lower triangle now that we're using upper-triangle
-      // indices
-      auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
-          block_ind_pair, max_n_blocks + 1);
-
-      int const block_ind1 = common::get<0>(upper_triangle_ind);
-      int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
-
-      // We still kill CTAs targetting non-neighboring block pairs, though,
-      // and that can be a lot
-      if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
-        return;
-      }
-      int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
-      int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
-
-      if (rot_ind1 < 0 || rot_ind2 < 0) {
-        return;
-      }
-
-      int const block_type1 = block_type_ind_for_rot[rot_ind1];
-      int const block_type2 = block_type_ind_for_rot[rot_ind2];
-
-      int const n_atoms1 = block_type_n_atoms[block_type1];
-      int const n_atoms2 = block_type_n_atoms[block_type2];
 
       auto load_tile_invariant_interres_data =
           ([=] LOAD_TILE_INVARIANT_INTERRES_DATA);
@@ -1442,8 +1424,7 @@ class LKBallRotamerScoreDispatch {
       // LKBall potential parameters
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       TView<Int, 2, Dev> dispatch_indices,  // from forward pass
-      TView<Real, 2, Dev> dTdV,
-      bool block_pair_scoring)
+      TView<Real, 2, Dev> dTdV)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>> {
     using tmol::score::common::accumulate;
     using Real3 = Vec<Real, 3>;
@@ -1525,6 +1506,11 @@ class LKBallRotamerScoreDispatch {
     CTA_REAL_REDUCE_T_TYPEDEF;
 
     auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
+      Vec<Real, 4> local_dTdV;
+      for (int i = 0; i < 4; ++i) {
+        local_dTdV[i] = dTdV[i][cta];
+      }
+
       auto lk_ball_atom_derivs =
           ([=] TMOL_DEVICE_FUNC(
                int pol_ind,
@@ -1537,12 +1523,6 @@ class LKBallRotamerScoreDispatch {
                LKBallSingleResData<Real> const& occ_dat,
                LKBallResPairData<Real> const& respair_dat,
                int cp_separation) {
-            // capture dTdV, dV_d_pose_coords, & dV_d_water_coords
-            Vec<Real, 4> local_dTdV;
-            for (int i = 0; i < 4; i++) {
-              local_dTdV[i] = dTdV[i][cta];
-            }
-
             lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
                 pol_ind,
                 occ_ind,
@@ -1555,10 +1535,8 @@ class LKBallRotamerScoreDispatch {
                 respair_dat,
                 cp_separation,
                 local_dTdV,
-                cta,
                 dV_d_pose_coords,
-                dV_d_water_coords,
-                block_pair_scoring);
+                dV_d_water_coords);
           });
 
       auto dscore_inter_lk_ball_atom_pair =

--- a/tmol/score/lk_ball/potentials/params.hh
+++ b/tmol/score/lk_ball/potentials/params.hh
@@ -11,8 +11,8 @@ namespace potentials {
 template <typename Real>
 struct LKBallTypeParams {
   Real lj_radius;
-  Real lk_dgfree;
-  Real lk_lambda;
+  Real lk_coeff;
+  Real lk_inv_lambda2;
   Real lk_volume;
   Real is_donor;
   Real is_hydroxyl;

--- a/tmol/score/lk_ball/potentials/params.pybind.hh
+++ b/tmol/score/lk_ball/potentials/params.pybind.hh
@@ -28,8 +28,10 @@ struct type_caster<tmol::score::lk_ball::potentials::LKBallTypeParams<Real>> {
     nvtx_range_function();
 
     CAST_ATTR(src, value, lj_radius);
-    CAST_ATTR(src, value, lk_dgfree);
-    CAST_ATTR(src, value, lk_lambda);
+    Real const lk_dgfree = src.attr("lk_dgfree").cast<Real>();
+    Real const lk_lambda = src.attr("lk_lambda").cast<Real>();
+    value.lk_coeff = -lk_dgfree / (Real(2) * Real(5.56832799683) * lk_lambda);
+    value.lk_inv_lambda2 = Real(1) / (lk_lambda * lk_lambda);
     CAST_ATTR(src, value, lk_volume);
     CAST_ATTR(src, value, is_donor);
     CAST_ATTR(src, value, is_hydroxyl);

--- a/tmol/score/ref/_ref_energy_term.py
+++ b/tmol/score/ref/_ref_energy_term.py
@@ -105,7 +105,8 @@ class RefEnergyTerm(EnergyTerm):
         bt = pose_stack.block_type_ind64
         weights = ref_weights[bt.clamp_min(0)]
         block_ref = torch.where(bt >= 0, weights, torch.zeros_like(weights))
-        return [block_ref, ref_weights]
+        pose_ref = torch.sum(block_ref, dim=1).unsqueeze(0)
+        return [block_ref, pose_ref, ref_weights]
 
 
 def eval_ref_energy_for_pose(
@@ -124,19 +125,17 @@ def eval_ref_energy_for_pose(
     _rot_offset_for_block,
     _max_n_rots_per_pose,
     block_ref,
+    pose_ref,
     _ref_weights,
     output_block_pair_energies: bool,
 ):
-    score = block_ref
-
     if output_block_pair_energies:
-        score = torch.diag_embed(score)
+        score = torch.diag_embed(block_ref)
+        score = torch.unsqueeze(score, 0)
     else:
-        # for each pose, sum up the block scores
-        score = torch.sum(score, 1)
-
-    # wrap this all in an extra dim (the output expects an outer dim to separate sub-terms)
-    score = torch.unsqueeze(score, 0)
+        # Reference energies are coordinate-independent. Their per-pose sum is
+        # computed once while rendering the scoring module, not on every call.
+        score = pose_ref.view_as(pose_ref)
 
     score.requires_grad = True  # a bit of a hack to make the benchmark test not error out because there are no grads
 
@@ -159,6 +158,7 @@ def eval_ref_energy_for_rotamers(
     _rot_offset_for_block,
     _max_n_rots_per_pose,
     _block_ref,
+    _pose_ref,
     ref_weights,
     output_block_pair_energies: bool,
 ):

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -16,6 +16,25 @@ def _history(m, n_segments, size, dtype, device, seed=0):
     return grad.to(device), dirs.to(device), stps.to(device)
 
 
+def test_dense_segment_layout_helpers(torch_device):
+    """Contiguous equal segments need no indexed padding or gathering."""
+    x = torch.nn.Parameter(torch.zeros(12, device=torch_device))
+    segment_ids = torch.arange(3, device=torch_device).repeat_interleave(4)
+    optimizer = LBFGS_Armijo([x], segment_ids=segment_ids)
+    values = torch.arange(12, dtype=x.dtype, device=torch_device)
+    expected = values.view(3, 4)
+
+    assert optimizer._segments_are_dense
+    torch.testing.assert_close(optimizer._pad(values), expected)
+    torch.testing.assert_close(optimizer._unpad(expected), values)
+    torch.testing.assert_close(optimizer._seg_sum(values), expected.sum(-1))
+    torch.testing.assert_close(optimizer._seg_amax(values), expected.amax(-1))
+
+    out = torch.empty_like(expected)
+    assert optimizer._pad(values, out=out).data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out, expected)
+
+
 def test_batched_two_loop_matches_one_problem_at_a_time(torch_device):
     grad, dirs, stps = _history(7, 4, 13, torch.float64, torch_device)
     batched = lbfgs_two_loop(grad, dirs, stps)

--- a/tmol/tests/optimization/test_pose_stack_minimization.py
+++ b/tmol/tests/optimization/test_pose_stack_minimization.py
@@ -119,6 +119,27 @@ def test_cart_network_segment_ids(
     assert torch.all(segment_ids[1:] >= segment_ids[:-1])
 
 
+def test_cart_network_all_coords_fast_path(distinct_pose_stacks, torch_device):
+    """An all-true mask keeps coordinates as a view and reconstructs a copy."""
+    pose_stack = distinct_pose_stacks[0]
+    original_coords = pose_stack.coords.clone()
+    sfxn = beta2016_score_function(torch_device)
+    coord_mask = torch.ones_like(pose_stack.real_atoms)
+    network = CartesianSfxnNetwork(sfxn, pose_stack, coord_mask)
+
+    assert network._all_coords_movable
+    energy = network().sum()
+    energy.backward()
+
+    assert network.full_coords.data_ptr() == network.masked_coords.data_ptr()
+    assert network.masked_coords.grad is not None
+
+    reconstructed = network.pose_stack_from_dofs()
+    torch.testing.assert_close(reconstructed.coords, network.full_coords)
+    assert reconstructed.coords.data_ptr() != network.masked_coords.data_ptr()
+    torch.testing.assert_close(pose_stack.coords, original_coords)
+
+
 def test_kin_network_segment_ids(
     distinct_pose_stacks, stack_of_distinct_poses, torch_device
 ):

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -117,7 +117,9 @@ if torch.cuda.is_available():
             f"/site-packages/nvidia/nvtx/include"
         )
 
-_default_cuda_flags = []
+# Match the Release AOT build. Without an explicit optimization level, local
+# JIT extensions can run materially slower than the packaged CUDA kernels.
+_default_cuda_flags = ["-O3"]
 
 
 # Add additional flags.


### PR DESCRIPTION
## Summary

This PR accelerates TMol CUDA scoring at both the individual-kernel and end-to-end workflow levels. It is based on merged master at `08d82941b`, which includes #417 and #418.

The forward energy path is intentionally optimized too: LJ and isotropic LK now share one heavy-pair traversal; out-of-cutoff pairs avoid square roots and derivative normalization; per-type invariants are precomputed; reciprocal distances, exponentials, and antisymmetric coordinate derivatives are reused; and LK-ball rejects padded waters, clamped ramps, and geometrically impossible bridges before expensive work.

No Hopper-only instruction is required. The implementation uses portable CUDA launch bounds and existing TMol abstractions, retains CPU dispatch, and preserves local `TMOL_USE_JIT=1` development.

## H200 results

Measured on one NVIDIA H200 (SM90), CUDA 13.x, with warm local JIT modules. Values are pytest-benchmark means; lower is better.

| Workload | merged master | this PR | improvement |
|---|---:|---:|---:|
| Combined score, forward, 100 poses | 4.437 ms | 3.250 ms | **26.7%** |
| Combined score, forward + backward, 100 poses | 10.358 ms | 5.705 ms | **44.9%** |
| 30-pose Cartesian minimization | 72.78 ms | 47.02 ms | **35.4%** |
| One-pose FastRelax, warm JIT mean (5 runs) | 7.31 s | 5.875 s | **19.6%** |

FastRelax is stochastic: small floating-point ordering differences can change packing and line-search trajectories. The five warm-JIT runs span 5.712–6.007 s (median 5.880 s). Five Release AOT runs span 5.167–5.259 s (mean 5.223 s); that absolute AOT result is reported separately because the master reference used JIT. The first run after a new specialization includes one-time JIT compilation and is excluded from steady-state timing.

The forward-energy work is visible in the individual 100-pose terms as well:

| Component workload | merged master | this PR | improvement |
|---|---:|---:|---:|
| Electrostatics, forward | 0.645 ms | 0.405 ms | **37.2%** |
| Electrostatics, full | 0.979 ms | 0.646 ms | **34.0%** |
| LJ/LK, forward | 1.307 ms | 0.694 ms | **46.9%** |
| LJ/LK, full | 2.853 ms | 1.213 ms | **57.5%** |
| LK-ball, forward | 1.027 ms | 0.864 ms | **15.9%** |
| LK-ball, full | 4.844 ms | 2.298 ms | **52.6%** |
| Cartesian bonded, forward | 0.757 ms | 0.600 ms | **20.7%** |
| Cartesian bonded, full | 0.817 ms | 0.707 ms | **13.4%** |

The Release AOT combined workload is 3.212 ms forward and 5.612 ms forward+backward. At one pose, forward latency improves 3.8% and full latency is statistically neutral (a 1% difference within the observed IQR); at 30 poses, forward/full improve 23.4%/38.3%. Nsight Compute reports 64 registers/thread for the fused LJ/LK forward kernel, 128 for the main LK-ball backward kernel (previously about 250), and no local-memory spills in the profiled hot kernels. The final minimization trace also removes 216 CUDA kernel launches and 216 device-to-device copies per invocation by activating the all-coordinate view path.

## What changed

### Forward energy evaluation

- fuse LJ and LK pose/rotamer energy traversal for heavy pairs
- skip square roots for pairs already beyond the common cutoff
- return before unused LJ/LK cutoff work
- precompute LJ well-depth roots, LK coefficients, inverse lambda squared, electrostatic smoothing constants, and reference energies
- reuse inverse distances and shared pair geometry
- stop LK-ball loops at contiguous NaN water padding
- avoid logarithms in already-clamped LK-ball ramps
- reject impossible LK-ball bridges before evaluating water-pair exponentials

### Derivatives and kernel structure

- specialize energy-only and derivative-capable kernels
- combine weighted term derivatives before global atomics
- reuse antisymmetric atom-pair derivatives instead of recomputing both directions
- reuse LK solvation values and LK-ball bridge exponentials
- tune one-warp launch bounds from measured register and occupancy limits
- remove unused backward flags and saved autograd state
- avoid unnecessary Cartesian, Dunbrack, and backbone-torsion derivatives when gradients are not requested

### End-to-end minimization and relax

- skip padding for already-dense minimizer segments
- bypass Cartesian coordinate scatters when every coordinate is movable
- precompute pose reference energies
- compile local JIT CUDA extensions with the same `-O3` optimization level as Release AOT builds
- preserve local JIT specialization for development and AOT-compatible dispatch for packaged builds

## Numerical behavior and validation

The mathematical energy definitions are unchanged; their CUDA evaluation paths are substantially optimized. Fast exits occur only outside an existing compact-support cutoff or in a piecewise region whose value and derivative are already clamped. Weighted derivative fusion changes floating-point accumulation order only.

Validation includes:

- broad score suite: 833 passed, 1 skipped, and 2 expected xfails; the only non-pass was a Hypothesis input-generation `too_slow` health check under shared-node load, whose exact seed passed immediately in isolation
- full optimization/relax suite: 90 passed, 3 skipped, 1 expected xfail, and 2 existing xpasses
- AOT SM90 build: all 98 C++/CUDA targets compiled successfully
- AOT CUDA smoke tests with `TMOL_USE_JIT=0`: 17/17 LJ/LK and LK-ball tests plus 44/44 optimization/relax tests passed
- runtime development builds with `TMOL_USE_JIT=1`, including fresh specializations
- repeated H200 benchmarks and Nsight Systems/Compute profiles
- full pre-commit and diff checks

GitHub CI remains the final merge gate.

## Measure-driven exclusions

Several plausible variants were benchmarked and removed because they regressed or did not justify their complexity: 64-thread residue-pair blocks, persistent grid-stride workgroups, more aggressive launch bounds that spilled registers, cooperative-groups pointer aggregation, a CUDA graph around the current minimizer, a classic two-loop LBFGS rewrite, and several branch/shared-memory micro-optimizations.

## Profiling references

- [CUDA Programming Guide: launch bounds](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#launch-bounds)
- [CUDA Best Practices Guide: occupancy and thread/block heuristics](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#thread-and-block-heuristics)
- [Nsight Compute Profiling Guide: scheduler and eligible-warp metrics](https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html)





