### PR TITLE
Derive carbohydrate topology from covalent graphs

### DIFF
--- a/tmol/io/_canonical_ordering.py
+++ b/tmol/io/_canonical_ordering.py
@@ -200,16 +200,24 @@ class CanonicalOrdering:
         restypes_alt_atom_name_mapping = defaultdict(dict)
 
         for restype in chemdb.residues:
-            for at in restype.atoms:
-                restypes_all_atom_names[restype.name3].add(at.name)
-            for at in restype.atom_aliases:
-                if at.alt_name in restypes_alt_atom_name_mapping[restype.name3]:
-                    assert (
-                        restypes_alt_atom_name_mapping[restype.name3][at.alt_name]
-                        == at.name
-                    )
-                else:
-                    restypes_alt_atom_name_mapping[restype.name3][at.alt_name] = at.name
+            # Most residue types use the same value for name3 and their I/O
+            # equivalence class.  Connection-capable carbohydrate clones use
+            # a private equivalence class so their graph-derived polymer flag
+            # does not alter initial assignment of the input-facing ligand.
+            # Keep canonical atom maps available under both identifiers.
+            for identifier in dict.fromkeys((restype.name3, restype.io_equiv_class)):
+                for at in restype.atoms:
+                    restypes_all_atom_names[identifier].add(at.name)
+                for at in restype.atom_aliases:
+                    if at.alt_name in restypes_alt_atom_name_mapping[identifier]:
+                        assert (
+                            restypes_alt_atom_name_mapping[identifier][at.alt_name]
+                            == at.name
+                        )
+                    else:
+                        restypes_alt_atom_name_mapping[identifier][
+                            at.alt_name
+                        ] = at.name
 
         # note that extra atoms are internal-use only and do not have "alternate" names
         extra = cls.extra_atoms()

--- a/tmol/io/_covalent_bonds.py
+++ b/tmol/io/_covalent_bonds.py
@@ -1,6 +1,6 @@
 """Import explicit, non-polymeric covalent bonds from Biotite structures."""
 
-from collections import defaultdict
+from collections import defaultdict, deque
 import math
 
 import attr
@@ -169,6 +169,93 @@ def _is_carbohydrate(residue_key):
     return "SACCHARIDE" in (get_chem_comp_type(residue_key[3]) or "").upper()
 
 
