### PR TITLE
Accelerate batched mutation, scoring, and relaxation workflows

### DIFF
--- a/tmol/database/scoring/_dunbrack_libraries.py
+++ b/tmol/database/scoring/_dunbrack_libraries.py
@@ -89,4 +89,7 @@ class DunbrackRotamerLibrary:
                 (RotamericDataForAA, f"{_OLD}.RotamericDataForAA"),
             ]
         ):
-            return torch.load(fname, mmap=True)
+            # Be explicit so application-level
+            # TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD does not bypass the safe-global
+            # aliases for pre-refactor class names stored in this database.
+            return torch.load(fname, mmap=True, weights_only=True)

--- a/tmol/database/scoring/_omega_bbdep.py
+++ b/tmol/database/scoring/_omega_bbdep.py
@@ -43,4 +43,4 @@ class OmegaBBDepDatabase:
                 (OmegaBBDepTables, f"{_OLD}.OmegaBBDepTables"),
             ]
         ):
-            return torch.load(fname, mmap=True)
+            return torch.load(fname, mmap=True, weights_only=True)

--- a/tmol/database/scoring/_rama.py
+++ b/tmol/database/scoring/_rama.py
@@ -42,4 +42,4 @@ class RamaDatabase:
                 (RamaMappingParams, f"{_OLD}.RamaMappingParams"),
             ]
         ):
-            return torch.load(fname, mmap=True)
+            return torch.load(fname, mmap=True, weights_only=True)

