### PR TITLE
Accelerate batched OptH pose construction

### DIFF
--- a/tmol/io/_build_context.py
+++ b/tmol/io/_build_context.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass, field
+from functools import cached_property
+
 from tmol.chemical import ResidueTypeSet
 from tmol.database import ParameterDatabase
 from tmol.io._canonical_ordering import CanonicalOrdering
@@ -24,3 +26,35 @@ class PoseBuildContext:
     fragment_definitions: tuple = ()
     # SMILES string -> residue type name, for ligands prepared from a sequence.
     ligand_names: dict = field(default_factory=dict)
+
+    @cached_property
+    def _packing_score_function(self):
+        """Return the score function shared by repeated pose builds."""
+        from tmol.score import beta2016_score_function
+
+        return beta2016_score_function(
+            self.packed_block_types.device,
+            param_db=self.parameter_database,
+        )
+
+    @cached_property
+    def _dunbrack_sampler(self):
+        """Return the Dunbrack sampler shared by repeated pose builds."""
+        from tmol.pack.rotamer.dunbrack import (
+            create_dunbrack_sampler_from_database,
+        )
+
+        return create_dunbrack_sampler_from_database(
+            self.parameter_database,
+            self.packed_block_types.device,
+        )
+
+    @cached_property
+    def _na_sampler(self):
+        """Return the nucleic-acid sampler shared by repeated pose builds."""
+        from tmol.pack.rotamer import NaChiRotamerSampler
+
+        return NaChiRotamerSampler.from_database(
+            self.parameter_database,
+            self.packed_block_types.device,
+        )

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -24,7 +24,6 @@ from tmol.utility import (
     get_all_residue_positions,
     resolve_device,
 )
-from tmol.score import beta2016_score_function
 
 logger = logging.getLogger(__name__)
 