+def _carbohydrate_graph(bonds, sugars):
+    sugar_edges = []
+    anchors = defaultdict(list)
+    adjacency = defaultdict(list)
+    for endpoint1, endpoint2 in bonds:
+        key1, key2 = endpoint1[0], endpoint2[0]
+        sugar1, sugar2 = key1 in sugars, key2 in sugars
+        if sugar1 and sugar2:
+            edge_index = len(sugar_edges)
+            sugar_edges.append((endpoint1, endpoint2))
+            adjacency[key1].append((key2, edge_index))
+            adjacency[key2].append((key1, edge_index))
+        elif sugar1:
+            anchors[key1].append(endpoint1)
+        elif sugar2:
+            anchors[key2].append(endpoint2)
+    return sugar_edges, anchors, adjacency
+
+
+def _connected_component(seed, adjacency):
+    component = set()
+    pending = [seed]
+    while pending:
+        current = pending.pop()
+        if current in component:
+            continue
+        component.add(current)
+        pending.extend(neighbor for neighbor, _ in adjacency[current])
+    return component
+
+
+def _root_carbohydrate_component(component, anchors, adjacency, key_to_index):
+    anchored = sorted(
+        (key for key in component if anchors[key]), key=key_to_index.__getitem__
+    )
+    root = anchored[0] if anchored else min(component, key=key_to_index.__getitem__)
+    parent = {root: None}
+    queue = deque([root])
+    tree_edges = set()
+    while queue:
+        current = queue.popleft()
+        for neighbor, edge_index in sorted(
+            adjacency[current], key=lambda item: key_to_index[item[0]]
+        ):
+            if neighbor in parent:
+                continue
+            parent[neighbor] = current
+            tree_edges.add(edge_index)
+            queue.append(neighbor)
+    return root, parent, tree_edges
+
+
+def _assign_carbohydrate_anchor_roles(roles, component, root, anchors, key_to_index):
+    for key in sorted(component, key=key_to_index.__getitem__):
+        for anchor_index, endpoint in enumerate(
+            sorted(anchors[key], key=lambda item: item[1])
+        ):
+            roles[endpoint] = (
+                "down" if key == root and anchor_index == 0 else f"branch_{endpoint[1]}"
+            )
+
+
+def _assign_carbohydrate_edge_roles(
+    roles, parent, tree_edges, sugar_edges, key_to_index
+):
+    children = defaultdict(list)
+    for edge_index in tree_edges:
+        endpoint1, endpoint2 = sugar_edges[edge_index]
+        if parent[endpoint2[0]] == endpoint1[0]:
+            parent_endpoint, child_endpoint = endpoint1, endpoint2
+        else:
+            parent_endpoint, child_endpoint = endpoint2, endpoint1
+        children[parent_endpoint[0]].append((child_endpoint[0], parent_endpoint))
+        roles[child_endpoint] = "down"
+    for entries in children.values():
+        for child_index, (_, endpoint) in enumerate(
+            sorted(entries, key=lambda item: key_to_index[item[0]])
+        ):
+            roles[endpoint] = "up" if child_index == 0 else f"branch_{endpoint[1]}"
+
+    for edge_index, endpoints in enumerate(sugar_edges):
+        if edge_index in tree_edges:
+            continue
+        for endpoint in endpoints:
+            roles[endpoint] = f"branch_{endpoint[1]}"
+
+
 def _carbohydrate_connection_roles(structure, bonds):
     """Name sugar connections from the input covalent graph, not residue names.
 
@@ -185,83 +272,20 @@ def _carbohydrate_connection_roles(structure, bonds):
     if not sugars:
         return {}
 
-    sugar_edges = []
-    anchors = defaultdict(list)
-    adjacency = defaultdict(list)
-    for endpoint1, endpoint2 in bonds:
-        key1, key2 = endpoint1[0], endpoint2[0]
-        sugar1, sugar2 = key1 in sugars, key2 in sugars
-        if sugar1 and sugar2:
-            edge_index = len(sugar_edges)
-            sugar_edges.append((endpoint1, endpoint2))
-            adjacency[key1].append((key2, edge_index))
-            adjacency[key2].append((key1, edge_index))
-        elif sugar1:
-            anchors[key1].append(endpoint1)
-        elif sugar2:
-            anchors[key2].append(endpoint2)
+    sugar_edges, anchors, adjacency = _carbohydrate_graph(bonds, sugars)
 
     roles = {}
     unvisited = set(sugars)
     while unvisited:
         seed = min(unvisited, key=key_to_index.__getitem__)
-        component = set()
-        pending = [seed]
-        while pending:
-            current = pending.pop()
-            if current in component:
-                continue
-            component.add(current)
-            pending.extend(neighbor for neighbor, _ in adjacency[current])
-
-        anchored = sorted(
-            (key for key in component if anchors[key]), key=key_to_index.__getitem__
+        component = _connected_component(seed, adjacency)
+        root, parent, tree_edges = _root_carbohydrate_component(
+            component, anchors, adjacency, key_to_index
         )
-        root = anchored[0] if anchored else min(component, key=key_to_index.__getitem__)
-        parent = {root: None}
-        queue = [root]
-        tree_edges = set()
-        while queue:
-            current = queue.pop(0)
-            for neighbor, edge_index in sorted(
-                adjacency[current], key=lambda item: key_to_index[item[0]]
-            ):
-                if neighbor in parent:
-                    continue
-                parent[neighbor] = current
-                tree_edges.add(edge_index)
-                queue.append(neighbor)
-
-        for key in sorted(component, key=key_to_index.__getitem__):
-            for anchor_index, endpoint in enumerate(
-                sorted(anchors[key], key=lambda item: item[1])
-            ):
-                roles[endpoint] = (
-                    "down"
-                    if key == root and anchor_index == 0
-                    else (f"branch_{endpoint[1]}")
-                )
-
-        children = defaultdict(list)
-        for edge_index in tree_edges:
-            endpoint1, endpoint2 = sugar_edges[edge_index]
-            if parent[endpoint2[0]] == endpoint1[0]:
-                parent_endpoint, child_endpoint = endpoint1, endpoint2
-            else:
-                parent_endpoint, child_endpoint = endpoint2, endpoint1
-            children[parent_endpoint[0]].append((child_endpoint[0], parent_endpoint))
-            roles[child_endpoint] = "down"
-        for key, entries in children.items():
-            for child_index, (_, endpoint) in enumerate(
-                sorted(entries, key=lambda item: key_to_index[item[0]])
-            ):
-                roles[endpoint] = "up" if child_index == 0 else f"branch_{endpoint[1]}"
-
-        for edge_index, (endpoint1, endpoint2) in enumerate(sugar_edges):
-            if edge_index in tree_edges:
-                continue
-            for endpoint in (endpoint1, endpoint2):
-                roles[endpoint] = f"branch_{endpoint[1]}"
+        _assign_carbohydrate_anchor_roles(roles, component, root, anchors, key_to_index)
+        _assign_carbohydrate_edge_roles(
+            roles, parent, tree_edges, sugar_edges, key_to_index
+        )
         unvisited -= component
     return roles
 

--- a/tmol/io/_covalent_bonds.py
+++ b/tmol/io/_covalent_bonds.py
@@ -102,7 +102,7 @@ def _dihedral(a, b, c, d):
     return float(np.arctan2(np.dot(np.cross(n1, b2 / norms[2]), n2), np.dot(n1, n2)))
 
 
-def _connection_icoor(raw, atom, local_coords, remote_coord):
+def _connection_icoor(raw, connection_name, atom, local_coords, remote_coord):
     adjacency = defaultdict(list)
     for name1, name2, *_ in raw.bonds:
         adjacency[name1].append(name2)
@@ -120,7 +120,7 @@ def _connection_icoor(raw, atom, local_coords, remote_coord):
         raise ValueError(f"connection atom {raw.name}:{atom} lacks a third frame atom")
     ggp = sorted(ggp_candidates)[0]
     return Icoor(
-        name=f"covalent_{atom}",
+        name=connection_name,
         phi=-_dihedral(
             remote_coord, local_coords[atom], local_coords[gp], local_coords[ggp]
         ),
@@ -163,6 +163,160 @@ def _virtualize_leaving_hydrogens(raw, attachment_atoms, atom_type_elements):
     return atoms, properties
 
 
+def _is_carbohydrate(residue_key):
+    from tmol.ligand._detect import get_chem_comp_type
+
+    return "SACCHARIDE" in (get_chem_comp_type(residue_key[3]) or "").upper()
+
+
+def _carbohydrate_connection_roles(structure, bonds):
+    """Name sugar connections from the input covalent graph, not residue names.
+
+    ``down`` points toward the non-carbohydrate anchor (or deterministic root),
+    ``up`` points toward the first child, and further children are branches.
+    """
+
+    if not bonds:
+        return {}
+    array = _template(structure)
+    _, _, keys, _ = _residue_keys(array)
+    key_to_index = {key: index for index, key in enumerate(keys)}
+    sugars = {key for bond in bonds for key, _ in bond if _is_carbohydrate(key)}
+    if not sugars:
+        return {}
+
+    sugar_edges = []
+    anchors = defaultdict(list)
+    adjacency = defaultdict(list)
+    for endpoint1, endpoint2 in bonds:
+        key1, key2 = endpoint1[0], endpoint2[0]
+        sugar1, sugar2 = key1 in sugars, key2 in sugars
+        if sugar1 and sugar2:
+            edge_index = len(sugar_edges)
+            sugar_edges.append((endpoint1, endpoint2))
+            adjacency[key1].append((key2, edge_index))
+            adjacency[key2].append((key1, edge_index))
+        elif sugar1:
+            anchors[key1].append(endpoint1)
+        elif sugar2:
+            anchors[key2].append(endpoint2)
+
+    roles = {}
+    unvisited = set(sugars)
+    while unvisited:
+        seed = min(unvisited, key=key_to_index.__getitem__)
+        component = set()
+        pending = [seed]
+        while pending:
+            current = pending.pop()
+            if current in component:
+                continue
+            component.add(current)
+            pending.extend(neighbor for neighbor, _ in adjacency[current])
+
+        anchored = sorted(
+            (key for key in component if anchors[key]), key=key_to_index.__getitem__
+        )
+        root = anchored[0] if anchored else min(component, key=key_to_index.__getitem__)
+        parent = {root: None}
+        queue = [root]
+        tree_edges = set()
+        while queue:
+            current = queue.pop(0)
+            for neighbor, edge_index in sorted(
+                adjacency[current], key=lambda item: key_to_index[item[0]]
+            ):
+                if neighbor in parent:
+                    continue
+                parent[neighbor] = current
+                tree_edges.add(edge_index)
+                queue.append(neighbor)
+
+        for key in sorted(component, key=key_to_index.__getitem__):
+            for anchor_index, endpoint in enumerate(
+                sorted(anchors[key], key=lambda item: item[1])
+            ):
+                roles[endpoint] = (
+                    "down"
+                    if key == root and anchor_index == 0
+                    else (f"branch_{endpoint[1]}")
+                )
+
+        children = defaultdict(list)
+        for edge_index in tree_edges:
+            endpoint1, endpoint2 = sugar_edges[edge_index]
+            if parent[endpoint2[0]] == endpoint1[0]:
+                parent_endpoint, child_endpoint = endpoint1, endpoint2
+            else:
+                parent_endpoint, child_endpoint = endpoint2, endpoint1
+            children[parent_endpoint[0]].append((child_endpoint[0], parent_endpoint))
+            roles[child_endpoint] = "down"
+        for key, entries in children.items():
+            for child_index, (_, endpoint) in enumerate(
+                sorted(entries, key=lambda item: key_to_index[item[0]])
+            ):
+                roles[endpoint] = "up" if child_index == 0 else f"branch_{endpoint[1]}"
+
+        for edge_index, (endpoint1, endpoint2) in enumerate(sugar_edges):
+            if edge_index in tree_edges:
+                continue
+            for endpoint in (endpoint1, endpoint2):
+                roles[endpoint] = f"branch_{endpoint[1]}"
+        unvisited -= component
+    return roles
+
+
+def _shortest_atom_path(raw, start, end):
+    adjacency = defaultdict(list)
+    for atom1, atom2, *_ in raw.bonds:
+        adjacency[atom1].append(atom2)
+        adjacency[atom2].append(atom1)
+    parent = {start: None}
+    queue = [start]
+    while queue and end not in parent:
+        current = queue.pop(0)
+        for neighbor in sorted(adjacency[current]):
+            if neighbor not in parent:
+                parent[neighbor] = current
+                queue.append(neighbor)
+    if end not in parent:
+        raise ValueError(f"{raw.name}: no bonded path from {start} to {end}")
+    path = []
+    current = end
+    while current is not None:
+        path.append(current)
+        current = parent[current]
+    return tuple(reversed(path))
+
+
+def _carbohydrate_properties(raw, connections, base_properties):
+    named = {name: atom for atom, name in connections}
+    if not ({"down", "up"} & set(named)):
+        return base_properties
+    if "down" in named and "up" in named:
+        mainchain = _shortest_atom_path(raw, named["down"], named["up"])
+    else:
+        mainchain = (named.get("down") or named["up"],)
+    polymer = attr.evolve(
+        base_properties.polymer,
+        is_polymer=True,
+        polymer_type="carbohydrate",
+        backbone_type="carbohydrate",
+        mainchain_atoms=mainchain,
+        sidechain_chirality="NA",
+        termini_variants=(),
+    )
+    return attr.evolve(
+        base_properties,
+        polymer=polymer,
+        chemical_modifications=tuple(
+            dict.fromkeys(
+                (*base_properties.chemical_modifications, "generated_carbohydrate")
+            )
+        ),
+    )
+
+
 def augment_database_for_covalent_bonds(structure, param_db):
     """Add same-atom-layout residue variants needed by explicit input bonds."""
 
@@ -173,11 +327,16 @@ def augment_database_for_covalent_bonds(structure, param_db):
     array = _template(structure)
     starts, ends, keys, _ = _residue_keys(array)
     key_to_residue = {key: i for i, key in enumerate(keys)}
-    attachment_atoms = defaultdict(set)
+    connection_roles = _carbohydrate_connection_roles(structure, bonds)
+    attachment_connections = defaultdict(dict)
     partner_coord = {}
     for (key1, atom1), (key2, atom2) in bonds:
-        attachment_atoms[key1].add(atom1)
-        attachment_atoms[key2].add(atom2)
+        attachment_connections[key1][atom1] = connection_roles.get(
+            (key1, atom1), f"covalent_{atom1}"
+        )
+        attachment_connections[key2][atom2] = connection_roles.get(
+            (key2, atom2), f"covalent_{atom2}"
+        )
         res1, res2 = key_to_residue[key1], key_to_residue[key2]
         inds1 = range(starts[res1], ends[res1])
         inds2 = range(starts[res2], ends[res2])
@@ -188,16 +347,18 @@ def augment_database_for_covalent_bonds(structure, param_db):
 
     patterns = set()
     geometry = {}
-    for key, atoms in attachment_atoms.items():
+    for key, connection_by_atom in attachment_connections.items():
         res_ind = key_to_residue[key]
         local = {
             str(array.atom_name[i]): np.asarray(array.coord[i], dtype=np.float64)
             for i in range(starts[res_ind], ends[res_ind])
         }
-        pattern = (key[3], tuple(sorted(atoms)))
+        connection_spec = tuple(sorted(connection_by_atom.items()))
+        pattern = (key[3], connection_spec)
         patterns.add(pattern)
         geometry.setdefault(
-            pattern, (local, {a: partner_coord[(key, a)] for a in atoms})
+            pattern,
+            (local, {atom: partner_coord[(key, atom)] for atom in connection_by_atom}),
         )
 
     clones = []
@@ -207,33 +368,54 @@ def augment_database_for_covalent_bonds(structure, param_db):
         atom_type.name: atom_type.element for atom_type in param_db.chemical.atom_types
     }
     for raw in param_db.chemical.residues:
-        for res_name, atoms in sorted(patterns):
+        for res_name, connection_spec in sorted(patterns):
+            atoms = tuple(atom for atom, _ in connection_spec)
             if raw.name3 != res_name or not set(atoms) <= {a.name for a in raw.atoms}:
                 continue
-            local, remotes = geometry[(res_name, atoms)]
-            suffix = ",".join(atoms)
+            local, remotes = geometry[(res_name, connection_spec)]
+            generic_names = all(
+                name == f"covalent_{atom}" for atom, name in connection_spec
+            )
+            suffix = ",".join(
+                atom if generic_names else name for atom, name in connection_spec
+            )
             clone_name = f"{raw.name}:covalent_{suffix}"
             added_connections = tuple(
-                Connection(name=f"covalent_{atom}", atom=atom, type="SINGLE")
-                for atom in atoms
+                Connection(name=name, atom=atom, type="SINGLE")
+                for atom, name in connection_spec
             )
             added_icoors = tuple(
-                _connection_icoor(raw, atom, local, remotes[atom]) for atom in atoms
+                _connection_icoor(raw, name, atom, local, remotes[atom])
+                for atom, name in connection_spec
             )
             clone_atoms, clone_properties = _virtualize_leaving_hydrogens(
                 raw, atoms, atom_type_elements
             )
+            is_carbohydrate = _is_carbohydrate(("", 0, "", res_name))
             clone = attr.evolve(
                 raw,
                 name=clone_name,
+                # Keep the input-facing NAG/MAN/etc. equivalence class
+                # non-polymeric while the pose is first assigned.  The
+                # connection-capable clone is swapped in afterwards, so its
+                # graph-derived polymer semantics must not make every member
+                # of the source equivalence class look like a sequence
+                # polymer.
+                io_equiv_class=clone_name if is_carbohydrate else raw.io_equiv_class,
                 atoms=clone_atoms,
                 connections=(*raw.connections, *added_connections),
                 icoors=(*raw.icoors, *added_icoors),
-                properties=clone_properties,
+                properties=(
+                    _carbohydrate_properties(raw, connection_spec, clone_properties)
+                    if is_carbohydrate
+                    else clone_properties
+                ),
             )
             clones.append(clone)
-            variant_names[(raw.name, atoms)] = clone_name
-            supported_patterns.add((res_name, atoms))
+            variant_names[(raw.name, connection_spec)] = clone_name
+            if generic_names:
+                variant_names[(raw.name, atoms)] = clone_name
+            supported_patterns.add((res_name, connection_spec))
 
     missing = sorted(set(patterns) - supported_patterns)
     if missing:
@@ -252,10 +434,13 @@ def apply_covalent_bonds_from_biotite(pose_stack, structure, variant_names):
     bonds = _explicit_cross_residue_bonds(structure)
     if not bonds:
         return pose_stack
-    attachment_atoms = defaultdict(set)
+    connection_roles = _carbohydrate_connection_roles(structure, bonds)
+    attachment_connections = defaultdict(dict)
     for endpoint1, endpoint2 in bonds:
-        attachment_atoms[endpoint1[0]].add(endpoint1[1])
-        attachment_atoms[endpoint2[0]].add(endpoint2[1])
+        for key, atom in (endpoint1, endpoint2):
+            attachment_connections[key][atom] = connection_roles.get(
+                (key, atom), f"covalent_{atom}"
+            )
 
     pbt = pose_stack.packed_block_types
     name_to_ind = {bt.name: i for i, bt in enumerate(pbt.active_block_types)}
@@ -273,10 +458,11 @@ def apply_covalent_bonds_from_biotite(pose_stack, structure, variant_names):
             key_to_block[(pose_index, key)] = block
 
     for pose_index in range(len(pose_stack)):
-        for input_key, atoms in attachment_atoms.items():
+        for input_key, connection_by_atom in attachment_connections.items():
             block = key_to_block[(pose_index, input_key[:3])]
             original = pbt.active_block_types[int(type64[pose_index, block])]
-            clone_name = variant_names[(original.name, tuple(sorted(atoms)))]
+            connection_spec = tuple(sorted(connection_by_atom.items()))
+            clone_name = variant_names[(original.name, connection_spec)]
             clone = pbt.active_block_types[name_to_ind[clone_name]]
             if tuple(a.name for a in clone.atoms) != tuple(
                 a.name for a in original.atoms
@@ -297,9 +483,9 @@ def apply_covalent_bonds_from_biotite(pose_stack, structure, variant_names):
                 InterResidueConnection(
                     pose_index,
                     key_to_block[(pose_index, key1[:3])],
-                    f"covalent_{atom1}",
+                    attachment_connections[key1][atom1],
                     key_to_block[(pose_index, key2[:3])],
-                    f"covalent_{atom2}",
+                    attachment_connections[key2][atom2],
                 )
             )
     return connect_pose_blocks(pose_stack, connections)

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -468,6 +468,16 @@ def biotite_from_pose_stack(
     structure = biotite_from_canonical_form(cf, co=co)
     residue_starts = biotite.structure.get_residue_starts(structure)
     residue_ends = numpy.append(residue_starts[1:], structure.array_length())
+    # Canonical I/O equivalence classes are internal selection identities.
+    # Connection-capable carbohydrate clones deliberately use private classes
+    # so they do not make the input-facing ligand class sequence-polymeric;
+    # export the deposited component identity from the active block type.
+    for block, (start, end) in enumerate(zip(residue_starts, residue_ends)):
+        block_type = int(pose_stack.block_type_ind64[0, block])
+        if block_type >= 0:
+            structure.res_name[start:end] = (
+                pose_stack.packed_block_types.active_block_types[block_type].name3
+            )
     _add_pose_inter_residue_bonds(structure, pose_stack, residue_starts, residue_ends)
     sbm = getattr(pose_stack, "split_block_mapping", None)
     if merge_fragments and sbm is not None and sbm.entries:

--- a/tmol/tests/io/test_carbohydrate_topology.py
+++ b/tmol/tests/io/test_carbohydrate_topology.py
@@ -1,0 +1,156 @@
+"""Programmatic carbohydrate connection tests."""
+
+import biotite.structure as struc
+import biotite.structure.info as struc_info
+import numpy as np
+import torch
+
+from tmol.io._covalent_bonds import (
+    _carbohydrate_connection_roles,
+    _explicit_cross_residue_bonds,
+)
+
+
+def _branched_glycan():
+    residue_atoms = (
+        ("ASN", ("ND2",)),
+        ("NAG", ("C1", "O4", "O6")),
+        ("MAN", ("C1",)),
+        ("FUC", ("C1",)),
+    )
+    n_atoms = sum(len(atoms) for _, atoms in residue_atoms)
+    array = struc.AtomArray(n_atoms)
+    offset = 0
+    atom_index = {}
+    for residue_index, (residue_name, atoms) in enumerate(residue_atoms, start=1):
+        end = offset + len(atoms)
+        array.chain_id[offset:end] = "A"
+        array.res_id[offset:end] = residue_index
+        array.res_name[offset:end] = residue_name
+        array.atom_name[offset:end] = atoms
+        array.element[offset:end] = [
+            "N" if atom.startswith("N") else "C" for atom in atoms
+        ]
+        for local_index, atom in enumerate(atoms):
+            atom_index[(residue_name, atom)] = offset + local_index
+        offset = end
+    array.coord = np.arange(n_atoms * 3, dtype=float).reshape((n_atoms, 3))
+    array.bonds = struc.BondList(
+        n_atoms,
+        np.asarray(
+            [
+                (
+                    atom_index[("ASN", "ND2")],
+                    atom_index[("NAG", "C1")],
+                    int(struc.BondType.SINGLE),
+                ),
+                (
+                    atom_index[("NAG", "O4")],
+                    atom_index[("MAN", "C1")],
+                    int(struc.BondType.SINGLE),
+                ),
+                (
+                    atom_index[("NAG", "O6")],
+                    atom_index[("FUC", "C1")],
+                    int(struc.BondType.SINGLE),
+                ),
+            ],
+            dtype=np.int32,
+        ),
+    )
+    return array
+
+
+def test_branched_carbohydrate_roles_follow_input_graph():
+    array = _branched_glycan()
+    roles = _carbohydrate_connection_roles(array, _explicit_cross_residue_bonds(array))
+
+    by_residue_atom = {(key[3], atom): role for (key, atom), role in roles.items()}
+    assert by_residue_atom[("NAG", "C1")] == "down"
+    assert by_residue_atom[("NAG", "O4")] == "up"
+    assert by_residue_atom[("MAN", "C1")] == "down"
+    assert by_residue_atom[("NAG", "O6")] == "branch_O6"
+    assert by_residue_atom[("FUC", "C1")] == "down"
+
+
+def test_generated_glycopeptide_builds_scores_and_differentiates(torch_device):
+    residues = []
+    atom_indices = {}
+    offset = 0
+    for residue_index, name in enumerate(("ASN", "NAG", "MAN"), start=1):
+        residue = struc_info.residue(name).copy()
+        keep = residue.element != "H"
+        if name == "ASN":
+            keep &= residue.atom_name != "OXT"
+        if name in ("NAG", "MAN"):
+            keep &= residue.atom_name != "O1"
+        residue = residue[keep]
+        residue.chain_id[:] = "A"
+        residue.res_id[:] = residue_index
+        residue.coord[:, 0] += 4.0 * (residue_index - 1)
+        for atom_index, atom_name in enumerate(residue.atom_name):
+            atom_indices[(name, str(atom_name))] = offset + atom_index
+        offset += len(residue)
+        residues.append(residue)
+    structure = struc.concatenate(residues)
+    bonds = structure.bonds.as_array().tolist()
+    bonds.extend(
+        (
+            (
+                atom_indices[("ASN", "ND2")],
+                atom_indices[("NAG", "C1")],
+                int(struc.BondType.SINGLE),
+            ),
+            (
+                atom_indices[("NAG", "O4")],
+                atom_indices[("MAN", "C1")],
+                int(struc.BondType.SINGLE),
+            ),
+        )
+    )
+    structure.bonds = struc.BondList(
+        structure.array_length(), np.asarray(bonds, dtype=np.int32)
+    )
+
+    from tmol import beta2016_score_function
+    from tmol.io import biotite_from_pose_stack, pose_stack_from_biotite
+
+    pose, context = pose_stack_from_biotite(
+        structure,
+        torch_device,
+        prepare_ligands=True,
+        no_optH=True,
+        return_context=True,
+    )
+    block_types = [
+        pose.packed_block_types.active_block_types[int(block_type)]
+        for block_type in pose.block_type_ind64[0]
+        if block_type >= 0
+    ]
+    nag = next(block for block in block_types if block.name3 == "NAG")
+    man = next(block for block in block_types if block.name3 == "MAN")
+    assert nag.properties.polymer.polymer_type == "carbohydrate"
+    assert {connection.name for connection in nag.connections} >= {"down", "up"}
+    assert {connection.name for connection in man.connections} >= {"down"}
+
+    coords = pose.coords.detach().clone().requires_grad_(True)
+    score = (
+        beta2016_score_function(torch_device, param_db=context.parameter_database)
+        .render_whole_pose_scoring_module(pose)(coords)
+        .sum()
+    )
+    score.backward()
+    assert torch.isfinite(score)
+    assert torch.isfinite(coords.grad).all()
+
+    exported = biotite_from_pose_stack(pose, co=context.canonical_ordering)
+    assert set(exported.res_name) >= {"ASN", "NAG", "MAN"}
+    rebuilt = pose_stack_from_biotite(
+        exported,
+        torch_device,
+        context=context,
+        no_optH=True,
+    )
+    assert torch.equal(
+        rebuilt.inter_residue_connections64, pose.inter_residue_connections64
+    )


### PR DESCRIPTION
Replacement for #421 after the PTM stack was removed from master. Intentionally left open.

## Summary
- derive carbohydrate roots and connection roles from explicit covalent graphs
- avoid residue-name-specific topology rules
- keep graph traversal decomposed and typed

Stack 3/4; depends on the modified-polymer PR.