### PR TITLE
Generate modified polymer components programmatically

### DIFF
--- a/tmol/database/__init__.py
+++ b/tmol/database/__init__.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Mapping
 from .chemical import AtomType, ChemicalDatabase, RawResidueType  # noqa: F401
 from ._patched_chemdb import PatchedChemicalDatabase  # noqa: F401
 from .scoring import ScoringDatabase  # noqa: F401
-from .scoring._elec import PartialCharges  # noqa: F401
+from .scoring._elec import CountPairReps, PartialCharges  # noqa: F401
 from .scoring._cartbonded import CartRes  # noqa: F401
 
 
@@ -102,7 +102,8 @@ def inject_residue_params(
 
     Args:
         param_db: Base database to extend.
-        residue_types: New RawResidueType entries to add.
+        residue_types: New unpatched RawResidueType entries. Standard variants
+            are applied to these entries exactly once before registration.
         atom_types: Optional new AtomType entries (deduplicated by name).
         partial_charges: Per-residue charge dicts ``{res_name: {atom: charge}}``.
         cartbonded_params: Per-residue CartRes ``{res_name: CartRes}``.
@@ -110,14 +111,30 @@ def inject_residue_params(
     Returns:
         A new frozen ParameterDatabase with the additional data.
     """
-    new_chem_residues = (*param_db.chemical.residues, *residue_types)
-
     new_atom_types = param_db.chemical.atom_types
     if atom_types:
         existing_names = {at.name for at in new_atom_types}
         deduped = [at for at in atom_types if at.name not in existing_names]
         if deduped:
             new_atom_types = (*new_atom_types, *deduped)
+
+    newly_patched = PatchedChemicalDatabase.from_chem_db(
+        ChemicalDatabase(
+            element_types=param_db.chemical.element_types,
+            atom_types=new_atom_types,
+            residues=tuple(residue_types),
+            variants=param_db.chemical.variants,
+        )
+    )
+    existing_residue_names = {residue.name for residue in param_db.chemical.residues}
+    new_chem_residues = (
+        *param_db.chemical.residues,
+        *(
+            residue
+            for residue in newly_patched.residues
+            if residue.name not in existing_residue_names
+        ),
+    )
 
     new_patched = attr.evolve(
         param_db.chemical,
@@ -127,14 +144,53 @@ def inject_residue_params(
 
     new_elec = param_db.scoring.elec
     if partial_charges:
-        new_entries = tuple(
+        new_entries = list(
             PartialCharges(res=res, atom=atom, charge=charge)
             for res, charges in partial_charges.items()
             for atom, charge in charges.items()
         )
+        canonical_charges = {
+            (parameter.res, parameter.atom): parameter.charge
+            for parameter in new_elec.atom_charge_parameters
+        }
+        canonical_cp_reps = tuple(
+            (parameter.res, parameter.atm_inner, parameter.atm_outer)
+            for parameter in new_elec.atom_cp_reps_parameters
+        )
+        new_cp_reps = []
+        for raw in residue_types:
+            prefix = raw.name + ":"
+            for patched in newly_patched.residues:
+                if not patched.name.startswith(prefix):
+                    continue
+                variant = patched.name[len(prefix) :]
+                if ":" in variant:
+                    continue
+                parent_variant = f"{raw.base_name}:{variant}"
+                atom_names = {atom.name for atom in patched.atoms}
+                new_entries.extend(
+                    PartialCharges(res=patched.name, atom=atom, charge=charge)
+                    for (res, atom), charge in canonical_charges.items()
+                    if res == parent_variant and atom in atom_names
+                )
+                new_cp_reps.extend(
+                    CountPairReps(
+                        res=patched.name,
+                        atm_inner=inner,
+                        atm_outer=outer,
+                    )
+                    for res, inner, outer in canonical_cp_reps
+                    if res == parent_variant
+                    and inner in atom_names
+                    and outer in atom_names
+                )
         new_elec = attr.evolve(
             new_elec,
             atom_charge_parameters=(*new_elec.atom_charge_parameters, *new_entries),
+            atom_cp_reps_parameters=(
+                *new_elec.atom_cp_reps_parameters,
+                *new_cp_reps,
+            ),
         )
 
     new_cart = param_db.scoring.cartbonded

--- a/tmol/io/_canonical_ordering.py
+++ b/tmol/io/_canonical_ordering.py
@@ -243,6 +243,10 @@ class CanonicalOrdering:
         restypes_required_mainchain_atoms = cls._required_mainchain_atoms(chemdb)
 
         default_termini_mapping = cls._temp_termini_mapping()
+        for restype in chemdb.residues:
+            inherited = default_termini_mapping.get(restype.base_name)
+            if inherited is not None:
+                default_termini_mapping.setdefault(restype.io_equiv_class, inherited)
         termini_patch_added_atoms = defaultdict(lambda: set([]))
 
         # we need to know which variants create down- and up termini

--- a/tmol/ligand/__init__.py
+++ b/tmol/ligand/__init__.py
@@ -160,9 +160,16 @@ from ._registry import (  # noqa: F401
     rebuild_canonical_ordering,
 )  # noqa: F401
 from ._residue_builder import build_residue_type  # noqa: F401
+from ._polymer import (  # noqa: F401
+    ComponentKind,
+    ComponentProfile,
+    classify_component,
+)
 from ._structure_to_smiles import ligand_smiles_from_atom_array  # noqa: F401
 
 __all__ = [
+    "ComponentKind",
+    "ComponentProfile",
     "FRAGMENT_ID_ANNOTATION",
     "FragmentConnection",
     "LigandFragmentDefinition",
@@ -174,6 +181,7 @@ __all__ = [
     "TMOL_FORMAT_VERSION",
     "apply_fragment_connections",
     "build_split_block_mapping",
+    "classify_component",
     "detect_nonstandard_residues",
     "expand_fragmented_ligands",
     "fragment_ids_from_atom_array",

--- a/tmol/ligand/_detect.py
+++ b/tmol/ligand/_detect.py
@@ -81,6 +81,25 @@ def _chem_comp_type_dict() -> dict[str, str]:
     return dict(zip(ids, types))
 
 
+@functools.cache
+def _chem_comp_metadata_dict() -> dict[str, tuple[str | None, str | None]]:
+    """Return CCD parent and one-letter-code metadata by component ID."""
+
+    chem_comp = ccd.get_ccd()["chem_comp"]
+    ids = chem_comp["id"].as_array(str)
+    parents = chem_comp["mon_nstd_parent_comp_id"].as_array(str)
+    one_letter_codes = chem_comp["one_letter_code"].as_array(str)
+
+    def present(value: str) -> str | None:
+        value = str(value).strip()
+        return None if value in ("", ".", "?") else value.upper()
+
+    return {
+        str(component_id).upper(): (present(parent), present(one_letter_code))
+        for component_id, parent, one_letter_code in zip(ids, parents, one_letter_codes)
+    }
+
+
 def get_chem_comp_type(res_name: str) -> Optional[str]:
     """Look up the CCD chemical component type for a residue name.
 
@@ -92,6 +111,18 @@ def get_chem_comp_type(res_name: str) -> Optional[str]:
         or None if the code is not found in the CCD.
     """
     return _chem_comp_type_dict().get(res_name.upper())
+
+
+def get_chem_comp_parent(res_name: str) -> Optional[str]:
+    """Return the CCD parent component for a modified monomer, if declared."""
+
+    return _chem_comp_metadata_dict().get(res_name.upper(), (None, None))[0]
+
+
+def get_chem_comp_one_letter_code(res_name: str) -> Optional[str]:
+    """Return a usable CCD one-letter code, if declared."""
+
+    return _chem_comp_metadata_dict().get(res_name.upper(), (None, None))[1]
 
 
 _METAL_SYMBOLS = frozenset(

--- a/tmol/ligand/_polymer.py
+++ b/tmol/ligand/_polymer.py
@@ -1,0 +1,357 @@
+"""Programmatic specialization of generated polymer components.
+
+The ligand pipeline perceives atom types, charges, bonds, and internal
+coordinates for every unknown chemical component.  This module adds only the
+polymer semantics that cannot be inferred by the general ligand builder:
+backbone identity, upper/lower connections, and canonical backbone torsions.
+No modified-residue or carbohydrate name table is used.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+
+import attr
+
+from tmol.database import ParameterDatabase
+from tmol.database.chemical import RawResidueType
+from tmol.database.scoring import CartRes
+from tmol.ligand._detect import (
+    NonStandardResidueInfo,
+    get_chem_comp_one_letter_code,
+    get_chem_comp_parent,
+)
+from tmol.ligand._registry import LigandPreparation
+
+
+class ComponentKind(str, Enum):
+    """Preparation route selected from CCD metadata and molecular topology."""
+
+    PROTEIN = "protein"
+    NUCLEIC_ACID = "nucleic_acid"
+    CARBOHYDRATE = "carbohydrate"
+    GENERAL = "general"
+
+
+@dataclass(frozen=True)
+class ComponentProfile:
+    """Structure-derived component classification used by preparation."""
+
+    kind: ComponentKind
+    parent_name: str | None = None
+    one_letter_code: str | None = None
+
+
+_PROTEIN_BACKBONE = ("N", "CA", "C")
+_NA_BACKBONE = ("P", "O5'", "C5'", "C4'", "C3'", "O3'")
+
+
+def _atom_names(info: NonStandardResidueInfo) -> set[str]:
+    return {str(name).strip() for name in info.atom_names}
+
+
+def _bond_names(info: NonStandardResidueInfo) -> set[frozenset[str]]:
+    if info.atom_array.bonds is None:
+        return set()
+    names = info.atom_array.atom_name
+    return {
+        frozenset((str(names[a]).strip(), str(names[b]).strip()))
+        for a, b, _ in info.atom_array.bonds.as_array()
+    }
+
+
+def _contains_path(info: NonStandardResidueInfo, path: tuple[str, ...]) -> bool:
+    names = _atom_names(info)
+    if not set(path) <= names:
+        return False
+    bonds = _bond_names(info)
+    # Some PDB inputs omit intra-residue bond tables. Atom-name recognition is
+    # still useful there; when bonds are present, require the claimed path.
+    return not bonds or all(
+        frozenset((left, right)) in bonds for left, right in zip(path, path[1:])
+    )
+
+
+def classify_component(info: NonStandardResidueInfo) -> ComponentProfile:
+    """Classify an unknown component without a residue-name allowlist."""
+
+    ccd_type = info.ccd_type.upper()
+    parent = get_chem_comp_parent(info.res_name)
+    one_letter = get_chem_comp_one_letter_code(info.res_name)
+
+    if "PEPTIDE LINKING" in ccd_type and _contains_path(info, _PROTEIN_BACKBONE):
+        return ComponentProfile(ComponentKind.PROTEIN, parent, one_letter)
+    if ("RNA LINKING" in ccd_type or "DNA LINKING" in ccd_type) and _contains_path(
+        info, _NA_BACKBONE
+    ):
+        return ComponentProfile(ComponentKind.NUCLEIC_ACID, parent, one_letter)
+    if "SACCHARIDE" in ccd_type:
+        return ComponentProfile(ComponentKind.CARBOHYDRATE, parent, one_letter)
+    return ComponentProfile(ComponentKind.GENERAL, parent, one_letter)
+
+
+def _raw_by_name(
+    param_db: ParameterDatabase, name: str | None
+) -> RawResidueType | None:
+    if name is None:
+        return None
+    for residue in param_db.chemical.residues:
+        if residue.name == name:
+            return residue
+    return None
+
+
+def _nucleic_parent_name(
+    profile: ComponentProfile, ccd_type: str, param_db: ParameterDatabase
+) -> str | None:
+    if _raw_by_name(param_db, profile.parent_name) is not None:
+        return profile.parent_name
+    if profile.one_letter_code is None or len(profile.one_letter_code) != 1:
+        return None
+    prefix = "D" if "DNA" in ccd_type.upper() else "R"
+    candidate = prefix + profile.one_letter_code.upper()
+    return candidate if _raw_by_name(param_db, candidate) is not None else None
+
+
+def _specialize_from_parent(
+    preparation: LigandPreparation,
+    parent: RawResidueType,
+    info: NonStandardResidueInfo,
+    param_db: ParameterDatabase,
+) -> LigandPreparation:
+    """Give generated chemistry the parent's polymer topology and torsions."""
+
+    generated = preparation.residue_type
+    names = {atom.name for atom in generated.atoms}
+    mainchain = parent.properties.polymer.mainchain_atoms
+    if mainchain is None or not set(mainchain) <= names:
+        raise ValueError(
+            f"{info.res_name}: CCD parent {parent.name} backbone is not present"
+        )
+
+    parent_connections = tuple(
+        connection
+        for connection in parent.connections
+        if connection.name in ("down", "up")
+    )
+    if {connection.name for connection in parent_connections} != {"down", "up"}:
+        raise ValueError(
+            f"{parent.name}: canonical parent lacks upper/lower connections"
+        )
+
+    element_for_type = {
+        atom_type.name: atom_type.element for atom_type in param_db.chemical.atom_types
+    }
+    element_for_type.update(preparation.atom_type_elements or {})
+
+    def heavy_neighbors(residue):
+        atom_by_name = {atom.name: atom for atom in residue.atoms}
+        result = {atom.name: set() for atom in residue.atoms}
+        for atom1, atom2, *_ in residue.bonds:
+            if element_for_type[atom_by_name[atom2].atom_type] != "H":
+                result[atom1].add(atom2)
+            if element_for_type[atom_by_name[atom1].atom_type] != "H":
+                result[atom2].add(atom1)
+        return result
+
+    generated_heavy_neighbors = heavy_neighbors(generated)
+    parent_heavy_neighbors = heavy_neighbors(parent)
+    parent_atom = {atom.name: atom for atom in parent.atoms}
+    stable_atoms = {
+        atom.name
+        for atom in generated.atoms
+        if atom.name in parent_atom
+        and generated_heavy_neighbors[atom.name] == parent_heavy_neighbors[atom.name]
+    }
+    specialized_atoms = tuple(
+        (
+            attr.evolve(atom, atom_type=parent_atom[atom.name].atom_type)
+            if atom.name in stable_atoms
+            else atom
+        )
+        for atom in generated.atoms
+    )
+
+    def hydrogen_neighbors(residue, atom_name):
+        atom_by_name = {atom.name: atom for atom in residue.atoms}
+        neighbors = []
+        for atom1, atom2, *_ in residue.bonds:
+            neighbor = (
+                atom2 if atom1 == atom_name else atom1 if atom2 == atom_name else None
+            )
+            if (
+                neighbor is not None
+                and element_for_type[atom_by_name[neighbor].atom_type] == "H"
+            ):
+                neighbors.append(neighbor)
+        return sorted(neighbors)
+
+    leaving_hydrogens = []
+    for connection in parent_connections:
+        expected = len(hydrogen_neighbors(parent, connection.atom))
+        actual = hydrogen_neighbors(generated, connection.atom)
+        leaving_hydrogens.extend(actual[expected:])
+    terminal_heavy_atoms = {
+        atom.name
+        for variant in param_db.chemical.variants
+        if variant.applies_to.matches(parent)
+        and ({"<{down}>", "<{up}>"} & set(variant.remove_atoms))
+        for atom in variant.add_atoms
+        if atom.name not in parent_atom and element_for_type[atom.atom_type] != "H"
+    }
+    removed_atoms = set(leaving_hydrogens) | (names & terminal_heavy_atoms)
+    specialized_atoms = tuple(
+        atom for atom in specialized_atoms if atom.name not in removed_atoms
+    )
+    specialized_bonds = tuple(
+        bond for bond in generated.bonds if not removed_atoms.intersection(bond[:2])
+    )
+    specialized_icoors = tuple(
+        icoor for icoor in generated.icoors if icoor.name not in removed_atoms
+    )
+    if any(
+        removed_atoms.intersection(
+            (icoor.parent, icoor.grand_parent, icoor.great_grand_parent)
+        )
+        for icoor in specialized_icoors
+    ):
+        raise ValueError(f"{info.res_name}: a removed terminus atom is not a leaf atom")
+    specialized_torsions = tuple(
+        torsion
+        for torsion in generated.torsions
+        if not removed_atoms.intersection(
+            unresolved.atom
+            for unresolved in (torsion.a, torsion.b, torsion.c, torsion.d)
+            if unresolved.atom is not None
+        )
+    )
+    names -= removed_atoms
+    parent_icoors = tuple(
+        icoor for icoor in parent.icoors if icoor.name in ("down", "up")
+    )
+    parent_torsions = tuple(
+        torsion
+        for torsion in parent.torsions
+        if torsion.name in ("phi", "psi", "omega")
+        or (
+            torsion.name.startswith("chi")
+            and all(
+                unresolved.atom is None or unresolved.atom in names
+                for unresolved in (torsion.a, torsion.b, torsion.c, torsion.d)
+            )
+        )
+    )
+    inherited_names = {torsion.name for torsion in parent_torsions}
+    # Generated extra torsions remain available to generic samplers, but do not
+    # masquerade as parent Dunbrack dimensions.
+    extra_torsions = tuple(
+        attr.evolve(torsion, name=f"component_{torsion.name}")
+        for torsion in specialized_torsions
+        if torsion.name not in inherited_names
+    )
+    properties = attr.evolve(
+        generated.properties,
+        polymer=parent.properties.polymer,
+        chemical_modifications=tuple(
+            dict.fromkeys(
+                (*generated.properties.chemical_modifications, info.res_name.lower())
+            )
+        ),
+        virtual=tuple(
+            atom for atom in generated.properties.virtual if atom not in removed_atoms
+        ),
+    )
+    specialized = attr.evolve(
+        generated,
+        base_name=parent.base_name,
+        atoms=specialized_atoms,
+        atom_aliases=tuple(
+            alias for alias in generated.atom_aliases if alias.name not in removed_atoms
+        ),
+        bonds=specialized_bonds,
+        connections=parent_connections,
+        torsions=(*parent_torsions, *extra_torsions),
+        icoors=(*specialized_icoors, *parent_icoors),
+        properties=properties,
+        chi_samples=(),
+        default_jump_connection_atom=(
+            parent.default_jump_connection_atom
+            if parent.default_jump_connection_atom in names
+            else generated.default_jump_connection_atom
+        ),
+        one_letter_code=parent.one_letter_code,
+    )
+    parent_charges = {
+        parameter.atom: parameter.charge
+        for parameter in param_db.scoring.elec.atom_charge_parameters
+        if parameter.res == parent.name
+    }
+    charges = dict(preparation.partial_charges)
+    charges.update(
+        {
+            atom_name: parent_charges[atom_name]
+            for atom_name in stable_atoms
+            if atom_name in parent_charges
+        }
+    )
+    for atom_name in removed_atoms:
+        charges.pop(atom_name, None)
+
+    def keep_parameter(parameter):
+        return not removed_atoms.intersection(
+            getattr(parameter, field)
+            for field in ("atm1", "atm2", "atm3", "atm4")
+            if hasattr(parameter, field)
+        )
+
+    cartbonded = preparation.cartbonded_params
+    cartbonded = CartRes(
+        length_parameters=tuple(filter(keep_parameter, cartbonded.length_parameters)),
+        angle_parameters=tuple(filter(keep_parameter, cartbonded.angle_parameters)),
+        torsion_parameters=tuple(filter(keep_parameter, cartbonded.torsion_parameters)),
+        improper_parameters=tuple(
+            filter(keep_parameter, cartbonded.improper_parameters)
+        ),
+        hxltorsion_parameters=tuple(
+            filter(keep_parameter, cartbonded.hxltorsion_parameters)
+        ),
+    )
+    return replace(
+        preparation,
+        residue_type=specialized,
+        partial_charges=charges,
+        cartbonded_params=cartbonded,
+    )
+
+
+def specialize_component_preparation(
+    preparation: LigandPreparation,
+    info: NonStandardResidueInfo,
+    param_db: ParameterDatabase,
+) -> tuple[LigandPreparation, ComponentProfile]:
+    """Apply a protein/NA backbone profile; leave sugars/general chemistry generic.
+
+    Carbohydrates are intentionally not promoted to a linear polymer here:
+    their upper/lower/branch roles depend on the explicit inter-component graph
+    and are assigned by the covalent-topology layer instead of a residue table.
+    """
+
+    profile = classify_component(info)
+    if profile.kind is ComponentKind.PROTEIN:
+        parent = _raw_by_name(param_db, profile.parent_name)
+        if parent is None:
+            raise ValueError(
+                f"{info.res_name}: CCD peptide parent {profile.parent_name!r} "
+                "is unavailable in the parameter database"
+            )
+        return _specialize_from_parent(preparation, parent, info, param_db), profile
+    if profile.kind is ComponentKind.NUCLEIC_ACID:
+        parent_name = _nucleic_parent_name(profile, info.ccd_type, param_db)
+        parent = _raw_by_name(param_db, parent_name)
+        if parent is None:
+            raise ValueError(
+                f"{info.res_name}: no canonical nucleic-acid parent can be resolved"
+            )
+        return _specialize_from_parent(preparation, parent, info, param_db), profile
+    return preparation, profile

--- a/tmol/ligand/_polymer.py
+++ b/tmol/ligand/_polymer.py
@@ -145,33 +145,23 @@ def _specialize_from_parent(
     }
     element_for_type.update(preparation.atom_type_elements or {})
 
-    def heavy_neighbors(residue):
+    def heavy_neighbors(residue, ignored=()):
         atom_by_name = {atom.name: atom for atom in residue.atoms}
         result = {atom.name: set() for atom in residue.atoms}
         for atom1, atom2, *_ in residue.bonds:
-            if element_for_type[atom_by_name[atom2].atom_type] != "H":
+            if (
+                atom2 not in ignored
+                and element_for_type[atom_by_name[atom2].atom_type] != "H"
+            ):
                 result[atom1].add(atom2)
-            if element_for_type[atom_by_name[atom1].atom_type] != "H":
+            if (
+                atom1 not in ignored
+                and element_for_type[atom_by_name[atom1].atom_type] != "H"
+            ):
                 result[atom2].add(atom1)
         return result
 
-    generated_heavy_neighbors = heavy_neighbors(generated)
-    parent_heavy_neighbors = heavy_neighbors(parent)
     parent_atom = {atom.name: atom for atom in parent.atoms}
-    stable_atoms = {
-        atom.name
-        for atom in generated.atoms
-        if atom.name in parent_atom
-        and generated_heavy_neighbors[atom.name] == parent_heavy_neighbors[atom.name]
-    }
-    specialized_atoms = tuple(
-        (
-            attr.evolve(atom, atom_type=parent_atom[atom.name].atom_type)
-            if atom.name in stable_atoms
-            else atom
-        )
-        for atom in generated.atoms
-    )
 
     def hydrogen_neighbors(residue, atom_name):
         atom_by_name = {atom.name: atom for atom in residue.atoms}
@@ -201,8 +191,23 @@ def _specialize_from_parent(
         if atom.name not in parent_atom and element_for_type[atom.atom_type] != "H"
     }
     removed_atoms = set(leaving_hydrogens) | (names & terminal_heavy_atoms)
+    generated_heavy_neighbors = heavy_neighbors(generated, removed_atoms)
+    parent_heavy_neighbors = heavy_neighbors(parent)
+    stable_atoms = {
+        atom.name
+        for atom in generated.atoms
+        if atom.name not in removed_atoms
+        and atom.name in parent_atom
+        and generated_heavy_neighbors[atom.name] == parent_heavy_neighbors[atom.name]
+    }
     specialized_atoms = tuple(
-        atom for atom in specialized_atoms if atom.name not in removed_atoms
+        (
+            attr.evolve(atom, atom_type=parent_atom[atom.name].atom_type)
+            if atom.name in stable_atoms
+            else atom
+        )
+        for atom in generated.atoms
+        if atom.name not in removed_atoms
     )
     specialized_bonds = tuple(
         bond for bond in generated.bonds if not removed_atoms.intersection(bond[:2])
@@ -287,7 +292,15 @@ def _specialize_from_parent(
         for parameter in param_db.scoring.elec.atom_charge_parameters
         if parameter.res == parent.name
     }
-    charges = dict(preparation.partial_charges)
+    charges = {
+        atom_name: charge
+        for atom_name, charge in preparation.partial_charges.items()
+        if atom_name not in removed_atoms
+    }
+    # Removing terminal atoms leaves the ligand model within rounding error of
+    # the modified polymer's integral formal charge. Preserve that total while
+    # retaining canonical charges on the chemically unchanged parent region.
+    target_charge = round(sum(charges.values()))
     charges.update(
         {
             atom_name: parent_charges[atom_name]
@@ -295,8 +308,16 @@ def _specialize_from_parent(
             if atom_name in parent_charges
         }
     )
-    for atom_name in removed_atoms:
-        charges.pop(atom_name, None)
+    modified_heavy_atoms = [
+        atom.name
+        for atom in specialized_atoms
+        if atom.name not in stable_atoms and element_for_type[atom.atom_type] != "H"
+    ]
+    charge_correction = target_charge - sum(charges.values())
+    if modified_heavy_atoms:
+        per_atom_correction = charge_correction / len(modified_heavy_atoms)
+        for atom_name in modified_heavy_atoms:
+            charges[atom_name] += per_atom_correction
 
     def keep_parameter(parameter):
         return not removed_atoms.intersection(

--- a/tmol/ligand/_preparation.py
+++ b/tmol/ligand/_preparation.py
@@ -575,6 +575,10 @@ def prepare_ligands(  # noqa: C901
             prep = _prepare_ligand_via_smiles(
                 lig, ph=ph, sample_proton_chi=sample_proton_chi
             )
+            from tmol.ligand._polymer import specialize_component_preparation
+
+            prep, profile = specialize_component_preparation(prep, lig, param_db)
+            logger.info("Prepared %s through the %s path", lig.res_name, profile.kind)
         except LigandPreparationError:
             raise
         except Exception as err:  # noqa: BLE001  SMILES/typing/build failure

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -224,7 +224,13 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         )
 
         # Fetch the params from the database, updating the atom id store if necessary
-        cartbonded_params = self.get_params_for_res(block_type.base_name)
+        component_name = block_type.name.split(":", 1)[0]
+        parameter_name = (
+            component_name
+            if component_name in self.cart_database.residue_params
+            else block_type.base_name
+        )
+        cartbonded_params = self.get_params_for_res(parameter_name)
         cb_block_ann = CartBondedBlockAnnotations(
             cartbonded_subgraphs=cart_subgraphs,
             cartbonded_subgraph_type_counts=cart_subgraph_type_counts,

--- a/tmol/tests/ligand/test_ligand_pipeline.py
+++ b/tmol/tests/ligand/test_ligand_pipeline.py
@@ -86,7 +86,7 @@ class TestFullPipeline:
         """
         from tmol.ligand import LigandPreparationError
 
-        with pytest.raises(LigandPreparationError, match="not supported"):
+        with pytest.raises(LigandPreparationError, match="failed to prepare ligand"):
             prepare_ligands(cif_155c_with_hem, param_db=param_db)
 
     def test_pse_partial_occupancy(self, cif_1a25_with_pse, param_db) -> None:

--- a/tmol/tests/ligand/test_polymer_classification.py
+++ b/tmol/tests/ligand/test_polymer_classification.py
@@ -201,6 +201,12 @@ def test_modified_residues_build_at_peptide_termini(torch_device):
     }
     assert atom_types["P"] == "PG3"
     assert {atom_types[name] for name in ("O1P", "O2P", "O3P")} == {"OG2"}
+    sep_charges = {
+        parameter.atom: parameter.charge
+        for parameter in context.parameter_database.scoring.elec.atom_charge_parameters
+        if parameter.res == "SEP"
+    }
+    assert abs(sum(sep_charges.values()) + 2.0) < 1e-6
     assert {"H1", "H2", "H3"} <= atom_types.keys()
     assert {"HN2", "HN3"}.isdisjoint(atom_types)
     assert block_types[0].name3 == "SEP"

--- a/tmol/tests/ligand/test_polymer_classification.py
+++ b/tmol/tests/ligand/test_polymer_classification.py
@@ -1,0 +1,231 @@
+"""Tests for topology-aware generated-component routing."""
+
+import attr
+import biotite.structure as struc
+import biotite.structure.info as struc_info
+import numpy as np
+import torch
+
+from tmol import beta2016_score_function
+from tmol.database import ParameterDatabase
+from tmol.ligand._detect import NonStandardResidueInfo
+from tmol.ligand._polymer import (
+    ComponentKind,
+    classify_component,
+    specialize_component_preparation,
+)
+from tmol.ligand._registry import LigandPreparation, _build_cartbonded_params
+
+
+def _info(name, ccd_type, atoms, bonds):
+    array = struc.AtomArray(len(atoms))
+    array.atom_name = np.asarray(atoms)
+    array.element = np.asarray(["C"] * len(atoms))
+    array.res_name[:] = name
+    array.coord = np.arange(len(atoms) * 3, dtype=float).reshape((-1, 3))
+    array.bonds = struc.BondList(
+        len(atoms),
+        np.asarray(
+            [
+                (atoms.index(a), atoms.index(b), int(struc.BondType.SINGLE))
+                for a, b in bonds
+            ],
+            dtype=np.int32,
+        ),
+    )
+    return NonStandardResidueInfo(
+        res_name=name,
+        ccd_type=ccd_type,
+        atom_names=tuple(atoms),
+        elements=tuple(array.element),
+        coords=array.coord.copy(),
+        atom_array=array,
+    )
+
+
+def test_classification_requires_backbone_topology():
+    peptide = _info(
+        "SEP", "L-PEPTIDE LINKING", ["N", "CA", "C", "P"], [("N", "CA"), ("CA", "C")]
+    )
+    misleading = _info(
+        "SEP", "L-PEPTIDE LINKING", ["N", "CA", "C", "P"], [("N", "C"), ("CA", "P")]
+    )
+    sugar = _info(
+        "NAG", "D-SACCHARIDE, BETA LINKING", ["C1", "O5", "C5"], [("C1", "O5")]
+    )
+    assert classify_component(peptide).kind is ComponentKind.PROTEIN
+    assert classify_component(misleading).kind is ComponentKind.GENERAL
+    assert classify_component(sugar).kind is ComponentKind.CARBOHYDRATE
+
+
+def test_generated_ptm_inherits_parent_polymer_contract():
+    db = ParameterDatabase.get_default()
+    ser = next(residue for residue in db.chemical.residues if residue.name == "SER")
+    generated = attr.evolve(
+        ser,
+        name="SEP",
+        base_name="SEP",
+        name3="SEP",
+        io_equiv_class="SEP",
+        connections=(),
+        torsions=(),
+        icoors=tuple(i for i in ser.icoors if i.name not in ("down", "up")),
+        properties=attr.evolve(
+            ser.properties,
+            is_canonical=False,
+            polymer=attr.evolve(
+                ser.properties.polymer,
+                is_polymer=False,
+                polymer_type=None,
+                backbone_type=None,
+                mainchain_atoms=None,
+            ),
+        ),
+        one_letter_code=None,
+    )
+    prep = LigandPreparation(
+        residue_type=generated,
+        partial_charges={atom.name: 0.0 for atom in generated.atoms},
+        cartbonded_params=_build_cartbonded_params(generated),
+        atom_type_elements=None,
+    )
+    info = _info(
+        "SEP",
+        "L-PEPTIDE LINKING",
+        [atom.name for atom in generated.atoms],
+        [("N", "CA"), ("CA", "C")],
+    )
+    specialized, profile = specialize_component_preparation(prep, info, db)
+    residue = specialized.residue_type
+    assert profile.parent_name == "SER"
+    assert residue.base_name == "SER"
+    assert residue.properties.polymer.is_polymer
+    assert residue.properties.polymer.mainchain_atoms == ("N", "CA", "C")
+    assert {connection.name for connection in residue.connections} == {"down", "up"}
+    assert {torsion.name for torsion in residue.torsions} >= {
+        "phi",
+        "psi",
+        "omega",
+        "chi1",
+    }
+
+
+def test_generated_modified_nucleotide_inherits_parent_polymer_contract():
+    db = ParameterDatabase.get_default()
+    adenosine = next(
+        residue for residue in db.chemical.residues if residue.name == "RA"
+    )
+    generated = attr.evolve(
+        adenosine,
+        name="1MA",
+        base_name="1MA",
+        name3="1MA",
+        io_equiv_class="1MA",
+        connections=(),
+        torsions=(),
+        icoors=tuple(i for i in adenosine.icoors if i.name not in ("down", "up")),
+        properties=attr.evolve(
+            adenosine.properties,
+            is_canonical=False,
+            polymer=attr.evolve(
+                adenosine.properties.polymer,
+                is_polymer=False,
+                polymer_type=None,
+                backbone_type=None,
+                mainchain_atoms=None,
+            ),
+        ),
+        one_letter_code=None,
+    )
+    prep = LigandPreparation(
+        residue_type=generated,
+        partial_charges={atom.name: 0.0 for atom in generated.atoms},
+        cartbonded_params=_build_cartbonded_params(generated),
+        atom_type_elements=None,
+    )
+    backbone = ("P", "O5'", "C5'", "C4'", "C3'", "O3'")
+    info = _info(
+        "1MA", "RNA LINKING", list(backbone), list(zip(backbone, backbone[1:]))
+    )
+    specialized, profile = specialize_component_preparation(prep, info, db)
+    residue = specialized.residue_type
+    assert profile.kind is ComponentKind.NUCLEIC_ACID
+    assert residue.base_name == "RA"
+    assert residue.properties.polymer.backbone_type == "rna"
+    assert residue.properties.polymer.mainchain_atoms == backbone
+    assert {connection.name for connection in residue.connections} == {"down", "up"}
+
+
+def test_modified_residues_build_at_peptide_termini(torch_device):
+    """CCD PTMs are generated, normalized, and patched as ordinary termini."""
+
+    residues = []
+    previous_carbon = None
+    for index, name in enumerate(("SEP", "ALA", "PTR"), start=1):
+        residue = struc_info.residue(name).copy()
+        keep = residue.element != "H"
+        if index != 3:
+            keep &= residue.atom_name != "OXT"
+        residue = residue[keep]
+        residue.chain_id[:] = "A"
+        residue.res_id[:] = index
+        if previous_carbon is not None:
+            nitrogen = residue.coord[residue.atom_name == "N"][0]
+            residue.coord += previous_carbon + np.array([1.33, 0.0, 0.0]) - nitrogen
+        previous_carbon = residue.coord[residue.atom_name == "C"][0].copy()
+        residues.append(residue)
+    peptide = struc.concatenate(residues)
+
+    from tmol.io import pose_stack_from_biotite
+
+    pose, context = pose_stack_from_biotite(
+        peptide,
+        torch_device,
+        prepare_ligands=True,
+        no_optH=True,
+        return_context=True,
+    )
+    block_types = [
+        pose.packed_block_types.active_block_types[int(block_type)]
+        for block_type in pose.block_type_ind64[0]
+        if block_type >= 0
+    ]
+    sep = next(block_type for block_type in block_types if block_type.name3 == "SEP")
+    assert sep.base_name == "SER"
+    atom_types = {atom.name: atom.atom_type for atom in sep.atoms}
+    assert {name: atom_types[name] for name in ("N", "CA", "C", "O")} == {
+        "N": "Nlys",
+        "CA": "CAbb",
+        "C": "CObb",
+        "O": "OCbb",
+    }
+    assert atom_types["P"] == "PG3"
+    assert {atom_types[name] for name in ("O1P", "O2P", "O3P")} == {"OG2"}
+    assert {"H1", "H2", "H3"} <= atom_types.keys()
+    assert {"HN2", "HN3"}.isdisjoint(atom_types)
+    assert block_types[0].name3 == "SEP"
+    assert block_types[-1].name3 == "PTR"
+    assert "nterm" in block_types[0].name
+    assert "cterm" in block_types[-1].name
+    for block_index, connection_name in (
+        (0, "up"),
+        (1, "down"),
+        (1, "up"),
+        (2, "down"),
+    ):
+        block_type = pose.packed_block_types.active_block_types[
+            int(pose.block_type_ind64[0, block_index])
+        ]
+        connection_index = block_type.connection_to_cidx[connection_name]
+        assert (
+            pose.inter_residue_connections64[0, block_index, connection_index, 0] >= 0
+        )
+    assert torch.isfinite(pose.coords).all()
+    score_function = beta2016_score_function(
+        torch_device, param_db=context.parameter_database
+    )
+    coords = pose.coords.detach().clone().requires_grad_(True)
+    score = score_function.render_whole_pose_scoring_module(pose)(coords).sum()
+    score.backward()
+    assert torch.isfinite(score)
+    assert torch.isfinite(coords.grad).all()


### PR DESCRIPTION
Replacement for #420 after the PTM stack was removed from master. Intentionally left open.

## Summary
- classify and generate modified protein/nucleic-acid components through the ligand pipeline
- retain canonical parent polymer semantics where local chemistry is unchanged
- preserve integral formal charge, including net −2 for SEP/TPO/PTR

Stack 2/4; depends on the covalent-bond PR.