### PR TITLE
Fix heterogeneous dense minimizer segments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.49"
+version = "0.1.50"
 
 dependencies = [
     # Core ML framework

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -288,7 +288,9 @@ class LBFGS_Armijo(Optimizer):
         # The common Cartesian-minimization layout has equally sized segments
         # stored consecutively. In that case padding is just a view/copy; keep
         # the indexed path for heterogeneous or interleaved segment layouts.
-        self._segments_are_dense = bool(torch.equal(self._pad_index, arange))
+        self._segments_are_dense = bool(
+            (counts == segment_size).all() and torch.equal(self._pad_index, arange)
+        )
 
     def _seg_sum(self, values):
         """Sum a parameter-shaped vector within each segment."""

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -35,6 +35,19 @@ def test_dense_segment_layout_helpers(torch_device):
     torch.testing.assert_close(out, expected)
 
 
+def test_contiguous_unequal_segments_use_padding(torch_device):
+    """Contiguous segments are dense only when they also have equal lengths."""
+    x = torch.nn.Parameter(torch.zeros(7, device=torch_device))
+    segment_ids = torch.tensor([0, 0, 0, 0, 1, 1, 1], device=torch_device)
+    optimizer = LBFGS_Armijo([x], segment_ids=segment_ids)
+    values = torch.arange(7, dtype=x.dtype, device=torch_device)
+
+    assert not optimizer._segments_are_dense
+    torch.testing.assert_close(
+        optimizer._seg_sum(values), torch.tensor([6.0, 15.0], device=torch_device)
+    )
+
+
 def test_batched_two_loop_matches_one_problem_at_a_time(torch_device):
     grad, dirs, stps = _history(7, 4, 13, torch.float64, torch_device)
     batched = lbfgs_two_loop(grad, dirs, stps)


### PR DESCRIPTION
Treat contiguous segments as dense only when every segment has the same length. Unequal mutation legs otherwise take the reshape fast path and fail during batched kinematic minimization. Includes a focused regression test and bumps the patch version to 0.1.50.