### PR TITLE
Reuse default pose-build setup across Biotite calls

### DIFF
--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -68,6 +68,11 @@ through `build_missing_sidechains()`. By default it also places and optimizes
 hydrogens for complete residues. Pass `no_optH=True` to skip that hydrogen
 optimization path.
 
+For standard residues and the default parameter database, TMol automatically
+reuses the structure-independent construction and packing setup. If many
+structures share prepared ligand definitions, explicitly reuse a
+`PoseBuildContext` as described in the ligand guide.
+
 ```python
 pose_stack = pose_stack_from_biotite(
     structure,

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -82,6 +82,7 @@ def build_context_from_biotite(
     if prepare_ligands:
         from tmol.ligand import prepare_ligands as _prepare_ligands
 
+        using_default_database = param_db is None
         if param_db is None:
             param_db = ParameterDatabase.get_default()
 
@@ -95,6 +96,13 @@ def build_context_from_biotite(
             strict_ligands=strict_ligands,
             return_fragment_definitions=True,
         )
+        if (
+            using_default_database
+            and param_db is _paramdb_for_biotite()
+            and not fragment_definitions
+        ):
+            return _default_pose_build_context(torch_device)
+
         rts = ResidueTypeSet.from_database(param_db.chemical)
         pbt = PackedBlockTypes.from_restype_list(
             rts.chem_db, rts, rts.residue_types, torch_device
@@ -108,13 +116,10 @@ def build_context_from_biotite(
         )
 
     if param_db is None:
-        co = canonical_ordering_for_biotite()
-        pbt = packed_block_types_for_biotite(torch_device)
-        db = _paramdb_for_biotite()
-        rts = _restype_set_for_biotite()
-    else:
-        db = param_db
-        co, rts, pbt = _derived_types_for_param_db(db, torch_device)
+        return _default_pose_build_context(torch_device)
+
+    db = param_db
+    co, rts, pbt = _derived_types_for_param_db(db, torch_device)
     return PoseBuildContext(
         canonical_ordering=co,
         packed_block_types=pbt,
@@ -924,6 +929,18 @@ def packed_block_types_for_biotite(device: torch.device) -> PackedBlockTypes:
 
     return PackedBlockTypes.from_restype_list(
         restype_set.chem_db, restype_set, restype_set.residue_types, device
+    )
+
+
+@validate_args
+@toolz.functoolz.memoize
+def _default_pose_build_context(device: torch.device) -> PoseBuildContext:
+    """Return the shared immutable context for the default database."""
+    return PoseBuildContext(
+        canonical_ordering=canonical_ordering_for_biotite(),
+        packed_block_types=packed_block_types_for_biotite(device),
+        parameter_database=_paramdb_for_biotite(),
+        restype_set=_restype_set_for_biotite(),
     )
 
 

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -219,7 +219,10 @@ def pose_stack_from_biotite(  # noqa: C901
                 "context= already contains prepared ligands; do not also pass "
                 "prepare_ligands=True."
             )
-        if context.packed_block_types.device.type != torch_device.type:
+        context_device = context.packed_block_types.device
+        if context_device.type != torch_device.type or (
+            context_device.type == "cuda" and context_device.index != torch_device.index
+        ):
             raise ValueError(
                 "context was built for device "
                 f"'{context.packed_block_types.device}' but torch_device is "
@@ -935,7 +938,7 @@ def packed_block_types_for_biotite(device: torch.device) -> PackedBlockTypes:
 @validate_args
 @toolz.functoolz.memoize
 def _default_pose_build_context(device: torch.device) -> PoseBuildContext:
-    """Return the shared immutable context for the default database."""
+    """Return the process-wide construction context for the default database."""
     return PoseBuildContext(
         canonical_ordering=canonical_ordering_for_biotite(),
         packed_block_types=packed_block_types_for_biotite(device),

--- a/tmol/io/_pose_stack_from_sequence.py
+++ b/tmol/io/_pose_stack_from_sequence.py
@@ -41,7 +41,10 @@ def create_pose_stack_from_sequences(
     tokens, chain_lengths = tokenize_sequences(seqs)
 
     if context is not None:
-        if context.packed_block_types.device.type != device.type:
+        context_device = context.packed_block_types.device
+        if context_device.type != device.type or (
+            context_device.type == "cuda" and context_device.index != device.index
+        ):
             raise ValueError(
                 f"context was built for device "
                 f"{context.packed_block_types.device} but device is {device}"
@@ -61,7 +64,10 @@ def create_pose_stack_from_sequences(
         else:
             param_db = param_db or ParameterDatabase.get_default()
             ligand_names = {}
-        restype_set = ResidueTypeSet.from_database(param_db.chemical)
+        if param_db is ParameterDatabase.get_default():
+            restype_set = ResidueTypeSet.get_default()
+        else:
+            restype_set = ResidueTypeSet.from_database(param_db.chemical)
         canonical_ordering = None
 
     names, chain_lengths = resolve_block_type_names(

--- a/tmol/tests/io/test_pose_stack_from_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite.py
@@ -72,21 +72,24 @@ def test_complete_protein_skips_na_sampler_setup(
     pose_stack_from_biotite(biotite_1ubq, torch_device=torch_device)
 
 
-def test_reused_context_caches_packing_setup(biotite_1ubq, torch_device):
-    context = build_context_from_biotite(biotite_1ubq, torch_device=torch_device)
-
+def test_default_pose_builds_reuse_packing_setup(biotite_1ubq, torch_device):
     torch.manual_seed(0)
-    first = pose_stack_from_biotite(
-        biotite_1ubq, torch_device=torch_device, context=context
+    first, context = pose_stack_from_biotite(
+        biotite_1ubq,
+        torch_device=torch_device,
+        return_context=True,
     )
     score_function = context._packing_score_function
     dunbrack_sampler = context._dunbrack_sampler
 
     torch.manual_seed(0)
-    second = pose_stack_from_biotite(
-        biotite_1ubq, torch_device=torch_device, context=context
+    second, second_context = pose_stack_from_biotite(
+        biotite_1ubq,
+        torch_device=torch_device,
+        return_context=True,
     )
 
+    assert second_context is context
     assert context._packing_score_function is score_function
     assert context._dunbrack_sampler is dunbrack_sampler
     assert torch.equal(torch.isnan(first.coords), torch.isnan(second.coords))

--- a/tmol/tests/io/test_pose_stack_from_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite.py
@@ -94,6 +94,21 @@ def test_reused_context_caches_packing_setup(biotite_1ubq, torch_device):
     assert torch.equal(first.coords[finite], second.coords[finite])
 
 
+def test_standard_only_ligand_preparation_reuses_default_context(
+    biotite_1ubq, torch_device
+):
+    default_context = build_context_from_biotite(
+        biotite_1ubq, torch_device=torch_device
+    )
+    ligand_aware_context = build_context_from_biotite(
+        biotite_1ubq,
+        torch_device=torch_device,
+        prepare_ligands=True,
+    )
+
+    assert ligand_aware_context is default_context
+
+
 # 1ubq with one residue's 3LC changed to ERR to test a non-recognized residue type
 def test_pose_stack_from_biotite_1ubq_err_smoke(biotite_1ubq_err, torch_device):
     starts = biotite.structure.get_residue_starts(biotite_1ubq_err)
@@ -281,7 +296,6 @@ def test_sample_proton_chi_integrated_pose_build_behavior(torch_device):
         torch_device,
         prepare_ligands=True,
         sample_proton_chi=False,
-        param_db=ParameterDatabase.get_default(),
         return_context=True,
     )
     assert torch.isfinite(pose_stack.coords[pose_stack.real_atoms]).all()

--- a/tmol/tests/io/test_pose_stack_from_sequence.py
+++ b/tmol/tests/io/test_pose_stack_from_sequence.py
@@ -6,6 +6,7 @@ import numpy
 import pytest
 import torch
 
+from tmol.chemical import ResidueTypeSet
 from tmol.io import (
     EXTENDED_BACKBONE_TORSIONS,
     create_pose_stack_from_sequences,
@@ -145,6 +146,14 @@ def test_extended_pose_stack_device(torch_device):
     pose_stack = extended_pose_stack_from_sequences("ACD", device=torch_device)
     assert pose_stack.coords.device.type == torch_device.type
     assert pose_stack.coords.dtype == torch.float32
+
+
+def test_default_sequence_context_reuses_default_restype_set(torch_device):
+    _, context = create_pose_stack_from_sequences(
+        "ACD", device=torch_device, return_context=True
+    )
+
+    assert context.restype_set is ResidueTypeSet.get_default()
 
 
 PROTEIN_GOLD_TORSION_NAMES = {


### PR DESCRIPTION
## Summary

- reuse a device-keyed `PoseBuildContext` for Biotite construction with the default parameter database
- preserve fresh contexts whenever ligand preparation changes the database or adds fragment definitions
- reuse the canonical default `ResidueTypeSet` during standard sequence construction
- reject reuse of a CUDA context on a different CUDA device
- document automatic standard-residue reuse and keep explicit context reuse as the ligand workflow

## Why

`pose_stack_from_biotite(..., prepare_ligands=True)` created a fresh context on every call, even when the input contained only standard residues. That discarded the context-level cached packing score function and samplers added for repeated construction, so each pose build repeated expensive packing setup. This was the source of the apparent v0.1.49/v0.1.51 FastRelax workflow regression: FastRelax itself was not responsible for most of the difference.

The cache is intentionally narrow. It is used only when the caller did not provide a database and ligand preparation returns the unchanged process-default database with no fragment definitions. Prepared ligands, params files, fragments, and custom databases retain independently built contexts.

## H200 benchmark

150-residue `5yzf`, `prepare_ligands=True`, OptH enabled, one FastRelax repeat, five measured trials after warmup. Each variant was run first and second to control for ordering. Values below average the two median-order results.

| | v0.1.51 | this PR | change |
|---|---:|---:|---:|
| pose construction | 1.396 s | 0.054 s | **96.1% faster** |
| FastRelax | 3.040 s | 2.908 s | — |
| build + FastRelax | 4.436 s | 2.962 s | **33.2% faster** |

Standard CPU sequence construction also drops from 2.313 ms to 1.866 ms median over 100 trials (**19.3% faster**).

## Validation

- 91 CPU/CUDA tests passed across the Biotite, sequence, and context-reuse suites
- implicit custom-ligand preparation remains covered and creates its extended database
- Ruff, Black, Flake8, and `git diff --check` pass on all changed Python files
- benchmarked from current v0.1.51 master (`a54eac791`) on an NVIDIA H200
