### PR TITLE
Add reproducible GPU workflow profiling

### DIFF
--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -86,6 +86,30 @@ Each case produces:
 The `.nsys-rep`, matching JSON, and manifest are the minimum NVIDIA handoff.
 Keep the SQLite and CSV files for analysis without the GUI.
 
+## Verify and summarize a run
+
+Turn the full result bundle into a readable table, a log-scale latency plot,
+and a compact Nsight summary:
+
+```bash
+python dev/profiling/analyze.py artifacts/nsys
+```
+
+The analyzer first verifies every size and SHA-256 checksum in `manifest.json`,
+then writes `analysis/timings.md`, `analysis/timings.svg`, and
+`analysis/trace_summary.csv`. The trace summary includes the profiled iteration
+time, total GPU-kernel time, kernel-launch count and API time, and dominant
+kernel. Compare regular runs from two revisions with:
+
+```bash
+python dev/profiling/analyze.py artifacts/current \
+  --baseline artifacts/baseline
+```
+
+This additionally writes `analysis/comparison.csv`; negative `delta_percent`
+is faster. Run regular timings and traces into separate directories because
+Nsight interception intentionally changes wall time.
+
 ## Slurm and Apptainer example
 
 Run the container itself inside the GPU allocation. Replace the two paths with

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -66,12 +66,21 @@ to replace them.
 
 `nsys` must be available in the GPU runtime. The trace command uses the CUDA
 Profiler API to exclude imports, topology construction, score-function
-rendering, and warm-up from the capture. CUDA graphs are traced at node
-granularity so their internal kernels remain visible:
+rendering, and warm-up from the capture:
 
 ```bash
 python dev/profiling/matrix.py \
   --trace --output-dir artifacts/nsys
+```
+
+Nsight's default graph-level mode keeps complete matrix captures fast and
+compact. Use the matching eager case to inspect the kernels inside a scorer.
+For a focused CUDA-graph investigation, node-level tracing is available but can
+add minutes of profiler overhead to one replay with Nsight Systems 2026.3.1:
+
+```bash
+python dev/profiling/matrix.py --trace --graph-node-trace \
+  --output-dir artifacts/graph-nodes --case score_graph-dna24-b1
 ```
 
 Each case produces:

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -1,0 +1,120 @@
+# TMol GPU workflow profiling
+
+This directory benchmarks complete TMol workflows and produces self-contained
+Nsight Systems captures for performance investigations and NVIDIA handoff. It
+complements the pytest microbenchmarks in `tmol/tests`: setup and warm-up happen
+before capture, while one synchronized steady-state invocation is enclosed by
+case-specific NVTX ranges.
+
+## Coverage
+
+The checked-in matrix spans:
+
+| Workflow | Systems | Batch coverage |
+|---|---|---|
+| eager and CUDA-graph scoring | 15-, 100-, and 400-residue proteins; DNA; RNA; protein–DNA; protein–ligand | one pose and a system-appropriate batch |
+| eager and CUDA-graph score + coordinate gradient | the same seven systems | one pose and a system-appropriate batch |
+| Cartesian minimization | all seven systems | one pose plus selected batches |
+| torsion-space minimization | proteins, DNA, RNA, and protein–DNA | one pose plus selected batches |
+| FastRelax | 15- and 100-residue proteins | one pose and a selected batch |
+
+Minimization uses ten LBFGS iterations. FastRelax uses one complete default
+four-stage ramp, with ten Cartesian LBFGS iterations per stage. These fixed
+budgets make implementations comparable; they are not convergence claims.
+
+## Run one case
+
+Use an AOT build on a CUDA node for stable results:
+
+```bash
+export TMOL_USE_JIT=0
+python dev/profiling/workflows.py \
+  --workflow score_grad --system protein100 --batch 16 \
+  --warmup 5 --iterations 30 --output artifacts/result.json
+```
+
+Valid workflow names are `score`, `score_grad`, `score_graph`,
+`score_graph_grad`, `cart_min`, `kin_min`, and `fast_relax`. The runner records
+the Git revision, imported TMol path and version, GPU, driver, CUDA and PyTorch
+versions, container path, Slurm job, system dimensions, synchronized
+system/workload setup times, steady-state timings, and allocated-memory
+high-water mark. CUDA-graph capture time is part of workload setup rather than
+replay timing.
+
+## Run the matrix
+
+Regular timings use more repetitions than trace captures:
+
+```bash
+python dev/profiling/matrix.py --output-dir artifacts/baseline
+```
+
+Select workflows or exact case slugs when iterating:
+
+```bash
+python dev/profiling/matrix.py --output-dir artifacts/baseline \
+  --workflow score --workflow score_grad
+
+python dev/profiling/matrix.py --output-dir artifacts/baseline \
+  --case cart_min-dna24-b1
+```
+
+Completed cases are skipped, so the command is safe to resume. Pass `--force`
+to replace them.
+
+## Capture Nsight Systems traces
+
+`nsys` must be available in the GPU runtime. The trace command uses the CUDA
+Profiler API to exclude imports, topology construction, score-function
+rendering, and warm-up from the capture:
+
+```bash
+python dev/profiling/matrix.py \
+  --trace --output-dir artifacts/nsys
+```
+
+Each case produces:
+
+- `results/<case>.json`: timing, memory, topology, and environment metadata;
+- `traces/<case>.nsys-rep`: the source trace to open in Nsight Systems;
+- `traces/<case>.sqlite`: an exported queryable trace database;
+- `traces/<case>.stats.csv`: kernel, CUDA API, and NVTX summaries;
+- `logs/<case>.log`: complete runner and profiler output;
+- `results/summary.csv`: one-row-per-case overview;
+- `manifest.json`: case inventory, sizes, and SHA-256 checksums.
+
+The `.nsys-rep`, matching JSON, and manifest are the minimum NVIDIA handoff.
+Keep the SQLite and CSV files for analysis without the GUI.
+
+## Slurm and Apptainer example
+
+Run the container itself inside the GPU allocation. Replace the two paths with
+the local environment and image:
+
+```bash
+sbatch --partition=<gpu-partition> --gres=gpu:1 --cpus-per-task=16 \
+  --mem=128G --time=04:00:00 --wrap="
+    apptainer exec --nv <tmol.sif> bash -lc '
+      source <tmol-venv>/bin/activate
+      export TMOL_USE_JIT=0
+      cd <tmol-checkout>
+      python dev/profiling/matrix.py --trace --output-dir <artifact-dir>
+    '"
+```
+
+Use an exclusive GPU when comparing revisions. Nsight interception adds host
+overhead, so use the regular matrix for latency comparisons and the trace
+matrix for causal analysis.
+
+## Interpreting the traces
+
+Start at `<case>/measure`, then inspect `<case>/iteration-0`. TMol's nested NVTX
+ranges identify score-term, water-generation, kinematics, packing, and optimizer
+work. The CSV reports answer three first-pass questions:
+
+1. `cuda_gpu_kern_sum`: which kernels account for device time?
+2. `cuda_api_sum`: is the workload launch- or synchronization-bound?
+3. `nvtx_sum`: which TMol phase owns the elapsed time?
+
+Record conclusions only after comparing the regular timing matrix with these
+traces; a profiled wall time is not a benchmark result.

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -66,7 +66,8 @@ to replace them.
 
 `nsys` must be available in the GPU runtime. The trace command uses the CUDA
 Profiler API to exclude imports, topology construction, score-function
