### PR TITLE
docs: document macOS build paths

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,7 +56,7 @@ tmol's C++/CUDA kernels can be loaded in two ways:
 
 - **AOT (Ahead-Of-Time)**: Pre-compiled `.so` libraries are bundled inside the installed package (e.g., from a wheel). Operations are registered in `torch.ops.tmol_*` namespaces. This is the default and requires no compiler at runtime.
 
-- **JIT (Just-In-Time)**: Source files (`.cpp`, `.cu`) are compiled on first use via `torch.utils.cpp_extension.load()`. This requires `nvcc` and a C++ compiler to be available. Useful for kernel development where you want to edit and reload C++/CUDA code without rebuilding the whole package.
+- **JIT (Just-In-Time)**: Source files (`.cpp`, `.cu`) are compiled on first use via `torch.utils.cpp_extension.load()`. This requires a C++ compiler and `ninja`; `nvcc` is needed **only** to build the CUDA kernels. On CPU-only platforms (e.g. macOS/Apple Silicon) `cuda_if_available()` drops the `.cu` sources automatically, so JIT works with no `nvcc`. Useful for kernel development where you want to edit and reload C++/CUDA code without rebuilding the whole package.
 
 Two environment variables control which path is taken:
 
@@ -93,10 +93,13 @@ flowchart TD
 | End user                      | `pip install tmol` (sdist) | None   | AOT (compiled at install time) |
 | Kernel developer              | `pip install -e .` | `TMOL_USE_JIT=1` | JIT |
 | CI without GPU                | Pre-built wheel    | None            | AOT  |
+| macOS / CPU-only from source  | `pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF` | None (or `TMOL_USE_JIT=1`) | AOT (or JIT) |
 
 ### CUDA toolkit for JIT mode
 
-JIT mode requires `nvcc` and CUDA headers. You can either:
+Building the **CUDA** kernels in JIT mode requires `nvcc` and CUDA headers.
+CPU-only JIT does not — it needs only a C++ compiler and `ninja` (this is the
+usual path on macOS/Apple Silicon). To build the CUDA kernels you can either:
 
 1. **Use a CUDA-enabled container** (NGC, conda) or set `CUDA_HOME` to point to your system CUDA toolkit.
 2. **Install the pip CUDA extra**, which downloads `nvcc` and runtime libraries:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,10 +77,22 @@ TMol can build CPU-only extensions:
 pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF
 ```
 
-The same CPU-only path is the normal macOS source install:
+The same CPU-only path is the normal macOS (Apple Silicon) source install:
 
 ```bash
 pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF
+```
+
+The `TMOL_ENABLE_CUDA=OFF` define is required on a machine with no CUDA toolkit:
+a plain `pip install -e .` there may build without loadable CPU kernels. This
+path needs CMake in the `>=3.18,<4` range and a C++ compiler; no `nvcc`.
+
+Alternatively, skip the ahead-of-time build entirely and compile the kernels on
+first import (JIT). CPU-only JIT needs just a C++ compiler and `ninja` — no
+`nvcc`:
+
+```bash
+TMOL_USE_JIT=1 python -c "import tmol; print(tmol.__version__)"
 ```
 
 ## Linux Runtime Notes
@@ -96,7 +108,7 @@ If `import tmol` fails with a `GLIBCXX_* not found` error, the host
 # Build against system libraries
 TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .
 
-# Or allow just-in-time extension compilation if nvcc is available
+# Or allow just-in-time extension compilation (CPU-only needs no nvcc)
 export TMOL_JIT_FALLBACK=1
 ```
 

--- a/tmol/_cpp_lib.py
+++ b/tmol/_cpp_lib.py
@@ -33,11 +33,13 @@ class TmolExtensionNotBuiltError(Exception):
             "tmol C++/CUDA extensions are not built.\n"
             "  Install tmol from a pre-built wheel:\n"
             "    pip install tmol\n"
-            "  Or build from source (requires CUDA toolkit):\n"
+            "  Or build from source (CPU-only, e.g. macOS: add\n"
+            "  -Ccmake.define.TMOL_ENABLE_CUDA=OFF; CUDA needs the CUDA toolkit):\n"
             "    pip install -e .\n"
             "  On older Linux clusters, prefer:\n"
             "    TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .\n"
-            "  or set TMOL_JIT_FALLBACK=1 if nvcc is available.\n"
+            "  or set TMOL_JIT_FALLBACK=1 (CPU-only needs just a C++ compiler + "
+            "ninja; nvcc only for CUDA).\n"
         )
 
 
@@ -70,7 +72,8 @@ def extension_load_error_details(exc: OSError) -> str:
             "    - Use a container with a recent base image\n"
             "    - Build tmol on this machine:\n"
             "        TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .\n"
-            "    - Or set TMOL_JIT_FALLBACK=1 (requires nvcc; slower first import)"
+            "    - Or set TMOL_JIT_FALLBACK=1 (CPU-only needs just a C++ compiler "
+            "+ ninja; nvcc only for CUDA; slower first import)"
         )
 
     if "glibc_" in lower and "libc.so" in lower:


### PR DESCRIPTION
## Summary

The AOT-vs-JIT documentation and the `extensions are not built` error message state that JIT mode **requires `nvcc`**. That is true only for the **CUDA** kernels — `cuda_if_available()` drops the `.cu` sources when CUDA is unavailable, so CPU-only platforms (e.g. macOS / Apple Silicon) compile the kernels with just a C++ compiler and `ninja`, no `nvcc`. The current wording steers Mac/CPU users away from the one path that works for them.

Verified on macOS-ARM (Apple Silicon, CPU-only, no CUDA toolkit):
- `TMOL_USE_JIT=1 python -c "import tmol"` compiles the CPU kernels via clang and imports cleanly — no `nvcc`.
- `pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF` (CMake in `>=3.18,<4`) builds loadable AOT CPU kernels; `tmol._cpp_lib._ensure_loaded()` succeeds without JIT.
- A plain `pip install -e .` on a machine with no CUDA toolkit can install without loadable CPU kernels, which is the trap this clarifies.

## Changes (docs + one error string)

- **DEVELOPMENT.md** — correct the JIT bullet and the *CUDA toolkit for JIT mode* section (nvcc is only for CUDA kernels; CPU-only JIT needs a C++ compiler + `ninja`); add a macOS / CPU-only row to the scenarios table.
- **docs/installation.md** — note that `TMOL_ENABLE_CUDA=OFF` is required when no CUDA toolkit is present, add a `TMOL_USE_JIT=1` alternative, and fix the "if nvcc is available" comment.
- **tmol/_cpp_lib.py** — correct the user-facing `TmolExtensionNotBuiltError` / loader-error guidance so CPU-only users are pointed at the working paths.

Docs/comment-only; no behavior change.