@@ -198,10 +197,6 @@ def pose_stack_from_biotite(  # noqa: C901
 
     from tmol.io import pose_stack_from_canonical_form
     from tmol.pack import build_missing_sidechains
-    from tmol.pack.rotamer import NaChiRotamerSampler
-    from tmol.pack.rotamer.dunbrack import (
-        create_dunbrack_sampler_from_database,
-    )
 
     if context is not None:
         if param_db is not None:
@@ -276,14 +271,9 @@ def pose_stack_from_biotite(  # noqa: C901
         has_missing_atoms or not no_optH
     )
     if needs_packing:
-        db = context.parameter_database
-        sfxn = beta2016_score_function(torch_device, param_db=db)
-        dunbrack_sampler = create_dunbrack_sampler_from_database(db, torch_device)
-        na_sampler = (
-            NaChiRotamerSampler.from_database(db, torch_device)
-            if has_missing_atoms
-            else None
-        )
+        sfxn = context._packing_score_function
+        dunbrack_sampler = context._dunbrack_sampler
+        na_sampler = context._na_sampler if has_missing_atoms else None
 
         if has_missing_atoms:
             logger.info(

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -266,19 +266,26 @@ def pose_stack_from_biotite(  # noqa: C901
         fragment_mapping = pose_stack.split_block_mapping
     block_has_missing_atoms = opt_return_vals["block_has_missing_atoms"]
 
-    if block_has_missing_atoms is not None and torch.any(block_has_missing_atoms):
+    has_missing_atoms = block_has_missing_atoms is not None and bool(
+        torch.any(block_has_missing_atoms)
+    )
+    if has_missing_atoms:
         _assert_no_ligand_with_missing_atoms(pose_stack, block_has_missing_atoms)
 
     needs_packing = block_has_missing_atoms is not None and (
-        torch.any(block_has_missing_atoms) or not no_optH
+        has_missing_atoms or not no_optH
     )
     if needs_packing:
         db = context.parameter_database
         sfxn = beta2016_score_function(torch_device, param_db=db)
         dunbrack_sampler = create_dunbrack_sampler_from_database(db, torch_device)
-        na_sampler = NaChiRotamerSampler.from_database(db, torch_device)
+        na_sampler = (
+            NaChiRotamerSampler.from_database(db, torch_device)
+            if has_missing_atoms
+            else None
+        )
 
-        if torch.any(block_has_missing_atoms):
+        if has_missing_atoms:
             logger.info(
                 "%i blocks with missing heavy atoms",
                 torch.count_nonzero(block_has_missing_atoms),

--- a/tmol/io/details/_select_from_canonical.py
+++ b/tmol/io/details/_select_from_canonical.py
@@ -226,27 +226,47 @@ def _assert_connections_are_well_formed(
     partner_conn = inter_residue_connections64[..., 1]
     has_partner = partner >= 0
 
+    n_poses, n_blocks, n_connections = partner.shape
+    pose = torch.arange(n_poses, device=partner.device)[:, None, None]
+    block = torch.arange(n_blocks, device=partner.device)[None, :, None]
+    safe_partner = partner.clamp(0, n_blocks - 1)
+    safe_partner_conn = partner_conn.clamp(0, n_connections - 1)
+    partner_resolved = block_type_ind64[pose, safe_partner] >= 0
+    points_back = (
+        inter_residue_connections64[pose, safe_partner, safe_partner_conn, 0] == block
+    )
+    bad_mask = has_partner & (
+        (block_type_ind64[:, :, None] < 0)
+        | (partner >= n_blocks)
+        | ~partner_resolved
+        | (partner_conn < 0)
+        | (partner_conn >= n_connections)
+        | ~points_back
+    )
+    if not torch.any(bad_mask):
+        return
+
     bad = []
-    for pose, block, conn in torch.nonzero(has_partner, as_tuple=False).tolist():
-        p = int(partner[pose, block, conn])
-        pc = int(partner_conn[pose, block, conn])
-        if int(block_type_ind64[pose, block]) < 0:
-            bad.append(f"block {block} has no resolved type but connects to {p}")
-        elif int(block_type_ind64[pose, p]) < 0:
-            bad.append(f"block {block} connects to {p}, which has no resolved type")
-        elif pc < 0:
-            bad.append(f"block {block} conn {conn} names block {p} connection {pc}")
-        elif int(inter_residue_connections64[pose, p, pc, 0]) != block:
+    for pose_i, block_i, conn_i in torch.nonzero(bad_mask, as_tuple=False)[
+        :20
+    ].tolist():
+        p = int(partner[pose_i, block_i, conn_i])
+        pc = int(partner_conn[pose_i, block_i, conn_i])
+        if int(block_type_ind64[pose_i, block_i]) < 0:
+            bad.append(f"block {block_i} has no resolved type but connects to {p}")
+        elif p >= n_blocks:
+            bad.append(f"block {block_i} connects to invalid block {p}")
+        elif int(block_type_ind64[pose_i, p]) < 0:
+            bad.append(f"block {block_i} connects to {p}, which has no resolved type")
+        elif pc < 0 or pc >= n_connections:
+            bad.append(f"block {block_i} conn {conn_i} names block {p} connection {pc}")
+        else:
+            back = int(inter_residue_connections64[pose_i, p, pc, 0])
             bad.append(
-                f"block {block} conn {conn} points at block {p} conn {pc}, "
-                f"which points back at {int(inter_residue_connections64[pose, p, pc, 0])}"
+                f"block {block_i} conn {conn_i} points at block {p} conn {pc}, "
+                f"which points back at {back}"
             )
-        if bad and len(bad) >= 20:
-            break
-    if bad:
-        raise RuntimeError(
-            "malformed inter-residue connections:\n  " + "\n  ".join(bad)
-        )
+    raise RuntimeError("malformed inter-residue connections:\n  " + "\n  ".join(bad))
 
 
 @validate_args
@@ -594,7 +614,6 @@ def select_best_block_type_candidate(  # noqa: C901
         best_candidate_ind2[is_real_res],
     ]
     if torch.any(best_candidate_score >= warning_threshold):
-
         nz_is_real_candidate = torch.nonzero(is_real_candidate)
         err_msg = []
         for cand_ind in range(nz_is_real_candidate.shape[0]):

--- a/tmol/pack/_build_missing_sidechains.py
+++ b/tmol/pack/_build_missing_sidechains.py
@@ -74,8 +74,17 @@ def build_missing_sidechains(
 
     task.add_conformer_sampler_by_block_mask(dunbrack_sampler, block_has_missing_atoms)
     task.add_conformer_sampler_by_block_mask(fixed_sampler, block_has_missing_atoms)
-    if na_sampler is not None:
-        task.add_conformer_sampler_by_block_mask(na_sampler, block_has_missing_atoms)
+    # An empty sampler mask still makes the general rotamer builder execute the
+    # sampler's setup path. Avoid that overhead for complete protein batches.
+    if na_sampler is not None and torch.any(block_has_missing_atoms):
+        block_type_ind = pose_stack.block_type_ind64
+        real_blocks = block_type_ind >= 0
+        na_blocks = na_sampler.defines_rotamers_for_bts(
+            pose_stack.packed_block_types, block_type_ind.clamp_min(0)
+        )
+        missing_na_blocks = block_has_missing_atoms & real_blocks & na_blocks
+        if torch.any(missing_na_blocks):
+            task.add_conformer_sampler_by_block_mask(na_sampler, missing_na_blocks)
     block_does_not_have_missing_atoms = torch.logical_not(block_has_missing_atoms)
     if not no_optH:
         task.add_conformer_sampler_by_block_mask(

--- a/tmol/pack/_build_missing_sidechains.py
+++ b/tmol/pack/_build_missing_sidechains.py
@@ -76,7 +76,7 @@ def build_missing_sidechains(
     task.add_conformer_sampler_by_block_mask(fixed_sampler, block_has_missing_atoms)
     # An empty sampler mask still makes the general rotamer builder execute the
     # sampler's setup path. Avoid that overhead for complete protein batches.
-    if na_sampler is not None and torch.any(block_has_missing_atoms):
+    if na_sampler is not None:
         block_type_ind = pose_stack.block_type_ind64
         real_blocks = block_type_ind >= 0
         na_blocks = na_sampler.defines_rotamers_for_bts(

--- a/tmol/pack/_build_missing_sidechains.py
+++ b/tmol/pack/_build_missing_sidechains.py
@@ -76,7 +76,7 @@ def build_missing_sidechains(
     task.add_conformer_sampler_by_block_mask(fixed_sampler, block_has_missing_atoms)
     # An empty sampler mask still makes the general rotamer builder execute the
     # sampler's setup path. Avoid that overhead for complete protein batches.
-    if na_sampler is not None:
+    if na_sampler is not None and torch.any(block_has_missing_atoms):
         block_type_ind = pose_stack.block_type_ind64
         real_blocks = block_type_ind >= 0
         na_blocks = na_sampler.defines_rotamers_for_bts(

--- a/tmol/pack/rotamer/__init__.py
+++ b/tmol/pack/rotamer/__init__.py
@@ -39,6 +39,7 @@ from ._opth_sampler import OptHSampler, OptHSamplerRTCache  # noqa: F401
 from ._build_rotamers import (  # noqa: F401
     _build_chi4_atom_table,
     _build_chi_phi_c_corrections,
+    _get_chi_dof_metadata,
     annotate_everything,
     annotate_packed_block_types,
     annotate_restype,

--- a/tmol/pack/rotamer/_build_rotamers.py
+++ b/tmol/pack/rotamer/_build_rotamers.py
@@ -120,6 +120,27 @@ def _build_chi_phi_c_corrections(pbt):
     return corrections
 
 
+def _get_chi_dof_metadata(pbt):
+    """Return immutable chi lookup tables on the PackedBlockTypes device."""
+    if hasattr(pbt, "_chi_dof_metadata"):
+        return pbt._chi_dof_metadata
+
+    metadata = (
+        torch.as_tensor(
+            pbt.rotamer_kinforest.kinforest_idx,
+            dtype=torch.int64,
+            device=pbt.device,
+        ),
+        torch.as_tensor(
+            _build_chi_phi_c_corrections(pbt),
+            dtype=torch.float32,
+            device=pbt.device,
+        ),
+    )
+    object.__setattr__(pbt, "_chi_dof_metadata", metadata)
+    return metadata
+
+
 def correct_phi_c_for_jump_parents(
     pbt,
     conformer_samples,
@@ -135,28 +156,19 @@ def correct_phi_c_for_jump_parents(
     """For chi-defining atoms whose kinforest parent is a jump atom, the phi_c
     written by assign_chi_dofs_from_samples does not directly map to the
     chi dihedral angle measured from coordinates.  This function:
-      1. Does a trial forward pass with the current DOFs.
-      2. For each such atom, measures the actual dihedral from the trial coords.
-      3. Adds (intended - measured) to conf_dofs_kto[atom_kto, 3] so the
+      1. Finds every sampled chi whose controlling atom has a jump parent.
+      2. If any exist, does a trial forward pass with the current DOFs.
+      3. Measures their actual dihedrals from the trial coordinates.
+      4. Adds (intended - measured) to conf_dofs_kto[atom_kto, 3] so the
          final forward pass produces the correct geometry.
     """
-    # trial forward pass to get coords in RTO
-    n_rots = block_type_ind_for_conformer_torch.shape[0]
-    n_at_total = (
-        n_atoms_offset_for_conformer_torch[-1].item()
-        + pbt.n_atoms[block_type_ind_for_conformer_torch[-1]].item()
-    )
-    trial_coords_rto = calculate_rotamer_coords(
-        pbt, n_rots, n_at_total, conformer_kinforest, nodes, scans, gens, conf_dofs_kto
-    )
-
     doftype_cpu = conformer_kinforest.doftype.cpu().numpy()
     parent_cpu = conformer_kinforest.parent.cpu().numpy()
     kfidx = pbt.rotamer_kinforest.kinforest_idx  # (n_types, max_n_atoms) numpy int32
     bt_ind_np = block_type_ind_for_conformer_torch.cpu().numpy()
     at_off_np = n_atoms_offset_for_conformer_torch.cpu().numpy()
     chi4_table = _build_chi4_atom_table(pbt)  # (n_types, max_n_chi, 4)
-    coords_np = trial_coords_rto.cpu().double().numpy()
+    corrections = []
 
     for i, sample_data in enumerate(conformer_samples):
         sample_dict = sample_data[2]
@@ -212,6 +224,25 @@ def correct_phi_c_for_jump_parents(
         intended_flat = chi_intended.numpy().reshape(-1)[valid_flat]  # (n_valid,)
         cda_kto_flat = cda_kto.reshape(-1)[valid_flat]  # (n_valid,)
 
+        corrections.append((four_abs_flat, intended_flat, cda_kto_flat))
+
+    if not corrections:
+        return
+
+    # Only conformers whose sampled chi has a jump parent need this trial
+    # forward pass. Most OptH-only builds have none, so avoid folding and
+    # copying every trial coordinate to the CPU in that common case.
+    n_rots = block_type_ind_for_conformer_torch.shape[0]
+    n_at_total = (
+        n_atoms_offset_for_conformer_torch[-1].item()
+        + pbt.n_atoms[block_type_ind_for_conformer_torch[-1]].item()
+    )
+    trial_coords_rto = calculate_rotamer_coords(
+        pbt, n_rots, n_at_total, conformer_kinforest, nodes, scans, gens, conf_dofs_kto
+    )
+    coords_np = trial_coords_rto.cpu().double().numpy()
+
+    for four_abs_flat, intended_flat, cda_kto_flat in corrections:
         # gather coordinates: (n_valid, 4, 3)
         xyzs = torch.tensor(
             coords_np[four_abs_flat], dtype=torch.float64, device=torch.device("cpu")
@@ -607,7 +638,6 @@ def merge_conformer_samples(
     # 3. chi_for_rotamers
 
     # everything needs to be on the same device
-    torch.set_printoptions(threshold=10000)
     for samples in conformer_samples:
         assert samples[0].device == samples[1].device
         assert conformer_samples[0][0].device == samples[0].device

--- a/tmol/pack/rotamer/_chi_sampler.py
+++ b/tmol/pack/rotamer/_chi_sampler.py
@@ -7,7 +7,7 @@ from tmol.types import (
     Tensor,
     validate_args,
 )
-from tmol.utility.tensor import exclusive_cumsum1d, stretch
+from tmol.utility.tensor import exclusive_cumsum1d
 from tmol.chemical import RefinedResidueType
 from tmol.pose import (
     PackedBlockTypes,
@@ -171,6 +171,9 @@ def create_dof_inds_to_copy_from_orig_to_rotamers_for_sampler(
 
     pbt = poses.packed_block_types
     n_rots_for_sampler = sampler_gbt_for_rotamer.shape[0]
+    from tmol.pack.rotamer import _get_chi_dof_metadata
+
+    kinforest_idx, _ = _get_chi_dof_metadata(pbt)
 
     # This could 100% be pre-computed
     pbts_sampler_ind = pbt.mc_fingerprints.sampler_mapping[sampler_name]
@@ -226,39 +229,34 @@ def create_dof_inds_to_copy_from_orig_to_rotamers_for_sampler(
         is_samplers_rots_mcfp_at_inds_rto_real
     ]
 
-    real_samplers_rots_block_type_ind_for_mcfp_ats = stretch(
-        block_type_ind_for_samplers_rots, max_n_mcfp_atoms
-    )[is_samplers_rots_mcfp_at_inds_rto_real]
+    samplers_rots_block_type_ind_for_mcfp_ats = (
+        block_type_ind_for_samplers_rots[:, None]
+        .expand(n_rots_for_sampler, max_n_mcfp_atoms)
+        .reshape(-1)
+    )
+    real_samplers_rots_block_type_ind_for_mcfp_ats = (
+        samplers_rots_block_type_ind_for_mcfp_ats[
+            is_samplers_rots_mcfp_at_inds_rto_real
+        ]
+    )
 
     samplers_rots_mcfp_at_inds_kto = torch.full_like(samplers_rots_mcfp_at_inds_rto, -1)
     samplers_rots_mcfp_at_inds_kto[is_samplers_rots_mcfp_at_inds_rto_real] = (
-        torch.tensor(
-            pbt.rotamer_kinforest.kinforest_idx[
-                real_samplers_rots_block_type_ind_for_mcfp_ats.cpu().numpy(),
-                real_samplers_rots_mcfp_at_inds_rto.cpu().numpy(),
-            ],
-            dtype=torch.int64,
-            device=pbt.device,
-        )
+        kinforest_idx[
+            real_samplers_rots_block_type_ind_for_mcfp_ats,
+            real_samplers_rots_mcfp_at_inds_rto,
+        ]
     )
 
     is_samplers_rots_mcfp_at_inds_kto_real = samplers_rots_mcfp_at_inds_kto != -1
     n_dof_atoms_offset_for_samplers_rot = n_dof_atoms_offset_for_rot[
         conf_inds_for_sampler
     ]
-    samplers_rots_mcfp_at_inds_kto[
-        is_samplers_rots_mcfp_at_inds_kto_real
-    ] += n_dof_atoms_offset_for_samplers_rot[
-        torch.div(  # to do: replace with expand
-            torch.arange(
-                n_rots_for_sampler * max_n_mcfp_atoms,
-                dtype=torch.int64,
-                device=poses.device,
-            ),
-            max_n_mcfp_atoms,
-            rounding_mode="trunc",
-        )[is_samplers_rots_mcfp_at_inds_kto_real]
-    ]
+    samplers_rots_mcfp_at_inds_kto[is_samplers_rots_mcfp_at_inds_kto_real] += (
+        n_dof_atoms_offset_for_samplers_rot[:, None]
+        .expand(n_rots_for_sampler, max_n_mcfp_atoms)
+        .reshape(-1)[is_samplers_rots_mcfp_at_inds_kto_real]
+    )
 
     # now get the indices in the orig_dofs array for the atoms to copy from.
     # The steps:
@@ -280,9 +278,13 @@ def create_dof_inds_to_copy_from_orig_to_rotamers_for_sampler(
         sampler_ind_for_orig, orig_res_mcfp, orig_block_type_ind, :
     ].view(-1)
 
-    real_orig_block_type_ind_for_orig_mcfp_ats = stretch(
-        orig_block_type_ind, max_n_mcfp_atoms
-    )[orig_mcfp_at_inds_rto != -1]
+    n_orig_blocks = orig_block_type_ind.shape[0]
+    orig_block_type_ind_for_mcfp_ats = (
+        orig_block_type_ind[:, None].expand(n_orig_blocks, max_n_mcfp_atoms).reshape(-1)
+    )
+    real_orig_block_type_ind_for_orig_mcfp_ats = orig_block_type_ind_for_mcfp_ats[
+        orig_mcfp_at_inds_rto != -1
+    ]
 
     orig_dof_atom_offset = exclusive_cumsum1d(pbt.n_atoms[orig_block_type_ind]).to(
         torch.int64
@@ -290,23 +292,14 @@ def create_dof_inds_to_copy_from_orig_to_rotamers_for_sampler(
 
     orig_mcfp_at_inds_kto = torch.full_like(orig_mcfp_at_inds_rto, -1)
     orig_mcfp_at_inds_kto[orig_mcfp_at_inds_rto != -1] = (
-        torch.tensor(
-            pbt.rotamer_kinforest.kinforest_idx[
-                real_orig_block_type_ind_for_orig_mcfp_ats.cpu().numpy(),
-                orig_mcfp_at_inds_rto[orig_mcfp_at_inds_rto != -1].cpu().numpy(),
-            ],
-            dtype=torch.int64,
-            device=pbt.device,
-        )
+        kinforest_idx[
+            real_orig_block_type_ind_for_orig_mcfp_ats,
+            orig_mcfp_at_inds_rto[orig_mcfp_at_inds_rto != -1],
+        ]
         + orig_dof_atom_offset[
-            torch.floor_divide(  # to do: replace w/ expand
-                torch.arange(
-                    orig_block_type_ind.shape[0] * max_n_mcfp_atoms,
-                    dtype=torch.int64,
-                    device=pbt.device,
-                ),
-                max_n_mcfp_atoms,
-            )
+            torch.arange(n_orig_blocks, dtype=torch.int64, device=pbt.device)[:, None]
+            .expand(n_orig_blocks, max_n_mcfp_atoms)
+            .reshape(-1)
         ][orig_mcfp_at_inds_rto != -1]
     )
 
@@ -354,27 +347,21 @@ def assign_chi_dofs_from_samples(
     n_rots_for_sampler = sampler_gbt_for_rotamer.shape[0]
 
     max_n_chi_atoms = chi_atoms.shape[1]
-    real_atoms = chi_atoms.view(-1) != -1
+    real_atoms = chi_atoms != -1
 
-    sampler_rot_ind_for_real_atom = torch.floor_divide(  # to do: replace w/ expand
-        torch.arange(
-            max_n_chi_atoms * n_rots_for_sampler, dtype=torch.int64, device=pbt.device
-        ),
-        max_n_chi_atoms,
-    )[real_atoms]
+    sampler_rot_ind_for_real_atom = torch.arange(
+        n_rots_for_sampler, dtype=torch.int64, device=pbt.device
+    )[:, None].expand_as(chi_atoms)[real_atoms]
     global_rot_ind_for_real_atom = conf_inds_for_sampler[sampler_rot_ind_for_real_atom]
 
-    block_type_ind_for_rot_atom = (
-        block_type_ind_for_rot[global_rot_ind_for_real_atom].cpu().numpy()
-    )
+    block_type_ind_for_rot_atom = block_type_ind_for_rot[global_rot_ind_for_real_atom]
 
-    rot_chi_atoms_kto = torch.tensor(
-        pbt.rotamer_kinforest.kinforest_idx[
-            block_type_ind_for_rot_atom, chi_atoms.view(-1)[real_atoms].cpu().numpy()
-        ],
-        dtype=torch.int64,
-        device=pbt.device,
-    )
+    from tmol.pack.rotamer import _get_chi_dof_metadata
+
+    kinforest_idx, correction_table = _get_chi_dof_metadata(pbt)
+    rot_chi_atoms_kto = kinforest_idx[
+        block_type_ind_for_rot_atom, chi_atoms[real_atoms]
+    ]
 
     # increment with the atom offsets for the source rotamer and by
     # one to include the virtual root
@@ -383,28 +370,12 @@ def assign_chi_dofs_from_samples(
     )
 
     # chi index (0, 1, 2, ...) for each real (rot, chi) entry
-    chi_idx_for_real_atom = (
-        (
-            torch.arange(
-                max_n_chi_atoms * n_rots_for_sampler,
-                dtype=torch.int64,
-                device=pbt.device,
-            )
-            % max_n_chi_atoms
-        )[real_atoms]
-        .cpu()
-        .numpy()
-    )
+    chi_idx_for_real_atom = torch.arange(
+        max_n_chi_atoms, dtype=torch.int64, device=pbt.device
+    )[None, :].expand_as(chi_atoms)[real_atoms]
 
-    # precomputed correction: phi_c = chi_intended - correction => chi_measured = chi_intended
-    from tmol.pack.rotamer import _build_chi_phi_c_corrections
-
-    corrections_np = _build_chi_phi_c_corrections(pbt)[
-        block_type_ind_for_rot_atom, chi_idx_for_real_atom
-    ]
-    corrections = torch.tensor(
-        corrections_np, dtype=rot_dofs_kto.dtype, device=pbt.device
-    )
+    # phi_c = chi_intended - correction => chi_measured = chi_intended
+    corrections = correction_table[block_type_ind_for_rot_atom, chi_idx_for_real_atom]
 
     # overwrite the "downstream torsion" for the atoms that control each chi
-    rot_dofs_kto[rot_chi_atoms_kto, 3] = chi.view(-1)[real_atoms] - corrections
+    rot_dofs_kto[rot_chi_atoms_kto, 3] = chi[real_atoms] - corrections

--- a/tmol/pack/rotamer/_mainchain_fingerprint.py
+++ b/tmol/pack/rotamer/_mainchain_fingerprint.py
@@ -420,13 +420,8 @@ def find_unique_fingerprints(  # noqa: C901
 
     # we do not need to re-annotate this PackedBlockTypes object if there
     # are no sidechain samplers that it has not encountered before
-    if hasattr(pbt, "mc_atom_mapping"):
-        all_found = True
-        for bt in sampler_types:
-            if bt not in pbt.mc_atom_mapping:
-                all_found = False
-                break
-        if all_found:
+    if hasattr(pbt, "mc_fingerprints"):
+        if sampler_types.issubset(pbt.mc_fingerprints.sampler_mapping):
             return
     sampler_types = sorted(list(sampler_types))
     n_samplers = len(sampler_types)

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -71,6 +71,7 @@ class OptHSamplerPackedBlockTypeCache:
     nhq_chi_atom: Tensor[torch.int32][:]
     nhq_chi_4atoms: Tensor[torch.int32][:, 4]
     nhq_downstream_kfo: Tensor[torch.int32][:, :]
+    nhq_downstream_count: Tensor[torch.int32][:]
     is_his: Tensor[torch.bool][:]
 
     # These two tensors use 0 or 1 as an index to dim=0 to represent
@@ -184,59 +185,48 @@ def _opth_fill_dofs(
     conf_dofs_kto[dst + 1, :] = orig_dofs_kto[src + 1, :]
 
     # Steps 2 & 3: only for rotamers that have a chi override
-    if chi_atoms.shape[0] == 0 or not (chi_atoms >= 0).any():
+    if chi_atoms.shape[0] == 0:
         return
 
-    kfidx = pbt.rotamer_kinforest.kinforest_idx  # (n_types, max_n_atoms) numpy
+    chi_mask = chi_atoms >= 0
+    has_chi_override = chi_mask.any(dim=1)
     dofs_ideal_t = torch.as_tensor(
         pbt.rotamer_kinforest.dofs_ideal, dtype=torch.float32, device=dev
     )
-    corrections = _build_chi_phi_c_corrections(pbt)  # (n_types, max_n_chi) numpy
+    opth_cache = pbt.opth_sample_cache
 
-    reset_kto, reset_bt, reset_k = [], [], []
-    chi_kto, chi_val_list = [], []
-
-    # chi_atoms is set >= 0 only for rotamers needing a chi override:
-    # NHQ flips, HIS tautomer swaps, and proton-chi samples.  Step 2 and
-    # step 3 below run only over those rotamers.
-    flip_sis = (chi_atoms >= 0).any(dim=1).nonzero(as_tuple=True)[0].tolist()
-    for si in flip_sis:
-        bt_idx = bt_inds[si].item()
-        at_off = at_offs[si].item()
-
-        # Step 2: reset downstream atoms to ideal.
-        if flip_NHQ:
-            downstream = pbt.active_block_types[
-                bt_idx
-            ].opth_sampler_cache.nhq_downstream_kfo
-            for k in downstream:
-                k = int(k)
-                reset_kto.append(k + at_off + 1)
-                reset_bt.append(bt_idx)
-                reset_k.append(k)
-
-        # Step 3: write the chi torsion(s) into DOF column 3.
-        for chi_col in range(chi_atoms.shape[1]):
-            chi_rto = chi_atoms[si, chi_col].item()
-            if chi_rto < 0:
-                continue
-            kfo = int(kfidx[bt_idx, chi_rto])
-            corr = float(corrections[bt_idx, chi_col])
-            chi_kto.append(kfo + at_off + 1)
-            chi_val_list.append(chi_vals[si, chi_col].item() - corr)
-
-    if reset_kto:
-        conf_dofs_kto[torch.tensor(reset_kto, dtype=torch.int64, device=dev)] = (
-            dofs_ideal_t[
-                torch.tensor(reset_bt, dtype=torch.int64, device=dev),
-                torch.tensor(reset_k, dtype=torch.int64, device=dev),
-            ]
+    # Reset NHQ atoms downstream of the flipped chi to ideal geometry. Keep
+    # this entirely on-device: reading each rotamer's offsets with .item()
+    # serializes large CUDA batches.
+    if flip_NHQ:
+        downstream = opth_cache.nhq_downstream_kfo[bt_inds]
+        downstream_count = opth_cache.nhq_downstream_count[bt_inds]
+        downstream_slot = torch.arange(
+            downstream.shape[1], dtype=torch.int32, device=dev
         )
-
-    if chi_kto:
-        conf_dofs_kto[torch.tensor(chi_kto, dtype=torch.int64, device=dev), 3] = (
-            torch.tensor(chi_val_list, dtype=torch.float32, device=dev)
+        reset_mask = (downstream_slot[None, :] < downstream_count[:, None]) & (
+            has_chi_override[:, None]
         )
+        reset_k = downstream[reset_mask].to(torch.int64)
+        reset_bt = bt_inds[:, None].expand_as(downstream)[reset_mask]
+        reset_kto = (downstream + at_offs[:, None].to(downstream.dtype) + 1)[
+            reset_mask
+        ].to(torch.int64)
+        conf_dofs_kto[reset_kto] = dofs_ideal_t[reset_bt, reset_k]
+
+    # Write every chi override in one indexed assignment.
+    kfidx = torch.as_tensor(
+        pbt.rotamer_kinforest.kinforest_idx, dtype=torch.int64, device=dev
+    )
+    corrections = torch.as_tensor(
+        _build_chi_phi_c_corrections(pbt), dtype=torch.float32, device=dev
+    )
+    safe_chi_atoms = chi_atoms.clamp_min(0).to(torch.int64)
+    rotamer_bt = bt_inds[:, None].expand_as(safe_chi_atoms)
+    chi_kto = kfidx[rotamer_bt, safe_chi_atoms] + at_offs[:, None] + 1
+    chi_cols = torch.arange(chi_atoms.shape[1], device=dev)[None, :]
+    corrected_chi = chi_vals - corrections[rotamer_bt, chi_cols]
+    conf_dofs_kto[chi_kto[chi_mask], 3] = corrected_chi[chi_mask]
 
 
 def _n_rots_for_gbt(sampler, blt, orig, orig_cache, bt, bt_cache):
@@ -467,6 +457,11 @@ class OptHSampler(ConformerSampler):
             dtype=torch.int32,
             device=packed_block_types.device,
         )
+        nhq_downstream_count = torch.zeros(
+            (packed_block_types.n_types,),
+            dtype=torch.int32,
+            device=packed_block_types.device,
+        )
         is_his = torch.zeros(
             (packed_block_types.n_types,),
             dtype=torch.bool,
@@ -544,6 +539,7 @@ class OptHSampler(ConformerSampler):
                 dtype=torch.int32,
                 device=packed_block_types.device,
             )
+            nhq_downstream_count[i] = len(orig_bt.opth_sampler_cache.nhq_downstream_kfo)
             is_his[i] = orig_bt.opth_sampler_cache.is_his
 
         cache = OptHSamplerPackedBlockTypeCache(
@@ -558,6 +554,7 @@ class OptHSampler(ConformerSampler):
             nhq_chi_atom=nhq_chi_atom,
             nhq_chi_4atoms=nhq_chi_4atoms,
             nhq_downstream_kfo=nhq_downstream_kfo,
+            nhq_downstream_count=nhq_downstream_count,
             is_his=is_his,
             n_samples_for_bt_by_orig_bt=n_samples_for_bt_by_orig_bt,
             n_chi_needed_for_bt=n_chi_needed_for_bt,
@@ -655,9 +652,7 @@ class OptHSampler(ConformerSampler):
         ]  # size (n_allowed_bt,)
         nz_allowed_bt_is_optH_buildable = torch.nonzero(
             allowed_bt_is_optH_buildable, as_tuple=True
-        )[
-            0
-        ]  # size (n_allowed_and_buildable_bt,)
+        )[0]  # size (n_allowed_and_buildable_bt,)
         allowed_and_buildable_pose = task.allowed_bt_pose[
             nz_allowed_bt_is_optH_buildable
         ]
@@ -854,10 +849,14 @@ class OptHSampler(ConformerSampler):
         bt_for_flipped_rotamer = bt_for_rotamer[flipped_rotamers]
 
         is_his_rotamer = opth_cache.is_his[bt_for_rotamer]
-        is_orig_bt_rotamer = bt_for_rotamer == (
-            pose_stack.block_type_ind64[
-                task.cons_bt_pose[gbt_for_rotamer], task.cons_bt_block[gbt_for_rotamer]
-            ]
+        is_orig_bt_rotamer = (
+            bt_for_rotamer
+            == (
+                pose_stack.block_type_ind64[
+                    task.cons_bt_pose[gbt_for_rotamer],
+                    task.cons_bt_block[gbt_for_rotamer],
+                ]
+            )
         )
         is_his_taut_rotamer = torch.logical_and(is_his_rotamer, ~is_orig_bt_rotamer)
         is_unflipped_rotamer = torch.zeros(
@@ -942,7 +941,11 @@ class OptHSampler(ConformerSampler):
         self,
         pose_stack: PoseStack,
         task: "SetPackerTask",  # noqa: F821
-    ) -> Tuple[Tensor[torch.int32][:], Tensor[torch.int32][:], dict,]:
+    ) -> Tuple[
+        Tensor[torch.int32][:],
+        Tensor[torch.int32][:],
+        dict,
+    ]:
         self._annotate_packed_block_types(pose_stack.packed_block_types)
 
         # ensure dunbrack and optH sampler are not _both_ specified for the same block

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -141,7 +141,7 @@ def _opth_fill_dofs(
     3. Write the corrected chi torsion into DOF column 3 for
        the chi-defining atom of each flip / proton-chi rotamer.
     """
-    from tmol.pack.rotamer import _build_chi_phi_c_corrections
+    from tmol.pack.rotamer import _get_chi_dof_metadata
 
     pbt = pose_stack.packed_block_types
     dev = conf_dofs_kto.device
@@ -215,47 +215,13 @@ def _opth_fill_dofs(
         conf_dofs_kto[reset_kto] = dofs_ideal_t[reset_bt, reset_k]
 
     # Write every chi override in one indexed assignment.
-    kfidx = torch.as_tensor(
-        pbt.rotamer_kinforest.kinforest_idx, dtype=torch.int64, device=dev
-    )
-    corrections = torch.as_tensor(
-        _build_chi_phi_c_corrections(pbt), dtype=torch.float32, device=dev
-    )
+    kfidx, corrections = _get_chi_dof_metadata(pbt)
     safe_chi_atoms = chi_atoms.clamp_min(0).to(torch.int64)
     rotamer_bt = bt_inds[:, None].expand_as(safe_chi_atoms)
     chi_kto = kfidx[rotamer_bt, safe_chi_atoms] + at_offs[:, None] + 1
     chi_cols = torch.arange(chi_atoms.shape[1], device=dev)[None, :]
     corrected_chi = chi_vals - corrections[rotamer_bt, chi_cols]
     conf_dofs_kto[chi_kto[chi_mask], 3] = corrected_chi[chi_mask]
-
-
-def _n_rots_for_gbt(sampler, blt, orig, orig_cache, bt, bt_cache):
-    """Return the number of rotamers OptHSampler generates for one GBT entry."""
-    # Proton chi: only for the original block type
-    if bt_cache.has_proton_chi and bt is blt.original_block_type:
-        return bt_cache.n_proton_samples
-
-    # NHQ flip
-    if sampler.flip_NHQ and orig_cache.nhq_chi_col >= 0:
-        if orig_cache.is_his:
-            # HIS/HIS_D: 2 rotamers for EVERY HIS/HIS_D considered block type
-            if bt_cache.is_his:
-                return 2
-        else:
-            # ASN/GLN: 2 rotamers only for the original block type
-            if bt is blt.original_block_type:
-                return 2
-
-    return 0
-
-
-def _chi_cols_needed(bt_cache, orig_cache, flip_NHQ):
-    """Return the minimum chi tensor width needed for a GBT with non-zero rots."""
-    if bt_cache.has_proton_chi:
-        return bt_cache.n_chi_total
-    if flip_NHQ and orig_cache.nhq_chi_col >= 0:
-        return orig_cache.nhq_chi_col + 1
-    return 1
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -616,19 +582,7 @@ class OptHSampler(ConformerSampler):
         c = c.to(dtype=torch.float64)
         return coord_dihedrals(c[:, 0], c[:, 1], c[:, 2], c[:, 3])  # (n,)
 
-    def _measure_nhq_flip_chi(self, pose_stack, coords, pose_i, block_j, orig_cache):
-        off = int(pose_stack.block_coord_offset[pose_i, block_j].item())
-        a4 = orig_cache.nhq_chi_4atoms
-        c = coords[pose_i][
-            torch.tensor(
-                [off + int(a4[k]) for k in range(4)],
-                dtype=torch.int64,
-                device=pose_stack.device,
-            )
-        ]  # (4, 3)
-        return float(coord_dihedrals(c[0:1], c[1:2], c[2:3], c[3:4])[0].item())
-
-    def _count_rots_and_measure_all_flips(self, pose_stack, task, coords):
+    def _count_rots_and_measure_all_flips(self, pose_stack, task):
         # First we have to get the list of all the blocks where we are using
         # this sampler. Next we will identify the subset of the NHQ blocks
         # where we will measure the chi dihedrals for the flip. Then we will
@@ -710,40 +664,6 @@ class OptHSampler(ConformerSampler):
                 )
                 pos_flip_chi[pose_inds_nhq, block_inds_nhq] = pos_flip_chi_nhq
         return n_rots_for_gbt, max_n_chi_cols, pos_flip_chi
-
-    def _count_rots_and_measure_flips(self, pose_stack, task, coords):
-        # pos_flip_chi[(pose_i, block_j)] = current last-chi in radians
-        pos_flip_chi = {}
-        n_rots_for_gbt_list = []
-        max_n_chi_cols = 1
-        for pose_i, one_pose_blts in enumerate(task.blts):
-            for block_j, blt in enumerate(one_pose_blts):
-                orig = blt.original_block_type
-                orig_cache = orig.opth_sampler_cache
-                opth_assigned = self in blt.conformer_samplers
-
-                # Measure chi-to-flip for NHQ
-                if opth_assigned and self.flip_NHQ and orig_cache.nhq_chi_col >= 0:
-                    pos_flip_chi[(pose_i, block_j)] = self._measure_nhq_flip_chi(
-                        pose_stack, coords, pose_i, block_j, orig_cache
-                    )
-
-                for bt in blt.considered_block_types:
-                    if not opth_assigned:
-                        n_rots_for_gbt_list.append(0)
-                        continue
-                    bt_cache = bt.opth_sampler_cache
-                    if not opth_assigned:
-                        n_rots_for_gbt_list.append(0)
-                        continue
-                    n_rots = _n_rots_for_gbt(self, blt, orig, orig_cache, bt, bt_cache)
-                    n_rots_for_gbt_list.append(n_rots)
-                    if n_rots > 0:
-                        max_n_chi_cols = max(
-                            max_n_chi_cols,
-                            _chi_cols_needed(bt_cache, orig_cache, self.flip_NHQ),
-                        )
-        return n_rots_for_gbt_list, max_n_chi_cols, pos_flip_chi
 
     def _fill_proton_chi_for_all_blocks(
         self,
@@ -951,9 +871,8 @@ class OptHSampler(ConformerSampler):
         #      max chi tensor width
         #      current last-chi angle
         # for each NHQ position in the input
-        coords = pose_stack.coords.double()  # coord_dihedrals needs float64
         n_rots_for_gbt, max_n_chi_cols, pos_flip_chi = (
-            self._count_rots_and_measure_all_flips(pose_stack, task, coords)
+            self._count_rots_and_measure_all_flips(pose_stack, task)
         )
 
         n_rots_total = int(n_rots_for_gbt.sum().item())

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -652,7 +652,9 @@ class OptHSampler(ConformerSampler):
         ]  # size (n_allowed_bt,)
         nz_allowed_bt_is_optH_buildable = torch.nonzero(
             allowed_bt_is_optH_buildable, as_tuple=True
-        )[0]  # size (n_allowed_and_buildable_bt,)
+        )[
+            0
+        ]  # size (n_allowed_and_buildable_bt,)
         allowed_and_buildable_pose = task.allowed_bt_pose[
             nz_allowed_bt_is_optH_buildable
         ]
@@ -849,14 +851,11 @@ class OptHSampler(ConformerSampler):
         bt_for_flipped_rotamer = bt_for_rotamer[flipped_rotamers]
 
         is_his_rotamer = opth_cache.is_his[bt_for_rotamer]
-        is_orig_bt_rotamer = (
-            bt_for_rotamer
-            == (
-                pose_stack.block_type_ind64[
-                    task.cons_bt_pose[gbt_for_rotamer],
-                    task.cons_bt_block[gbt_for_rotamer],
-                ]
-            )
+        is_orig_bt_rotamer = bt_for_rotamer == (
+            pose_stack.block_type_ind64[
+                task.cons_bt_pose[gbt_for_rotamer],
+                task.cons_bt_block[gbt_for_rotamer],
+            ]
         )
         is_his_taut_rotamer = torch.logical_and(is_his_rotamer, ~is_orig_bt_rotamer)
         is_unflipped_rotamer = torch.zeros(
@@ -941,11 +940,7 @@ class OptHSampler(ConformerSampler):
         self,
         pose_stack: PoseStack,
         task: "SetPackerTask",  # noqa: F821
-    ) -> Tuple[
-        Tensor[torch.int32][:],
-        Tensor[torch.int32][:],
-        dict,
-    ]:
+    ) -> Tuple[Tensor[torch.int32][:], Tensor[torch.int32][:], dict,]:
         self._annotate_packed_block_types(pose_stack.packed_block_types)
 
         # ensure dunbrack and optH sampler are not _both_ specified for the same block

--- a/tmol/tests/io/details/test_select_from_canonical.py
+++ b/tmol/tests/io/details/test_select_from_canonical.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 import torch
 
 import cattr
@@ -24,6 +25,9 @@ from tmol.io.details import (
     _annotate_packed_block_types_w_canonical_res_order,
     CanonicalOrderingAnnotation,
 )
+from tmol.io.details._select_from_canonical import (
+    _assert_connections_are_well_formed,
+)
 from tmol.pose import (
     PoseStackBuilder,
     PackedBlockTypes,
@@ -33,6 +37,34 @@ from tmol.tests.io.details.test_left_justify_canonical_form import add_two_res_a
 
 def not_any_nancoord(coords):
     return torch.logical_not(torch.any(torch.isnan(coords), dim=3))
+
+
+def test_assert_connections_are_well_formed_batched(torch_device):
+    block_types = torch.zeros((16, 3), dtype=torch.int64, device=torch_device)
+    connections = torch.full((16, 3, 2, 2), -1, dtype=torch.int64, device=torch_device)
+    connections[:, 0, 0] = torch.tensor([1, 1], device=torch_device)
+    connections[:, 1, 1] = torch.tensor([0, 0], device=torch_device)
+
+    _assert_connections_are_well_formed(None, block_types, connections)
+
+
+def test_assert_connections_are_well_formed_reports_malformed(torch_device):
+    block_types = torch.zeros((1, 3), dtype=torch.int64, device=torch_device)
+    connections = torch.full((1, 3, 2, 2), -1, dtype=torch.int64, device=torch_device)
+    connections[0, 0, 0] = torch.tensor([1, 1], device=torch_device)
+    connections[0, 1, 1] = torch.tensor([2, 0], device=torch_device)
+
+    with pytest.raises(RuntimeError, match="which points back at 2"):
+        _assert_connections_are_well_formed(None, block_types, connections)
+
+
+def test_assert_connections_are_well_formed_reports_out_of_range(torch_device):
+    block_types = torch.zeros((1, 3), dtype=torch.int64, device=torch_device)
+    connections = torch.full((1, 3, 2, 2), -1, dtype=torch.int64, device=torch_device)
+    connections[0, 0, 0] = torch.tensor([3, 0], device=torch_device)
+
+    with pytest.raises(RuntimeError, match="connects to invalid block 3"):
+        _assert_connections_are_well_formed(None, block_types, connections)
 
 
 def dslf_and_his_resolved_pose_stack_from_canonical_form(

--- a/tmol/tests/io/test_pose_stack_from_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite.py
@@ -60,6 +60,18 @@ def test_pose_stack_from_biotite_1ubq_smoke(biotite_1ubq, torch_device):
     pose_stack_from_biotite(biotite_1ubq, torch_device=torch_device)
 
 
+def test_complete_protein_skips_na_sampler_setup(
+    biotite_1ubq, torch_device, monkeypatch
+):
+    from tmol.pack.rotamer import NaChiRotamerSampler
+
+    def unexpected_na_sampler(*_args, **_kwargs):
+        raise AssertionError("NA sampler is unnecessary for a complete protein")
+
+    monkeypatch.setattr(NaChiRotamerSampler, "from_database", unexpected_na_sampler)
+    pose_stack_from_biotite(biotite_1ubq, torch_device=torch_device)
+
+
 # 1ubq with one residue's 3LC changed to ERR to test a non-recognized residue type
 def test_pose_stack_from_biotite_1ubq_err_smoke(biotite_1ubq_err, torch_device):
     starts = biotite.structure.get_residue_starts(biotite_1ubq_err)

--- a/tmol/tests/io/test_pose_stack_from_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite.py
@@ -72,6 +72,28 @@ def test_complete_protein_skips_na_sampler_setup(
     pose_stack_from_biotite(biotite_1ubq, torch_device=torch_device)
 
 
+def test_reused_context_caches_packing_setup(biotite_1ubq, torch_device):
+    context = build_context_from_biotite(biotite_1ubq, torch_device=torch_device)
+
+    torch.manual_seed(0)
+    first = pose_stack_from_biotite(
+        biotite_1ubq, torch_device=torch_device, context=context
+    )
+    score_function = context._packing_score_function
+    dunbrack_sampler = context._dunbrack_sampler
+
+    torch.manual_seed(0)
+    second = pose_stack_from_biotite(
+        biotite_1ubq, torch_device=torch_device, context=context
+    )
+
+    assert context._packing_score_function is score_function
+    assert context._dunbrack_sampler is dunbrack_sampler
+    assert torch.equal(torch.isnan(first.coords), torch.isnan(second.coords))
+    finite = torch.isfinite(first.coords) & torch.isfinite(second.coords)
+    assert torch.equal(first.coords[finite], second.coords[finite])
+
+
 # 1ubq with one residue's 3LC changed to ERR to test a non-recognized residue type
 def test_pose_stack_from_biotite_1ubq_err_smoke(biotite_1ubq_err, torch_device):
     starts = biotite.structure.get_residue_starts(biotite_1ubq_err)

--- a/tmol/tests/pack/rotamer/test_mainchain_fingerprint.py
+++ b/tmol/tests/pack/rotamer/test_mainchain_fingerprint.py
@@ -179,6 +179,9 @@ def test_merge_fingerprints(default_database):  # noqa: C901
         default_database.chemical, rts, rt_list, device=torch_device
     )
     find_unique_fingerprints(pbt)
+    cached_fingerprints = pbt.mc_fingerprints
+    find_unique_fingerprints(pbt)
+    assert pbt.mc_fingerprints is cached_fingerprints
 
     # we should find that the pbt has been annotated
     # we should find that it has discovered two backbone types

--- a/tmol/tests/pack/test_build_missing_sidechains.py
+++ b/tmol/tests/pack/test_build_missing_sidechains.py
@@ -1,4 +1,5 @@
 import torch
+import tmol.pack._build_missing_sidechains as build_missing_sidechains_module
 
 from tmol.pack import build_missing_sidechains
 from tmol.score import beta2016_score_function
@@ -7,7 +8,6 @@ from tmol.tests.score.common import pose_stack_from_pdb_and_resnums
 
 
 def test_build_missing_sidechains_jagged_pose_stack(ubq_pdb, torch_device, dun_sampler):
-
     res_50 = [(0, 50)]
     res_30 = [(20, 50)]
     p1 = pose_stack_from_pdb_and_resnums(ubq_pdb, torch_device)
@@ -31,7 +31,6 @@ def test_build_missing_sidechains_jagged_pose_stack(ubq_pdb, torch_device, dun_s
 
 
 def test_build_missing_sidechains_no_optH(ubq_pdb, torch_device, dun_sampler):
-
     res_50 = [(0, 50)]
     res_30 = [(20, 50)]
     p1 = pose_stack_from_pdb_and_resnums(ubq_pdb, torch_device)
@@ -52,3 +51,36 @@ def test_build_missing_sidechains_no_optH(ubq_pdb, torch_device, dun_sampler):
         no_optH=True,
         block_has_missing_atoms=block_has_missing_atoms,
     )
+
+
+def test_build_missing_sidechains_skips_na_sampler_for_complete_pose(
+    ubq_pdb, torch_device, dun_sampler, monkeypatch
+):
+    pose_stack = pose_stack_from_pdb_and_resnums(ubq_pdb, torch_device)
+    block_has_missing_atoms = torch.zeros(
+        (pose_stack.n_poses, pose_stack.max_n_blocks),
+        dtype=torch.bool,
+        device=torch_device,
+    )
+
+    class UnexpectedNASampler:
+        def defines_rotamers_for_bts(self, *_args, **_kwargs):
+            raise AssertionError(
+                "NA sampler should not run for a complete protein pose"
+            )
+
+    monkeypatch.setattr(
+        build_missing_sidechains_module,
+        "pack_rotamers",
+        lambda pose_stack, *_args, **_kwargs: pose_stack,
+    )
+    result = build_missing_sidechains(
+        pose_stack=pose_stack,
+        sfxn=beta2016_score_function(torch_device),
+        dunbrack_sampler=dun_sampler,
+        no_optH=True,
+        block_has_missing_atoms=block_has_missing_atoms,
+        na_sampler=UnexpectedNASampler(),
+    )
+
+    assert result is pose_stack


### PR DESCRIPTION
## Summary

- vectorize inter-residue connection validation instead of synchronizing once per CUDA scalar
- vectorize OptH DOF filling, removing tens of thousands of `.item()` calls for large batches
- cache the OptH packing score function and conformer samplers in the reusable `PoseBuildContext`
- avoid constructing and annotating the nucleotide sampler for complete protein inputs
- keep generic chi/mainchain DOF lookup on device and cache immutable lookup tables
- skip the jump-parent trial fold and full coordinate copy when no correction is required
- remove the superseded scalar OptH implementation and a global `torch.set_printoptions` side effect
- bump the package version to `0.1.50`

OptH remains enabled throughout: benchmarks invoke `pose_stack_from_biotite(..., no_optH=False)`.

## Benchmarks

Warm, synchronized pose construction plus one-repeat FastRelax for a 150-residue protein, with context and the external FastRelax score function reused:

| batch | stock v0.1.49 E2E | release candidate E2E | speedup |
|---:|---:|---:|---:|
| 1 | 3.964 s | 2.941 s | 34.8% |
| 4 | 5.616 s | 4.516 s | 24.4% |
| 16 | — | 13.394 s | — |

In a 30-trial pose-only run, release-candidate medians were 44.0, 53.9, and 105.4 ms at batches 1, 4, and 16. The earlier stock-v0.1.49 medians at batches 1/2/4 were 300/342/430 ms; release-candidate medians were 47/53/59 ms in the same run.

Compared with the official v0.1.46 wheel, prior release-candidate measurements showed 7.2–13.6% faster E2E throughput across residue lengths 100–300 and batches 8–16.

## Correctness and rejected experiments

- 46 focused rotamer tests pass on CPU and CUDA.
- Matched-seed protein (batch 4) and DNA (batch 2) OptH coordinates—including hydrogens—are bit-for-bit identical to unmodified v0.1.49. Block types and coordinate offsets are also identical.
- Repeated cached and fresh-context outputs are bit-for-bit identical.
- CUDA-graph scoring, a last-topology cache, CUDA stream-ordered allocation, and PyTorch caching allocation were benchmarked but rejected because they did not improve the batched synchronized E2E result consistently.
- Black, flake8, and `git diff --check` pass.

Nsight Systems traces and CSV summaries for v0.1.46, stock v0.1.49, and this release candidate are being captured while CI runs.