-rendering, and warm-up from the capture:
+rendering, and warm-up from the capture. CUDA graphs are traced at node
+granularity so their internal kernels remain visible:
 
 ```bash
 python dev/profiling/matrix.py \

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -22,6 +22,65 @@ Minimization uses ten LBFGS iterations. FastRelax uses one complete default
 four-stage ramp, with ten Cartesian LBFGS iterations per stage. These fixed
 budgets make implementations comparable; they are not convergence claims.
 
+## H200 reference result
+
+The 2026-08-27 reference run used one NVIDIA H200, driver 595.71.05, Python
+3.12.3, PyTorch 2.11.0+cu128, CUDA runtime 12.8, the
+`latent-dev-cuda13-26.06-tmol0.1.42.sif` image, AOT extensions, and runtime JIT
+disabled. These are synchronized steady-state medians; setup and warm-up are
+excluded.
+
+| Workflow and input | Batch 1 (ms) | Larger batch | Batch time (ms) | Throughput gain |
+|---|---:|---:|---:|---:|
+| score, 15-residue protein | 0.517 | 32 | 0.569 | 29.1x |
+| score, 400-residue protein | 0.735 | 4 | 1.375 | 2.1x |
+| score, 24-nt DNA | 2.729 | 32 | 2.776 | 31.5x |
+| score, protein–ligand | 0.808 | 8 | 2.295 | 2.8x |
+| Cartesian min, 15-residue protein | 41.623 | 32 | 42.117 | 31.6x |
+| Cartesian min, 24-nt DNA | 183.181 | 8 | 176.959 | 8.3x |
+| torsion min, 24-nt DNA | 238.398 | 4 | 249.866 | 3.8x |
+| FastRelax, 15-residue protein | 348.194 | 8 | 521.822 | 5.3x |
+| FastRelax, 100-residue protein | 1247.685 | 4 | 2247.399 | 2.2x |
+
+CUDA graphs pay off for repeated fixed layouts, especially nucleic acids. At
+batch 1, graph replay changed DNA forward scoring from 2.729 to 0.867 ms (3.15x)
+and forward plus coordinate gradient from 7.262 to 1.686 ms (4.31x). The RNA
+gains were 2.92x and 3.97x. A 15-residue protein gained 1.26x and 1.87x, while a
+protein–ligand case gained only 1.07x and 1.05x because its larger kernels were
+already device-bound. Graph construction remains a one-time setup cost.
+
+### Optimization and trace conclusions
+
+The nucleic-acid term previously rebuilt immutable atom indices, masks, base
+identities, ring indices, and predecessor links on every score evaluation.
+Caching them on `PoseStack` removed 67 launches per forward call. A sequential
+same-H200 A/B across DNA, RNA, and protein–DNA reduced eager forward latency by
+11–19%, eager forward plus gradient by 4–6%, and graph replay by about 11%.
+The final DNA trace has 339 launches versus 406 before the change and a 5.28 ms
+profiled wall time versus 6.11 ms. The cache adds less than 0.5 MiB in the
+largest measured NA batch and did not regress protein-only setup or scoring.
+
+The full trace matrix points to three distinct regimes:
+
+- Small protein eager scores are launch-sensitive; larger protein and
+  protein–ligand batches spend most device time in `lk_ball` and are
+  compute-bound. Batch similarly sized poses for throughput.
+- Eager NA scoring and gradients remain host/launch-bound: only 12–30% of the
+  profiled wall time is GPU activity, with 339 forward and 823–829 gradient
+  launches. CUDA graphs raise GPU occupancy to roughly 70–80% of the profiled
+  wall time without changing the fixed-layout public API.
+- NA Cartesian and torsion minimization still enqueue about 19k–28k kernels in
+  ten LBFGS iterations. FastRelax shifts from host-sensitive at a tiny protein
+  to 75–85% GPU activity for 100 residues; simulated annealing is its dominant
+  kernel. Further gains there require larger fusion or optimizer/packer changes,
+  not another small Python cleanup, and should preserve minimization trajectory
+  semantics.
+
+Treat the regular matrix as the timing source. Nsight interception materially
+inflates host-heavy workflows; use its traces to explain time, not to publish
+latency. `analyze.py` produces the complete 83-row table and SVG rather than
+embedding a stale full matrix here.
+
 ## Run one case
 
 Use an AOT build on a CUDA node for stable results:
@@ -108,9 +167,9 @@ python dev/profiling/analyze.py artifacts/nsys
 The analyzer first verifies every size and SHA-256 checksum in `manifest.json`,
 then writes `analysis/timings.md`, `analysis/timings.svg`, and
 `analysis/trace_summary.csv`. The trace summary includes the profiled iteration
-wall time, NVTX enqueue-range time, total GPU-kernel time, kernel-launch count
-and API time, largest cumulative NVTX range, and dominant kernel. Compare
-regular runs from two revisions with:
+wall time, NVTX enqueue-range time, kernel and CUDA-graph device time, ordinary
+and graph launch counts/API time, largest cumulative NVTX range, and dominant
+kernel. Compare regular runs from two revisions with:
 
 ```bash
 python dev/profiling/analyze.py artifacts/current \

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -99,8 +99,9 @@ python dev/profiling/analyze.py artifacts/nsys
 The analyzer first verifies every size and SHA-256 checksum in `manifest.json`,
 then writes `analysis/timings.md`, `analysis/timings.svg`, and
 `analysis/trace_summary.csv`. The trace summary includes the profiled iteration