--- a/tmol/io/_pose_stack_construction.py
+++ b/tmol/io/_pose_stack_construction.py
@@ -203,31 +203,35 @@ def pose_stack_from_canonical_form(  # noqa: C901
     # their Poses to ensure that the polymeric-bond-detection logic
     # downstream will work properly. This effectively means "shifting left"
     # all the other residues in the Pose to fill the vacated slots.
-    (
-        chain_id,
-        res_types,
-        coords,
-        atom_is_present,
-        disulfides,
-        res_not_connected,
-        res_labels,
-        res_ins_codes,
-        chain_labels,
-        atom_occupancy,
-        atom_b_factor,
-    ) = left_justify_canonical_form(
-        chain_id,
-        res_types,
-        coords,
-        atom_is_present,
-        disulfides,
-        res_not_connected,
-        res_labels,
-        res_ins_codes,
-        chain_labels,
-        atom_occupancy,
-        atom_b_factor,
-    )
+    # A single residue slot is already left-justified: each pose either has its
+    # residue in slot zero or is empty. Avoid the GPU compaction and host index
+    # copies for the common batched-ligand scoring case.
+    if res_types.shape[1] != 1:
+        (
+            chain_id,
+            res_types,
+            coords,
+            atom_is_present,
+            disulfides,
+            res_not_connected,
+            res_labels,
+            res_ins_codes,
+            chain_labels,
+            atom_occupancy,
+            atom_b_factor,
+        ) = left_justify_canonical_form(
+            chain_id,
+            res_types,
+            coords,
+            atom_is_present,
+            disulfides,
+            res_not_connected,
+            res_labels,
+            res_ins_codes,
+            chain_labels,
+            atom_occupancy,
+            atom_b_factor,
+        )
 
     if res_types.shape[1] == 0:
         raise ValueError(
@@ -238,9 +242,19 @@ def pose_stack_from_canonical_form(  # noqa: C901
         )
 
     # 3
-    found_disulfides, res_type_variants = find_disulfides(
-        canonical_ordering, res_types, coords, disulfides, find_additional_disulfides
-    )
+    if res_types.shape[1] == 1 and disulfides is None:
+        found_disulfides = torch.zeros(
+            (0, 3), dtype=torch.int64, device=res_types.device
+        )
+        res_type_variants = torch.zeros_like(res_types)
+    else:
+        found_disulfides, res_type_variants = find_disulfides(
+            canonical_ordering,
+            res_types,
+            coords,
+            disulfides,
+            find_additional_disulfides,
+        )
 
     # 4
     (

--- a/tmol/io/details/_his_taut_resolution.py
+++ b/tmol/io/details/_his_taut_resolution.py
@@ -50,6 +50,9 @@ def resolve_his_tautomerization(
     his_pose_ind, his_res_ind = torch.nonzero(
         res_types == his_inds.his_co_aa_ind, as_tuple=True
     )
+    if his_pose_ind.shape[0] == 0:
+        return (torch.zeros_like(res_types), res_type_variants, coords, atom_is_present)
+
     his_remapping_dst_index = torch.tile(
         torch.arange(
             canonical_ordering.max_n_canonical_atoms,

--- a/tmol/ligand/_openbabel_compat.py
+++ b/tmol/ligand/_openbabel_compat.py
@@ -78,14 +78,19 @@ def normalize_azide(smiles: str) -> str:
 
 
 def source_atom_order_from_mapped_smiles(smiles: str) -> Optional[tuple[int, ...]]:
-    """Map numbers (source indices) in SMILES/mol2 atom order, or None if any
-    atom is unmapped. Normalized identically to the mol2 path so order matches."""
+    """Heavy-atom source indices in SMILES/mol2 order, or None if one is unmapped.
+
+    Explicit input hydrogens are intentionally ignored: OpenBabel regenerates
+    hydrogens after protonation, while only heavy atoms retain source names.
+    """
     smiles = normalize_azide(strip_nontetrahedral_stereo(smiles))
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return None
     order: list[int] = []
     for atom in mol.GetAtoms():
+        if atom.GetAtomicNum() == 1:
+            continue
         mapnum = atom.GetAtomMapNum()
         if mapnum <= 0:
             return None

--- a/tmol/ligand/_structure_to_smiles.py
+++ b/tmol/ligand/_structure_to_smiles.py
@@ -149,11 +149,12 @@ def apply_geometry_bond_corrections(mol: Chem.Mol) -> Chem.Mol:
 def _tag_source_atom_map(mol: Chem.Mol, atom_array: AtomArray) -> None:
     """Tag each heavy atom with map number = source index + 1 (rides the SMILES
     through the mol2 pipeline for atom naming). No-op if counts disagree."""
-    heavy_idx = [i for i, e in enumerate(atom_array.element) if str(e) != "H"]
-    if mol.GetNumAtoms() != len(heavy_idx):
+    source_heavy = [i for i, e in enumerate(atom_array.element) if str(e) != "H"]
+    mol_heavy = [atom.GetIdx() for atom in mol.GetAtoms() if atom.GetAtomicNum() != 1]
+    if len(mol_heavy) != len(source_heavy):
         return
-    for j in range(mol.GetNumAtoms()):
-        mol.GetAtomWithIdx(j).SetAtomMapNum(int(heavy_idx[j]) + 1)
+    for mol_idx, source_idx in zip(mol_heavy, source_heavy):
+        mol.GetAtomWithIdx(mol_idx).SetAtomMapNum(int(source_idx) + 1)
 
 
 def ligand_smiles_from_atom_array(

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -399,7 +399,10 @@ class LBFGS_Armijo(Optimizer):
 
         # evaluate initial f(x)
         orig_loss = closure()
-        loss = orig_loss.item()
+        # The optimizer uses the per-segment tensor below for all line-search
+        # and convergence decisions. Materializing a Python scalar here forces
+        # a device synchronization and is only useful for verbose reporting.
+        loss = float(orig_loss) if self.verbose else None
         loss_vec = self._last_loss_vec
         state["func_evals"] += 1
 
@@ -469,6 +472,11 @@ class LBFGS_Armijo(Optimizer):
             stalled=state["stalled"],
             needs_reset=state["needs_reset"],
             was_reset=state["was_reset"],
+            # Host mirrors of predicates already synchronized in the previous
+            # iteration. Reusing them avoids repeating identical device-to-host
+            # checks at the start of the next iteration.
+            any_needs_reset=state.get("any_needs_reset", False),
+            any_inactive=state.get("any_inactive", False),
             gtd_seg=None,
             # current eval
             orig_loss=orig_loss,
@@ -549,7 +557,7 @@ class LBFGS_Armijo(Optimizer):
         Its history is dropped (zeroed slots read as absent) and it is marked as
         restarted, so a second failure retires it instead of searching again.
         """
-        if not bool(ctx.needs_reset.any()):
+        if not ctx.any_needs_reset:
             ctx.was_reset = torch.zeros_like(ctx.needs_reset)
             return
         ctx.was_reset = ctx.needs_reset.clone()
@@ -560,6 +568,7 @@ class LBFGS_Armijo(Optimizer):
         ctx.d.copy_(torch.where(reset_elem, -ctx.flat_grad, ctx.d))
         ctx.x_ref = torch.where(reset_elem, ctx.x, ctx.x_ref)
         ctx.needs_reset = torch.zeros_like(ctx.needs_reset)
+        ctx.any_needs_reset = False
 
     def _inactive(self, ctx):
         """Segments that no longer move: converged or retired."""
@@ -568,7 +577,7 @@ class LBFGS_Armijo(Optimizer):
     def _freeze_converged(self, ctx):
         """Hold converged or retired segments still by zeroing their direction."""
         inactive = self._inactive(ctx)
-        if not bool(inactive.any()):
+        if not ctx.any_inactive:
             return
         ctx.d.mul_((~inactive).to(ctx.d.dtype)[self._segment_ids])
 
@@ -616,7 +625,9 @@ class LBFGS_Armijo(Optimizer):
         if not trial_is_accepted:
             self._closure_fn()
         ctx.loss_vec = self._last_loss_vec
-        ctx.loss = float(ctx.loss_vec.sum())
+        # Keep the normal optimization path asynchronous. The scalar total is
+        # only needed for human-readable progress output.
+        ctx.loss = float(ctx.loss_vec.sum()) if self.verbose else None
 
         # a failed search gets one steepest-descent restart, applied on the next
         # iteration so the other segments are not held up; then it is retired
@@ -625,9 +636,14 @@ class LBFGS_Armijo(Optimizer):
         retry_t = torch.clamp((-ctx.gtd_seg).clamp(min=self._minstep).rsqrt(), max=1.0)
         ctx.t = torch.where(failed, retry_t, accepted)
         ctx.t = torch.where(searching, ctx.t, start_t)
-        if bool(failed.any()):
+        any_failed = bool(failed.any())
+        if any_failed:
             ctx.stalled |= failed & ctx.was_reset
             ctx.needs_reset |= failed & ~ctx.was_reset
+        # A failure is the only way needs_reset can become true. It is safe to
+        # be conservative when all failed segments were already restarted;
+        # the next iteration will process an empty mask and clear this flag.
+        ctx.any_needs_reset = any_failed
 
     def _check_segment_convergence(self, ctx, n_iter):
         """Freeze independently converged segments; stop when all are done.
@@ -649,6 +665,7 @@ class LBFGS_Armijo(Optimizer):
         done = self._inactive(ctx)
 
         n_done = int(done.sum().item())
+        ctx.any_inactive = n_done != 0
         if self.verbose:
             n_stalled = int(ctx.stalled.sum().item())
             print(
@@ -758,5 +775,7 @@ class LBFGS_Armijo(Optimizer):
         ctx.state["x_ref"] = ctx.x_ref
         ctx.state["needs_reset"] = ctx.needs_reset
         ctx.state["was_reset"] = ctx.was_reset
+        ctx.state["any_needs_reset"] = ctx.any_needs_reset
+        ctx.state["any_inactive"] = ctx.any_inactive
 
         return ctx.orig_loss

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -28,7 +28,7 @@ def build_kinforest_network(
     start_time = time.perf_counter()
 
     kin_module = PoseStackKinematicsModule(pose_stack, ff)
-    if torch.cuda.is_available():
+    if verbose and torch.cuda.is_available():
         torch.cuda.synchronize()
     end_time1 = time.perf_counter()
 

--- a/tmol/pack/_packer_task.py
+++ b/tmol/pack/_packer_task.py
@@ -9,7 +9,7 @@ from tmol.pose import (
     PackedBlockTypes,
     PoseStack,
 )
-from typing import TYPE_CHECKING
+from typing import Collection, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tmol.pack.rotamer._conformer_sampler import ConformerSampler
@@ -307,50 +307,53 @@ class PackerTask:
         )
         self._bump_check = False
 
-    def restrict_to_repacking(self):
-        # Use the pre-calculated masks to disable packing for
-        # all block types that are not allowed except those which
-        # meet the definition of "repacking" for the original
-        # packer palette (i.e. same name3)
+    def restrict_to_repacking(self, block_mask: Tensor[torch.bool][:, :] | None = None):
+        """Restrict selected blocks to the original residue name.
+
+        If ``block_mask`` is omitted, restrict every block for backward
+        compatibility. Otherwise, only ``True`` pose/block entries are changed.
+        """
+        if block_mask is not None:
+            assert block_mask.device == self.per_block_is_block_type_allowed.device
+            assert block_mask.shape == self.per_block_is_block_type_allowed.shape[:2]
+            restriction = torch.logical_or(
+                self.restrict_to_repacking_masks, ~block_mask.unsqueeze(-1)
+            )
+        else:
+            restriction = self.restrict_to_repacking_masks
+
         self.per_block_is_block_type_allowed = torch.logical_and(
-            self.per_block_is_block_type_allowed, self.restrict_to_repacking_masks
+            self.per_block_is_block_type_allowed, restriction
         )
 
-    def restrict_absent_name3s(self, name3s):
-        """Disallow all block types at all positions except those with the given name3s.
+    def restrict_absent_name3s(
+        self,
+        name3s: Collection[str],
+        block_mask: Tensor[torch.bool][:, :] | None = None,
+    ):
+        """Restrict selected blocks to block types with the given name3s.
 
-        This is somewhat slow and does not cache the relationship between name3s and
-        permitted block types, so consider writing your own version of this function
-        if you call with the same list of name3s many times.
+        If ``block_mask`` is omitted, restrict every block for backward compatibility.
+        This operation only disables choices and may therefore be composed safely with
+        other task restrictions.
         """
+        if block_mask is not None:
+            assert block_mask.device == self.per_block_is_block_type_allowed.device
+            assert block_mask.shape == self.per_block_is_block_type_allowed.shape[:2]
+
         bt_name3_matches = torch.tensor(
             [bt.name3 in name3s for bt in self.pbt.active_block_types],
             dtype=torch.bool,
             device=self.device,
         )
-        is_real_considered_block_type = self.per_block_considered_block_types != -1
-        (
-            nz_real_cons_bt_pose,
-            nz_real_cons_bt_block,
-            nz_real_cons_bt_which_block_type,
-        ) = torch.nonzero(is_real_considered_block_type, as_tuple=True)
-        self.per_block_is_block_type_allowed[
-            nz_real_cons_bt_pose,
-            nz_real_cons_bt_block,
-            nz_real_cons_bt_which_block_type,
-        ] = torch.logical_and(
-            self.per_block_is_block_type_allowed[
-                nz_real_cons_bt_pose,
-                nz_real_cons_bt_block,
-                nz_real_cons_bt_which_block_type,
-            ],
-            bt_name3_matches[
-                self.per_block_considered_block_types[
-                    nz_real_cons_bt_pose,
-                    nz_real_cons_bt_block,
-                    nz_real_cons_bt_which_block_type,
-                ]
-            ],
+        considered = self.per_block_considered_block_types
+        restriction = torch.logical_and(
+            considered >= 0, bt_name3_matches[considered.clamp_min(0)]
+        )
+        if block_mask is not None:
+            restriction = torch.logical_or(restriction, ~block_mask.unsqueeze(-1))
+        self.per_block_is_block_type_allowed = torch.logical_and(
+            self.per_block_is_block_type_allowed, restriction
         )
 
     def add_conformer_sampler(self, sampler: ConformerSampler):

--- a/tmol/pack/rotamer/_fallback_sampler.py
+++ b/tmol/pack/rotamer/_fallback_sampler.py
@@ -147,8 +147,6 @@ class FallbackSampler(ConformerSampler):
         if n_rots == 0:
             return
 
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
         dst, src = (
             create_full_dof_inds_to_copy_from_orig_to_rotamers_for_include_current_sampler(
                 pose_stack,
@@ -163,5 +161,3 @@ class FallbackSampler(ConformerSampler):
         )
 
         conf_dofs_kto[dst + 1, :] = orig_dofs_kto[src + 1, :]
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()

--- a/tmol/pack/rotamer/_include_current_sampler.py
+++ b/tmol/pack/rotamer/_include_current_sampler.py
@@ -48,8 +48,8 @@ class IncludeCurrentSampler(ConformerSampler):
     def create_samples_for_poses(
         self,
         pose_stack: PoseStack,
-        task: "SetPackerTask",  # noqa: 821
-    ) -> Tuple[  # noqa F821
+        task: "SetPackerTask",  # noqa: F821
+    ) -> Tuple[
         Tensor[torch.int32][:],  # n_rots_for_gbt
         Tensor[torch.int32][:],  # gbt_for_rotamer
         dict,  # anything else the sampler wants to save for later
@@ -80,7 +80,7 @@ class IncludeCurrentSampler(ConformerSampler):
     def fill_dofs_for_samples(
         self,
         pose_stack: PoseStack,
-        task: "PackerTask",  # noqa: 821
+        task: "PackerTask",  # noqa: F821
         orig_kinforest: KinForest,
         orig_dofs_kto: Tensor[torch.float32][:, 9],
         gbt_for_conformer: Tensor[torch.int64][:],
@@ -99,8 +99,6 @@ class IncludeCurrentSampler(ConformerSampler):
         if n_rots == 0:
             return
 
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
         dst, src = (
             create_full_dof_inds_to_copy_from_orig_to_rotamers_for_include_current_sampler(
                 pose_stack,
@@ -115,8 +113,6 @@ class IncludeCurrentSampler(ConformerSampler):
         )
 
         conf_dofs_kto[dst + 1, :] = orig_dofs_kto[src + 1, :]
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
 
 
 # @validate_args

--- a/tmol/pack/rotamer/_mainchain_fingerprint.py
+++ b/tmol/pack/rotamer/_mainchain_fingerprint.py
@@ -124,6 +124,34 @@ def create_non_sidechain_fingerprint(  # noqa: C901
     mc_ind = numpy.full(rt.n_atoms, -1, dtype=numpy.int32)
     mc_ind[mc_atoms] = numpy.arange(mc_atoms.shape[0], dtype=numpy.int32)
 
+    # A kinematic parent tree has to cut cycles. For polymer rings branching
+    # from the mainchain (notably the nucleotide sugar), following parents can
+    # therefore reach the tree root without ever visiting a declared mainchain
+    # atom. Keep the parent-tree path as the normal definition, but fall back to
+    # the shortest chemical-bond path for those atoms.
+    bonded_neighbors = [[] for _ in range(rt.n_atoms)]
+    for atom1, atom2 in rt.bond_indices:
+        bonded_neighbors[atom1].append(atom2)
+        bonded_neighbors[atom2].append(atom1)
+
+    def closest_mainchain_atom(atom):
+        visited = {atom}
+        frontier = [atom]
+        for bond_distance in range(rt.n_atoms):
+            mainchain = sorted(a for a in frontier if mc_ind[a] >= 0)
+            if mainchain:
+                return mc_ind[mainchain[0]], bond_distance
+            frontier = sorted(
+                {
+                    neighbor
+                    for current in frontier
+                    for neighbor in bonded_neighbors[current]
+                    if neighbor not in visited
+                }
+            )
+            visited.update(frontier)
+        raise ValueError(f"Atom {atom} in {rt.name} is disconnected from its mainchain")
+
     # fd temporary fix for terminal variants
     # count the number of bonds to non-H for each atom
     # apl maybe undoing this change
@@ -159,6 +187,9 @@ def create_non_sidechain_fingerprint(  # noqa: C901
             mc_anc = mc_ind[par]
             atom = par
             bonds_from_mc += 1
+
+        if mc_anc == -1:
+            mc_anc, bonds_from_mc = closest_mainchain_atom(nsc_at)
 
         # now lets figure out the chirality of this atom
         # "chirality" here is interpretted in the most liberal of ways

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -1030,9 +1030,6 @@ class OptHSampler(ConformerSampler):
         if sampler_gbt_for_rotamer.shape[0] == 0:
             return
 
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-
         _opth_fill_dofs(
             pose_stack,
             task,
@@ -1046,6 +1043,3 @@ class OptHSampler(ConformerSampler):
             conf_dofs_kto,
             self.flip_NHQ,
         )
-
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -11,6 +11,7 @@ from tmol.score.common import (
     TermWholePoseScoringModule,
     TermBlockPairScoringModule,
     TermRotamerScoringModule,
+    ZeroTermPoseScoringModule,
 )
 
 if TYPE_CHECKING:
@@ -120,7 +121,18 @@ class EnergyTerm:
     def get_rotamer_score_term_function(self):
         raise NotImplementedError()
 
+    def pose_score_term_is_invariant_zero(self, pose_stack: PoseStack):
+        """Whether this term is identically zero for this fixed pose topology."""
+        return False
+
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
+        if self.pose_score_term_is_invariant_zero(pose_stack):
+            return ZeroTermPoseScoringModule(
+                self.class_name(),
+                len(self.score_types()),
+                pose_stack.n_poses,
+                pose_stack.device,
+            )
         f = self.get_pose_score_term_function()
 
         return TermWholePoseScoringModule(
@@ -131,6 +143,14 @@ class EnergyTerm:
         )
 
     def render_block_pair_scoring_module(self, pose_stack: PoseStack):
+        if self.pose_score_term_is_invariant_zero(pose_stack):
+            return ZeroTermPoseScoringModule(
+                self.class_name(),
+                len(self.score_types()),
+                pose_stack.n_poses,
+                pose_stack.device,
+                pose_stack.max_n_blocks,
+            )
         f = self.get_pose_score_term_function()
         return TermBlockPairScoringModule(
             self.class_name(),

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -48,17 +48,31 @@ class ScoreFunction:
 
         self._weights_tensor_out_of_date = True
         self._weights_tensor = None
+        self._weight_indices_tensor = None
         self._term_for_st = [None] * ScoreType.n_score_types.value
         self._param_db = param_db
         self._device = device
+        self._terms_version = 0
+        self._options_version = 0
+        self._prepared_packed_block_types = None
+        self._prepared_versions = None
+        self._setup_token = object()
 
         self.term_options = {}
 
     def set_weight(self, st: ScoreType, weight: float):
+        # Do not construct an energy term merely to assign it a zero weight.
+        # FastRelax updates its (usually disabled) constraint weight at every
+        # schedule step; constructing that term adds a device-to-host sync to
+        # every subsequent score evaluation even though it contributes zero.
+        if weight == 0 and not self.score_type_covered_by_contained_term(st):
+            self._weights[st.value] = weight
+            self._weights_tensor_out_of_date = True
+            return
         if not self.score_type_covered_by_contained_term(st):
             self.retrieve_term_for_score_type(st)
         if weight == 0 and self.term_for_st_has_no_other_non_zero_weights(st):
-            self.remove_term_for_score_type(st)  # TO DO!
+            self.remove_term_for_score_type(st)
         self._weights[st.value] = weight
         self._weights_tensor_out_of_date = True
 
@@ -66,10 +80,10 @@ class ScoreFunction:
         return self._weights[st.value]
 
     def score_type_covered_by_contained_term(self, st: ScoreType):
-        for term in self._all_terms:
-            if st in term.score_types():
-                return True
-        return False
+        # `_all_terms` is a lazily refreshed sorted cache; consulting it while
+        # weights are being populated can miss a term already present in the
+        # unordered source lists and construct duplicate term objects.
+        return self._term_for_st[st.value] is not None
 
     def retrieve_term_for_score_type(self, st: ScoreType):
         term = ScoreTermFactory.create_term_for_score_type(
@@ -82,6 +96,8 @@ class ScoreFunction:
             self._term_for_st[tst.value] = term
         self._all_terms_unordered.append(term)
         self._all_terms_out_of_date = True
+        self._weight_indices_tensor = None
+        self._terms_version += 1
         if term.n_bodies() == 1:
             self._one_body_terms_unordered.append(term)
             self._one_body_terms_out_of_date = True
@@ -98,8 +114,31 @@ class ScoreFunction:
             if st2 == st:
                 continue
             if self._weights[st2.value] != 0:
-                return True
-        return False
+                return False
+        return True
+
+    def remove_term_for_score_type(self, st: ScoreType):
+        """Remove the term containing ``st`` once all its weights are zero."""
+        term = self._term_for_st[st.value]
+        if term is None:
+            return
+
+        self._all_terms_unordered.remove(term)
+        self._all_terms_out_of_date = True
+        self._weight_indices_tensor = None
+        if term.n_bodies() == 1:
+            self._one_body_terms_unordered.remove(term)
+            self._one_body_terms_out_of_date = True
+        elif term.n_bodies() == 2:
+            self._two_body_terms_unordered.remove(term)
+            self._two_body_terms_out_of_date = True
+        else:
+            self._multi_body_terms_unordered.remove(term)
+            self._multi_body_terms_out_of_date = True
+
+        for covered_st in term.score_types():
+            self._term_for_st[covered_st.value] = None
+        self._terms_version += 1
 
     def all_terms(self):
         """Grant read access to the list of terms.
@@ -213,15 +252,31 @@ class ScoreFunction:
     def pre_work_initialization(self, pose_stack: PoseStack):
         # set_options must be first, since some of the logic that follows it
         # may depend on the options
-        for energy_term in self.all_terms():
+        terms = self.all_terms()
+        for energy_term in terms:
             energy_term.set_options(self.term_options)
 
-        for block_type in pose_stack.packed_block_types.active_block_types:
-            for energy_term in self.all_terms():
-                energy_term.setup_block_type(block_type)
-        for energy_term in self.all_terms():
-            energy_term.setup_packed_block_types(pose_stack.packed_block_types)
-        for energy_term in self.all_terms():
+        packed_block_types = pose_stack.packed_block_types
+        versions = (self._terms_version, self._options_version)
+        if not (
+            packed_block_types is self._prepared_packed_block_types
+            and versions == self._prepared_versions
+            and getattr(packed_block_types, "_score_setup_token", None)
+            is self._setup_token
+        ):
+            for block_type in packed_block_types.active_block_types:
+                for energy_term in terms:
+                    energy_term.setup_block_type(block_type)
+            for energy_term in terms:
+                energy_term.setup_packed_block_types(packed_block_types)
+            self._prepared_packed_block_types = packed_block_types
+            self._prepared_versions = versions
+            # Packed-block annotations can be score-function-specific (for
+            # example, beta2016 and beta_soft reference energies). Record a
+            # non-owning identity token so another score function using the
+            # shared object invalidates this fast path.
+            packed_block_types._score_setup_token = self._setup_token
+        for energy_term in terms:
             energy_term.setup_poses(pose_stack)
 
     def set_option(self, key: str, value):
@@ -231,6 +286,7 @@ class ScoreFunction:
         as a dictionary during pre_work_initialization.
         """
         self.term_options[key] = value
+        self._options_version += 1
 
     def set_options(self, options: Dict):
         """Set the score function options by a dict.
@@ -239,18 +295,25 @@ class ScoreFunction:
         are gone.
         """
         self.term_options = options
+        self._options_version += 1
 
     def weights_tensor(self):
         if self._weights_tensor_out_of_date:
-            self._weights_tensor = torch.tensor(
-                [
-                    self._weights[st.value]
-                    for term in self.all_terms()
-                    for st in term.score_types()
-                ],
-                dtype=torch.float32,
-                device=self._device,
-            )
+            # Keep weight collection on-device. Constructing a tensor from a
+            # Python list of CUDA scalar tensors calls ``item()`` on every
+            # entry, serializing the host with the scoring stream each time a
+            # FastRelax stage changes a weight and renders a new scorer.
+            if self._weight_indices_tensor is None:
+                self._weight_indices_tensor = torch.tensor(
+                    [
+                        st.value
+                        for term in self.all_terms()
+                        for st in term.score_types()
+                    ],
+                    dtype=torch.int64,
+                    device=self._device,
+                )
+            self._weights_tensor = self._weights[self._weight_indices_tensor]
             self._weights_tensor_out_of_date = False
         return self._weights_tensor
 
@@ -344,7 +407,11 @@ class WholePoseScoringModule:
         if sum_terms and apply_weights:
             needs_grad = torch.is_grad_enabled() and coords.requires_grad
             if needs_grad and hasattr(self, "_cuda_graphed_autograd"):
-                return self._cuda_graphed_autograd(coords)
+                # Graphed callables reuse their output storage. Optimizers such
+                # as LBFGS retain prior loss tensors across closure calls, so
+                # return owned storage rather than allowing a later replay to
+                # mutate an earlier loss.
+                return self._cuda_graphed_autograd(coords).clone()
             if not needs_grad and hasattr(self, "_cuda_graphed_forward"):
                 return self._cuda_graphed_forward(coords)
         if not torch.is_grad_enabled() and coords.requires_grad:

--- a/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
+++ b/tmol/score/backbone_torsion/potentials/compiled.ops.cpp
@@ -7,6 +7,7 @@
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "params.hh"
 #include "backbone_torsion_pose_score.hh"
@@ -165,19 +166,11 @@ class BackboneTorsionPoseScoreOp
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
+      auto saved_grad = saved[0];
 
       tensor_list result;
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-
-      result.emplace_back(saved_grad * atom_ingrads);
+      result.emplace_back(
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]));
 
       int i = 0;
 

--- a/tmol/score/cartbonded/potentials/compiled.ops.cpp
+++ b/tmol/score/cartbonded/potentials/compiled.ops.cpp
@@ -7,6 +7,7 @@
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include <pybind11/pybind11.h>
 
@@ -160,21 +161,12 @@ class CartBondedPoseScoreOp
     // use the number of stashed variables to determine if we are in
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
-      // TO DO: make this a function so it's not duplicated everywhere
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
+      auto saved_grad = saved[0];
 
       tensor_list result;
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-
-      result.emplace_back(saved_grad * atom_ingrads);
+      result.emplace_back(
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]));
 
       int i = 0;
       dV_d_pose_coords = result[i++];

--- a/tmol/score/common/__init__.py
+++ b/tmol/score/common/__init__.py
@@ -21,6 +21,7 @@ from ._scoring_module import (  # noqa: F401
     TermRotamerScoringModule,
     TermScoringModule,
     TermWholePoseScoringModule,
+    ZeroTermPoseScoringModule,
 )  # noqa: F401
 from ._stack_condense import (  # noqa: F401
     arg_tile_subset_indices,

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -4,6 +4,52 @@ import torch
 from tmol.score.common import convert_float64
 
 
+class _ZeroCoordinates(torch.autograd.Function):
+    """Attach a no-op coordinate gradient without launching a device kernel."""
+
+    @staticmethod
+    def forward(ctx, coords, zero, shape):
+        return zero.expand(shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None, None, None
+
+
+class ZeroTermPoseScoringModule(torch.nn.Module):
+    """A zero-cost placeholder for a score term absent from a pose topology.
+
+    The scalar buffers expand to the requested output shape without allocating
+    or launching a device kernel. Keeping the module in the score-function
+    output preserves score-type ordering for callers requesting per-term
+    energies.
+    """
+
+    def __init__(self, classname, n_score_types, n_poses, device, max_n_blocks=None):
+        super().__init__()
+        self.classname = classname
+        shape = [n_score_types, n_poses]
+        if max_n_blocks is not None:
+            shape.extend([max_n_blocks, max_n_blocks])
+        self.shape = tuple(shape)
+        self.register_buffer(
+            "_zero_f32", torch.zeros((), dtype=torch.float32, device=device)
+        )
+        self.register_buffer(
+            "_zero_f64", torch.zeros((), dtype=torch.float64, device=device)
+        )
+
+    def forward(self, coords):
+        zero = self._zero_f64 if coords.dtype == torch.float64 else self._zero_f32
+        # Some callers benchmark or inspect a single energy term by calling
+        # backward() even when that term has no coordinate dependence. Attach
+        # a custom no-op edge so that convention remains valid without a
+        # reduction kernel or a persistent leaf gradient.
+        if torch.is_grad_enabled() and coords.requires_grad:
+            return _ZeroCoordinates.apply(coords, zero, self.shape)
+        return zero.expand(self.shape)
+
+
 class TermScoringModule(torch.nn.Module):
     def __init__(
         self,

--- a/tmol/score/common/whole_pose_scoring.hh
+++ b/tmol/score/common/whole_pose_scoring.hh
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace tmol {
+namespace score {
+namespace common {
+
+/// Apply per-score-type, per-pose upstream gradients to saved coordinate
+/// derivatives from a whole-pose score kernel.
+///
+/// PoseStack coordinates are flattened from a dense [pose, atom, xyz] tensor,
+/// so atoms belonging to each pose are contiguous. Reshaping to recover that
+/// layout avoids the index_select kernel that the older implementation used
+/// to expand each pose gradient to its atoms.
+inline torch::Tensor accumulate_whole_pose_gradients(
+    torch::Tensor const& saved_grad,
+    torch::Tensor const& score_grad) {
+  TORCH_INTERNAL_ASSERT(saved_grad.dim() == 3);
+  TORCH_INTERNAL_ASSERT(score_grad.dim() == 2);
+  TORCH_INTERNAL_ASSERT(saved_grad.size(0) == score_grad.size(0));
+
+  int64_t const n_score_types = saved_grad.size(0);
+  int64_t const n_poses = score_grad.size(1);
+  int64_t const n_atoms = saved_grad.size(1);
+  TORCH_INTERNAL_ASSERT(n_poses > 0 && n_atoms % n_poses == 0);
+
+  auto derivatives_by_pose = saved_grad.reshape(
+      {n_score_types, n_poses, n_atoms / n_poses, saved_grad.size(2)});
+  auto weighted = derivatives_by_pose * score_grad.reshape(
+      {n_score_types, n_poses, 1, 1});
+
+  // Avoid launching a reduction for the many single-channel terms.
+  auto accumulated = n_score_types == 1 ? weighted.select(0, 0)
+                                        : weighted.sum(0);
+  return accumulated.reshape({n_atoms, saved_grad.size(2)});
+}
+
+}  // namespace common
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/common/whole_pose_scoring.hh
+++ b/tmol/score/common/whole_pose_scoring.hh
@@ -14,8 +14,7 @@ namespace common {
 /// layout avoids the index_select kernel that the older implementation used
 /// to expand each pose gradient to its atoms.
 inline torch::Tensor accumulate_whole_pose_gradients(
-    torch::Tensor const& saved_grad,
-    torch::Tensor const& score_grad) {
+    torch::Tensor const& saved_grad, torch::Tensor const& score_grad) {
   TORCH_INTERNAL_ASSERT(saved_grad.dim() == 3);
   TORCH_INTERNAL_ASSERT(score_grad.dim() == 2);
   TORCH_INTERNAL_ASSERT(saved_grad.size(0) == score_grad.size(0));
@@ -27,12 +26,12 @@ inline torch::Tensor accumulate_whole_pose_gradients(
 
   auto derivatives_by_pose = saved_grad.reshape(
       {n_score_types, n_poses, n_atoms / n_poses, saved_grad.size(2)});
-  auto weighted = derivatives_by_pose * score_grad.reshape(
-      {n_score_types, n_poses, 1, 1});
+  auto weighted =
+      derivatives_by_pose * score_grad.reshape({n_score_types, n_poses, 1, 1});
 
   // Avoid launching a reduction for the many single-channel terms.
-  auto accumulated = n_score_types == 1 ? weighted.select(0, 0)
-                                        : weighted.sum(0);
+  auto accumulated =
+      n_score_types == 1 ? weighted.select(0, 0) : weighted.sum(0);
   return accumulated.reshape({n_atoms, saved_grad.size(2)});
 }
 

--- a/tmol/score/constraint/_constraint_energy_term.py
+++ b/tmol/score/constraint/_constraint_energy_term.py
@@ -163,36 +163,34 @@ class ConstraintEnergyTerm(EnergyTerm):
 
         # Early exit if we have no constraints
         if constraint_set is None:
+            n_poses = first_rot_block_type.shape[0]
+            if not output_block_pair_energies:
+                # Whole-pose scoring never represents multiple rotamers per
+                # block. Handle it before inspecting the CUDA tensor so an
+                # empty constraint set does not synchronize every evaluation.
+                return (
+                    torch.zeros((1, n_poses), dtype=torch.float32, device=device),
+                    torch.zeros((3, 0), dtype=torch.int32, device=device),
+                )
+
+            # Block-pair and rotamer scoring share this entry point. Only this
+            # infrequent path needs to distinguish their output conventions.
             max_n_rots_per_block = n_rots_for_block.max().item()
             if max_n_rots_per_block > 1:
                 return (
                     torch.zeros((1, 0), dtype=coords.dtype, device=device),
                     torch.zeros((3, 0), dtype=torch.int32, device=device),
                 )
-            else:
-                n_poses = first_rot_block_type.shape[0]
-                max_n_blocks = first_rot_block_type.shape[1]
-                if output_block_pair_energies:
-                    return (
-                        torch.zeros(
-                            (1, n_poses, max_n_blocks, max_n_blocks),
-                            dtype=torch.float32,
-                            device=device,
-                        ),
-                        torch.zeros((3, 0), dtype=torch.int32, device=device),
-                    )
-                else:
-                    return (
-                        torch.zeros(
-                            (
-                                1,
-                                n_poses,
-                            ),
-                            dtype=torch.float32,
-                            device=device,
-                        ),
-                        torch.zeros((3, 0), dtype=torch.int32, device=device),
-                    )
+
+            max_n_blocks = first_rot_block_type.shape[1]
+            return (
+                torch.zeros(
+                    (1, n_poses, max_n_blocks, max_n_blocks),
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                torch.zeros((3, 0), dtype=torch.int32, device=device),
+            )
 
         unique_blocks = constraint_set.constraint_num_unique_blocks
         constraint_atoms = constraint_set.constraint_atoms
@@ -422,7 +420,12 @@ class ConstraintEnergyTerm(EnergyTerm):
                 (rotamerized_inds, constraint_set.constraint_unique_blocks)
             )
 
-        has_rotamers = (n_rots_for_block.max() > 1).item()
+        # Whole-pose scoring always supplies exactly one rotamer for each
+        # block. Avoid reducing a CUDA tensor to the host on every scoring
+        # call; only block-pair/rotamer scoring needs to inspect this value.
+        has_rotamers = output_block_pair_energies and bool(
+            (n_rots_for_block.max() > 1).item()
+        )
         if has_rotamers:
             add_twobody_vectorized()
             add_onebody_vectorized()

--- a/tmol/score/disulfide/_disulfide_energy_term.py
+++ b/tmol/score/disulfide/_disulfide_energy_term.py
@@ -82,6 +82,17 @@ class DisulfideEnergyTerm(EnergyTerm):
 
         return disulfide_rotamer_scores
 
+    def pose_score_term_is_invariant_zero(self, pose_stack):
+        """Disulfide scoring is zero unless the pose has a connected dslf edge."""
+        pbt = pose_stack.packed_block_types
+        block_types = pose_stack.block_type_ind64
+        real_blocks = block_types >= 0
+        dslf_connections = pbt.disulfide_conns[block_types.clamp_min(0)]
+        connected = pose_stack.inter_residue_connections[..., 0] >= 0
+        return not bool(
+            (dslf_connections & connected & real_blocks.unsqueeze(-1)).any()
+        )
+
     def get_score_term_attributes(self, pose_stack):
         def _t(ts):
             return tuple(map(lambda t: t.to(torch.float), ts))

--- a/tmol/score/disulfide/potentials/compiled.ops.cpp
+++ b/tmol/score/disulfide/potentials/compiled.ops.cpp
@@ -7,6 +7,7 @@
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "params.hh"
 #include "disulfide_pose_score.hh"
@@ -140,19 +141,11 @@ class DisulfidePoseScoreOp
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
+      auto saved_grad = saved[0];
 
       tensor_list result;
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-
-      result.emplace_back(saved_grad * atom_ingrads);
+      result.emplace_back(
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]));
 
       int i = 0;
       dV_d_pose_coords = result[i++];

--- a/tmol/score/dunbrack/potentials/compiled.ops.cpp
+++ b/tmol/score/dunbrack/potentials/compiled.ops.cpp
@@ -6,6 +6,7 @@
 #include <tmol/utility/function_dispatch/aten.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "dunbrack_pose_score.hh"
 
@@ -224,19 +225,11 @@ class DunbrackPoseScoreOp
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
       // whole-pose-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
+      auto saved_grad = saved[0];
 
       tensor_list result;
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-
-      result.emplace_back(saved_grad * atom_ingrads);
+      result.emplace_back(
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]));
 
       int i = 0;
       dV_d_pose_coords = result[i++];

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -25,6 +25,11 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         super(ElecEnergyTerm, self).__init__(param_db=param_db, device=device)
         self.param_resolver = param_resolver
         self.global_params = self.param_resolver.global_params
+        # The cutoff/smoothing coefficients depend only on the parameter
+        # database. Computing them from CUDA scalar tensors synchronizes the
+        # stream, so retain the first exact result for subsequent renders.
+        self._scoring_global_params = None
+        self._max_dis = None
 
     @classmethod
     def class_name(cls):
@@ -159,62 +164,61 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         return elec_rotamer_scores
 
     def get_score_term_attributes(self, pose_stack):
-        def _t(ts):
-            return tuple(map(lambda t: t.to(torch.float), ts))
+        if self._scoring_global_params is None:
+            D = self.global_params.elec_sigmoidal_die_D
+            D0 = self.global_params.elec_sigmoidal_die_D0
+            S = self.global_params.elec_sigmoidal_die_S
+            min_dis = self.global_params.elec_min_dis
+            max_dis = self.global_params.elec_max_dis
 
-        D = self.global_params.elec_sigmoidal_die_D
-        D0 = self.global_params.elec_sigmoidal_die_D0
-        S = self.global_params.elec_sigmoidal_die_S
-        min_dis = self.global_params.elec_min_dis
-        max_dis = self.global_params.elec_max_dis
+            def eps(dist):
+                return D - 0.5 * (D - D0) * (
+                    2 + 2 * dist * S + dist * dist * S * S
+                ) * math.exp(-dist * S)
 
-        def eps(dist):
-            return D - 0.5 * (D - D0) * (
-                2 + 2 * dist * S + dist * dist * S * S
-            ) * math.exp(-dist * S)
+            def deps(dist):
+                return 0.5 * (D - D0) * dist * dist * S * S * S * math.exp(-dist * S)
 
-        def deps(dist):
-            return 0.5 * (D - D0) * dist * dist * S * S * S * math.exp(-dist * S)
+            eps_at_cutoff = eps(max_dis)
+            cutoff_offset = 322.0637 / (max_dis * eps_at_cutoff)
+            min_score = 322.0637 / (min_dis * eps(min_dis)) - cutoff_offset
 
-        eps_at_cutoff = eps(max_dis)
-        cutoff_offset = 322.0637 / (max_dis * eps_at_cutoff)
-        min_score = 322.0637 / (min_dis * eps(min_dis)) - cutoff_offset
+            low_end = min_dis + 0.25
+            low_eps = eps(low_end)
+            low_score = 322.0637 / (low_end * low_eps) - cutoff_offset
+            low_deriv = (
+                -322.0637
+                * (low_eps + low_end * deps(low_end))
+                / (low_end * low_end * low_eps * low_eps)
+            )
 
-        low_end = min_dis + 0.25
-        low_eps = eps(low_end)
-        low_score = 322.0637 / (low_end * low_eps) - cutoff_offset
-        low_deriv = (
-            -322.0637
-            * (low_eps + low_end * deps(low_end))
-            / (low_end * low_end * low_eps * low_eps)
-        )
+            high_start = max_dis - 1.0
+            high_eps = eps(high_start)
+            high_score = 322.0637 / (high_start * high_eps) - cutoff_offset
+            high_deriv = (
+                -322.0637
+                * (high_eps + high_start * deps(high_start))
+                / (high_start * high_start * high_eps * high_eps)
+            )
 
-        high_start = max_dis - 1.0
-        high_eps = eps(high_start)
-        high_score = 322.0637 / (high_start * high_eps) - cutoff_offset
-        high_deriv = (
-            -322.0637
-            * (high_eps + high_start * deps(high_start))
-            / (high_start * high_start * high_eps * high_eps)
-        )
-
-        global_params = torch.tensor(
-            [
-                D,
-                D0,
-                S,
-                min_dis,
-                max_dis,
-                cutoff_offset,
-                min_score,
-                low_score,
-                low_deriv,
-                high_score,
-                high_deriv,
-            ],
-            dtype=torch.float32,
-            device=pose_stack.device,
-        )[None, :]
+            self._scoring_global_params = torch.tensor(
+                [
+                    D,
+                    D0,
+                    S,
+                    min_dis,
+                    max_dis,
+                    cutoff_offset,
+                    min_score,
+                    low_score,
+                    low_deriv,
+                    high_score,
+                    high_deriv,
+                ],
+                dtype=torch.float32,
+                device=pose_stack.device,
+            )[None, :]
+            self._max_dis = float(max_dis)
 
         return [
             pose_stack.min_block_bondsep,
@@ -226,7 +230,7 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             pose_stack.packed_block_types.elec_inter_repr_path_distance,
             pose_stack.packed_block_types.elec_intra_repr_path_distance,
             pose_stack.packed_block_types.elec_is_ligand_fragment,
-            global_params,
+            self._scoring_global_params,
             # elec_max_dis as host scalar for detect-neighbors call
-            float(self.global_params.elec_max_dis),
+            self._max_dis,
         ]

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -6,6 +6,7 @@
 #include <tmol/utility/function_dispatch/aten.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "elec_pose_score.hh"
 
@@ -156,16 +157,9 @@ class ElecPoseScoreOp
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-      dV_d_pose_coords = saved_grad * atom_ingrads;
+      auto saved_grad = saved[0];
+      dV_d_pose_coords =
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]);
 
     } else {
       // block-pair mode

--- a/tmol/score/genbonded/potentials/compiled.ops.cpp
+++ b/tmol/score/genbonded/potentials/compiled.ops.cpp
@@ -7,6 +7,7 @@
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include <pybind11/pybind11.h>
 
@@ -161,12 +162,8 @@ class GenBondedPoseScoreOp
     if (saved.size() == 2) {
       // Single-score mode: reuse the pre-computed gradient
       auto saved_grad = saved[0];
-      auto pose_ind_for_atom = saved[1];
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-      dV_d_pose_coords = saved_grad * atom_ingrads;
+      dV_d_pose_coords =
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]);
     } else {
       // Block-pair mode: re-run backward dispatch
       using Int = int32_t;

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -7,6 +7,7 @@
 
 #include <tmol/score/common/device_operations.hh>
 #include <tmol/score/common/tuple.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include <tmol/score/hbond/potentials/gen_hbond_bases.hh>
 #include <tmol/score/hbond/potentials/hbond_pose_score.hh>
@@ -225,16 +226,9 @@ class HBondPoseScoresOp
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
-
-      auto atom_ingrads = grad_outputs[0].index_select(1, pose_ind_for_atom);
-
-      while (atom_ingrads.dim() < saved_grad.dim()) {
-        atom_ingrads = atom_ingrads.unsqueeze(-1);
-      }
-      dV_d_pose_coords = saved_grad * atom_ingrads;
+      auto saved_grad = saved[0];
+      dV_d_pose_coords =
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]);
     } else {
       // block-pair mode
       int i = 0;

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -6,6 +6,7 @@
 #include <tmol/utility/function_dispatch/aten.hh>
 
 #include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "ljlk_pose_score.hh"
 // #include "rotamer_pair_energy_lj.hh"
@@ -162,15 +163,10 @@ class LJLKPoseScoreOp
     // use the number of stashed variables to determine if we are in
     //   block-pair scoring mode or single-score mode
     if (saved.size() == 2) {
-      // TO DO: make this a function so it's not duplicated everywhere
       // single-score mode
-      auto saved_grads = ctx->get_saved_variables();
-      auto saved_grad = saved_grads[0];
-      auto pose_ind_for_atom = saved_grads[1];
-      auto atom_ingrads =
-          grad_outputs[0].index_select(1, pose_ind_for_atom).unsqueeze(-1);
-
-      dV_d_pose_coords = saved_grad * atom_ingrads;
+      auto saved_grad = saved[0];
+      dV_d_pose_coords =
+          common::accumulate_whole_pose_gradients(saved_grad, grad_outputs[0]);
     } else {
       // block-pair mode
       int i = 0;

--- a/tmol/score/na_torsion/_na_torsion_energy_term.py
+++ b/tmol/score/na_torsion/_na_torsion_energy_term.py
@@ -102,13 +102,19 @@ class NaTorsionEnergyTerm(EnergyTerm):
     def get_rotamer_score_term_function(self):
         return eval_na_torsion_for_rotamers
 
-    def get_score_term_attributes(self, pose_stack):
+    def _pose_has_na(self, pose_stack):
         pbt = pose_stack.packed_block_types
-        p = self.params
         bt = pose_stack.block_type_ind64
-        has_na = bool(
+        return bool(
             (pbt.na_torsion_base.to(torch.int64)[bt.clamp_min(0)] >= 0)[bt >= 0].any()
         )
+
+    def pose_score_term_is_invariant_zero(self, pose_stack):
+        return not self._pose_has_na(pose_stack)
+
+    def get_score_term_attributes(self, pose_stack):
+        p = self.params
+        has_na = self._pose_has_na(pose_stack)
         return [
             has_na,
             *self.subterm_attributes(pose_stack),

--- a/tmol/tests/database/test_param_db.py
+++ b/tmol/tests/database/test_param_db.py
@@ -1,10 +1,25 @@
+from pathlib import Path
+
+import tmol.database
+
 from tmol.database import ParameterDatabase
+from tmol.database.scoring import ScoringDatabase
 
 
 def test_get_default():
     param_db1 = ParameterDatabase.get_default()
     param_db2 = ParameterDatabase.get_default()
     assert param_db1 is param_db2
+
+
+def test_scoring_database_ignores_forced_unsafe_torch_load(monkeypatch):
+    """RF-style process settings must not disable legacy pickle aliases."""
+    monkeypatch.setenv("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
+    scoring_path = Path(tmol.database.__file__).parent / "default" / "scoring"
+    scoring = ScoringDatabase.from_file(str(scoring_path))
+    assert scoring.dun.rotameric_libraries
+    assert scoring.rama.rama_tables
+    assert scoring.omega_bbdep.bbdep_omega_lookup
 
 
 def test_create_stable_subset(default_database):

--- a/tmol/tests/ligand/test_cif_to_dg.py
+++ b/tmol/tests/ligand/test_cif_to_dg.py
@@ -144,6 +144,21 @@ def test_cif_smiles_matches_reference(stem: str, variant: str) -> None:
     assert _canonical(smiles) == _canonical(expected)
 
 
+@pytest.mark.parametrize("stem", sorted(_LIGANDS))
+def test_mapped_smiles_preserves_heavy_atom_source_order(stem: str) -> None:
+    """Explicit input hydrogens do not suppress heavy-atom map numbers."""
+    from tmol.ligand import ligand_smiles_from_atom_array
+    from tmol.ligand._openbabel_compat import source_atom_order_from_mapped_smiles
+
+    code, _ = _LIGANDS[stem]
+    arr = _load_ligand_array(stem, "bonds_present")
+    smiles = ligand_smiles_from_atom_array(arr, res_name=code, with_atom_map=True)
+    source_order = source_atom_order_from_mapped_smiles(smiles)
+    expected = tuple(i for i, element in enumerate(arr.element) if element != "H")
+    assert source_order is not None
+    assert sorted(source_order) == sorted(expected)
+
+
 @pytest.mark.parametrize("stem", _PREPARABLE)
 @pytest.mark.parametrize("variant", _VARIANTS)
 def test_prepare_ligand_from_cif_registers_residue(stem: str, variant: str) -> None:

--- a/tmol/tests/pack/rotamer/test_na_chi_sampler.py
+++ b/tmol/tests/pack/rotamer/test_na_chi_sampler.py
@@ -146,3 +146,56 @@ def test_na_build_rotamers(fixture, request, default_database, torch_device):
     assert rotamer_set is not None
     assert rotamer_set.coords.shape[0] > 0
     assert not bool(torch.any(torch.isnan(rotamer_set.coords)))
+
+
+def test_na_mutation_rotamers_preserve_sugar_coordinates(
+    dna_pdb, default_database, torch_device
+):
+    """A base substitution is anchored to the input nucleotide sugar."""
+    poses = _pose_stack(dna_pdb, torch_device)
+    pbt = poses.packed_block_types
+    name3 = [bt.name3 for bt in pbt.active_block_types]
+    dg_ind = name3.index("DG")
+    pose_ind, block_ind = torch.nonzero(poses.block_type_ind == dg_ind, as_tuple=True)
+    pose_ind = int(pose_ind[0])
+    block_ind = int(block_ind[0])
+
+    mutation_mask = torch.zeros_like(poses.block_type_ind, dtype=torch.bool)
+    mutation_mask[pose_ind, block_ind] = True
+    task = PackerTask(poses, PackerPalette())
+    task.restrict_to_repacking(~mutation_mask)
+    task.restrict_absent_name3s({"DA"}, mutation_mask)
+    sampler = NaChiRotamerSampler.from_database(default_database, torch_device)
+    task.add_conformer_sampler(sampler)
+    task = SetPackerTask.from_packer_task(task)
+
+    _, rotamers = build_rotamers(poses, task, default_database.chemical)
+    da_inds = torch.tensor(
+        [i for i, bt in enumerate(pbt.active_block_types) if bt.name3 == "DA"],
+        dtype=torch.int64,
+        device=torch_device,
+    )
+    is_da = torch.isin(rotamers.block_type_ind_for_rot, da_inds)
+    selected = torch.nonzero(
+        (rotamers.pose_for_rot == pose_ind)
+        & (rotamers.block_ind_for_rot == block_ind)
+        & is_da
+    ).flatten()
+    assert selected.numel() > 0
+
+    original_bt = pbt.active_block_types[dg_ind]
+    original_offset = int(poses.block_coord_offset[pose_ind, block_ind])
+    sugar_atoms = ("P", "O5'", "C5'", "C4'", "O4'", "C3'", "O3'", "C2'", "C1'")
+    original = poses.coords[
+        pose_ind,
+        [original_offset + original_bt.atom_to_idx[name] for name in sugar_atoms],
+    ]
+    for rot_ind in selected.tolist():
+        rotamer_bt = pbt.active_block_types[
+            int(rotamers.block_type_ind_for_rot[rot_ind])
+        ]
+        rotamer_offset = int(rotamers.coord_offset_for_rot[rot_ind])
+        mutated = rotamers.coords[
+            [rotamer_offset + rotamer_bt.atom_to_idx[name] for name in sugar_atoms]
+        ]
+        torch.testing.assert_close(mutated, original, atol=1e-3, rtol=0)

--- a/tmol/tests/pack/test_packer_task.py
+++ b/tmol/tests/pack/test_packer_task.py
@@ -109,6 +109,46 @@ def test_residue_level_task_his_restrict_to_repacking_backward_compat(
     assert sum(restrict_to_repacking_masks[0, 0].to(torch.int64)) == 2
 
 
+def test_packer_task_masked_restrictions(ubq_pdb, torch_device):
+    p1 = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=5)
+    p2 = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=5)
+    poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
+    task = PackerTask(poses, PackerPalette())
+
+    initially_allowed = task.per_block_is_block_type_allowed.clone()
+    repack_mask = torch.zeros(
+        task.per_block_n_considered_block_types.shape,
+        dtype=torch.bool,
+        device=torch_device,
+    )
+    repack_mask[0, 0] = True
+    task.restrict_to_repacking(repack_mask)
+
+    assert torch.equal(
+        task.per_block_is_block_type_allowed[0, 0],
+        initially_allowed[0, 0] & task.restrict_to_repacking_masks[0, 0],
+    )
+    assert torch.equal(task.per_block_is_block_type_allowed[1], initially_allowed[1])
+
+    before_name_restriction = task.per_block_is_block_type_allowed.clone()
+    mutation_mask = torch.zeros_like(repack_mask)
+    mutation_mask[1, 1] = True
+    task.restrict_absent_name3s({"ALA"}, mutation_mask)
+
+    assert torch.equal(
+        task.per_block_is_block_type_allowed[0], before_name_restriction[0]
+    )
+    allowed_types = task.per_block_considered_block_types[1, 1][
+        task.per_block_is_block_type_allowed[1, 1]
+    ]
+    assert allowed_types.numel() > 0
+    assert all(
+        task.pbt.active_block_types[bt_ind].name3 == "ALA"
+        for bt_ind in allowed_types.tolist()
+    )
+    assert torch.all(task.per_block_is_block_type_allowed <= before_name_restriction)
+
+
 def test_packer_task_ctor(ubq_pdb, default_restype_set, torch_device):
     palette = PackerPalette()
     p1 = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=5)

--- a/tmol/tests/score/disulfide/test_disulfide_energy_term.py
+++ b/tmol/tests/score/disulfide/test_disulfide_energy_term.py
@@ -1,6 +1,8 @@
 import torch
 
+from tmol.io import pose_stack_from_pdb
 from tmol.score.disulfide import DisulfideEnergyTerm
+from tmol.score.common import ZeroTermPoseScoringModule
 
 from tmol.tests.score.common import EnergyTermTestBase
 
@@ -36,6 +38,35 @@ def test_annotate_disulfide_conns(
     assert (
         pbt.disulfide_conns is disulfide_conns
     )  # Test to make sure the parameters remain the same instance
+
+
+def test_pose_without_disulfides_uses_zero_term(
+    ubq_pdb, default_database, torch_device: torch.device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+
+    whole_pose = TestDisulfideEnergyTerm.get_whole_pose_scorer(
+        pose_stack, default_database, torch_device
+    )
+    block_pair = TestDisulfideEnergyTerm.get_block_pair_scorer(
+        pose_stack, default_database, torch_device
+    )
+
+    assert isinstance(whole_pose, ZeroTermPoseScoringModule)
+    assert isinstance(block_pair, ZeroTermPoseScoringModule)
+    torch.testing.assert_close(
+        whole_pose(pose_stack.coords),
+        torch.zeros((1, 1), device=torch_device),
+    )
+    torch.testing.assert_close(
+        block_pair(pose_stack.coords),
+        torch.zeros((1, 1, 10, 10), device=torch_device),
+    )
+
+    # Coordinate-independent terms still support the single-term benchmark
+    # convention of calling backward() on their scalar output.
+    coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    whole_pose(coords).sum().backward()
 
 
 class TestDisulfideEnergyTerm(EnergyTermTestBase):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -40,6 +40,120 @@ def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
     assert scores is not None
 
 
+def test_whole_pose_gradients_respect_per_pose_upstream_weights(
+    ubq_pdb, default_database, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    stack = PoseStackBuilder.from_poses([pose] * 3, torch_device)
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+    sfxn.set_weight(ScoreType.fa_ljrep, 0.55)
+    sfxn.set_weight(ScoreType.fa_lk, 0.8)
+
+    single_scorer = sfxn.render_whole_pose_scoring_module(pose)
+    single_coords = pose.coords.detach().clone().requires_grad_(True)
+    single_grad = torch.autograd.grad(
+        single_scorer(single_coords).sum(), single_coords
+    )[0]
+
+    stack_scorer = sfxn.render_whole_pose_scoring_module(stack)
+    stack_coords = stack.coords.detach().clone().requires_grad_(True)
+    upstream = torch.tensor([0.25, -1.5, 2.0], device=torch_device)
+    stack_grad = torch.autograd.grad(
+        (stack_scorer(stack_coords) * upstream).sum(), stack_coords
+    )[0]
+
+    torch.testing.assert_close(
+        stack_grad,
+        single_grad.expand_as(stack_grad) * upstream[:, None, None],
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+
+def test_zero_weight_does_not_construct_energy_term(default_database, torch_device):
+    sfxn = ScoreFunction(default_database, torch_device)
+
+    sfxn.set_weight(ScoreType.constraint, 0.0)
+
+    assert sfxn.all_terms() == []
+    assert sfxn.get_weight(ScoreType.constraint) == 0
+
+    sfxn.set_weight(ScoreType.constraint, 1.0)
+    assert len(sfxn.all_terms()) == 1
+
+    sfxn.set_weight(ScoreType.constraint, 0.0)
+    assert sfxn.all_terms() == []
+
+
+def test_zero_weight_removes_term_only_after_last_subterm(
+    default_database, torch_device
+):
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+    sfxn.set_weight(ScoreType.fa_ljrep, 1.0)
+
+    sfxn.set_weight(ScoreType.fa_ljrep, 0.0)
+    assert len(sfxn.all_terms()) == 1
+
+    sfxn.set_weight(ScoreType.fa_ljatr, 0.0)
+    assert sfxn.all_terms() == []
+
+
+def test_weight_tensor_refresh_preserves_score_type_order(
+    default_database, torch_device
+):
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+    sfxn.set_weight(ScoreType.fa_ljrep, 2.0)
+    sfxn.set_weight(ScoreType.fa_lk, 3.0)
+
+    torch.testing.assert_close(
+        sfxn.weights_tensor(),
+        torch.tensor([1.0, 2.0, 3.0], device=torch_device),
+    )
+
+    indices = sfxn._weight_indices_tensor
+    sfxn.set_weight(ScoreType.fa_ljrep, 4.0)
+    torch.testing.assert_close(
+        sfxn.weights_tensor(),
+        torch.tensor([1.0, 4.0, 3.0], device=torch_device),
+    )
+    assert sfxn._weight_indices_tensor is indices
+
+
+def test_packed_block_setup_is_reused_and_cross_score_function_safe(
+    ubq_pdb, default_database, torch_device, monkeypatch
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.ref, 1.0)
+    term = sfxn.all_terms()[0]
+    original = term.setup_block_type
+    calls = 0
+
+    def counted(block_type):
+        nonlocal calls
+        calls += 1
+        return original(block_type)
+
+    monkeypatch.setattr(term, "setup_block_type", counted)
+    sfxn.pre_work_initialization(pose)
+    first_calls = calls
+    assert first_calls == len(pose.packed_block_types.active_block_types)
+
+    sfxn.pre_work_initialization(pose)
+    assert calls == first_calls
+
+    # Packed block types are shared. Another score function may replace
+    # option-dependent annotations, so its setup must invalidate this cache.
+    other = ScoreFunction(default_database, torch_device)
+    other.set_weight(ScoreType.ref, 1.0)
+    other.pre_work_initialization(pose)
+    sfxn.pre_work_initialization(pose)
+    assert calls == 2 * first_calls
+
+
 def test_no_grad_scoring_detaches_coordinates():
     class RecordingTerm(torch.nn.Module):
         def forward(self, coords):
@@ -78,6 +192,12 @@ def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):
 
     torch.testing.assert_close(graph_score, expected_score, rtol=1e-5, atol=1e-3)
     torch.testing.assert_close(graph_grad, expected_grad, rtol=1e-4, atol=1e-3)
+
+    # A later replay must not mutate a score retained by an optimizer.
+    retained_graph_score = graph_score.detach().clone()
+    replay_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    graphed(replay_coords)
+    torch.testing.assert_close(graph_score, retained_graph_score)
     # Non-default reductions intentionally retain their normal eager semantics.
     torch.testing.assert_close(
         graphed(pose_stack.coords, sum_terms=False, apply_weights=False),


### PR DESCRIPTION
## Summary

Improve heterogeneous mutation workflows and reduce repeated scoring, minimization, and pose-construction overhead for RF4-style ligand AE and interface ddG workloads.

## Mutation and correctness changes

- let PackerTask.restrict_to_repacking() and restrict_absent_name3s() target a [pose, block] mask while preserving disable-only semantics
- preserve nucleotide sugar coordinates when a mutation rotamer parent path is cut by a ring
- preserve heavy-atom source mapping for structures containing explicit hydrogens
- remove unconditional CUDA synchronizations from rotamer sampling
- retain verbose-only minimizer timing synchronization

## Scoring and relaxation performance

- avoid constructing zero-weight energy terms and remove a term after its last active subterm is disabled
- cache score-type weight gathers and packed-block setup safely across repeated scorer renders
- cache electrostatic cutoff coefficients instead of synchronizing CUDA scalars on every render
- skip disulfide and nucleic-acid torsion kernels when the pose topology proves those terms are zero
- replace whole-pose backward index-select expansion in eight score terms with contiguous per-pose gradient accumulation
- avoid redundant LBFGS host synchronizations while retaining per-segment convergence and restart behavior
- skip unnecessary one-residue pose compaction, disulfide search, and histidine processing
- force safe weights-only loading for bundled scoring databases even when an application changes the process default

## H200 measurements

Representative ACE protein-ligand workload, steady state:

- whole-pose energy plus coordinate gradient: 1.822 ms to 1.738 ms, about 4.6% faster
- CUDA-graphed energy plus gradient: 1.720 ms to 1.668 ms, about 3.0% faster
- repeated scorer rendering: 3.03 ms to 1.29 ms, about 58% faster
- individual whole-pose backward paths improve by about 4-13% depending on term
- representative FastRelax workflow improved from about 3.70 s to 3.27 s; trajectory-level timing remains convergence-sensitive

Rejected experiments that regressed H200 performance or weakened buffer contracts are not included.

## Validation

- 142 focused CPU/CUDA tests passed locally, with one intentional skip and one expected xfail
- pre-commit, Black, Flake8, clang-format, and diff checks pass
- CUDA operators compile and run with TMOL_USE_JIT=1 on H200 / sm_90
- eager and CUDA-graph scores and coordinate gradients remain within existing numerical tolerances
- prior PR validation covered 74 focused packing, DNA mutation, ligand preparation, minimization, IncludeCurrent, and OptH tests
- downstream RFD mutation scans produced finite protein-DNA, DNA-side, antibody, and protein-small-molecule results; representative three-mutant scans were 2.22-3.22x faster than sequential evaluation