-time, total GPU-kernel time, kernel-launch count and API time, dominant NVTX
-range, and dominant kernel. Compare regular runs from two revisions with:
+wall time, NVTX enqueue-range time, total GPU-kernel time, kernel-launch count
+and API time, largest cumulative NVTX range, and dominant kernel. Compare
+regular runs from two revisions with:
 
 ```bash
 python dev/profiling/analyze.py artifacts/current \

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -32,22 +32,23 @@ excluded.
 
 | Workflow and input | Batch 1 (ms) | Larger batch | Batch time (ms) | Throughput gain |
 |---|---:|---:|---:|---:|
-| score, 15-residue protein | 0.517 | 32 | 0.569 | 29.1x |
-| score, 400-residue protein | 0.735 | 4 | 1.375 | 2.1x |
-| score, 24-nt DNA | 2.729 | 32 | 2.776 | 31.5x |
-| score, protein–ligand | 0.808 | 8 | 2.295 | 2.8x |
-| Cartesian min, 15-residue protein | 41.623 | 32 | 42.117 | 31.6x |
-| Cartesian min, 24-nt DNA | 183.181 | 8 | 176.959 | 8.3x |
-| torsion min, 24-nt DNA | 238.398 | 4 | 249.866 | 3.8x |
-| FastRelax, 15-residue protein | 348.194 | 8 | 521.822 | 5.3x |
-| FastRelax, 100-residue protein | 1247.685 | 4 | 2247.399 | 2.2x |
+| score, 15-residue protein | 0.527 | 32 | 0.557 | 30.3x |
+| score, 400-residue protein | 0.743 | 4 | 1.374 | 2.2x |
+| score, 24-nt DNA | 2.771 | 32 | 2.898 | 30.6x |
+| score, protein–ligand | 0.809 | 8 | 2.294 | 2.8x |
+| Cartesian min, 15-residue protein | 41.492 | 32 | 42.342 | 31.4x |
+| Cartesian min, 24-nt DNA | 174.446 | 8 | 170.993 | 8.2x |
+| torsion min, 24-nt DNA | 245.590 | 4 | 253.509 | 3.9x |
+| FastRelax, 15-residue protein | 349.066 | 8 | 521.468 | 5.4x |
+| FastRelax, 100-residue protein | 1238.964 | 4 | 2251.062 | 2.2x |
 
 CUDA graphs pay off for repeated fixed layouts, especially nucleic acids. At
-batch 1, graph replay changed DNA forward scoring from 2.729 to 0.867 ms (3.15x)
-and forward plus coordinate gradient from 7.262 to 1.686 ms (4.31x). The RNA
-gains were 2.92x and 3.97x. A 15-residue protein gained 1.26x and 1.87x, while a
-protein–ligand case gained only 1.07x and 1.05x because its larger kernels were
-already device-bound. Graph construction remains a one-time setup cost.
+batch 1, graph replay changed DNA forward scoring from 2.771 to 0.863 ms (3.21x)
+and forward plus coordinate gradient from 7.392 to 1.676 ms (4.41x). The RNA
+gains were 2.94x and 3.99x. A 15-residue protein gained 1.28x and 1.82x, while a
+protein–ligand case gained only 1.08x for both forward and gradient because its
+larger kernels were already device-bound. Graph construction remains a one-time
+setup cost.
 
 ### Optimization and trace conclusions
 
@@ -56,7 +57,7 @@ identities, ring indices, and predecessor links on every score evaluation.
 Caching them on `PoseStack` removed 67 launches per forward call. A sequential
 same-H200 A/B across DNA, RNA, and protein–DNA reduced eager forward latency by
 11–19%, eager forward plus gradient by 4–6%, and graph replay by about 11%.
-The final DNA trace has 339 launches versus 406 before the change and a 5.28 ms
+The final DNA trace has 339 launches versus 406 before the change and a 5.24 ms
 profiled wall time versus 6.11 ms. The cache adds less than 0.5 MiB in the
 largest measured NA batch and did not regress protein-only setup or scoring.
 

--- a/dev/profiling/README.md
+++ b/dev/profiling/README.md
@@ -98,8 +98,8 @@ python dev/profiling/analyze.py artifacts/nsys
 The analyzer first verifies every size and SHA-256 checksum in `manifest.json`,
 then writes `analysis/timings.md`, `analysis/timings.svg`, and
 `analysis/trace_summary.csv`. The trace summary includes the profiled iteration
-time, total GPU-kernel time, kernel-launch count and API time, and dominant
-kernel. Compare regular runs from two revisions with:
+time, total GPU-kernel time, kernel-launch count and API time, dominant NVTX
+range, and dominant kernel. Compare regular runs from two revisions with:
 
 ```bash
 python dev/profiling/analyze.py artifacts/current \

--- a/dev/profiling/analyze.py
+++ b/dev/profiling/analyze.py
@@ -37,7 +37,21 @@ def verify_manifest(run_dir: Path) -> None:
     if not path.is_file():
         return
     manifest = json.loads(path.read_text())
-    errors = []
+    errors = (
+        ["results/summary.csv"]
+        if not (run_dir / "results/summary.csv").is_file()
+        else []
+    )
+    for case in manifest["cases"]:
+        required = [f"results/{case}.json", f"logs/{case}.log"]
+        if manifest["trace"]:
+            required += [
+                f"traces/{case}.nsys-rep",
+                f"traces/{case}.sqlite",
+                f"traces/{case}.stats.csv",
+            ]
+        errors += [name for name in required if not (run_dir / name).is_file()]
+    errors = [f"missing: {name}" for name in errors]
     for entry in manifest["files"]:
         artifact = run_dir / entry["path"]
         if not artifact.is_file():
@@ -105,6 +119,13 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
             (row for row in nvtx if "/iteration-" in row.get("Range", "")), {}
         )
         top = max(kernels, key=lambda row: int(row["Total Time (ns)"]))
+        nested = [
+            row
+            for row in nvtx
+            if "/iteration-" not in row.get("Range", "")
+            and not row.get("Range", "").endswith("/measure")
+        ]
+        top_range = max(nested, key=lambda row: int(row["Total Time (ns)"]), default={})
         rows.append(
             {
                 "case": path.name.removesuffix(".stats.csv"),
@@ -113,6 +134,8 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
                 / 1e6,
                 "kernel_launches": int(launches.get("Num Calls", 0)),
                 "launch_api_ms": int(launches.get("Total Time (ns)", 0)) / 1e6,
+                "top_nvtx": top_range.get("Range", "").removeprefix(":"),
+                "top_nvtx_ms": int(top_range.get("Total Time (ns)", 0)) / 1e6,
                 "top_kernel": _short_kernel(top["Name"]),
                 "top_kernel_ms": int(top["Total Time (ns)"]) / 1e6,
             }

--- a/dev/profiling/analyze.py
+++ b/dev/profiling/analyze.py
@@ -74,7 +74,10 @@ def _short_kernel(name: str) -> str:
     for term in score_terms:
         if term != "common":
             return f"tmol::score::{term}"
-    for namespace in ("tmol::kinematics::", "at::native::", "c10::cuda::"):
+    tmol_names = re.findall(r"tmol::([a-z_]+)::([a-z_]+)", name)
+    if tmol_names:
+        return "tmol::" + "::".join(tmol_names[-1])
+    for namespace in ("at::native::", "c10::cuda::"):
         if namespace in name:
             suffix = name.split(namespace, 1)[1].split("<", 1)[0].split("(", 1)[0]
             return namespace + suffix
@@ -110,17 +113,17 @@ def _stats_sections(path: Path) -> dict[str, list[dict[str, str]]]:
 def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
     rows = []
     for path in sorted((run_dir / "traces").glob("*.stats.csv")):
+        case = path.name.removesuffix(".stats.csv")
+        result = json.loads((run_dir / "results" / f"{case}.json").read_text())
         sections = _stats_sections(path)
         kernels = sections.get("kernels", [])
         api = sections.get("api", [])
         nvtx = sections.get("nvtx", [])
-        if not kernels:
-            raise RuntimeError(f"no CUDA kernel statistics in {path}")
         launches = next((row for row in api if row["Name"] == "cudaLaunchKernel"), {})
         iteration = next(
             (row for row in nvtx if "/iteration-" in row.get("Range", "")), {}
         )
-        top = max(kernels, key=lambda row: int(row["Total Time (ns)"]))
+        top = max(kernels, key=lambda row: int(row["Total Time (ns)"]), default={})
         nested = [
             row
             for row in nvtx
@@ -130,16 +133,17 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
         top_range = max(nested, key=lambda row: int(row["Total Time (ns)"]), default={})
         rows.append(
             {
-                "case": path.name.removesuffix(".stats.csv"),
-                "profiled_iteration_ms": int(iteration.get("Total Time (ns)", 0)) / 1e6,
+                "case": case,
+                "profiled_wall_ms": result["median_ms"],
+                "nvtx_iteration_ms": int(iteration.get("Total Time (ns)", 0)) / 1e6,
                 "gpu_kernel_ms": sum(int(row["Total Time (ns)"]) for row in kernels)
                 / 1e6,
                 "kernel_launches": int(launches.get("Num Calls", 0)),
                 "launch_api_ms": int(launches.get("Total Time (ns)", 0)) / 1e6,
                 "top_nvtx": top_range.get("Range", "").removeprefix(":"),
                 "top_nvtx_ms": int(top_range.get("Total Time (ns)", 0)) / 1e6,
-                "top_kernel": _short_kernel(top["Name"]),
-                "top_kernel_ms": int(top["Total Time (ns)"]) / 1e6,
+                "top_kernel": _short_kernel(top.get("Name", "")),
+                "top_kernel_ms": int(top.get("Total Time (ns)", 0)) / 1e6,
             }
         )
     return rows

--- a/dev/profiling/analyze.py
+++ b/dev/profiling/analyze.py
@@ -10,8 +10,8 @@ import html
 import json
 import math
 import re
+import sqlite3
 from pathlib import Path
-
 
 COLORS = {
     "score": "#2563eb",
@@ -35,7 +35,7 @@ def _sha256(path: Path) -> str:
 def verify_manifest(run_dir: Path) -> None:
     path = run_dir / "manifest.json"
     if not path.is_file():
-        return
+        raise FileNotFoundError(f"no completed-run manifest: {path}")
     manifest = json.loads(path.read_text())
     errors = (
         ["results/summary.csv"]
@@ -74,6 +74,9 @@ def _short_kernel(name: str) -> str:
     for term in score_terms:
         if term != "common":
             return f"tmol::score::{term}"
+    pack = re.search(r"tmol::pack::compiled::([A-Za-z_]+)", name)
+    if pack:
+        return f"tmol::pack::compiled::{pack.group(1)}"
     tmol_names = re.findall(r"tmol::([a-z_]+)::([a-z_]+)", name)
     if tmol_names:
         return "tmol::" + "::".join(tmol_names[-1])
@@ -110,6 +113,18 @@ def _stats_sections(path: Path) -> dict[str, list[dict[str, str]]]:
     return sections
 
 
+def _graph_gpu_activity(path: Path) -> tuple[int, float]:
+    with sqlite3.connect(path) as database:
+        try:
+            count, duration = database.execute(
+                "SELECT count(*), coalesce(sum(end - start), 0) "
+                "FROM CUPTI_ACTIVITY_KIND_GRAPH_TRACE WHERE start >= 0"
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return 0, 0.0
+    return count, duration / 1e6
+
+
 def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
     rows = []
     for path in sorted((run_dir / "traces").glob("*.stats.csv")):
@@ -120,6 +135,12 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
         api = sections.get("api", [])
         nvtx = sections.get("nvtx", [])
         launches = next((row for row in api if row["Name"] == "cudaLaunchKernel"), {})
+        graph_launches = next(
+            (row for row in api if row["Name"] == "cudaGraphLaunch"), {}
+        )
+        graph_count, graph_ms = _graph_gpu_activity(
+            run_dir / "traces" / f"{case}.sqlite"
+        )
         iteration = next(
             (row for row in nvtx if "/iteration-" in row.get("Range", "")), {}
         )
@@ -131,15 +152,21 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
             and not row.get("Range", "").endswith("/measure")
         ]
         top_range = max(nested, key=lambda row: int(row["Total Time (ns)"]), default={})
+        kernel_ms = sum(int(row["Total Time (ns)"]) for row in kernels) / 1e6
         rows.append(
             {
                 "case": case,
                 "profiled_wall_ms": result["median_ms"],
                 "nvtx_iteration_ms": int(iteration.get("Total Time (ns)", 0)) / 1e6,
-                "gpu_kernel_ms": sum(int(row["Total Time (ns)"]) for row in kernels)
-                / 1e6,
+                "gpu_activity_ms": kernel_ms + graph_ms,
+                "gpu_kernel_ms": kernel_ms,
+                "gpu_graph_ms": graph_ms,
                 "kernel_launches": int(launches.get("Num Calls", 0)),
+                "graph_executions": graph_count,
+                "graph_launches": int(graph_launches.get("Num Calls", 0)),
                 "launch_api_ms": int(launches.get("Total Time (ns)", 0)) / 1e6,
+                "graph_launch_api_ms": int(graph_launches.get("Total Time (ns)", 0))
+                / 1e6,
                 "top_nvtx": top_range.get("Range", "").removeprefix(":"),
                 "top_nvtx_ms": int(top_range.get("Total Time (ns)", 0)) / 1e6,
                 "top_kernel": _short_kernel(top.get("Name", "")),

--- a/dev/profiling/analyze.py
+++ b/dev/profiling/analyze.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Verify and summarize a TMol workflow profiling run."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import json
+import math
+import re
+from pathlib import Path
+
+
+COLORS = {
+    "score": "#2563eb",
+    "score_grad": "#7c3aed",
+    "score_graph": "#0891b2",
+    "score_graph_grad": "#0f766e",
+    "cart_min": "#ea580c",
+    "kin_min": "#dc2626",
+    "fast_relax": "#9333ea",
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_manifest(run_dir: Path) -> None:
+    path = run_dir / "manifest.json"
+    if not path.is_file():
+        return
+    manifest = json.loads(path.read_text())
+    errors = []
+    for entry in manifest["files"]:
+        artifact = run_dir / entry["path"]
+        if not artifact.is_file():
+            errors.append(f"missing: {entry['path']}")
+        elif artifact.stat().st_size != entry["bytes"]:
+            errors.append(f"size changed: {entry['path']}")
+        elif _sha256(artifact) != entry["sha256"]:
+            errors.append(f"checksum changed: {entry['path']}")
+    if errors:
+        raise RuntimeError("manifest verification failed:\n" + "\n".join(errors))
+
+
+def read_timings(run_dir: Path) -> list[dict[str, str]]:
+    with (run_dir / "results" / "summary.csv").open(newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _short_kernel(name: str) -> str:
+    score_terms = re.findall(r"tmol::score::([a-z_]+)", name)
+    for term in score_terms:
+        if term != "common":
+            return f"tmol::score::{term}"
+    for namespace in ("tmol::kinematics::", "at::native::", "c10::cuda::"):
+        if namespace in name:
+            suffix = name.split(namespace, 1)[1].split("<", 1)[0].split("(", 1)[0]
+            return namespace + suffix
+    return name.split("<", 1)[0].split("(", 1)[0][:100]
+
+
+def _stats_sections(path: Path) -> dict[str, list[dict[str, str]]]:
+    sections: dict[str, list[dict[str, str]]] = {}
+    section = None
+    header = None
+    for line in path.read_text(errors="replace").splitlines():
+        if "cuda_gpu_kern_sum.py" in line:
+            section = "kernels"
+            header = None
+        elif "cuda_api_sum.py" in line:
+            section = "api"
+            header = None
+        elif "nvtx_sum.py" in line:
+            section = "nvtx"
+            header = None
+        elif section and line.startswith("Time (%)"):
+            header = next(csv.reader([line]))
+            sections[section] = []
+        elif section and header and line:
+            values = next(csv.reader([line]))
+            if len(values) == len(header):
+                sections[section].append(dict(zip(header, values)))
+        elif not line:
+            header = None
+    return sections
+
+
+def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
+    rows = []
+    for path in sorted((run_dir / "traces").glob("*.stats.csv")):
+        sections = _stats_sections(path)
+        kernels = sections.get("kernels", [])
+        api = sections.get("api", [])
+        nvtx = sections.get("nvtx", [])
+        launches = next((row for row in api if row["Name"] == "cudaLaunchKernel"), {})
+        iteration = next(
+            (row for row in nvtx if "/iteration-" in row.get("Range", "")), {}
+        )
+        top = max(kernels, key=lambda row: int(row["Total Time (ns)"]))
+        rows.append(
+            {
+                "case": path.name.removesuffix(".stats.csv"),
+                "profiled_iteration_ms": int(iteration.get("Total Time (ns)", 0)) / 1e6,
+                "gpu_kernel_ms": sum(int(row["Total Time (ns)"]) for row in kernels)
+                / 1e6,
+                "kernel_launches": int(launches.get("Num Calls", 0)),
+                "launch_api_ms": int(launches.get("Total Time (ns)", 0)) / 1e6,
+                "top_kernel": _short_kernel(top["Name"]),
+                "top_kernel_ms": int(top["Total Time (ns)"]) / 1e6,
+            }
+        )
+    return rows
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=rows[0])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown(path: Path, timings: list[dict[str, str]]) -> None:
+    lines = [
+        "# TMol GPU workflow timings",
+        "",
+        "Steady-state medians exclude system construction, scorer rendering, warm-up, "
+        "and CUDA-graph capture. Throughput is poses per synchronized workflow call.",
+    ]
+    for workflow in COLORS:
+        selected = [row for row in timings if row["workflow"] == workflow]
+        if not selected:
+            continue
+        lines += [
+            "",
+            f"## `{workflow}`",
+            "",
+            "| System | Batch | Median (ms) | ms / pose | "
+            "Poses / s | Peak delta (MiB) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        for row in selected:
+            median = float(row["median_ms"])
+            poses = int(row["poses"])
+            peak = int(row["peak_memory_delta_bytes"]) / 2**20
+            lines.append(
+                f"| {row['system']} | {row['batch']} | {median:.3f} | "
+                f"{median / poses:.3f} | {poses * 1000 / median:.1f} | {peak:.1f} |"
+            )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def write_latency_svg(path: Path, timings: list[dict[str, str]]) -> None:
+    rows = sorted(
+        timings,
+        key=lambda row: (
+            list(COLORS).index(row["workflow"]),
+            row["system"],
+            int(row["batch"]),
+        ),
+    )
+    values = [float(row["median_ms"]) for row in rows]
+    low = 10 ** math.floor(math.log10(min(values)))
+    high = 10 ** math.ceil(math.log10(max(values)))
+    if low == high:
+        high *= 10
+    label_width, plot_width, row_height = 285, 820, 18
+    width, height = label_width + plot_width + 105, 70 + row_height * len(rows)
+
+    def x(value: float) -> float:
+        ratio = math.log10(value / low) / math.log10(high / low)
+        return label_width + plot_width * ratio
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        "<style>text{font:12px ui-monospace,SFMono-Regular,monospace;fill:#111827}"
+        ".axis{stroke:#d1d5db;stroke-width:1}</style>",
+        '<text x="10" y="22" font-size="16" font-weight="600">'
+        "Steady-state H200 latency (log scale)</text>",
+    ]
+    tick = low
+    while tick <= high:
+        tx = x(tick)
+        parts += [
+            f'<line class="axis" x1="{tx:.1f}" y1="35" x2="{tx:.1f}" '
+            f'y2="{height - 15}"/>',
+            f'<text x="{tx:.1f}" y="33" text-anchor="middle">{tick:g} ms</text>',
+        ]
+        tick *= 10
+    for index, row in enumerate(rows):
+        y = 52 + index * row_height
+        value = float(row["median_ms"])
+        label = html.escape(f"{row['workflow']}  {row['system']}  b{row['batch']}")
+        parts += [
+            f'<text x="8" y="{y + 11}">{label}</text>',
+            f'<rect x="{label_width}" y="{y}" '
+            f'width="{max(1, x(value) - label_width):.1f}" '
+            f'height="12" rx="2" fill="{COLORS[row["workflow"]]}"/>',
+            f'<text x="{x(value) + 5:.1f}" y="{y + 11}">{value:.3f}</text>',
+        ]
+    parts.append("</svg>")
+    path.write_text("\n".join(parts) + "\n")
+
+
+def comparison_rows(
+    timings: list[dict[str, str]], baseline: list[dict[str, str]]
+) -> list[dict[str, str | float]]:
+    before = {row["case"]: row for row in baseline}
+    rows = []
+    for row in timings:
+        if row["case"] not in before:
+            continue
+        baseline_ms = float(before[row["case"]]["median_ms"])
+        current_ms = float(row["median_ms"])
+        rows.append(
+            {
+                "case": row["case"],
+                "baseline_ms": baseline_ms,
+                "current_ms": current_ms,
+                "speedup": baseline_ms / current_ms,
+                "delta_percent": 100 * (current_ms / baseline_ms - 1),
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    args = parser.parse_args()
+
+    verify_manifest(args.run_dir)
+    output = args.output_dir or args.run_dir / "analysis"
+    output.mkdir(parents=True, exist_ok=True)
+    timings = read_timings(args.run_dir)
+    write_markdown(output / "timings.md", timings)
+    write_latency_svg(output / "timings.svg", timings)
+    _write_csv(output / "trace_summary.csv", read_traces(args.run_dir))
+    if args.baseline:
+        verify_manifest(args.baseline)
+        _write_csv(
+            output / "comparison.csv",
+            comparison_rows(timings, read_timings(args.baseline)),
+        )
+    print(f"verified {args.run_dir}; wrote {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/profiling/analyze.py
+++ b/dev/profiling/analyze.py
@@ -114,6 +114,8 @@ def read_traces(run_dir: Path) -> list[dict[str, str | int | float]]:
         kernels = sections.get("kernels", [])
         api = sections.get("api", [])
         nvtx = sections.get("nvtx", [])
+        if not kernels:
+            raise RuntimeError(f"no CUDA kernel statistics in {path}")
         launches = next((row for row in api if row["Name"] == "cudaLaunchKernel"), {})
         iteration = next(
             (row for row in nvtx if "/iteration-" in row.get("Range", "")), {}

--- a/dev/profiling/matrix.py
+++ b/dev/profiling/matrix.py
@@ -248,6 +248,7 @@ def main():
                 "--capture-range=cudaProfilerApi",
                 "--capture-range-end=stop",
                 "--trace=cuda,nvtx,osrt",
+                "--cuda-graph-trace=node",
                 "--sample=none",
                 "--cpuctxsw=none",
                 "--output",

--- a/dev/profiling/matrix.py
+++ b/dev/profiling/matrix.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 RUNNER = ROOT / "dev" / "profiling" / "workflows.py"
 
@@ -195,6 +194,8 @@ def main():
     parser.add_argument("--max-iter", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="replace completed cases")
     args = parser.parse_args()
+    if args.graph_node_trace and not args.trace:
+        parser.error("--graph-node-trace requires --trace")
 
     workflows = args.workflow or list(MATRIX)
     cases = [

--- a/dev/profiling/matrix.py
+++ b/dev/profiling/matrix.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Run the supported TMol workflow benchmark or Nsight Systems matrix."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "dev" / "profiling" / "workflows.py"
+
+# Small, medium, and large proteins plus non-protein chemistry. Batch sizes are
+# intentionally capped so the complete suite is practical on one H200.
+SCORE_CASES = [
+    (system, batch)
+    for system, batches in {
+        "protein015": (1, 32),
+        "protein100": (1, 16),
+        "protein400": (1, 4),
+        "dna24": (1, 32),
+        "rna33": (1, 32),
+        "protein_dna": (1, 8),
+        "protein_ligand": (1, 8),
+    }.items()
+    for batch in batches
+]
+
+MATRIX = {
+    workflow: SCORE_CASES
+    for workflow in ("score", "score_grad", "score_graph", "score_graph_grad")
+}
+MATRIX.update(
+    {
+        "cart_min": [
+            ("protein015", 1),
+            ("protein015", 32),
+            ("protein100", 1),
+            ("protein100", 8),
+            ("protein400", 1),
+            ("dna24", 1),
+            ("dna24", 8),
+            ("rna33", 1),
+            ("rna33", 8),
+            ("protein_dna", 1),
+            ("protein_dna", 4),
+            ("protein_ligand", 1),
+            ("protein_ligand", 4),
+        ],
+        "kin_min": [
+            ("protein015", 1),
+            ("protein015", 16),
+            ("protein100", 1),
+            ("protein100", 4),
+            ("dna24", 1),
+            ("dna24", 4),
+            ("rna33", 1),
+            ("rna33", 4),
+            ("protein_dna", 1),
+            ("protein_dna", 2),
+        ],
+        "fast_relax": [
+            ("protein015", 1),
+            ("protein015", 8),
+            ("protein100", 1),
+            ("protein100", 4),
+        ],
+    }
+)
+
+
+def _defaults(workflow: str, trace: bool) -> tuple[int, int]:
+    if trace:
+        return (1, 1)
+    if workflow.startswith("score"):
+        return (5, 30)
+    if workflow == "fast_relax":
+        return (1, 3)
+    return (1, 5)
+
+
+def _run(command: list[str], log: Path):
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("w") as stream:
+        subprocess.run(
+            command, cwd=ROOT, check=True, stdout=stream, stderr=subprocess.STDOUT
+        )
+
+
+def _write_summary(result_dir: Path):
+    rows = []
+    for path in sorted(result_dir.glob("*.json")):
+        data = json.loads(path.read_text())
+        rows.append(
+            {
+                key: data[key]
+                for key in (
+                    "case",
+                    "workflow",
+                    "system",
+                    "batch",
+                    "poses",
+                    "system_setup_ms",
+                    "workload_setup_ms",
+                    "median_ms",
+                    "mean_ms",
+                    "min_ms",
+                    "p95_ms",
+                    "memory_before_bytes",
+                    "peak_memory_bytes",
+                    "peak_memory_delta_bytes",
+                )
+            }
+        )
+    if not rows:
+        return
+    with (result_dir / "summary.csv").open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=rows[0])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_manifest(output_dir: Path, cases, trace: bool):
+    files = [
+        {
+            "path": str(path.relative_to(output_dir)),
+            "bytes": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        for path in sorted(output_dir.rglob("*"))
+        if path.is_file() and path.name != "manifest.json"
+    ]
+    manifest = {
+        "runner_revision": subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip(),
+        "python": platform.python_version(),
+        "nsys": (
+            subprocess.run(
+                ["nsys", "--version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            if trace
+            else None
+        ),
+        "trace": trace,
+        "cases": [f"{workflow}-{system}-b{batch}" for workflow, system, batch in cases],
+        "files": files,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--trace", action="store_true")
+    parser.add_argument("--workflow", choices=MATRIX, action="append")
+    parser.add_argument("--case", action="append", help="exact case slug to select")
+    parser.add_argument("--max-iter", type=int, default=10)
+    parser.add_argument("--force", action="store_true", help="replace completed cases")
+    args = parser.parse_args()
+
+    workflows = args.workflow or list(MATRIX)
+    cases = [
+        (workflow, system, batch)
+        for workflow in workflows
+        for system, batch in MATRIX[workflow]
+        if not args.case or f"{workflow}-{system}-b{batch}" in args.case
+    ]
+    if args.case and len(cases) != len(set(args.case)):
+        parser.error("one or more --case values are not in the supported matrix")
+
+    result_dir = args.output_dir / "results"
+    trace_dir = args.output_dir / "traces"
+    log_dir = args.output_dir / "logs"
+    for workflow, system, batch in cases:
+        case = f"{workflow}-{system}-b{batch}"
+        warmup, iterations = _defaults(workflow, args.trace)
+        output = result_dir / f"{case}.json"
+        complete = [output]
+        if args.trace:
+            complete.extend(
+                [
+                    trace_dir / f"{case}.nsys-rep",
+                    trace_dir / f"{case}.stats.csv",
+                ]
+            )
+        if not args.force and all(path.is_file() for path in complete):
+            print(f"[skip] {case}", flush=True)
+            continue
+        command = [
+            sys.executable,
+            str(RUNNER),
+            "--workflow",
+            workflow,
+            "--system",
+            system,
+            "--batch",
+            str(batch),
+            "--max-iter",
+            str(args.max_iter),
+            "--warmup",
+            str(warmup),
+            "--iterations",
+            str(iterations),
+            "--output",
+            str(output),
+        ]
+        if args.trace:
+            trace_dir.mkdir(parents=True, exist_ok=True)
+            command += ["--capture"]
+            command = [
+                "nsys",
+                "profile",
+                "--force-overwrite=true",
+                "--capture-range=cudaProfilerApi",
+                "--capture-range-end=stop",
+                "--trace=cuda,nvtx,osrt",
+                "--sample=none",
+                "--cpuctxsw=none",
+                "--output",
+                str(trace_dir / case),
+                *command,
+            ]
+        print(
+            f"[{cases.index((workflow, system, batch)) + 1}/{len(cases)}] {case}",
+            flush=True,
+        )
+        _run(command, log_dir / f"{case}.log")
+        if args.trace:
+            report = trace_dir / f"{case}.nsys-rep"
+            _run(
+                [
+                    "nsys",
+                    "stats",
+                    "--force-export=true",
+                    "--report",
+                    "cuda_gpu_kern_sum,cuda_api_sum,nvtx_sum",
+                    "--format",
+                    "csv",
+                    str(report),
+                ],
+                trace_dir / f"{case}.stats.csv",
+            )
+
+    _write_summary(result_dir)
+    _write_manifest(args.output_dir, cases, args.trace)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/profiling/matrix.py
+++ b/dev/profiling/matrix.py
@@ -185,6 +185,11 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--trace", action="store_true")
+    parser.add_argument(
+        "--graph-node-trace",
+        action="store_true",
+        help="trace individual CUDA graph nodes (high overhead)",
+    )
     parser.add_argument("--workflow", choices=MATRIX, action="append")
     parser.add_argument("--case", action="append", help="exact case slug to select")
     parser.add_argument("--max-iter", type=int, default=10)
@@ -248,7 +253,7 @@ def main():
                 "--capture-range=cudaProfilerApi",
                 "--capture-range-end=stop",
                 "--trace=cuda,nvtx,osrt",
-                "--cuda-graph-trace=node",
+                *(["--cuda-graph-trace=node"] if args.graph_node_trace else []),
                 "--sample=none",
                 "--cpuctxsw=none",
                 "--output",

--- a/dev/profiling/matrix.py
+++ b/dev/profiling/matrix.py
@@ -152,6 +152,15 @@ def _write_manifest(output_dir: Path, cases, trace: bool):
             capture_output=True,
             text=True,
         ).stdout.strip(),
+        "runner_dirty": bool(
+            subprocess.run(
+                ["git", "status", "--porcelain", "--untracked-files=no"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        ),
         "python": platform.python_version(),
         "nsys": (
             subprocess.run(
@@ -204,6 +213,7 @@ def main():
             complete.extend(
                 [
                     trace_dir / f"{case}.nsys-rep",
+                    trace_dir / f"{case}.sqlite",
                     trace_dir / f"{case}.stats.csv",
                 ]
             )

--- a/dev/profiling/workflows.py
+++ b/dev/profiling/workflows.py
@@ -218,6 +218,18 @@ def _git_revision() -> str:
     ).stdout.strip()
 
 
+def _git_dirty() -> bool:
+    return bool(
+        subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+
+
 def _nvidia_driver() -> str:
     return subprocess.run(
         ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
@@ -300,6 +312,7 @@ def run(args: argparse.Namespace) -> dict:
         "atoms_per_pose": int(pose.real_atoms[0].sum()),
         "environment": {
             "git_revision": _git_revision(),
+            "git_dirty": _git_dirty(),
             "python": platform.python_version(),
             "torch": torch.__version__,
             "tmol": tmol.__version__,

--- a/dev/profiling/workflows.py
+++ b/dev/profiling/workflows.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Benchmark representative end-to-end TMol GPU workflows."""
+
+# ruff: noqa: E402 -- import the checkout containing this developer script
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import numpy as np
+import torch
+
+import tmol
+from tmol.database import ParameterDatabase
+from tmol.io import (
+    build_context_from_biotite,
+    pose_stack_from_biotite,
+    pose_stack_from_pdb,
+)
+from tmol.kinematics import CartesianMoveMap, FoldForest, MoveMap
+from tmol.optimization import run_cart_min, run_kin_min
+from tmol.pack import PackerPalette
+from tmol.pose import PoseStackBuilder
+from tmol.relax import fast_relax
+from tmol.score import beta2016_score_function
+from tmol.utility._nvtx import nvtx_range
+
+
+DATA = ROOT / "tmol" / "tests" / "data"
+SEED = 20260827
+
+
+@dataclass(frozen=True)
+class SystemSpec:
+    path: str
+    kind: str = "pdb"
+    ligand_params: str | None = None
+
+
+SYSTEMS = {
+    "protein015": SystemSpec("pdb/bysize_015_res_1lu6.pdb"),
+    "protein100": SystemSpec("pdb/bysize_100_res_5umr.pdb"),
+    "protein400": SystemSpec("pdb/bysize_400_res_6azu.pdb"),
+    "dna24": SystemSpec("cif/1BNA.cif", "polymer_cif"),
+    "rna33": SystemSpec("cif/1EHT.cif", "polymer_cif"),
+    "protein_dna": SystemSpec("cif/1HDD.cif", "polymer_cif"),
+    "protein_ligand": SystemSpec(
+        "protein_ligand_test/ada.tmol.nomin.cif",
+        "ligand_cif",
+        "protein_ligand_test/ada.xtal-lig.mmff94.tmol",
+    ),
+}
+
+WORKFLOWS = (
+    "score",
+    "score_grad",
+    "score_graph",
+    "score_graph_grad",
+    "cart_min",
+    "kin_min",
+    "fast_relax",
+)
+
+
+def _load_system(name: str, batch: int, device: torch.device):
+    spec = SYSTEMS[name]
+    path = DATA / spec.path
+    param_db = None
+
+    if spec.kind == "pdb":
+        pose = pose_stack_from_pdb(str(path), device)
+    else:
+        import biotite.structure as struc
+        from biotite.structure.io import load_structure
+
+        structure = load_structure(str(path), model=1, include_bonds=True)
+        if isinstance(structure, struc.AtomArrayStack):
+            structure = structure[0]
+        if spec.kind == "polymer_cif":
+            structure = structure[~structure.hetero]
+            pose = pose_stack_from_biotite(structure, device, no_optH=True)
+        else:
+            context = build_context_from_biotite(
+                structure,
+                device,
+                prepare_ligands=True,
+                ligand_params_files=[str(DATA / spec.ligand_params)],
+                param_db=ParameterDatabase.get_default(),
+                sample_proton_chi=False,
+            )
+            pose = pose_stack_from_biotite(
+                structure, device, context=context, no_optH=True
+            )
+            param_db = context.parameter_database
+
+    if batch > 1:
+        pose = PoseStackBuilder.from_poses([pose] * batch, device)
+    return pose, beta2016_score_function(device, param_db=param_db)
+
+
+def _score_workload(pose, score_function, with_grad: bool, cuda_graph: bool = False):
+    graph_mode = "forward_backward" if with_grad else "forward"
+    scorer = score_function.render_whole_pose_scoring_module(
+        pose, cuda_graph=graph_mode if cuda_graph else False
+    )
+    coords = pose.coords.detach().clone().requires_grad_(with_grad)
+
+    if with_grad:
+
+        def run():
+            coords.grad = None
+            scorer(coords).sum().backward()
+
+    else:
+
+        def run():
+            with torch.no_grad():
+                scorer(coords)
+
+    return run
+
+
+def _cart_min_workload(pose, score_function, max_iter: int):
+    def run():
+        result = run_cart_min(
+            pose.clone(), score_function, optimizer_kwargs={"max_iter": max_iter}
+        )
+        if not torch.isfinite(result.coords[result.real_atoms]).all():
+            raise RuntimeError("Cartesian minimization produced non-finite coordinates")
+
+    return run
+
+
+def _kin_min_workload(pose, score_function, max_iter: int):
+    fold_forest = FoldForest.reasonable_fold_forest(pose)
+    move_map = MoveMap.from_pose_stack(pose)
+    move_map.move_all_named_torsions = True
+    move_map.move_all_jumps = False
+    move_map.move_all_root_jumps = False
+
+    def run():
+        result = run_kin_min(
+            pose.clone(),
+            score_function,
+            fold_forest,
+            move_map,
+            optimizer_kwargs={"max_iter": max_iter},
+        )
+        if not torch.isfinite(result.coords[result.real_atoms]).all():
+            raise RuntimeError("Kinematic minimization produced non-finite coordinates")
+
+    return run
+
+
+def _fast_relax_workload(pose, score_function, max_iter: int):
+    fold_forest = FoldForest.reasonable_fold_forest(pose)
+
+    def minimize(stage_pose, stage_score_function, **_):
+        return run_cart_min(
+            stage_pose,
+            stage_score_function,
+            optimizer_kwargs={"max_iter": max_iter},
+        )
+
+    def run():
+        result = fast_relax(
+            pose.clone(),
+            score_function,
+            PackerPalette(),
+            CartesianMoveMap(),
+            fold_forest,
+            num_repeats=1,
+            min_fn=minimize,
+        )
+        if not torch.isfinite(result.coords[result.real_atoms]).all():
+            raise RuntimeError("FastRelax produced non-finite coordinates")
+
+    return run
+
+
+def _workload(pose, score_function, workflow: str, max_iter: int):
+    if workflow == "score":
+        return _score_workload(pose, score_function, False)
+    if workflow == "score_grad":
+        return _score_workload(pose, score_function, True)
+    if workflow == "score_graph":
+        return _score_workload(pose, score_function, False, True)
+    if workflow == "score_graph_grad":
+        return _score_workload(pose, score_function, True, True)
+    if workflow == "cart_min":
+        return _cart_min_workload(pose, score_function, max_iter)
+    if workflow == "kin_min":
+        return _kin_min_workload(pose, score_function, max_iter)
+    if workflow == "fast_relax":
+        return _fast_relax_workload(pose, score_function, max_iter)
+    raise ValueError(workflow)
+
+
+def _git_revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _nvidia_driver() -> str:
+    return subprocess.run(
+        ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()[0]
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    return float(np.percentile(np.asarray(values), percentile))
+
+
+def run(args: argparse.Namespace) -> dict:
+    if not torch.cuda.is_available():
+        raise RuntimeError("workflow profiling requires a CUDA GPU")
+
+    torch.manual_seed(SEED)
+    torch.cuda.manual_seed_all(SEED)
+    device = torch.device("cuda", torch.cuda.current_device())
+    case = f"{args.workflow}-{args.system}-b{args.batch}"
+
+    with nvtx_range(f"{case}/setup"):
+        torch.cuda.synchronize()
+        setup_start = time.perf_counter()
+        pose, score_function = _load_system(args.system, args.batch, device)
+        torch.cuda.synchronize()
+        system_setup_ms = (time.perf_counter() - setup_start) * 1e3
+
+        workload_start = time.perf_counter()
+        workload = _workload(pose, score_function, args.workflow, args.max_iter)
+        torch.cuda.synchronize()
+        workload_setup_ms = (time.perf_counter() - workload_start) * 1e3
+
+    with nvtx_range(f"{case}/warmup"):
+        for _ in range(args.warmup):
+            workload()
+        torch.cuda.synchronize()
+
+    torch.cuda.reset_peak_memory_stats(device)
+    memory_before = torch.cuda.memory_allocated(device)
+    if args.capture:
+        torch.cuda.cudart().cudaProfilerStart()
+
+    durations = []
+    try:
+        with nvtx_range(f"{case}/measure"):
+            for iteration in range(args.iterations):
+                torch.cuda.synchronize()
+                start = time.perf_counter()
+                with nvtx_range(f"{case}/iteration-{iteration}"):
+                    workload()
+                torch.cuda.synchronize()
+                durations.append((time.perf_counter() - start) * 1e3)
+    finally:
+        if args.capture:
+            torch.cuda.cudart().cudaProfilerStop()
+
+    result = {
+        "case": case,
+        "workflow": args.workflow,
+        "system": args.system,
+        "batch": args.batch,
+        "max_iter": args.max_iter,
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "system_setup_ms": system_setup_ms,
+        "workload_setup_ms": workload_setup_ms,
+        "duration_ms": durations,
+        "median_ms": statistics.median(durations),
+        "mean_ms": statistics.mean(durations),
+        "min_ms": min(durations),
+        "p95_ms": _percentile(durations, 95),
+        "memory_before_bytes": memory_before,
+        "peak_memory_bytes": torch.cuda.max_memory_allocated(device),
+        "peak_memory_delta_bytes": torch.cuda.max_memory_allocated(device)
+        - memory_before,
+        "poses": pose.n_poses,
+        "blocks_per_pose": int((pose.block_type_ind64[0] >= 0).sum()),
+        "atoms_per_pose": int(pose.real_atoms[0].sum()),
+        "environment": {
+            "git_revision": _git_revision(),
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "tmol": tmol.__version__,
+            "tmol_path": tmol.__file__,
+            "cuda_runtime": torch.version.cuda,
+            "gpu": torch.cuda.get_device_name(device),
+            "gpu_capability": ".".join(
+                map(str, torch.cuda.get_device_capability(device))
+            ),
+            "driver": _nvidia_driver(),
+            "hostname": platform.node(),
+            "tmol_use_jit": os.environ.get("TMOL_USE_JIT"),
+            "apptainer_container": os.environ.get("APPTAINER_CONTAINER"),
+            "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        },
+        "system_spec": asdict(SYSTEMS[args.system]),
+    }
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", choices=WORKFLOWS, required=True)
+    parser.add_argument("--system", choices=SYSTEMS, required=True)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--max-iter", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--capture", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.batch < 1 or args.max_iter < 1 or args.warmup < 0 or args.iterations < 1:
+        parser.error(
+            "batch, max-iter, and iterations must be positive; warmup non-negative"
+        )
+    if args.workflow == "fast_relax" and args.system not in {
+        "protein015",
+        "protein100",
+        "protein400",
+    }:
+        parser.error("the FastRelax matrix currently covers canonical proteins only")
+    return args
+
+
+def main():
+    args = parse_args()
+    result = run(args)
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/profiling/workflows.py
+++ b/dev/profiling/workflows.py
@@ -2,6 +2,7 @@
 """Benchmark representative end-to-end TMol GPU workflows."""
 
 # ruff: noqa: E402 -- import the checkout containing this developer script
+# flake8: noqa
 
 from __future__ import annotations
 
@@ -36,7 +37,6 @@ from tmol.pose import PoseStackBuilder
 from tmol.relax import fast_relax
 from tmol.score import beta2016_score_function
 from tmol.utility._nvtx import nvtx_range
-
 
 DATA = ROOT / "tmol" / "tests" / "data"
 SEED = 20260827

--- a/docs/user_guide/benchmarking.md
+++ b/docs/user_guide/benchmarking.md
@@ -60,10 +60,12 @@ an environment manifest alongside each capture:
 
 ```bash
 python dev/profiling/matrix.py --trace --output-dir artifacts/nsys
+python dev/profiling/analyze.py artifacts/nsys
 ```
 
 See `dev/profiling/README.md` for the supported matrix, individual-case
-commands, Slurm/Apptainer usage, and the NVIDIA handoff format.
+commands, Slurm/Apptainer usage, checksum verification, timing plot, and the
+NVIDIA handoff format.
 
 ### Legacy microbenchmark profiler
 

--- a/docs/user_guide/benchmarking.md
+++ b/docs/user_guide/benchmarking.md
@@ -53,6 +53,20 @@ Ancillary benchmark plots live near the tests as `plot_*.py` scripts.
 
 ## Profiling
 
+For complete scoring, minimization, and FastRelax workflows, use the modern
+Nsight Systems harness in `dev/profiling`. It covers protein, nucleic-acid, and
+ligand systems, eager and CUDA-graph scoring, multiple batch sizes, and writes
+an environment manifest alongside each capture:
+
+```bash
+python dev/profiling/matrix.py --trace --output-dir artifacts/nsys
+```
+
+See `dev/profiling/README.md` for the supported matrix, individual-case
+commands, Slurm/Apptainer usage, and the NVIDIA handoff format.
+
+### Legacy microbenchmark profiler
+
 `dev/bin/profile_benchmark` wraps the legacy `nvprof` command and the TMol
 pytest CUDA-profile hook:
 


### PR DESCRIPTION
## Summary

- add a reproducible 83-case GPU benchmark and Nsight Systems trace matrix for scoring, gradients, CUDA graphs, Cartesian/torsion minimization, and FastRelax
- cover protein, DNA, RNA, protein-DNA, and protein-ligand systems across representative batch and system sizes
- verify manifests and checksums, report synchronized timing plus kernel and CUDA-graph activity, and generate Markdown/CSV/SVG summaries
- document exact commands, environments, measured results, bottlenecks, and NVIDIA handoff packaging

The nucleic-acid topology cache originally developed and measured in this PR was moved into #439 and is now on `master` for v0.1.51. This PR no longer contains that implementation.

## Measured result

The topology cache now on `master` improved eager nucleic-acid forward scoring by 11-19%, forward plus gradient by 4-6%, and graph replay by about 11%. The DNA forward trace fell from 406 to 339 launches and from 6.11 to 5.24 ms profiled wall time. Protein-only setup and scoring showed no regression. CUDA graph replay provides up to 4.41x lower steady-state latency in the measured fixed-layout cases.

## Validation

- 83/83 final regular benchmark cases, 167-file manifest verified
- 83/83 final Nsight traces, 416-file manifest verified; GPU activity present in every trace and 28 CUDA-graph cases accounted for
- selected baseline trace set and sequential same-GPU A/B
- clean native build, CPU lane 1,463 passed with zero failures, CUDA lane 849 passed with zero failures, benchmark lane 475 passed with zero failures
- 111 passed, 1 skipped in focused NA/profiling GPU tests
- pre-commit, Black, Flake8, Ruff, and Sphinx warning-as-error build passed