### PR TITLE
Accelerate FastRelax annealing and single-block ddG scans

### DIFF
--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -1,18 +1,36 @@
 import torch
 
-from tmol.score import beta2016_score_function
+from tmol.database import ParameterDatabase
+from tmol.pose import PoseStack
+from tmol.score import ScoreFunction, beta2016_score_function
 from tmol.pack import pack_rotamers, PackerTask, PackerPalette
 from tmol.pack.rotamer import IncludeCurrentSampler, FixedAAChiSampler
 from tmol.pack.rotamer.dunbrack import create_dunbrack_sampler_from_database
 from tmol.optimization import run_cart_min
+from tmol.types import Tensor
 
 _EINSUM_MIN_BYTES = 512 * 1024 * 1024
+_INTERACTION_DISTANCE_WORKSPACE_BYTES = 256 * 1024 * 1024
 
 
 def _sum_cross_block_scores(
-    block_pair_scores, mask, other_mask, *, memory_efficient=False
-):
-    """Sum both orientations of block-pair scores selected by two masks."""
+    block_pair_scores: Tensor[torch.float32][:, :, :, :],
+    mask: Tensor[torch.bool][:, :],
+    other_mask: Tensor[torch.bool][:, :],
+    *,
+    memory_efficient: bool = False,
+) -> Tensor[torch.float32][:, :]:
+    """Sum both orientations selected by two block masks.
+
+    Args:
+        block_pair_scores: Scores shaped ``[n_terms, n_poses, n_blocks, n_blocks]``.
+        mask: First block set shaped ``[n_poses, n_blocks]``.
+        other_mask: Second block set with the same shape as ``mask``.
+        memory_efficient: Avoid a term-expanded selection for large inputs.
+
+    Returns:
+        Per-term, per-pose sums shaped ``[n_terms, n_poses]``.
+    """
     cross_mask = (mask.unsqueeze(2) & other_mask.unsqueeze(1)) | (
         other_mask.unsqueeze(2) & mask.unsqueeze(1)
     )
@@ -34,9 +52,23 @@ def _sum_cross_block_scores(
 
 
 def _sum_single_block_cross_scores(
-    block_pair_scores, block_indices, other_mask, *, sets_are_disjoint=False
-):
-    """Sum interactions between one block per pose and selected partners."""
+    block_pair_scores: Tensor[torch.float32][:, :, :, :],
+    block_indices: Tensor[torch.int64][:],
+    other_mask: Tensor[torch.bool][:, :],
+    *,
+    sets_are_disjoint: bool = False,
+) -> Tensor[torch.float32][:, :]:
+    """Sum interactions between one block per pose and selected partners.
+
+    Args:
+        block_pair_scores: Scores shaped ``[n_terms, n_poses, n_blocks, n_blocks]``.
+        block_indices: One selected block index per pose, shaped ``[n_poses]``.
+        other_mask: Partner blocks shaped ``[n_poses, n_blocks]``.
+        sets_are_disjoint: Skip diagonal correction when the sets cannot overlap.
+
+    Returns:
+        Per-term, per-pose sums shaped ``[n_terms, n_poses]``.
+    """
     n_terms, n_poses, n_blocks, _ = block_pair_scores.shape
     gather_rows = block_indices.reshape(1, n_poses, 1, 1).expand(
         n_terms, -1, 1, n_blocks
@@ -58,46 +90,38 @@ def _sum_single_block_cross_scores(
 
 
 def calculate_block_pair_ddg(
-    pose_stack,
-    mask,
-    mask2=None,
-    sfxn=None,
-    sum_terms=True,
-    minimize=True,
-    pack=False,
-    database=None,
-    return_pose_stack=False,
+    pose_stack: PoseStack,
+    mask: Tensor[torch.bool][:, :] | Tensor[torch.int64][:],
+    mask2: Tensor[torch.bool][:, :] | None = None,
+    sfxn: ScoreFunction | None = None,
+    sum_terms: bool = True,
+    minimize: bool = True,
+    pack: bool = False,
+    database: ParameterDatabase | None = None,
+    return_pose_stack: bool = False,
     *,
-    memory_efficient=False,
-):
-    """Calculate DDG score between two subsets of blocks within each pose, defined by 2 masks.
-    If only one mask is provided, it will use the inverse of the first mask for the second.
+    memory_efficient: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, PoseStack]:
+    """Score interactions between two block sets in each pose.
 
     Args:
-        pose_stack: The pose stack to score
-        mask: Boolean tensor of shape [n_poses, n_blocks]. True values indicate masked indices.
-            For the common single-site scan, an integer tensor of shape [n_poses] may instead
-            give the selected block in each pose. This avoids constructing and reducing a dense
-            block-pair mask; its floating-point reduction order may differ from the Boolean path.
-        mask2: Boolean tensor of shape [n_poses, n_blocks]. If not provided, it will use the inverse
-            of the first mask as the second mask.
-        sfxn: Optional score function to use. If not provided, will default to beta2016
-        sum_terms: If True, sum all score terms into a single score per pose. If False,
-            return per-term scores.
-        minimize: If True (default), run cartesian minimization on the masked atoms before
-            computing the DDG score.
-        pack: If True, pack (repack) rotamers of residues in the mask and residues adjacent
-            to the mask (computed via ``compute_block_adjacency``) before the minimization step.
-        return_pose_stack: If True, also return the (possibly packed/minimized) pose stack
-            that was actually scored, as ``(ddg_scores, pose_stack)``.
-        memory_efficient: If True, use a lower-memory interface reduction. This also supports
-            poses that select different numbers of block pairs, but may differ slightly from
-            the default result because floating-point values are summed in a different order.
+        pose_stack: Poses to score.
+        mask: First set shaped ``[n_poses, n_blocks]``. For single-site scans,
+            integer indices shaped ``[n_poses]`` avoid a dense pair-mask reduction.
+        mask2: Optional second block set. The complement of ``mask`` is used by
+            default.
+        sfxn: Score function; defaults to beta2016 on the pose device.
+        sum_terms: Sum score terms into one value per pose.
+        minimize: Minimize selected and nearby side-chain atoms before scoring.
+        pack: Repack selected and adjacent blocks before minimization.
+        database: Parameter database used to construct the Dunbrack sampler.
+        return_pose_stack: Return the packed/minimized poses with their scores.
+        memory_efficient: Use a lower-memory Boolean-mask reduction. Its floating-
+            point summation order may differ from the default path.
 
     Returns:
-        Tensor of shape [n_poses] or [n_terms, n_poses] containing the ddg score for each pose,
-        separated by terms if requested. If ``return_pose_stack`` is True, returns a tuple
-        ``(ddg_scores, pose_stack)``.
+        Scores shaped ``[n_poses]`` or ``[n_terms, n_poses]``. When requested,
+        returns ``(scores, scored_pose_stack)``.
     """
     torch_device = pose_stack.device
 
@@ -164,8 +188,6 @@ def calculate_block_pair_ddg(
         pose_stack.coords, sum_terms=False, apply_weights=not defer_weights
     )
 
-    # mask shape: [n_poses, n_blocks]
-    # Use mask2 if provided, otherwise use ~mask for the second set of indices
     other_mask = mask2 if mask2 is not None else ~mask
     if single_block_indices is None:
         ddg_scores = _sum_cross_block_scores(
@@ -190,204 +212,122 @@ def calculate_block_pair_ddg(
     return ddg_scores
 
 
-def res_mask_to_coord_mask(pose_stack, mask):
-    """Convert a block-level (residue) boolean mask to an atom-level coordinate mask.
-
-    For each pose, atoms belonging to blocks where the mask is True are marked as True
-    in the output. The output mask can be used as a ``coord_mask`` argument to
-    functions like ``run_cart_min``.
+def res_mask_to_coord_mask(
+    pose_stack: PoseStack, mask: Tensor[torch.bool][:, :]
+) -> Tensor[torch.bool][:, :]:
+    """Expand a block-level selection into an atom coordinate mask.
 
     Args:
-        pose_stack: The pose stack. Must have attributes ``coords``, ``max_n_blocks``,
-            ``max_n_block_atoms``, ``block_coord_offset64``, and ``real_atoms``.
-        mask: Boolean tensor of shape ``[n_poses, n_blocks]``. ``True`` at
-            ``mask[i, j]`` indicates that all atoms of block ``j`` in pose ``i``
-            should be marked.
+        pose_stack: Poses supplying the block-to-coordinate layout.
+        mask: Selected blocks shaped ``[n_poses, n_blocks]``.
 
     Returns:
-        Boolean tensor of shape ``[n_poses, max_n_atoms_per_pose]``, where
-        ``max_n_atoms_per_pose = pose_stack.coords.shape[1]``.
+        Selected real atoms shaped ``[n_poses, max_n_atoms]``.
     """
-    n_poses, max_n_atoms, _ = pose_stack.coords.shape
-    n_blocks = pose_stack.max_n_blocks
-    max_n_block_atoms = pose_stack.max_n_block_atoms
-
-    # Expand the block mask to per-atom indices
-    block_coord_offset64 = pose_stack.block_coord_offset64  # [n_poses, n_blocks]
-
-    # For each block, we need to know which flat coord indices are real atoms.
-    # block_coord_offset64[i, j] is the starting flat index of block j in pose i.
-    # The k-th atom (0 <= k < max_n_block_atoms) of block j has flat index
-    #   flat_idx[i, j, k] = block_coord_offset64[i, j] + k
-    #
-    # Not every k corresponds to a real atom (due to padding); we only mark
-    # those where real_expanded_pose_ats[i, j, k] is True.
-
-    # atom_local_idx[k] = k
-    atom_local_idx = (
-        torch.arange(max_n_block_atoms, device=pose_stack.device)
-        .unsqueeze(0)
-        .unsqueeze(0)
-        .expand(n_poses, n_blocks, -1)
-    )
-
-    # flat_atom_idx[i, j, k] = block_coord_offset64[i, j] + k
-    flat_atom_idx = (
-        block_coord_offset64.unsqueeze(2) + atom_local_idx
-    )  # [n_poses, n_blocks, max_n_block_atoms]
-
-    # Keep an auxiliary index for scatter: [n_poses, -1]  (in case of binning we need 2D)
-    flat_atom_idx_flat = flat_atom_idx.reshape(n_poses, -1)
-
-    # Real-atom expanded mask: [n_poses, n_blocks, max_n_block_atoms]
-    _, real_expanded_pose_ats = pose_stack.expand_coords()
-
-    # Block mask expanded to atom granularity: [n_poses, n_blocks, max_n_block_atoms]
-    block_mask_expanded = mask.unsqueeze(2).expand(-1, -1, max_n_block_atoms)
-
-    # Atom is masked if its block is masked AND it is a real atom
-    atom_is_masked = block_mask_expanded & real_expanded_pose_ats
-
-    # Flatten for scatter
-    atom_is_masked_flat = atom_is_masked.reshape(n_poses, -1)  # [n_poses, ...]
-
-    # Build output coord_mask
-    coord_mask = torch.zeros(
-        (n_poses, max_n_atoms), dtype=torch.bool, device=pose_stack.device
-    )
-
-    # Guard against out-of-range flat indices (padding in expanded view can exceed max_n_atoms)
-    valid_flat_idx = flat_atom_idx_flat < max_n_atoms
-
-    atom_is_masked_flat_safe = atom_is_masked_flat.clone()
-    atom_is_masked_flat_safe[~valid_flat_idx] = False
-
-    flat_atom_idx_flat_safe = flat_atom_idx_flat.clone()
-    flat_atom_idx_flat_safe[~valid_flat_idx] = 0
-
-    coord_mask.scatter_(1, flat_atom_idx_flat_safe, atom_is_masked_flat_safe)
-
-    return coord_mask
+    block_for_atom, _, real_atoms = _compact_atom_layout(pose_stack)
+    return mask.gather(1, block_for_atom) & real_atoms
 
 
-def build_sidechain_coord_mask(pose_stack):
-    """Build a coord_mask that selects only atoms belonging to sidechains.
-
-    For polymeric residues, sidechain atoms are defined as real atoms that are
-    NOT mainchain atoms. For non-polymeric residues, all real atoms are
-    considered sidechain atoms. The output mask can be used as a ``coord_mask``
-    argument to functions like ``run_cart_min``.
+def _compact_atom_layout(
+    pose_stack: PoseStack,
+) -> tuple[
+    Tensor[torch.int64][:, :],
+    Tensor[torch.int64][:, :],
+    Tensor[torch.bool][:, :],
+]:
+    """Map compact pose coordinates to their blocks and local atom indices.
 
     Args:
-        pose_stack: The pose stack. Must have attributes ``coords``,
-            ``max_n_blocks``, ``max_n_block_atoms``, ``block_coord_offset64``,
-            ``real_atoms``, ``block_type_ind64``, and ``packed_block_types``.
+        pose_stack: Poses whose immutable topology defines the mapping.
 
     Returns:
-        Boolean tensor of shape ``[n_poses, max_n_atoms_per_pose]``, where
-        ``max_n_atoms_per_pose = pose_stack.coords.shape[1]``. True at
-        ``coord_mask[i, j]`` indicates that atom ``j`` of pose ``i`` is a
-        sidechain atom.
+        Block indices, within-block atom indices, and real-atom flags, each
+        shaped ``[n_poses, max_n_atoms]``. The mapping is cached on the pose.
     """
+    cache_name = "_score_utils_compact_atom_layout"
+    if hasattr(pose_stack, cache_name):
+        return getattr(pose_stack, cache_name)
+
     n_poses, max_n_atoms, _ = pose_stack.coords.shape
-    n_blocks = pose_stack.max_n_blocks
-    max_n_block_atoms = pose_stack.max_n_block_atoms
+    atom_index = (
+        torch.arange(max_n_atoms, device=pose_stack.device)
+        .expand(n_poses, -1)
+        .contiguous()
+    )
+    # PoseStackBuilder leaves padded block offsets at zero. Replace them with
+    # an end sentinel so every row is sorted before the batched search.
+    block_starts = pose_stack.block_coord_offset64.masked_fill(
+        pose_stack.block_type_ind64 < 0, max_n_atoms
+    )
+    block_for_atom = torch.searchsorted(
+        block_starts.contiguous(), atom_index, right=True
+    ).sub_(1)
+    block_for_atom.clamp_(0, pose_stack.max_n_blocks - 1)
+    block_offset_for_atom = pose_stack.block_coord_offset64.gather(1, block_for_atom)
+    real_atoms = pose_stack.real_atoms
+    atom_in_block = atom_index.sub(block_offset_for_atom)
+    atom_in_block.masked_fill_(~real_atoms, 0)
+
+    layout = (block_for_atom, atom_in_block, real_atoms)
+    object.__setattr__(pose_stack, cache_name, layout)
+    return layout
+
+
+def _sidechain_atom_mask_for_block_type(
+    pose_stack: PoseStack,
+) -> Tensor[torch.bool][:, :]:
+    """Return a cached ``[n_types, max_n_block_atoms]`` side-chain mask."""
     pbt = pose_stack.packed_block_types
+    cache_name = "_sidechain_atom_mask"
+    if hasattr(pbt, cache_name):
+        return getattr(pbt, cache_name)
 
-    # Expand coords to get real atom mask [n_poses, n_blocks, max_n_block_atoms]
-    _, real_expanded_pose_ats = pose_stack.expand_coords()
-
-    # block_coord_offset64[i, j] = starting flat coord index of block j in pose i
-    block_coord_offset64 = pose_stack.block_coord_offset64  # [n_poses, n_blocks]
-
-    # atom_local_idx[i, j, k] = k  (atom index within block)
-    atom_local_idx = (
-        torch.arange(max_n_block_atoms, device=pose_stack.device)
-        .unsqueeze(0)
-        .unsqueeze(0)
-        .expand(n_poses, n_blocks, -1)
-    )
-
-    # flat_atom_idx[i, j, k] = block_coord_offset64[i, j] + k
-    flat_atom_idx = block_coord_offset64.unsqueeze(2) + atom_local_idx
-    flat_atom_idx_flat = flat_atom_idx.reshape(n_poses, -1)
-
-    # Build expanded sidechain mask [n_poses, n_blocks, max_n_block_atoms]
-    block_type_ind64 = pose_stack.block_type_ind64  # [n_poses, n_blocks]
-
-    is_sidechain_expanded = torch.zeros(
-        (n_poses, n_blocks, max_n_block_atoms),
-        dtype=torch.bool,
-        device=pose_stack.device,
-    )
-
-    for bt_idx in range(pbt.n_types):
-        rt = pbt.active_block_types[bt_idx]
-        mc_atoms = (
-            rt.properties.polymer.mainchain_atoms if rt.properties.polymer else None
-        )
-
-        # Get positions of this block type in the pose stack
-        bt_positions = block_type_ind64 == bt_idx  # [n_poses, n_blocks]
-        if not bt_positions.any():
+    sidechain_atom_mask = pbt.atom_is_real.clone()
+    for block_type_index, residue_type in enumerate(pbt.active_block_types):
+        polymer = residue_type.properties.polymer
+        if polymer is None:
             continue
+        mainchain_atom_indices = [
+            residue_type.atom_to_idx[atom] for atom in polymer.mainchain_atoms
+        ]
+        sidechain_atom_mask[block_type_index, mainchain_atom_indices] = False
 
-        # Create mask for real atoms of this block type
-        bt_real_atoms = real_expanded_pose_ats & bt_positions.unsqueeze(
-            2
-        )  # [n_poses, n_blocks, max_n_block_atoms]
-
-        if mc_atoms is not None and len(mc_atoms) > 0:
-            # Get mainchain atom indices
-            mc_atom_indices = torch.tensor(
-                [rt.atom_to_idx[at] for at in mc_atoms], device=pose_stack.device
-            )
-            # Create mask for mainchain atoms
-            mc_mask = torch.zeros(
-                max_n_block_atoms, dtype=torch.bool, device=pose_stack.device
-            )
-            mc_mask[mc_atom_indices] = True
-            # Sidechain = real atoms that are NOT mainchain
-            is_sidechain_expanded[bt_positions] = bt_real_atoms[bt_positions] & ~mc_mask
-        else:
-            # Non-polymeric: all real atoms are sidechain
-            is_sidechain_expanded[bt_positions] = bt_real_atoms[bt_positions]
-
-    # Flatten sidechain mask for scatter operation
-    is_sidechain_flat = is_sidechain_expanded.reshape(n_poses, -1)
-
-    # Build output coord_mask
-    coord_mask = torch.zeros(
-        (n_poses, max_n_atoms), dtype=torch.bool, device=pose_stack.device
-    )
-
-    # Guard against out-of-range flat indices (padding can exceed max_n_atoms)
-    valid_flat_idx = flat_atom_idx_flat < max_n_atoms
-    is_sidechain_flat_safe = is_sidechain_flat.clone()
-    is_sidechain_flat_safe[~valid_flat_idx] = False
-    flat_atom_idx_flat_safe = flat_atom_idx_flat.clone()
-    flat_atom_idx_flat_safe[~valid_flat_idx] = 0
-
-    coord_mask.scatter_(1, flat_atom_idx_flat_safe, is_sidechain_flat_safe)
-
-    return coord_mask
+    object.__setattr__(pbt, cache_name, sidechain_atom_mask)
+    return sidechain_atom_mask
 
 
-def compute_block_centroids_and_furthest_dist(pose_stack):
-    """For each block in a pose stack, compute the average coordinate (centroid)
-    of all of its atoms, as well as the distance of the furthest atom from this
-    average.
+def build_sidechain_coord_mask(
+    pose_stack: PoseStack,
+) -> Tensor[torch.bool][:, :]:
+    """Select side-chain atoms in each pose.
 
     Args:
-        pose_stack: A PoseStack object.
+        pose_stack: Poses supplying block types and coordinate layout.
 
     Returns:
-        block_centroids: Tensor of shape [n_poses, n_blocks, 3] containing
-            the average coordinate (centroid) of all real atoms in each block.
-            Padding blocks and blocks with no atoms will have NaN centroids.
-        block_furthest_dist: Tensor of shape [n_poses, n_blocks] containing
-            the distance of the furthest atom from the centroid for each block.
-            Padding blocks and blocks with no atoms will have NaN values.
+        Mask shaped ``[n_poses, max_n_atoms]``. Non-polymers contribute all
+        real atoms; polymers exclude their declared main-chain atoms.
+    """
+    block_for_atom, atom_in_block, real_atoms = _compact_atom_layout(pose_stack)
+    block_type_for_atom = pose_stack.block_type_ind64.gather(1, block_for_atom)
+    sidechain_atom_mask = _sidechain_atom_mask_for_block_type(pose_stack)
+    return (
+        sidechain_atom_mask[block_type_for_atom.clamp_min(0), atom_in_block]
+        & real_atoms
+    )
+
+
+def compute_block_centroids_and_furthest_dist(
+    pose_stack: PoseStack,
+) -> tuple[Tensor[torch.float32][:, :, 3], Tensor[torch.float32][:, :]]:
+    """Compute each block's centroid and enclosing radius.
+
+    Args:
+        pose_stack: Poses to summarize.
+
+    Returns:
+        Centroids shaped ``[n_poses, n_blocks, 3]`` and maximum distances
+        shaped ``[n_poses, n_blocks]``. Padding blocks contain NaNs.
     """
     # Expand coords to [n_poses, n_blocks, max_n_block_atoms, 3]
     expanded_coords, real_expanded_pose_ats = pose_stack.expand_coords()
@@ -435,288 +375,121 @@ def compute_block_centroids_and_furthest_dist(pose_stack):
     return block_centroids, block_furthest_dist
 
 
-def build_coord_mask_for_mask_and_interacting_atoms(pose_stack, mask):
-    # Build coord_mask: True for atoms in masked blocks and sidechain atoms within 5.0 Angstroms.
-    n_poses, max_n_atoms, _ = pose_stack.coords.shape
-    n_blocks = pose_stack.max_n_blocks
-    max_n_block_atoms = pose_stack.max_n_block_atoms
-    pbt = pose_stack.packed_block_types
-
-    # Expand coords to [n_poses, n_blocks, max_n_block_atoms, 3]
-    expanded_coords, real_expanded_pose_ats = pose_stack.expand_coords()
-
-    # Get number of atoms per block [n_poses, n_blocks]
-    # n_ats_per_block = pose_stack.n_ats_per_block
-
-    # Create atom-level mask for atoms in masked blocks
-    # block_atom_mask[i, j, k] = True if block j is masked for pose i and atom k is real
-    block_mask_expanded = mask.unsqueeze(2).expand(
-        -1, -1, max_n_block_atoms
-    )  # [n_poses, n_blocks, max_n_block_atoms]
-    atom_in_masked_block = (
-        block_mask_expanded & real_expanded_pose_ats
-    )  # [n_poses, n_blocks, max_n_block_atoms]
-
-    # Flatten to per-atom mask [n_poses, n_blocks * max_n_block_atoms]
-    atom_in_masked_block_flat = atom_in_masked_block.reshape(n_poses, -1)
-
-    # Create a mask for real atoms in the pose [n_poses, max_n_atoms]
-    real_atoms = pose_stack.real_atoms
-
-    # Map expanded atom indices to flat coords indices
-    # For each pose, the atoms are laid out contiguously in coords
-    # We need to figure out which flat index each (block, atom_in_block) pair maps to
-    block_coord_offset64 = pose_stack.block_coord_offset64  # [n_poses, n_blocks]
-
-    # Create flat indices for all atoms in expanded view
-    # atom_local_idx[i, j, k] = k (atom index within block)
-    atom_local_idx = (
-        torch.arange(max_n_block_atoms, device=pose_stack.device)
-        .unsqueeze(0)
-        .unsqueeze(0)
-        .expand(n_poses, n_blocks, -1)
-    )
-
-    # flat_atom_idx[i, j, k] = block_coord_offset64[i, j] + k
-    flat_atom_idx = (
-        block_coord_offset64.unsqueeze(2) + atom_local_idx
-    )  # [n_poses, n_blocks, max_n_block_atoms]
-    flat_atom_idx_flat = flat_atom_idx.reshape(
-        n_poses, -1
-    )  # [n_poses, n_blocks * max_n_block_atoms]
-
-    # Create coord_mask initialized to False
-    coord_mask = torch.zeros(
-        (n_poses, max_n_atoms), dtype=torch.bool, device=pose_stack.device
-    )
-
-    # Set True for atoms in masked blocks
-    # Use scatter to set the appropriate indices
-    # Only include valid flat indices (some may exceed max_n_atoms
-    # due to padding in the expanded block view).
-    valid_flat_idx = flat_atom_idx_flat < max_n_atoms
-    # Keep 2D shape; for invalid positions set src to False (no-op) and index to 0 (safe dummy)
-    atom_in_masked_block_flat_safe = atom_in_masked_block_flat.clone()
-    atom_in_masked_block_flat_safe[~valid_flat_idx] = False
-    flat_atom_idx_flat_safe = flat_atom_idx_flat.clone()
-    flat_atom_idx_flat_safe[~valid_flat_idx] = 0
-    coord_mask.scatter_(1, flat_atom_idx_flat_safe, atom_in_masked_block_flat_safe)
-
-    # Build sidechain atom mask: True for atoms that are sidechain atoms
-    # An atom is a sidechain atom if it's real and NOT a mainchain atom
-    # For non-polymeric residues, all atoms are considered sidechain
-    block_type_ind64 = pose_stack.block_type_ind64  # [n_poses, n_blocks]
-
-    # Create expanded sidechain mask [n_poses, n_blocks, max_n_block_atoms]
-    is_sidechain_expanded = torch.zeros(
-        (n_poses, n_blocks, max_n_block_atoms),
-        dtype=torch.bool,
-        device=pose_stack.device,
-    )
-
-    for bt_idx in range(pbt.n_types):
-        rt = pbt.active_block_types[bt_idx]
-        mc_atoms = (
-            rt.properties.polymer.mainchain_atoms if rt.properties.polymer else None
-        )
-
-        # Get positions of this block type in pose_stack
-        bt_positions = block_type_ind64 == bt_idx  # [n_poses, n_blocks]
-        if not bt_positions.any():
-            continue
-
-        # Create mask for real atoms of this block type
-        bt_real_atoms = real_expanded_pose_ats & bt_positions.unsqueeze(
-            2
-        )  # [n_poses, n_blocks, max_n_block_atoms]
-
-        if mc_atoms is not None and len(mc_atoms) > 0:
-            # Get mainchain atom indices
-            mc_atom_indices = torch.tensor(
-                [rt.atom_to_idx[at] for at in mc_atoms], device=pose_stack.device
-            )
-            # Create mask for mainchain atoms
-            mc_mask = torch.zeros(
-                max_n_block_atoms, dtype=torch.bool, device=pose_stack.device
-            )
-            mc_mask[mc_atom_indices] = True
-            # Sidechain = real atoms that are NOT mainchain
-            is_sidechain_expanded[bt_positions] = bt_real_atoms[bt_positions] & ~mc_mask
-        else:
-            # Non-polymeric: all real atoms are sidechain
-            is_sidechain_expanded[bt_positions] = bt_real_atoms[bt_positions]
-
-    # Now find atoms within 5.0 Angstroms of any masked atom
-    # Get coordinates of masked atoms and all real atoms
-    coords = pose_stack.coords  # [n_poses, max_n_atoms, 3]
-
-    # Create a per-pose distance computation
-    # For each pose, compute distance from each real atom to nearest masked atom
-    for p in range(n_poses):
-        # Get masked atom indices for this pose (flat indices into coords)
-        masked_flat_idx = flat_atom_idx_flat[
-            p, atom_in_masked_block_flat[p]
-        ]  # [n_masked_atoms]
-
-        if masked_flat_idx.numel() == 0:
-            continue
-
-        # Get masked atom coordinates [n_masked_atoms, 3]
-        masked_atom_coords = coords[p, masked_flat_idx, :]  # [n_masked_atoms, 3]
-
-        # Get all real atom coordinates for this pose [n_real_atoms, 3]
-        real_atom_indices = torch.nonzero(real_atoms[p], as_tuple=True)[
-            0
-        ]  # [n_real_atoms]
-        all_real_coords = coords[p, real_atom_indices, :]  # [n_real_atoms, 3]
-
-        # Compute pairwise distances [n_real_atoms, n_masked_atoms]
-        # Using broadcasting: all_real_coords[:, None, :] - masked_atom_coords[None, :, :]
-        diff = all_real_coords.unsqueeze(1) - masked_atom_coords.unsqueeze(
-            0
-        )  # [n_real_atoms, n_masked_atoms, 3]
-        distances = torch.sqrt((diff**2).sum(dim=2))  # [n_real_atoms, n_masked_atoms]
-
-        # Find atoms within 5.0 Angstroms of any masked atom.
-        min_distances = distances.min(dim=1)[0]  # [n_real_atoms]
-        nearby_atoms = min_distances <= 5.0  # [n_real_atoms]
-
-        # For nearby atoms NOT in the original mask, only include sidechain atoms
-        # First, get the expanded sidechain mask for this pose, flattened
-        is_sidechain_flat = is_sidechain_expanded[p].reshape(
-            -1
-        )  # [n_blocks * max_n_block_atoms]
-
-        # Create a per-atom sidechain mask for flat atom indices
-        # Some flat indices may exceed max_n_atoms due to padding in expanded view
-        is_sidechain_per_atom = torch.zeros(
-            max_n_atoms, dtype=torch.bool, device=pose_stack.device
-        )
-        valid_flat_idx_p = flat_atom_idx_flat[p] < max_n_atoms
-        flat_atom_idx_flat_p_safe = flat_atom_idx_flat[p][valid_flat_idx_p]
-        is_sidechain_flat_safe = is_sidechain_flat[valid_flat_idx_p]
-        is_sidechain_per_atom.scatter_(
-            0, flat_atom_idx_flat_p_safe, is_sidechain_flat_safe
-        )
-
-        # Check which nearby atoms are sidechain atoms
-        nearby_is_sidechain = is_sidechain_per_atom[real_atom_indices[nearby_atoms]]
-
-        # Determine which nearby atoms to include:
-        # - Atoms in masked blocks are always included (already in coord_mask)
-        # - Atoms NOT in masked blocks are only included if they are sidechain atoms
-        atoms_in_masked_blocks = coord_mask[p, real_atom_indices[nearby_atoms]]
-        atoms_to_add = nearby_atoms.clone()
-        atoms_to_add[nearby_atoms] = atoms_in_masked_blocks | nearby_is_sidechain
-
-        # Update coord_mask for this pose
-        coord_mask[p, real_atom_indices[atoms_to_add]] = True
-
-    return coord_mask
-
-
-def build_coord_mask_for_mask_and_nearby_blocks(pose_stack, mask):
-    """Build a coord mask starting from a per-block mask, extending to
-    sidechain atoms of blocks whose centroid is within dynamic range of
-    any masked block centroid.
-
-    All atoms from blocks in ``mask`` are unconditionally included.
-    Additionally, sidechain atoms from any *unmasked* block are included
-    if the distance between its centroid and the centroid of **any** masked
-    block is **less than the sum of their respective furthest-atom-from-centroid
-    distances**.
+def build_coord_mask_for_mask_and_interacting_atoms(
+    pose_stack: PoseStack,
+    mask: Tensor[torch.bool][:, :],
+    interaction_distance: float = 5.0,
+) -> Tensor[torch.bool][:, :]:
+    """Select masked blocks and nearby side-chain atoms.
 
     Args:
-        pose_stack: The pose stack. Must have attributes ``coords``,
-            ``max_n_blocks``, ``max_n_block_atoms``, ``block_coord_offset64``,
-            ``real_atoms``, ``block_type_ind64``, ``block_type_ind``, and
-            ``packed_block_types``.
-        mask: Boolean tensor of shape ``[n_poses, n_blocks]``.
+        pose_stack: Poses containing coordinates shaped ``[n_poses, n_atoms, 3]``.
+        mask: Selected blocks shaped ``[n_poses, n_blocks]``.
+        interaction_distance: Maximum atom-to-selected-atom distance in Angstroms.
 
     Returns:
-        Boolean tensor of shape ``[n_poses, max_n_atoms]`` suitable for
-        use as a ``coord_mask`` argument to ``run_cart_min``.
+        Coordinate mask shaped ``[n_poses, n_atoms]``. All atoms in selected
+        blocks are included; only side-chain atoms are added from other blocks.
     """
-    # ---------------------------------------------------------------
-    # 1.  All atoms from the masked blocks themselves.
-    # ---------------------------------------------------------------
     coord_mask = res_mask_to_coord_mask(pose_stack, mask)
+    sidechain_mask = build_sidechain_coord_mask(pose_stack)
+    n_masked_atoms = coord_mask.sum(dim=1)
+    max_n_masked_atoms = int(n_masked_atoms.max().item())
+    if max_n_masked_atoms == 0:
+        return coord_mask
 
-    # ---------------------------------------------------------------
-    # 2.  Per-atom sidechain mask.
-    # ---------------------------------------------------------------
+    # Pack each pose's selected coordinates into a padded dense tensor so
+    # mutants share distance kernels instead of launching once per pose.
+    n_poses, max_n_atoms, coordinate_dim = pose_stack.coords.shape
+    masked_coords = torch.zeros(
+        (n_poses, max_n_masked_atoms, coordinate_dim),
+        dtype=pose_stack.coords.dtype,
+        device=pose_stack.device,
+    )
+    masked_coords_are_real = torch.zeros(
+        (n_poses, max_n_masked_atoms), dtype=torch.bool, device=pose_stack.device
+    )
+    masked_pose, masked_atom = torch.nonzero(coord_mask, as_tuple=True)
+    first_masked_atom = torch.cumsum(n_masked_atoms, dim=0) - n_masked_atoms
+    masked_slot = torch.arange(masked_pose.shape[0], device=pose_stack.device)
+    masked_slot -= first_masked_atom[masked_pose]
+    masked_coords[masked_pose, masked_slot] = pose_stack.coords[
+        masked_pose, masked_atom
+    ]
+    masked_coords_are_real[masked_pose, masked_slot] = True
+
+    # Bound the temporary [chunk, n_atoms, n_masked_atoms, 3] difference tensor.
+    bytes_per_pose = (
+        max_n_atoms
+        * max_n_masked_atoms
+        * (coordinate_dim + 1)
+        * pose_stack.coords.element_size()
+    )
+    poses_per_chunk = max(1, _INTERACTION_DISTANCE_WORKSPACE_BYTES // bytes_per_pose)
+    nearby_atoms = torch.empty_like(coord_mask)
+    for first_pose in range(0, n_poses, poses_per_chunk):
+        last_pose = min(first_pose + poses_per_chunk, n_poses)
+        differences = (
+            pose_stack.coords[first_pose:last_pose, :, None, :]
+            - masked_coords[first_pose:last_pose, None, :, :]
+        )
+        differences.square_()
+        distances = differences.sum(dim=3).sqrt_()
+        distances.masked_fill_(
+            ~masked_coords_are_real[first_pose:last_pose, None, :], float("inf")
+        )
+        nearby_atoms[first_pose:last_pose] = distances.amin(dim=2).le(
+            interaction_distance
+        )
+
+    return coord_mask | (nearby_atoms & pose_stack.real_atoms & sidechain_mask)
+
+
+def build_coord_mask_for_mask_and_nearby_blocks(
+    pose_stack: PoseStack, mask: Tensor[torch.bool][:, :]
+) -> Tensor[torch.bool][:, :]:
+    """Select masked blocks and side chains of centroid-adjacent blocks.
+
+    Args:
+        pose_stack: Poses to select from.
+        mask: Selected blocks shaped ``[n_poses, n_blocks]``.
+
+    Returns:
+        Coordinate mask shaped ``[n_poses, max_n_atoms]``.
+    """
+    coord_mask = res_mask_to_coord_mask(pose_stack, mask)
     sidechain_mask = build_sidechain_coord_mask(pose_stack)  # [n_poses, max_n_atoms]
 
-    # ---------------------------------------------------------------
-    # 3.  Block centroids and furthest-atom-from-centroid distances.
-    # ---------------------------------------------------------------
     block_centroids, block_furthest_dist = compute_block_centroids_and_furthest_dist(
         pose_stack
     )
-
-    # ---------------------------------------------------------------
-    # 4.  Block-block adjacency matrix.
-    # ---------------------------------------------------------------
     adjacency = compute_block_adjacency(
         block_centroids, block_furthest_dist
     )  # [n_poses, n_blocks, n_blocks]
 
-    # ---------------------------------------------------------------
-    # 5.  Find unmasked blocks adjacent to any masked block.
-    # ---------------------------------------------------------------
-    # adjacency[mask] -> [n_poses, n_masked, n_blocks]
-    # any masked block adjacent to block j means block j should contribute sidechains
-    # Expand mask for broadcasting: mask[:, :, None] & adjacency
+    # A block is nearby when any selected block is adjacent to it.
     nearby_mask = (mask.unsqueeze(2) & adjacency).any(dim=1)  # [n_poses, n_blocks]
 
-    # ---------------------------------------------------------------
-    # 6.  Sidechain atoms from nearby blocks.
-    # ---------------------------------------------------------------
-    # all atoms from nearby blocks
     coord_mask_nearby = res_mask_to_coord_mask(pose_stack, nearby_mask)
-    # keep only the sidechain atoms among those
     sidechain_nearby_mask = coord_mask_nearby & sidechain_mask
-
-    # ---------------------------------------------------------------
-    # 7.  Combine: all atoms from original masked blocks + sidechain
-    #     atoms from nearby blocks.  Avoid double-counting the masked
-    #     blocks themselves (their full atoms are already in coord_mask).
-    # ---------------------------------------------------------------
-    coord_mask = coord_mask | sidechain_nearby_mask
-
-    return coord_mask
+    return coord_mask | sidechain_nearby_mask
 
 
-def compute_block_adjacency(block_centroids, block_furthest_dist, constant=5.0):
-    """Compute a boolean block-level adjacency matrix.
-
-    Two blocks *i* and *j* (in the same pose) are considered adjacent when
-    the distance between their centroids is **less than the sum of their
-    furthest-atom-from-centroid distances plus a constant**.
-
-    .. math::
-
-        \\|\\mathbf{c}_i - \\mathbf{c}_j\\|
-        < d_i + d_j + \\text{constant}
+def compute_block_adjacency(
+    block_centroids: Tensor[torch.float32][:, :, 3],
+    block_furthest_dist: Tensor[torch.float32][:, :],
+    constant: float = 5.0,
+) -> Tensor[torch.bool][:, :, :]:
+    """Find blocks whose enclosing spheres are within a fixed gap.
 
     Args:
-        block_centroids: Tensor of shape ``[n_poses, n_blocks, 3]``
-            containing the centroid coordinate of each block (e.g. as
-            returned by :func:`compute_block_centroids_and_furthest_dist`).
-        block_furthest_dist: Tensor of shape ``[n_poses, n_blocks]``
-            containing the distance of the atom furthest from the centroid
-            for each block.
-        constant: A scalar added to the sum of furthest distances.  Default
-            is ``5.0``.
+        block_centroids: Centroids shaped ``[n_poses, n_blocks, 3]``.
+        block_furthest_dist: Enclosing radii shaped ``[n_poses, n_blocks]``.
+        constant: Maximum gap between two enclosing spheres.
 
     Returns:
-        Boolean tensor of shape ``[n_poses, n_blocks, n_blocks]`` where
-        ``adjacency[p, i, j]`` is ``True`` when the two blocks *i* and *j*
-        in pose *p* are adjacent.
-
-        The diagonal is always ``False`` (a block is not adjacent to itself).
-        Padding / NaN-containing blocks are treated as not adjacent to any
-        block.
+        Adjacency shaped ``[n_poses, n_blocks, n_blocks]`` with a false
+        diagonal and false entries for padding blocks.
     """
     n_poses, n_blocks, _ = block_centroids.shape
 

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -46,12 +46,12 @@ def _sum_single_block_cross_scores(
     )
     rows = block_pair_scores.gather(2, gather_rows).squeeze(2)
     columns = block_pair_scores.gather(3, gather_columns).squeeze(3)
-    cross_scores = ((rows + columns) * other_mask.unsqueeze(0)).sum(dim=2)
     if sets_are_disjoint:
-        return cross_scores
+        return rows.add_(columns).mul_(other_mask.unsqueeze(0)).sum(dim=2)
 
-    diagonal_selected = other_mask.gather(1, block_indices[:, None]).squeeze(1)
     diagonal = rows.gather(2, block_indices[None, :, None].expand(n_terms, -1, 1))
+    cross_scores = rows.add_(columns).mul_(other_mask.unsqueeze(0)).sum(dim=2)
+    diagonal_selected = other_mask.gather(1, block_indices[:, None]).squeeze(1)
     # A block present in both sets contributes its diagonal score once; the row
     # plus column reduction includes it twice, so subtract one copy.
     return cross_scores - (diagonal.squeeze(2) * diagonal_selected.unsqueeze(0))

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -10,7 +10,7 @@ from tmol.optimization import run_cart_min
 from tmol.types import Tensor
 
 _EINSUM_MIN_BYTES = 512 * 1024 * 1024
-_INTERACTION_DISTANCE_WORKSPACE_BYTES = 256 * 1024 * 1024
+_DEFAULT_INTERACTION_DISTANCE_WORKSPACE_BYTES = 256 * 1024 * 1024
 
 
 def _sum_cross_block_scores(
@@ -101,6 +101,7 @@ def calculate_block_pair_ddg(
     return_pose_stack: bool = False,
     *,
     memory_efficient: bool = False,
+    max_workspace_bytes: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, PoseStack]:
     """Score interactions between two block sets in each pose.
 
@@ -118,6 +119,8 @@ def calculate_block_pair_ddg(
         return_pose_stack: Return the packed/minimized poses with their scores.
         memory_efficient: Use a lower-memory Boolean-mask reduction. Its floating-
             point summation order may differ from the default path.
+        max_workspace_bytes: Optional temporary-memory cap for the batched
+            nearby-atom search used by minimization. Defaults to 256 MiB.
 
     Returns:
         Scores shaped ``[n_poses]`` or ``[n_terms, n_poses]``. When requested,
@@ -179,7 +182,9 @@ def calculate_block_pair_ddg(
         pose_stack = pack_rotamers(pose_stack, sfxn, task)
 
     if minimize:
-        coord_mask = build_coord_mask_for_mask_and_interacting_atoms(pose_stack, mask)
+        coord_mask = build_coord_mask_for_mask_and_interacting_atoms(
+            pose_stack, mask, max_workspace_bytes=max_workspace_bytes
+        )
         pose_stack = run_cart_min(pose_stack, sfxn, coord_mask)
 
     scorer = sfxn.render_block_pair_scoring_module(pose_stack)
@@ -379,6 +384,8 @@ def build_coord_mask_for_mask_and_interacting_atoms(
     pose_stack: PoseStack,
     mask: Tensor[torch.bool][:, :],
     interaction_distance: float = 5.0,
+    *,
+    max_workspace_bytes: int | None = None,
 ) -> Tensor[torch.bool][:, :]:
     """Select masked blocks and nearby side-chain atoms.
 
@@ -386,11 +393,21 @@ def build_coord_mask_for_mask_and_interacting_atoms(
         pose_stack: Poses containing coordinates shaped ``[n_poses, n_atoms, 3]``.
         mask: Selected blocks shaped ``[n_poses, n_blocks]``.
         interaction_distance: Maximum atom-to-selected-atom distance in Angstroms.
+        max_workspace_bytes: Temporary-memory cap for batched pairwise
+            differences. Defaults to 256 MiB; smaller values use more chunks.
 
     Returns:
         Coordinate mask shaped ``[n_poses, n_atoms]``. All atoms in selected
         blocks are included; only side-chain atoms are added from other blocks.
+
+    Raises:
+        ValueError: If ``max_workspace_bytes`` is not positive.
     """
+    if max_workspace_bytes is None:
+        max_workspace_bytes = _DEFAULT_INTERACTION_DISTANCE_WORKSPACE_BYTES
+    if max_workspace_bytes <= 0:
+        raise ValueError("max_workspace_bytes must be positive")
+
     coord_mask = res_mask_to_coord_mask(pose_stack, mask)
     sidechain_mask = build_sidechain_coord_mask(pose_stack)
     n_masked_atoms = coord_mask.sum(dim=1)
@@ -425,7 +442,7 @@ def build_coord_mask_for_mask_and_interacting_atoms(
         * (coordinate_dim + 1)
         * pose_stack.coords.element_size()
     )
-    poses_per_chunk = max(1, _INTERACTION_DISTANCE_WORKSPACE_BYTES // bytes_per_pose)
+    poses_per_chunk = max(1, max_workspace_bytes // bytes_per_pose)
     nearby_atoms = torch.empty_like(coord_mask)
     for first_pose in range(0, n_poses, poses_per_chunk):
         last_pose = min(first_pose + poses_per_chunk, n_poses)

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -290,7 +290,7 @@ def _sidechain_atom_mask_for_block_type(
     sidechain_atom_mask = pbt.atom_is_real.clone()
     for block_type_index, residue_type in enumerate(pbt.active_block_types):
         polymer = residue_type.properties.polymer
-        if polymer is None:
+        if polymer is None or not polymer.mainchain_atoms:
             continue
         mainchain_atom_indices = [
             residue_type.atom_to_idx[atom] for atom in polymer.mainchain_atoms

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -33,6 +33,30 @@ def _sum_cross_block_scores(
     return block_pair_scores.masked_fill(~cross_mask.unsqueeze(0), 0).sum(dim=(2, 3))
 
 
+def _sum_single_block_cross_scores(
+    block_pair_scores, block_indices, other_mask, *, sets_are_disjoint=False
+):
+    """Sum interactions between one block per pose and selected partners."""
+    n_terms, n_poses, n_blocks, _ = block_pair_scores.shape
+    gather_rows = block_indices.reshape(1, n_poses, 1, 1).expand(
+        n_terms, -1, 1, n_blocks
+    )
+    gather_columns = block_indices.reshape(1, n_poses, 1, 1).expand(
+        n_terms, -1, n_blocks, 1
+    )
+    rows = block_pair_scores.gather(2, gather_rows).squeeze(2)
+    columns = block_pair_scores.gather(3, gather_columns).squeeze(3)
+    cross_scores = ((rows + columns) * other_mask.unsqueeze(0)).sum(dim=2)
+    if sets_are_disjoint:
+        return cross_scores
+
+    diagonal_selected = other_mask.gather(1, block_indices[:, None]).squeeze(1)
+    diagonal = rows.gather(2, block_indices[None, :, None].expand(n_terms, -1, 1))
+    # A block present in both sets contributes its diagonal score once; the row
+    # plus column reduction includes it twice, so subtract one copy.
+    return cross_scores - (diagonal.squeeze(2) * diagonal_selected.unsqueeze(0))
+
+
 def calculate_block_pair_ddg(
     pose_stack,
     mask,
@@ -52,6 +76,9 @@ def calculate_block_pair_ddg(
     Args:
         pose_stack: The pose stack to score
         mask: Boolean tensor of shape [n_poses, n_blocks]. True values indicate masked indices.
+            For the common single-site scan, an integer tensor of shape [n_poses] may instead
+            give the selected block in each pose. This avoids constructing and reducing a dense
+            block-pair mask; its floating-point reduction order may differ from the Boolean path.
         mask2: Boolean tensor of shape [n_poses, n_blocks]. If not provided, it will use the inverse
             of the first mask as the second mask.
         sfxn: Optional score function to use. If not provided, will default to beta2016
@@ -73,6 +100,14 @@ def calculate_block_pair_ddg(
         ``(ddg_scores, pose_stack)``.
     """
     torch_device = pose_stack.device
+
+    single_block_indices = None
+    if mask.ndim == 1 and mask.dtype != torch.bool:
+        if mask.shape[0] != pose_stack.n_poses:
+            raise ValueError("mask must contain one block index per pose")
+        single_block_indices = mask.to(device=torch_device, dtype=torch.long)
+        mask = torch.zeros_like(pose_stack.block_type_ind, dtype=torch.bool)
+        mask.scatter_(1, single_block_indices[:, None], True)
 
     if sfxn is None:
         sfxn = beta2016_score_function(torch_device)
@@ -127,9 +162,17 @@ def calculate_block_pair_ddg(
     # mask shape: [n_poses, n_blocks]
     # Use mask2 if provided, otherwise use ~mask for the second set of indices
     other_mask = mask2 if mask2 is not None else ~mask
-    ddg_scores = _sum_cross_block_scores(
-        block_pair_scores, mask, other_mask, memory_efficient=memory_efficient
-    )
+    if single_block_indices is None:
+        ddg_scores = _sum_cross_block_scores(
+            block_pair_scores, mask, other_mask, memory_efficient=memory_efficient
+        )
+    else:
+        ddg_scores = _sum_single_block_cross_scores(
+            block_pair_scores,
+            single_block_indices,
+            other_mask,
+            sets_are_disjoint=mask2 is None,
+        )
 
     if sum_terms:
         ddg_scores = ddg_scores.sum(dim=0)

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -157,7 +157,10 @@ def calculate_block_pair_ddg(
         pose_stack = run_cart_min(pose_stack, sfxn, coord_mask)
 
     scorer = sfxn.render_block_pair_scoring_module(pose_stack)
-    block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
+    defer_weights = single_block_indices is not None
+    block_pair_scores = scorer(
+        pose_stack.coords, sum_terms=False, apply_weights=not defer_weights
+    )
 
     # mask shape: [n_poses, n_blocks]
     # Use mask2 if provided, otherwise use ~mask for the second set of indices
@@ -173,6 +176,8 @@ def calculate_block_pair_ddg(
             other_mask,
             sets_are_disjoint=mask2 is None,
         )
+        term_weights = scorer.weights[:, 0, 0, 0].unsqueeze(1)
+        ddg_scores = ddg_scores * term_weights
 
     if sum_terms:
         ddg_scores = ddg_scores.sum(dim=0)

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -103,6 +103,8 @@ def calculate_block_pair_ddg(
 
     single_block_indices = None
     if mask.ndim == 1 and mask.dtype != torch.bool:
+        if torch.is_floating_point(mask) or torch.is_complex(mask):
+            raise TypeError("single-block mask indices must have an integer dtype")
         if mask.shape[0] != pose_stack.n_poses:
             raise ValueError("mask must contain one block index per pose")
         single_block_indices = mask.to(device=torch_device, dtype=torch.long)

--- a/tmol/pack/_pack_rotamers.py
+++ b/tmol/pack/_pack_rotamers.py
@@ -18,9 +18,19 @@ def pack_rotamers(
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
     task: PackerTask,
-    verbose=False,
-    **sa_params,
-):
+    verbose: bool = False,
+) -> PoseStack:
+    """Optimize side-chain conformers for a pose stack.
+
+    Args:
+        pose_stack: Poses whose task-enabled blocks will be packed.
+        sfxn: Score function used to rank rotamer assignments.
+        task: Allowed block types, conformers, and packing positions.
+        verbose: Print synchronized stage timings when true.
+
+    Returns:
+        A new pose stack containing the lowest-ranked assignment per pose.
+    """
 
     if verbose and torch.cuda.is_available():
         torch.cuda.synchronize()
@@ -48,9 +58,7 @@ def pack_rotamers(
         torch.cuda.synchronize()
     end_time4 = time.perf_counter()
 
-    scores, rotamer_assignments = run_simulated_annealing(
-        packer_energy_tables, **sa_params
-    )
+    _, rotamer_assignments = run_simulated_annealing(packer_energy_tables)
     if verbose and torch.cuda.is_available():
         torch.cuda.synchronize()
     end_time5 = time.perf_counter()

--- a/tmol/pack/_simulated_annealing.py
+++ b/tmol/pack/_simulated_annealing.py
@@ -1,15 +1,25 @@
+import torch
+
 from tmol.pack import PackerEnergyTables
+from tmol.types import Tensor
 
 
-def run_simulated_annealing(energy_tables: PackerEnergyTables):
-    """Run GPU simulated annealing.
+def run_simulated_annealing(
+    energy_tables: PackerEnergyTables,
+) -> tuple[Tensor[torch.float32][:, :], Tensor[torch.int32][:, :, :]]:
+    """Rank rotamer assignments with GPU simulated annealing.
 
-    Phase 1 (hi-temp SA): 500 trajectories run at high temperature
-    Phase 2 (lo-temp SA): Each top hi-temp trajectory seeds 10 lo-temp
-    trajectories, then round1_cut = 0.25 keeps the top 25%
-      -> 500 * 10 * 0.25 = 1250 trajectories
-    Phase 3 (full quench): round2_cut = 0.25 keeps the top 25% of those
-      -> int(1250 * 0.25) = 312 trajectories
+    Args:
+        energy_tables: One- and two-body energies plus their rotamer layout.
+
+    Returns:
+        Scores shaped ``[n_poses, n_final_trajectories]`` and local rotamer
+        assignments shaped ``[n_poses, n_final_trajectories, max_n_res]``.
+
+    Notes:
+        The annealer starts 500 high-temperature trajectories. The best 25%
+        seed ten low-temperature trajectories each, and the best 25% of those
+        are fully quenched, leaving 312 ranked assignments per pose.
     """
     from tmol.pack.compiled import pack_anneal
 

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -211,6 +211,7 @@ MGPU_DEVICE int set_quench_32_order(
 //     standard Metropolis accept/reject
 template <
     int ChunkSize,
+    bool ReturnFinalScore,
     tmol::Device D,
     uint n_threads,
     typename Int,
@@ -422,8 +423,13 @@ MGPU_DEVICE float warp_wide_sim_annealing(
 
   }  // end outer loop
 
-  return ig.template total_energy_for_assignment_parallel<ChunkSize>(
-      pose, g, current_rotamer_assignment);
+  // Transition phases consume only the assignments; avoid their otherwise
+  // unused exact rescore while retaining it for ranking phases.
+  if constexpr (ReturnFinalScore) {
+    return ig.template total_energy_for_assignment_parallel<ChunkSize>(
+        pose, g, current_rotamer_assignment);
+  }
+  return 0.0f;
 }
 
 template <tmol::Device D, class IG, int ChunkSize>
@@ -618,7 +624,7 @@ struct Annealer {
       }
 
       // Full SA run with geometric cooling
-      warp_wide_sim_annealing<ChunkSize>(
+      warp_wide_sim_annealing<ChunkSize, false>(
           pose,
           traj_id,
           &state,
@@ -644,22 +650,23 @@ struct Annealer {
       }
 
       // Quench-lite to produce a score for ranking
-      float after_first_quench_lite_totalE = warp_wide_sim_annealing<ChunkSize>(
-          pose,
-          traj_id,
-          &state,
-          g,
-          ig,
-          current_rotamer_assignments_hitemp_quenchlite[pose][traj_id],
-          best_rotamer_assignments_hitemp[pose][traj_id],
-          quench_order[pose][traj_id],
-          high_temp_initial,
-          low_temp_initial,
-          1,  // quench on the (only) iteration
-          n_inner_iterations_hitemp,
-          n_rotamers,
-          true,
-          true);
+      float after_first_quench_lite_totalE =
+          warp_wide_sim_annealing<ChunkSize, true>(
+              pose,
+              traj_id,
+              &state,
+              g,
+              ig,
+              current_rotamer_assignments_hitemp_quenchlite[pose][traj_id],
+              best_rotamer_assignments_hitemp[pose][traj_id],
+              quench_order[pose][traj_id],
+              high_temp_initial,
+              low_temp_initial,
+              1,  // quench on the (only) iteration
+              n_inner_iterations_hitemp,
+              n_rotamers,
+              true,
+              true);
       if (g.thread_rank() == 0) {
         scores_hitemp[pose][traj_id] = after_first_quench_lite_totalE;
       }
@@ -697,7 +704,7 @@ struct Annealer {
       }
 
       // Low-temperature cooling trajectory
-      warp_wide_sim_annealing<ChunkSize>(
+      warp_wide_sim_annealing<ChunkSize, false>(
           pose,
           traj_id,
           &state,
@@ -716,7 +723,7 @@ struct Annealer {
 
       // Quench-lite to score for the next round of selection
       float after_lotemp_quench_lite_totalE =
-          warp_wide_sim_annealing<ChunkSize>(
+          warp_wide_sim_annealing<ChunkSize, true>(
               pose,
               traj_id,
               &state,
@@ -764,7 +771,7 @@ struct Annealer {
         best_rotamer_assignments_fullquench[pose][traj_id][i] = i_rot;
       }
 
-      warp_wide_sim_annealing<ChunkSize>(
+      warp_wide_sim_annealing<ChunkSize, false>(
           pose,
           traj_id,
           &state,

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -69,11 +69,7 @@ struct InteractionGraph {
 
   int n_poses_cpu() const { return pose_n_res_.size(0); }
   int max_n_res_cpu() const { return n_rotamers_for_res_.size(1); }
-  int n_rotamers_total_cpu() const { return res_for_rot_.size(0); }
   int max_n_rotamers_per_pose_cpu() const { return max_n_rotamers_per_pose_; }
-
-  MGPU_DEVICE
-  int n_poses() const { return pose_n_res_.size(0); }
 
   MGPU_DEVICE
   int n_res(int pose) const { return pose_n_res_[pose]; }
@@ -87,72 +83,15 @@ struct InteractionGraph {
   }
 
   MGPU_DEVICE
-  TView<Int, 2, D> const& oneb_offsets() const { return oneb_offsets_; }
-
-  MGPU_DEVICE
   TView<Int, 1, D> const& res_for_rot() const { return res_for_rot_; }
 
-  MGPU_DEVICE
-  Real energy1b(int global_rot_ind) const { return energy1b_[global_rot_ind]; }
-
-  // Return the 1b + 2b energy for a substited rotamer at a residue
-  MGPU_DEVICE
-  Real rotamer_energy_against_background(
-      int pose,
-      int sub_res,
-      int sub_res_n_rots,
-      int local_sub_rot,
-      int global_sub_rot,
-      TensorAccessor<Int, 1, D> rotamer_assignment,
-      bool this_thread_active) const {
-    float new_e = 1e30;
-    if (this_thread_active) {
-      new_e = energy1b_[global_sub_rot];
-    }
-    int sub_rot_chunk = local_sub_rot / chunk_size_;
-    int sub_rot_in_chunk = local_sub_rot - sub_rot_chunk * chunk_size_;
-    int sub_res_n_chunks = (sub_res_n_rots - 1) / chunk_size_ + 1;
-    int sub_rot_chunk_size =
-        min(chunk_size_, sub_res_n_rots - chunk_size_ * sub_rot_chunk);
-
-    if (this_thread_active) {
-      int const nb_start = neighbor_starts_[pose][sub_res];
-      int const n_nb = n_neighbors_[pose][sub_res];
-      for (int nb_idx = 0; nb_idx < n_nb; ++nb_idx) {
-        int const k = neighbor_list_[nb_start + nb_idx];
-        int const local_k_rot = rotamer_assignment[k];
-        int const k_chunk = local_k_rot / chunk_size_;
-        int64_t const k_sub_chunk_offset_offset =
-            chunk_offset_offsets_[pose][k][sub_res];
-        if (k_sub_chunk_offset_offset == -1) {
-          continue;
-        }
-
-        int const k_in_chunk = local_k_rot - k_chunk * chunk_size_;
-        int const k_res_n_rots = n_rotamers_for_res_[pose][k];
-        int const k_chunk_size =
-            min(chunk_size_, k_res_n_rots - chunk_size_ * k_chunk);
-        int64_t const k_sub_chunk_start = chunk_offsets_
-            [k_sub_chunk_offset_offset + k_chunk * sub_res_n_chunks
-             + sub_rot_chunk];
-
-        if (k_sub_chunk_start == -1) {
-          continue;
-        }
-
-        new_e += energy2b_
-            [k_sub_chunk_start + sub_rot_chunk_size * k_in_chunk
-             + sub_rot_in_chunk];
-      }
-    }
-    return new_e;
-  }
-
-  template <unsigned int n_threads>
+  template <int ChunkSize, unsigned int n_threads>
   MGPU_DEVICE Real total_energy_for_assignment_parallel(
       int pose,
       cooperative_groups::thread_block_tile<n_threads> g,
       TensorAccessor<Int, 1, D> rotamer_assignment) const {
+    int32_t const chunk_size =
+        ChunkSize == 0 ? chunk_size_ : static_cast<int32_t>(ChunkSize);
     Real totalE = 0;
     int const n_res = pose_n_res_[pose];
     for (int i = g.thread_rank(); i < n_res; i += n_threads) {
@@ -165,12 +104,8 @@ struct InteractionGraph {
     // TO DO: iterate across upper-triangle indices only
     for (int i = g.thread_rank(); i < n_res; i += n_threads) {
       int const irot_local = rotamer_assignment[i];
-      int const irot_chunk = irot_local / chunk_size_;
-      int const irot_in_chunk = irot_local - chunk_size_ * irot_chunk;
-      int const ires_n_rots = n_rotamers_for_res_[pose][i];
-      int const ires_n_chunks = (ires_n_rots - 1) / chunk_size_ + 1;
-      int const irot_chunk_size =
-          min(chunk_size_, ires_n_rots - chunk_size_ * irot_chunk);
+      int const irot_chunk = irot_local / chunk_size;
+      int const irot_in_chunk = irot_local - chunk_size * irot_chunk;
 
       for (int j = i + 1; j < n_res; ++j) {
         int const jrot_local = rotamer_assignment[j];
@@ -179,13 +114,13 @@ struct InteractionGraph {
         if (ij_chunk_offset_offset == -1) {
           continue;
         }
-        int const jrot_chunk = jrot_local / chunk_size_;
-        int const jrot_in_chunk = jrot_local - chunk_size_ * jrot_chunk;
+        int const jrot_chunk = jrot_local / chunk_size;
+        int const jrot_in_chunk = jrot_local - chunk_size * jrot_chunk;
 
         int const jres_n_rots = n_rotamers_for_res_[pose][j];
-        int const jres_n_chunks = (jres_n_rots - 1) / chunk_size_ + 1;
+        int const jres_n_chunks = (jres_n_rots - 1) / chunk_size + 1;
         int const jrot_chunk_size =
-            min(chunk_size_, jres_n_rots - chunk_size_ * jrot_chunk);
+            min(chunk_size, jres_n_rots - chunk_size * jrot_chunk);
         int64_t const ij_chunk_offset = chunk_offsets_
             [ij_chunk_offset_offset + irot_chunk * jres_n_chunks + jrot_chunk];
         if (ij_chunk_offset == -1) {
@@ -210,34 +145,6 @@ struct InteractionGraph {
 MGPU_DEVICE
 int curand_in_range(curandStatePhilox4_32_10_t* state, int n) {
   return int(curand_uniform(state) * n) % n;
-}
-
-template <unsigned int n_threads, typename T, typename F>
-MGPU_DEVICE __inline__ T exclusive_scan_shfl(
-    cooperative_groups::thread_block_tile<n_threads> g, T val, F f) {
-  for (unsigned int i = 1; i <= n_threads; i *= 2) {
-    T const shfl_val = g.shfl_up(val, i);
-    if (i < g.thread_rank()) {
-      val = f(shfl_val, val);
-    }
-  }
-  val = g.shfl_up(val, 1);
-  if (g.thread_rank() == 0) {
-    val = 0;
-  }
-  return val;
-}
-
-template <unsigned int n_threads, typename T, typename F>
-MGPU_DEVICE __inline__ T inclusive_scan_shfl(
-    cooperative_groups::thread_block_tile<n_threads> g, T val, F f) {
-  for (unsigned int i = 1; i <= n_threads; i *= 2) {
-    T const shfl_val = g.shfl_up(val, i);
-    if (g.thread_rank() >= i) {
-      val = f(shfl_val, val);
-    }
-  }
-  return val;
 }
 
 template <tmol::Device D>
@@ -302,7 +209,12 @@ MGPU_DEVICE int set_quench_32_order(
 //     all 32 threads cooperatively sum _dE_ over neighbor list
 //     warp-reduce sum gives total dE
 //     standard Metropolis accept/reject
-template <tmol::Device D, uint n_threads, typename Int, typename Real>
+template <
+    int ChunkSize,
+    tmol::Device D,
+    uint n_threads,
+    typename Int,
+    typename Real>
 MGPU_DEVICE float warp_wide_sim_annealing(
     int pose,
     int traj_id,  // debugging purposes only
@@ -320,14 +232,16 @@ MGPU_DEVICE float warp_wide_sim_annealing(
     bool quench_on_last_iteration,
     bool quench_lite) {
   float const cooling_factor = 0.35f;
-  int32_t const chunk_size = ig.chunk_size_;
+  int32_t const chunk_size =
+      ChunkSize == 0 ? ig.chunk_size_ : static_cast<int32_t>(ChunkSize);
   int const n_res = ig.n_res(pose);
   int const n_rotamers = ig.n_rotamers(pose);
   int const pose_rotamer_offset = ig.pose_rotamer_offset_[pose];
 
   float temperature = hi_temp;
-  float best_energy = ig.total_energy_for_assignment_parallel(
-      pose, g, current_rotamer_assignment);
+  float best_energy =
+      ig.template total_energy_for_assignment_parallel<ChunkSize>(
+          pose, g, current_rotamer_assignment);
   float current_total_energy = best_energy;
   int n_steps = 0;
 
@@ -345,8 +259,9 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       for (int j = g.thread_rank(); j < n_res; j += 32) {
         current_rotamer_assignment[j] = best_rotamer_assignment[j];
       }
-      current_total_energy = ig.total_energy_for_assignment_parallel(
-          pose, g, current_rotamer_assignment);
+      current_total_energy =
+          ig.template total_energy_for_assignment_parallel<ChunkSize>(
+              pose, g, current_rotamer_assignment);
     }
 
     for (int j = 0; j < i_n_inner_iterations; ++j) {
@@ -432,11 +347,8 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       for (int nb_idx = g.thread_rank(); nb_idx < n_nb; nb_idx += 32) {
         int const k = ig.neighbor_list_[nb_start + nb_idx];
         int const local_k_rot = current_rotamer_assignment[k];
-        int const k_n_rots = ig.n_rotamers_for_res_[pose][k];
         int const k_chunk = local_k_rot / chunk_size;
         int const k_in_chunk = local_k_rot - k_chunk * chunk_size;
-        int const k_chunk_size =
-            min(chunk_size, k_n_rots - chunk_size * k_chunk);
 
         int64_t const k_offset_offset =
             ig.chunk_offset_offsets_[pose][k][ran_res];
@@ -498,8 +410,9 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       // Periodically recompute total energy to correct floating-point drift
       if (++n_steps > 10000) {
         n_steps = 0;
-        current_total_energy = ig.total_energy_for_assignment_parallel(
-            pose, g, current_rotamer_assignment);
+        current_total_energy =
+            ig.template total_energy_for_assignment_parallel<ChunkSize>(
+                pose, g, current_rotamer_assignment);
       }
 
     }  // end inner loop
@@ -509,35 +422,23 @@ MGPU_DEVICE float warp_wide_sim_annealing(
 
   }  // end outer loop
 
-  return ig.total_energy_for_assignment_parallel(
+  return ig.template total_energy_for_assignment_parallel<ChunkSize>(
       pose, g, current_rotamer_assignment);
 }
 
-// IG must respond to
-// - nres()
-// - nrotamers()
-// - nrotamers_for_res()
-// - oneb_offsets() <-- i.e. rotamer_offset_for_res
-// - res_for_rot()
-// - total_energy_for_assignment_parallel(thread_group, rot_assignment)
-//
-
-template <tmol::Device D, class IG>
+template <tmol::Device D, class IG, int ChunkSize>
 struct Annealer {
   static auto run_simulated_annealing(
       ContextManager& mgr, IG ig, at::CUDAGeneratorImpl* gen)
       -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D> > {
     int const n_poses = ig.n_poses_cpu();
     int const max_n_res = ig.max_n_res_cpu();
-    int const n_rotamers_total = ig.n_rotamers_total_cpu();
     int const max_n_rotamers = ig.max_n_rotamers_per_pose_cpu();
 
     // SA hyperparameters
     int const n_hitemp_simA_traj = 500;
     double const inner_iter_mult_hitemp = 1.5;
     double const inner_iter_mult_lotemp = 0.5;
-    float const cooling_factor = 0.35f;
-
     // Temperature schedule
     float const high_temp_initial = 30.0f;
     float const low_temp_initial = 0.3f;
@@ -717,7 +618,7 @@ struct Annealer {
       }
 
       // Full SA run with geometric cooling
-      warp_wide_sim_annealing(
+      warp_wide_sim_annealing<ChunkSize>(
           pose,
           traj_id,
           &state,
@@ -743,7 +644,7 @@ struct Annealer {
       }
 
       // Quench-lite to produce a score for ranking
-      float after_first_quench_lite_totalE = warp_wide_sim_annealing(
+      float after_first_quench_lite_totalE = warp_wide_sim_annealing<ChunkSize>(
           pose,
           traj_id,
           &state,
@@ -796,7 +697,7 @@ struct Annealer {
       }
 
       // Low-temperature cooling trajectory
-      warp_wide_sim_annealing(
+      warp_wide_sim_annealing<ChunkSize>(
           pose,
           traj_id,
           &state,
@@ -814,22 +715,23 @@ struct Annealer {
           false);
 
       // Quench-lite to score for the next round of selection
-      float after_lotemp_quench_lite_totalE = warp_wide_sim_annealing(
-          pose,
-          traj_id,
-          &state,
-          g,
-          ig,
-          current_rotamer_assignments_lotemp[pose][traj_id],
-          best_rotamer_assignments_lotemp[pose][traj_id],
-          quench_order[pose][traj_id],
-          high_temp_later,
-          low_temp_later,
-          1,  // quench on the (only) iteration
-          n_inner_iterations_lotemp,
-          n_rotamers,
-          true,
-          true);
+      float after_lotemp_quench_lite_totalE =
+          warp_wide_sim_annealing<ChunkSize>(
+              pose,
+              traj_id,
+              &state,
+              g,
+              ig,
+              current_rotamer_assignments_lotemp[pose][traj_id],
+              best_rotamer_assignments_lotemp[pose][traj_id],
+              quench_order[pose][traj_id],
+              high_temp_later,
+              low_temp_later,
+              1,  // quench on the (only) iteration
+              n_inner_iterations_lotemp,
+              n_rotamers,
+              true,
+              true);
       if (g.thread_rank() == 0) {
         scores_lotemp[pose][traj_id] = after_lotemp_quench_lite_totalE;
       }
@@ -862,7 +764,7 @@ struct Annealer {
         best_rotamer_assignments_fullquench[pose][traj_id][i] = i_rot;
       }
 
-      warp_wide_sim_annealing(
+      warp_wide_sim_annealing<ChunkSize>(
           pose,
           traj_id,
           &state,
@@ -879,8 +781,9 @@ struct Annealer {
           true,
           false);
       // rescore best assignment
-      float best_totalE = ig.total_energy_for_assignment_parallel(
-          pose, g, best_rotamer_assignments_fullquench[pose][traj_id]);
+      float best_totalE =
+          ig.template total_energy_for_assignment_parallel<ChunkSize>(
+              pose, g, best_rotamer_assignments_fullquench[pose][traj_id]);
       if (g.thread_rank() == 0) {
         scores_fullquench[pose][traj_id] = best_totalE;
       }
@@ -1061,9 +964,11 @@ auto AnnealerDispatch<D>::forward(
   auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
       std::nullopt, at::cuda::detail::getDefaultCUDAGenerator());
 
-  auto result =
-      Annealer<D, InteractionGraph<D, int, float> >::run_simulated_annealing(
-          mgr, ig, gen);
+  auto result = chunk_size == 16
+                    ? Annealer<D, InteractionGraph<D, int, float>, 16>::
+                          run_simulated_annealing(mgr, ig, gen)
+                    : Annealer<D, InteractionGraph<D, int, float>, 0>::
+                          run_simulated_annealing(mgr, ig, gen);
 
   return result;
 }

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -59,11 +59,10 @@ struct InteractionGraph {
   TView<int64_t, 1, D> chunk_offsets_;
   TView<Real, 1, D> energy1b_;
   TView<Real, 1, D> energy2b_;
-  TView<Int, 2, D> n_neighbors_;  // [n_poses, max_n_res]
-  TView<Int, 2, D>
-      neighbor_starts_;  // [n_poses, max_n_res] exclusive prefix sum
-  TView<Int, 1, D>
-      neighbor_list_;  // [total_neighbors] flat neighbor block indices
+  TView<Int, 2, D> n_neighbors_;    // [n_poses, max_n_res]
+  TView<Int, 3, D> neighbor_list_;  // [n_poses, max_n_res, max_n_res]
+  TView<int64_t, 3, D>
+      neighbor_chunk_offset_offsets_;  // [n_poses, max_n_res, max_n_res]
 
   int n_poses_cpu() const { return pose_n_res_.size(0); }
   int max_n_res_cpu() const { return n_rotamers_for_res_.size(1); }
@@ -99,7 +98,6 @@ struct InteractionGraph {
       totalE += energy1b_[irot_global];
     }
 
-    // TO DO: iterate across upper-triangle indices only
     for (int i = g.thread_rank(); i < n_res; i += n_threads) {
       int const irot_local = rotamer_assignment[i];
       int const irot_chunk = irot_local / chunk_size;
@@ -211,6 +209,7 @@ template <
     int ChunkSize,
     bool ReturnFinalScore,
     bool EntryAssignmentIsBest,
+    bool TrackBestAssignment,
     tmol::Device D,
     uint n_threads,
     typename Int,
@@ -343,18 +342,16 @@ MGPU_DEVICE float warp_wide_sim_annealing(
               ? ig.energy1b_[global_new_rot] - ig.energy1b_[global_prev_rot]
               : 0.0f;
 
-      int const nb_start = ig.neighbor_starts_[pose][ran_res];
       int const n_nb = ig.n_neighbors_[pose][ran_res];
 
       for (int nb_idx = g.thread_rank(); nb_idx < n_nb; nb_idx += 32) {
-        int const k = ig.neighbor_list_[nb_start + nb_idx];
+        int const k = ig.neighbor_list_[pose][ran_res][nb_idx];
         int const local_k_rot = current_rotamer_assignment[k];
         int const k_chunk = local_k_rot / chunk_size;
         int const k_in_chunk = local_k_rot - k_chunk * chunk_size;
 
         int64_t const k_offset_offset =
-            ig.chunk_offset_offsets_[pose][k][ran_res];
-        if (k_offset_offset == -1) continue;
+            ig.neighbor_chunk_offset_offsets_[pose][ran_res][nb_idx];
 
         int64_t const k_new_chunk_offset =
             ig.chunk_offsets_
@@ -401,10 +398,14 @@ MGPU_DEVICE float warp_wide_sim_annealing(
           current_total_energy += total_delta_e;
         }
         current_total_energy = g.shfl(current_total_energy, 0);
-        if (current_total_energy < best_energy) {
-          best_energy = current_total_energy;
-          for (int k = g.thread_rank(); k < n_res; k += 32) {
-            best_rotamer_assignment[k] = current_rotamer_assignment[k];
+        // Pure quench phases are monotonic and consume current directly, so
+        // they do not need an O(n_res) assignment copy after every acceptance.
+        if constexpr (TrackBestAssignment) {
+          if (current_total_energy < best_energy) {
+            best_energy = current_total_energy;
+            for (int k = g.thread_rank(); k < n_res; k += 32) {
+              best_rotamer_assignment[k] = current_rotamer_assignment[k];
+            }
           }
         }
       }
@@ -499,8 +500,6 @@ struct Annealer {
         TPack<float, 2, D>::zeros({n_poses, n_fullquench_traj});
     auto current_rotamer_assignments_fullquench_t =
         TPack<int, 3, D>::zeros({n_poses, n_fullquench_traj, max_n_res});
-    auto best_rotamer_assignments_fullquench_t =
-        TPack<int, 3, D>::zeros({n_poses, n_fullquench_traj, max_n_res});
     auto sorted_fullquench_traj_t =
         TPack<int, 2, D>::zeros({n_poses, n_fullquench_traj});
 
@@ -534,8 +533,6 @@ struct Annealer {
     auto scores_fullquench = scores_fullquench_t.view;
     auto current_rotamer_assignments_fullquench =
         current_rotamer_assignments_fullquench_t.view;
-    auto best_rotamer_assignments_fullquench =
-        best_rotamer_assignments_fullquench_t.view;
     auto sorted_fullquench_traj = sorted_fullquench_traj_t.view;
 
     auto scores_final = scores_final_t.view;
@@ -625,7 +622,7 @@ struct Annealer {
       }
 
       // Full SA run with geometric cooling
-      warp_wide_sim_annealing<ChunkSize, false, false>(
+      warp_wide_sim_annealing<ChunkSize, false, false, true>(
           pose,
           &state,
           g,
@@ -641,7 +638,7 @@ struct Annealer {
           false,
           false);
 
-      // Copy best state into current and quench-lite buffer
+      // Copy best state into current and quench-lite buffer.
       for (int i = g.thread_rank(); i < n_res; i += 32) {
         int i_assignment = best_rotamer_assignments_hitemp[pose][traj_id][i];
         current_rotamer_assignments_hitemp[pose][traj_id][i] = i_assignment;
@@ -651,7 +648,7 @@ struct Annealer {
 
       // Quench-lite to produce a score for ranking
       float after_first_quench_lite_totalE =
-          warp_wide_sim_annealing<ChunkSize, true, true>(
+          warp_wide_sim_annealing<ChunkSize, true, true, false>(
               pose,
               &state,
               g,
@@ -703,7 +700,7 @@ struct Annealer {
       }
 
       // Low-temperature cooling trajectory
-      warp_wide_sim_annealing<ChunkSize, false, false>(
+      warp_wide_sim_annealing<ChunkSize, false, false, true>(
           pose,
           &state,
           g,
@@ -725,7 +722,7 @@ struct Annealer {
             best_rotamer_assignments_lotemp[pose][traj_id][i];
       }
       float after_lotemp_quench_lite_totalE =
-          warp_wide_sim_annealing<ChunkSize, true, true>(
+          warp_wide_sim_annealing<ChunkSize, true, true, false>(
               pose,
               &state,
               g,
@@ -769,16 +766,15 @@ struct Annealer {
       for (int i = g.thread_rank(); i < n_res; i += 32) {
         int i_rot = current_rotamer_assignments_lotemp[pose][source_traj][i];
         current_rotamer_assignments_fullquench[pose][traj_id][i] = i_rot;
-        best_rotamer_assignments_fullquench[pose][traj_id][i] = i_rot;
       }
 
-      warp_wide_sim_annealing<ChunkSize, false, true>(
+      warp_wide_sim_annealing<ChunkSize, false, true, false>(
           pose,
           &state,
           g,
           ig,
           current_rotamer_assignments_fullquench[pose][traj_id],
-          best_rotamer_assignments_fullquench[pose][traj_id],
+          current_rotamer_assignments_fullquench[pose][traj_id],
           quench_order[pose][traj_id],
           high_temp_later,
           low_temp_later,
@@ -787,10 +783,10 @@ struct Annealer {
           n_rotamers,
           true,
           false);
-      // rescore best assignment
+      // A greedy quench only accepts improvements, so current is also best.
       float best_totalE =
           ig.template total_energy_for_assignment_parallel<ChunkSize>(
-              pose, g, best_rotamer_assignments_fullquench[pose][traj_id]);
+              pose, g, current_rotamer_assignments_fullquench[pose][traj_id]);
       if (g.thread_rank() == 0) {
         scores_fullquench[pose][traj_id] = best_totalE;
       }
@@ -810,7 +806,7 @@ struct Annealer {
       }
       for (int i = g.thread_rank(); i < n_res; i += 32) {
         rotamer_assignments_final[pose][traj_id][i] =
-            best_rotamer_assignments_fullquench[pose][source_traj][i];
+            current_rotamer_assignments_fullquench[pose][source_traj][i];
       }
     });
 
@@ -877,12 +873,18 @@ auto AnnealerDispatch<D>::forward(
   int const n_poses_cpu = pose_n_res.size(0);
   int const max_n_res_cpu = chunk_offset_offsets.size(1);
 
-  // Build CSR neighbor list from chunk_offset_offsets.
+  // Build fixed-stride neighbor rows from chunk_offset_offsets.
   // chunk_offset_offsets[pose][b1][b2] == -1 means no interaction.
   // It is already symmetric, so we iterate each row to find neighbors.
 
-  auto n_neighbors_t = TPack<int, 2, D>::zeros({n_poses_cpu, max_n_res_cpu});
+  auto n_neighbors_t = TPack<int, 2, D>::empty({n_poses_cpu, max_n_res_cpu});
   auto n_neighbors = n_neighbors_t.view;
+  auto neighbor_list_t =
+      TPack<int, 3, D>::empty({n_poses_cpu, max_n_res_cpu, max_n_res_cpu});
+  auto neighbor_list = neighbor_list_t.view;
+  auto neighbor_chunk_offset_offsets_t =
+      TPack<int64_t, 3, D>::empty({n_poses_cpu, max_n_res_cpu, max_n_res_cpu});
+  auto neighbor_chunk_offset_offsets = neighbor_chunk_offset_offsets_t.view;
   std::shared_ptr<mgpu::standard_context_t> context = current_context(mgr);
 
   {
@@ -898,52 +900,14 @@ auto AnnealerDispatch<D>::forward(
           }
           int cnt = 0;
           for (int b2 = 0; b2 < n; ++b2) {
-            if (b2 != b && chunk_offset_offsets[pose][b][b2] != -1) ++cnt;
-          }
-          n_neighbors[pose][b] = cnt;
-        },
-        count,
-        *context);
-  }
-
-  auto neighbor_starts_t =
-      TPack<int, 2, D>::zeros({n_poses_cpu, max_n_res_cpu});
-  auto neighbor_starts = neighbor_starts_t.view;
-  int total_neighbors;
-  {
-    mgpu::mem_t<int> total(1, *context, mgpu::memory_space_host);
-    mgpu::scan<mgpu::scan_type_exc>(
-        n_neighbors.data(),
-        n_poses_cpu * max_n_res_cpu,
-        neighbor_starts.data(),
-        mgpu::plus_t<int>(),
-        total.data(),
-        *context);
-    CUDA_CHECK(cudaStreamSynchronize(context->stream()));
-    total_neighbors = total.data()[0];
-  }
-
-  auto neighbor_list_t =
-      TPack<int, 1, D>::zeros({total_neighbors > 0 ? total_neighbors : 1});
-  auto neighbor_list = neighbor_list_t.view;
-
-  {
-    int const count = n_poses_cpu * max_n_res_cpu;
-    mgpu::transform<128, 1>(
-        [=] MGPU_DEVICE(int idx) {
-          if (idx >= count) return;
-          int pose = idx / max_n_res_cpu;
-          int b = idx % max_n_res_cpu;
-          int n = pose_n_res[pose];
-          if (b >= n) {
-            return;
-          }
-          int offset = neighbor_starts[pose][b];
-          for (int b2 = 0; b2 < n; ++b2) {
             if (b2 != b && chunk_offset_offsets[pose][b][b2] != -1) {
-              neighbor_list[offset++] = b2;
+              neighbor_list[pose][b][cnt] = b2;
+              neighbor_chunk_offset_offsets[pose][b][cnt] =
+                  chunk_offset_offsets[pose][b2][b];
+              ++cnt;
             }
           }
+          n_neighbors[pose][b] = cnt;
         },
         count,
         *context);
@@ -963,8 +927,8 @@ auto AnnealerDispatch<D>::forward(
        energy1b,
        energy2b,
        n_neighbors,
-       neighbor_starts,
-       neighbor_list});
+       neighbor_list,
+       neighbor_chunk_offset_offsets});
 
   auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
       std::nullopt, at::cuda::detail::getDefaultCUDAGenerator());

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -20,8 +20,6 @@
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
 
-#include <ctime>
-
 #include "compiled.impl.hh"
 
 namespace tmol {
@@ -219,7 +217,6 @@ template <
     typename Real>
 MGPU_DEVICE float warp_wide_sim_annealing(
     int pose,
-    int traj_id,  // debugging purposes only
     curandStatePhilox4_32_10_t* state,
     cooperative_groups::thread_block_tile<n_threads> g,
     InteractionGraph<D, Int, Real> ig,
@@ -630,7 +627,6 @@ struct Annealer {
       // Full SA run with geometric cooling
       warp_wide_sim_annealing<ChunkSize, false, false>(
           pose,
-          traj_id,
           &state,
           g,
           ig,
@@ -657,7 +653,6 @@ struct Annealer {
       float after_first_quench_lite_totalE =
           warp_wide_sim_annealing<ChunkSize, true, true>(
               pose,
-              traj_id,
               &state,
               g,
               ig,
@@ -710,7 +705,6 @@ struct Annealer {
       // Low-temperature cooling trajectory
       warp_wide_sim_annealing<ChunkSize, false, false>(
           pose,
-          traj_id,
           &state,
           g,
           ig,
@@ -733,7 +727,6 @@ struct Annealer {
       float after_lotemp_quench_lite_totalE =
           warp_wide_sim_annealing<ChunkSize, true, true>(
               pose,
-              traj_id,
               &state,
               g,
               ig,
@@ -781,7 +774,6 @@ struct Annealer {
 
       warp_wide_sim_annealing<ChunkSize, false, true>(
           pose,
-          traj_id,
           &state,
           g,
           ig,
@@ -882,8 +874,6 @@ auto AnnealerDispatch<D>::forward(
     TView<float, 1, D> energy1b,
     TView<float, 1, D> energy2b)
     -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D> > {
-  clock_t start = clock();
-
   int const n_poses_cpu = pose_n_res.size(0);
   int const max_n_res_cpu = chunk_offset_offsets.size(1);
 

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -212,6 +212,7 @@ MGPU_DEVICE int set_quench_32_order(
 template <
     int ChunkSize,
     bool ReturnFinalScore,
+    bool EntryAssignmentIsBest,
     tmol::Device D,
     uint n_threads,
     typename Int,
@@ -255,14 +256,17 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       i_n_inner_iterations = n_quench_iterations;
       quench = true;
       temperature = 0.0f;
-      // recover the lowest energy rotamer assignment encountered
-      // and begin quench from there
-      for (int j = g.thread_rank(); j < n_res; j += 32) {
-        current_rotamer_assignment[j] = best_rotamer_assignment[j];
+      // Recover the lowest-energy assignment before quenching. Ranking phases
+      // enter with this assignment already current, so their first exact score
+      // above can be reused.
+      if (i != 0 || !EntryAssignmentIsBest) {
+        for (int j = g.thread_rank(); j < n_res; j += 32) {
+          current_rotamer_assignment[j] = best_rotamer_assignment[j];
+        }
+        current_total_energy =
+            ig.template total_energy_for_assignment_parallel<ChunkSize>(
+                pose, g, current_rotamer_assignment);
       }
-      current_total_energy =
-          ig.template total_energy_for_assignment_parallel<ChunkSize>(
-              pose, g, current_rotamer_assignment);
     }
 
     for (int j = 0; j < i_n_inner_iterations; ++j) {
@@ -624,7 +628,7 @@ struct Annealer {
       }
 
       // Full SA run with geometric cooling
-      warp_wide_sim_annealing<ChunkSize, false>(
+      warp_wide_sim_annealing<ChunkSize, false, false>(
           pose,
           traj_id,
           &state,
@@ -651,7 +655,7 @@ struct Annealer {
 
       // Quench-lite to produce a score for ranking
       float after_first_quench_lite_totalE =
-          warp_wide_sim_annealing<ChunkSize, true>(
+          warp_wide_sim_annealing<ChunkSize, true, true>(
               pose,
               traj_id,
               &state,
@@ -704,7 +708,7 @@ struct Annealer {
       }
 
       // Low-temperature cooling trajectory
-      warp_wide_sim_annealing<ChunkSize, false>(
+      warp_wide_sim_annealing<ChunkSize, false, false>(
           pose,
           traj_id,
           &state,
@@ -722,8 +726,12 @@ struct Annealer {
           false);
 
       // Quench-lite to score for the next round of selection
+      for (int i = g.thread_rank(); i < n_res; i += 32) {
+        current_rotamer_assignments_lotemp[pose][traj_id][i] =
+            best_rotamer_assignments_lotemp[pose][traj_id][i];
+      }
       float after_lotemp_quench_lite_totalE =
-          warp_wide_sim_annealing<ChunkSize, true>(
+          warp_wide_sim_annealing<ChunkSize, true, true>(
               pose,
               traj_id,
               &state,
@@ -771,7 +779,7 @@ struct Annealer {
         best_rotamer_assignments_fullquench[pose][traj_id][i] = i_rot;
       }
 
-      warp_wide_sim_annealing<ChunkSize, false>(
+      warp_wide_sim_annealing<ChunkSize, false, true>(
           pose,
           traj_id,
           &state,

--- a/tmol/pack/rotamer/_build_rotamers.py
+++ b/tmol/pack/rotamer/_build_rotamers.py
@@ -3,7 +3,7 @@ import numba
 import toolz
 import torch
 
-from typing import List, Tuple
+from typing import Any
 
 from tmol.types import (
     NDArray,
@@ -28,6 +28,12 @@ from tmol.pack.rotamer import (
 )
 from tmol.pack import SetPackerTask
 from tmol.numeric import coord_dihedrals
+
+ConformerSample = tuple[
+    Tensor[torch.int32][:],
+    Tensor[torch.int32][:],
+    dict[str, Any],
+]
 
 
 def _build_chi4_atom_table(
@@ -153,121 +159,117 @@ def _get_chi_dof_metadata(
     return metadata
 
 
+def _get_chi_atom_table(
+    pbt: PackedBlockTypes,
+) -> Tensor[torch.int64][:, :, 4]:
+    """Return cached chi-defining atom quartets on the block-type device."""
+    if hasattr(pbt, "_chi_atom_table"):
+        return pbt._chi_atom_table
+
+    table = torch.as_tensor(
+        _build_chi4_atom_table(pbt), dtype=torch.int64, device=pbt.device
+    )
+    object.__setattr__(pbt, "_chi_atom_table", table)
+    return table
+
+
 def correct_phi_c_for_jump_parents(
-    pbt,
-    conformer_samples,
-    new_ind_for_sampler_rotamer,
-    block_type_ind_for_conformer_torch,
-    n_atoms_offset_for_conformer_torch,
-    conformer_kinforest,
-    nodes,
-    scans,
-    gens,
-    conf_dofs_kto,
-):
-    """For chi-defining atoms whose kinforest parent is a jump atom, the phi_c
-    written by assign_chi_dofs_from_samples does not directly map to the
-    chi dihedral angle measured from coordinates.  This function:
-      1. Finds every sampled chi whose controlling atom has a jump parent.
-      2. If any exist, does a trial forward pass with the current DOFs.
-      3. Measures their actual dihedrals from the trial coordinates.
-      4. Adds (intended - measured) to conf_dofs_kto[atom_kto, 3] so the
-         final forward pass produces the correct geometry.
+    pbt: PackedBlockTypes,
+    conformer_samples: list[ConformerSample],
+    new_ind_for_sampler_rotamer: list[Tensor[torch.int64][:]],
+    block_type_ind_for_conformer: Tensor[torch.int64][:],
+    atom_offset_for_conformer: Tensor[torch.int64][:],
+    conformer_kinforest: KinForest,
+    nodes: NDArray[numpy.int32][:],
+    scans: NDArray[numpy.int32][:],
+    gens: NDArray[numpy.int32][:],
+    conformer_dofs: Tensor[torch.float32][:, 9],
+) -> None:
+    """Correct sampled chis whose controlling atom has a jump parent.
+
+    The jump frame makes its ``phi_c`` offset pose-dependent. This performs one
+    trial fold, measures all affected chis in a batch, and adjusts their DOFs.
+
+    Args:
+        pbt: Packed block types for the conformers.
+        conformer_samples: Per-sampler rotamer counts, indices, and metadata.
+        new_ind_for_sampler_rotamer: Sampler-to-merged-conformer mappings.
+        block_type_ind_for_conformer: Block type for each conformer.
+        atom_offset_for_conformer: First coordinate for each conformer.
+        conformer_kinforest: Coalesced conformer kinematic forest.
+        nodes: Kinematic nodes in generation order.
+        scans: Segmented-scan starts.
+        gens: Generation boundaries.
+        conformer_dofs: DOFs to correct in place.
     """
-    doftype_cpu = conformer_kinforest.doftype.cpu().numpy()
-    parent_cpu = conformer_kinforest.parent.cpu().numpy()
-    kfidx = pbt.rotamer_kinforest.kinforest_idx  # (n_types, max_n_atoms) numpy int32
-    bt_ind_np = block_type_ind_for_conformer_torch.cpu().numpy()
-    at_off_np = n_atoms_offset_for_conformer_torch.cpu().numpy()
-    chi4_table = _build_chi4_atom_table(pbt)  # (n_types, max_n_chi, 4)
-    corrections = []
+    kinforest_idx, _ = _get_chi_dof_metadata(pbt)
+    chi_atom_table = _get_chi_atom_table(pbt)
+    intended_chis = []
+    chi_dof_indices = []
+    chi_coord_indices = []
+    affected_chis = []
 
     for i, sample_data in enumerate(conformer_samples):
         sample_dict = sample_data[2]
         if "chi_for_rotamers" not in sample_dict:
             continue
-        chi_intended = sample_dict["chi_for_rotamers"].cpu()  # (n_samp_rots, max_n_chi)
-        chi_atoms_rto = sample_dict[
-            "chi_defining_atom_for_rotamer"
-        ].cpu()  # (n_samp_rots, max_n_chi)
+        chi_intended = sample_dict["chi_for_rotamers"]
+        chi_atoms_rto = sample_dict["chi_defining_atom_for_rotamer"].to(torch.int64)
         if chi_intended.shape[0] == 0:
             continue
 
         _, max_n_chi = chi_atoms_rto.shape
-        conf_inds = new_ind_for_sampler_rotamer[i].cpu().numpy()  # (n_samp,)
+        conformer_indices = new_ind_for_sampler_rotamer[i]
+        block_type_indices = block_type_ind_for_conformer[conformer_indices]
+        atom_offsets = atom_offset_for_conformer[conformer_indices]
 
-        # global rot index and per-rot metadata for every (samp_rot, chi) pair
-        g_rot = conf_inds  # (n_samp,)
-        bt_idx = bt_ind_np[g_rot]  # (n_samp,)
-        at_off = at_off_np[g_rot]  # (n_samp,)
-
-        # chi-defining atom (RTO) for every (samp_rot, chi): (n_samp, max_n_chi)
-        cda_rto = chi_atoms_rto.numpy()
-
-        # KTO index of the chi-defining atom: (n_samp, max_n_chi)
-        # kinforest_idx[bt, atom_rto] + at_off + 1 (virtual root offset)
-        cda_kto = (
-            kfidx[
-                bt_idx[:, None], numpy.clip(cda_rto, 0, None)
-            ]  # clip -1 before indexing
-            + at_off[:, None]
-            + 1
+        # [n_sampler_conformers, max_n_chi]
+        chi_dof_index = (
+            kinforest_idx[block_type_indices[:, None], chi_atoms_rto.clamp_min(0)]
+            + atom_offsets[:, None]
+            + 1  # virtual root
         )
-        cda_kto[cda_rto < 0] = 0  # will be masked out below
+        parent_index = conformer_kinforest.parent[chi_dof_index]
+        affected_chis.append(
+            (
+                (chi_atoms_rto >= 0)
+                & (conformer_kinforest.doftype[parent_index] == NodeType.jump)
+            ).reshape(-1)
+        )
+        intended_chis.append(chi_intended.reshape(-1))
+        chi_dof_indices.append(chi_dof_index.reshape(-1))
 
-        # parent doftype for each chi-defining atom: (n_samp, max_n_chi)
-        parent_kto = parent_cpu[cda_kto]
-        is_jump_parent = doftype_cpu[parent_kto] == NodeType.jump  # (n_samp, max_n_chi)
-        valid = (cda_rto >= 0) & is_jump_parent  # (n_samp, max_n_chi)
+        chi_indices = torch.arange(max_n_chi, device=pbt.device)
+        chi_atom_indices = chi_atom_table[
+            block_type_indices[:, None], chi_indices[None, :]
+        ]
+        chi_coord_indices.append(
+            (chi_atom_indices + atom_offsets[:, None, None]).reshape(-1, 4)
+        )
 
-        if not valid.any():
-            continue
-
-        # 4-atom RTO indices for every (samp_rot, chi): (n_samp, max_n_chi, 4)
-        four_atoms_rto = chi4_table[bt_idx[:, None], numpy.arange(max_n_chi)[None, :]]
-
-        # absolute RTO indices into trial_coords_rto: (n_samp, max_n_chi, 4)
-        four_atoms_abs = four_atoms_rto + at_off[:, None, None]
-        four_atoms_abs[four_atoms_rto < 0] = 0  # clip invalid entries
-
-        # flatten to the valid (samp_rot, chi) pairs
-        valid_flat = valid.reshape(-1)
-        four_abs_flat = four_atoms_abs.reshape(-1, 4)[valid_flat]  # (n_valid, 4)
-        intended_flat = chi_intended.numpy().reshape(-1)[valid_flat]  # (n_valid,)
-        cda_kto_flat = cda_kto.reshape(-1)[valid_flat]  # (n_valid,)
-
-        corrections.append((four_abs_flat, intended_flat, cda_kto_flat))
-
-    if not corrections:
+    if not affected_chis:
         return
 
-    # Only conformers whose sampled chi has a jump parent need this trial
-    # forward pass. Most OptH-only builds have none, so avoid folding and
-    # copying every trial coordinate to the CPU in that common case.
-    n_rots = block_type_ind_for_conformer_torch.shape[0]
+    affected_chis = torch.cat(affected_chis)
+    affected_indices = torch.nonzero(affected_chis, as_tuple=True)[0]
+    if affected_indices.numel() == 0:
+        return
+
     n_at_total = (
-        n_atoms_offset_for_conformer_torch[-1].item()
-        + pbt.n_atoms[block_type_ind_for_conformer_torch[-1]].item()
+        atom_offset_for_conformer[-1].item()
+        + pbt.n_atoms[block_type_ind_for_conformer[-1]].item()
     )
     trial_coords_rto = calculate_rotamer_coords(
-        pbt, n_rots, n_at_total, conformer_kinforest, nodes, scans, gens, conf_dofs_kto
+        pbt, n_at_total, conformer_kinforest, nodes, scans, gens, conformer_dofs
     )
-    coords_np = trial_coords_rto.cpu().double().numpy()
-
-    for four_abs_flat, intended_flat, cda_kto_flat in corrections:
-        # gather coordinates: (n_valid, 4, 3)
-        xyzs = torch.tensor(
-            coords_np[four_abs_flat], dtype=torch.float64, device=torch.device("cpu")
-        )
-
-        meas_rad = coord_dihedrals(xyzs[:, 0], xyzs[:, 1], xyzs[:, 2], xyzs[:, 3])
-
-        delta = torch.tensor(intended_flat, dtype=torch.float64) - meas_rad
-        delta = (delta + numpy.pi) % (2 * numpy.pi) - numpy.pi
-
-        conf_dofs_kto[torch.tensor(cda_kto_flat, dtype=torch.int64), 3] += delta.to(
-            conf_dofs_kto.dtype
-        ).to(conf_dofs_kto.device)
+    xyzs = trial_coords_rto[torch.cat(chi_coord_indices)[affected_indices]].to(
+        torch.float64
+    )
+    measured_chis = coord_dihedrals(xyzs[:, 0], xyzs[:, 1], xyzs[:, 2], xyzs[:, 3])
+    delta = torch.cat(intended_chis)[affected_indices].to(torch.float64) - measured_chis
+    delta = (delta + numpy.pi) % (2 * numpy.pi) - numpy.pi
+    chi_dof_indices = torch.cat(chi_dof_indices)[affected_indices]
+    conformer_dofs[chi_dof_indices, 3] += delta.to(conformer_dofs.dtype)
 
 
 def exc_cumsum_from_inc_cumsum(cumsum):
@@ -296,25 +298,29 @@ def exc_cumsum_from_inc_cumsum(cumsum):
 
 def annotate_restype(
     restype: RefinedResidueType,
-    samplers: Tuple[ChiSampler, ...],
+    samplers: tuple[ChiSampler, ...],
     chem_db: ChemicalDatabase,
-):
+) -> None:
     construct_single_residue_kinforest(restype)
     annotate_residue_type_with_sampler_fingerprints(restype, samplers, chem_db)
 
 
-def annotate_packed_block_types(pbt: PackedBlockTypes):
+def annotate_packed_block_types(pbt: PackedBlockTypes) -> None:
     coalesce_single_residue_kinforests(pbt)
     find_unique_fingerprints(pbt)
 
 
 def annotate_everything(
-    chem_db: ChemicalDatabase, samplers: Tuple[ChiSampler, ...], pbt: PackedBlockTypes
-):
-    # annotate residue types and packed block types
-    # give the samplers a chance first to annotate the
-    # residue types, and pbt
-    # then we will call our own annotation functions
+    chem_db: ChemicalDatabase,
+    samplers: tuple[ChiSampler, ...],
+    pbt: PackedBlockTypes,
+) -> None:
+    """Attach sampler and kinematic metadata not already present on block types."""
+    sampler_names = frozenset(sampler.sampler_name() for sampler in samplers)
+    cache_name = "_annotated_conformer_sampler_names"
+    if hasattr(pbt, cache_name) and sampler_names.issubset(getattr(pbt, cache_name)):
+        return
+
     for sampler in samplers:
         for rt in pbt.active_block_types:
             sampler.annotate_residue_type(rt)
@@ -323,6 +329,8 @@ def annotate_everything(
     for rt in pbt.active_block_types:
         annotate_restype(rt, samplers, chem_db)
     annotate_packed_block_types(pbt)
+    previously_annotated = getattr(pbt, cache_name, frozenset())
+    object.__setattr__(pbt, cache_name, previously_annotated | sampler_names)
 
 
 @numba.jit(nopython=True)
@@ -560,7 +568,7 @@ def construct_kinforest_for_conformers(
 
 def measure_dofs_from_orig_coords(
     coords: Tensor[torch.float32][:, :, :], kinforest: KinForest
-):
+) -> Tensor[torch.float32][:, 9]:
     from tmol.kinematics.compiled import inverse_kin
 
     kinforest_coords = coords.view(-1, 3)[kinforest.id.to(torch.int64)]
@@ -577,7 +585,9 @@ def measure_dofs_from_orig_coords(
     return dofs_orig
 
 
-def measure_pose_dofs(poses):
+def measure_pose_dofs(
+    poses: PoseStack,
+) -> tuple[KinForest, Tensor[torch.float32][:, 9]]:
     # measure the DOFs for the original residues
     # -- first build kinforests for the original residues,
     # -- then call measure_dofs_from_orig_coords
@@ -624,30 +634,25 @@ def measure_pose_dofs(poses):
 
 
 def merge_conformer_samples(
-    conformer_samples,
-) -> Tuple[
+    conformer_samples: list[ConformerSample],
+) -> tuple[
+    Tensor[torch.int32][:],
     Tensor[torch.int64][:],
-    Tensor[torch.int64][:],
-    Tensor[torch.int64][:],
-    List[Tensor[torch.bool][:]],
-    List[Tensor[torch.int64][:]],
+    Tensor[torch.int32][:],
+    list[Tensor[torch.bool][:]],
+    list[Tensor[torch.int64][:]],
 ]:
-    """Merge the lists of conformers as described by different conformer samplers.
+    """Group samples from several conformer samplers by global block type.
 
-    The conformer_samples variable is a list of tuples:
-     - elem 0: Tensor[int][:] <-- the number of rotamers for each pose for each block for each block type
-        where each buildable block type for each real residue is given a global index
-     - elem 1: Tensor[int][:] <-- the global block-type index for each rotamer
-     - elem 2+: Extra data that the chi sampler needs to preserve, where the first dimension
-       is rotamer index based on elem 1's rotamer indices; the mapping from orig rotamer indices
-       to merged rotamer indices will be constructed by this routine
+    Args:
+        conformer_samples: Per-sampler rotamer counts, global block-type
+            indices, and sampler-specific metadata.
+
+    Returns:
+        Total rotamer counts per global block type, the sampler and block type
+        for each merged conformer, per-sampler membership masks, and mappings
+        from each sampler's original order into the merged order.
     """
-    # deprecated notes:
-    # chi_samples
-    # 0. n_rots_for_rt
-    # 1. rt_for_rotamer
-    # 2. chi_defining_atom_for_rotamer
-    # 3. chi_for_rotamers
 
     # everything needs to be on the same device
     for samples in conformer_samples:
@@ -702,13 +707,6 @@ def merge_conformer_samples(
     )
     argsort_ind_for_conformer = torch.argsort(sort_index_for_conformer)
 
-    # testing: remove this, probably
-    sort_ind_for_conformer_sorted = sort_index_for_conformer[argsort_ind_for_conformer]
-    uniq_sort_ind_for_conformer = torch.unique(sort_ind_for_conformer_sorted)
-    assert (
-        uniq_sort_ind_for_conformer.shape[0] == sort_ind_for_conformer_sorted.shape[0]
-    )
-
     sampler_for_conformer = sampler_for_conformer_unsorted[argsort_ind_for_conformer]
 
     # list of boolean tensors for each of the samplers: did you build the given rotamer
@@ -741,14 +739,27 @@ def merge_conformer_samples(
 
 def calculate_rotamer_coords(
     pbt: PackedBlockTypes,
-    n_rots: int,
     n_atoms_total: int,
     rot_kinforest: KinForest,
     nodes: NDArray[numpy.int32][:],
     scans: NDArray[numpy.int32][:],
     gens: NDArray[numpy.int32][:],
     rot_dofs_kto: Tensor[torch.float32][:, 9],
-):
+) -> Tensor[torch.float32][:, 3]:
+    """Fold conformer DOFs and restore residue-type atom ordering.
+
+    Args:
+        pbt: Packed block types defining the target device.
+        n_atoms_total: Number of real atoms across all conformers.
+        rot_kinforest: Coalesced conformer kinematic forest.
+        nodes: Kinematic nodes in generation order.
+        scans: Segmented-scan starts.
+        gens: Generation boundaries.
+        rot_dofs_kto: Conformer DOFs in kinematic-tree order.
+
+    Returns:
+        Rotamer coordinates shaped ``[n_atoms_total, 3]`` in residue-type order.
+    """
     from tmol.kinematics.compiled import forward_only_op
 
     def _p(t):
@@ -786,7 +797,16 @@ def calculate_rotamer_coords(
     return new_coords_rto
 
 
-def get_rotamer_origin_data(task: SetPackerTask, gbt_for_rot: Tensor[torch.int32][:]):
+def get_rotamer_origin_data(
+    task: SetPackerTask, gbt_for_rot: Tensor[torch.int32][:]
+) -> tuple[
+    Tensor[torch.int64][:],
+    Tensor[torch.int64][:],
+    Tensor[torch.int64][:, :],
+    Tensor[torch.int64][:, :],
+    Tensor[torch.int64][:],
+    Tensor[torch.int32][:],
+]:
     n_poses = task.per_block_orig_block_type.shape[0]
     pose_for_gbt = task.cons_bt_pose.to(torch.int32)
 
@@ -817,7 +837,20 @@ def get_rotamer_origin_data(task: SetPackerTask, gbt_for_rot: Tensor[torch.int32
     )
 
 
-def build_rotamers(poses: PoseStack, task: SetPackerTask, chem_db: ChemicalDatabase):
+def build_rotamers(
+    poses: PoseStack, task: SetPackerTask, chem_db: ChemicalDatabase
+) -> tuple[PoseStack, RotamerSet]:
+    """Build coordinates and indexing for every task-allowed conformer.
+
+    Args:
+        poses: Input poses supplying backbone geometry and current conformers.
+        task: Finalized packing choices and conformer samplers.
+        chem_db: Chemical definitions used to annotate residue types.
+
+    Returns:
+        The input poses and a device-resident rotamer set grouped by pose and
+        block.
+    """
     # step 1: replace the existing PBT in the Pose w/ a new one in case
     #     there will possibly be new block types in the repacked Pose;
     #     but since PoseStack should not be altered after construction,
@@ -859,8 +892,8 @@ def build_rotamers(poses: PoseStack, task: SetPackerTask, chem_db: ChemicalDatab
 
     # Step 5
     (
-        n_rots_for_gbt,
-        sampler_for_conformer,
+        _,
+        _,
         gbt_for_conformer,
         conformer_built_by_sampler,
         new_ind_for_sampler_rotamer,
@@ -872,8 +905,6 @@ def build_rotamers(poses: PoseStack, task: SetPackerTask, chem_db: ChemicalDatab
     gbt_for_conformer_np = gbt_for_conformer.cpu().numpy()
 
     gbt_for_conformer_torch = gbt_for_conformer.to(dtype=torch.int64, device=pbt.device)
-
-    n_conformers = sampler_for_conformer.shape[0]
 
     block_type_ind_for_conformer = gbt_block_type_ind[gbt_for_conformer_np]
     block_type_ind_for_conformer_torch = _t(block_type_ind_for_conformer, torch.int64)
@@ -952,7 +983,6 @@ def build_rotamers(poses: PoseStack, task: SetPackerTask, chem_db: ChemicalDatab
 
     rotamer_coords = calculate_rotamer_coords(
         pbt,
-        n_conformers,
         n_atoms_total,
         conformer_kinforest,
         nodes,

--- a/tmol/pack/rotamer/_fallback_sampler.py
+++ b/tmol/pack/rotamer/_fallback_sampler.py
@@ -124,7 +124,9 @@ class FallbackSampler(ConformerSampler):
             ),
         ).to(torch.int32)
 
-        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0]
+        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0].to(
+            torch.int32
+        )
         return (n_rots_for_gbt, gbt_for_rotamer, {})
 
     def fill_dofs_for_samples(

--- a/tmol/pack/rotamer/_fallback_sampler.py
+++ b/tmol/pack/rotamer/_fallback_sampler.py
@@ -124,9 +124,7 @@ class FallbackSampler(ConformerSampler):
             ),
         ).to(torch.int32)
 
-        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0].to(
-            torch.int32
-        )
+        gbt_for_rotamer = n_rots_for_gbt.nonzero(as_tuple=True)[0].to(torch.int32)
         return (n_rots_for_gbt, gbt_for_rotamer, {})
 
     def fill_dofs_for_samples(

--- a/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
+++ b/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
@@ -104,9 +104,7 @@ class FixedAAChiSampler(ChiSampler):
         ).to(torch.int32)
 
         n_fixed_rots = torch.sum(n_rots_for_gbt).item()
-        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt > 0, as_tuple=True)[0].to(
-            torch.int32
-        )
+        gbt_for_rotamer = n_rots_for_gbt.nonzero(as_tuple=True)[0].to(torch.int32)
         chi_for_rotamers = torch.zeros(
             (n_fixed_rots, 1), dtype=torch.float32, device=poses.device
         )

--- a/tmol/pack/rotamer/_include_current_sampler.py
+++ b/tmol/pack/rotamer/_include_current_sampler.py
@@ -74,9 +74,7 @@ class IncludeCurrentSampler(ConformerSampler):
             ],
         ).to(torch.int32)
 
-        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0].to(
-            torch.int32
-        )
+        gbt_for_rotamer = n_rots_for_gbt.nonzero(as_tuple=True)[0].to(torch.int32)
         return (n_rots_for_gbt, gbt_for_rotamer, {})
 
     def fill_dofs_for_samples(

--- a/tmol/pack/rotamer/_include_current_sampler.py
+++ b/tmol/pack/rotamer/_include_current_sampler.py
@@ -74,7 +74,9 @@ class IncludeCurrentSampler(ConformerSampler):
             ],
         ).to(torch.int32)
 
-        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0]
+        gbt_for_rotamer = torch.nonzero(n_rots_for_gbt, as_tuple=True)[0].to(
+            torch.int32
+        )
         return (n_rots_for_gbt, gbt_for_rotamer, {})
 
     def fill_dofs_for_samples(

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -2,14 +2,14 @@ import attr
 import torch
 import time
 import warnings
+from collections.abc import Callable, Sequence
+from typing import Protocol
 
 from tmol.pose import PoseStack
 from tmol.score import (
     ScoreFunction,
     ScoreType,
 )
-from typing import Optional, Union
-
 from tmol.kinematics import (
     CartesianMoveMap,
     MoveMap,
@@ -25,24 +25,29 @@ from tmol.pack.rotamer import (
     IncludeCurrentSampler,
 )
 from tmol.optimization import run_cart_min, run_kin_min
+from tmol.types import Tensor
 
-# Default schedule from Jack Maguire's tuned MonomerRelax2019.txt.
-# Each entry specifies fa_rep scale fractions for the packing and minimization
-# stages of a single pack-min step.  These fractions are multiplied by the
-# starting fa_rep weight to obtain the absolute weights used during each stage.
-#
-# Entries may be:
-#   - A single float: used as both the pack and min fraction.
-#     e.g.  0.559  =>  pack at 0.559 * fa_rep_start, min at 0.559 * fa_rep_start
-#   - A dict with keys "fa_rep_pack_frac", "fa_rep_min_frac", "cst_frac": allows the
-#     packing and minimization stages to use different fa_rep fractions and to
-#     specify a constraint weight.
-#     e.g.  {"fa_rep_pack_frac": 0.040, "fa_rep_min_frac": 0.051, "cst_frac": 0.5}
-#
-# The default behavior in Rosetta3 is to ramp constraints unless you explicitly
-# say that you should not, and that is preserved here.
-#
-# Both forms may be mixed freely within a single schedule list.
+RelaxScheduleEntry = float | int | dict[str, float]
+PackerTaskOperation = Callable[[PackerTask], None]
+
+
+class RelaxMinimizer(Protocol):
+    """Callable contract for a FastRelax minimization stage."""
+
+    def __call__(
+        self,
+        pose_stack: PoseStack,
+        sfxn: ScoreFunction,
+        *,
+        fold_forest: FoldForest,
+        move_map: MoveMap | CartesianMoveMap,
+        verbose: bool,
+    ) -> PoseStack:
+        """Minimize and return the updated poses."""
+
+
+# Jack Maguire's tuned MonomerRelax2019 schedule. Fractions scale the score
+# function's initial fa_rep and constraint weights at each pack-minimize stage.
 DEFAULT_RELAX_SCHEDULE = [
     {"fa_rep_pack_frac": 0.040, "fa_rep_min_frac": 0.051, "cst_frac": 1.0},
     {"fa_rep_pack_frac": 0.265, "fa_rep_min_frac": 0.280, "cst_frac": 0.5},
@@ -52,37 +57,27 @@ DEFAULT_RELAX_SCHEDULE = [
 
 
 def _normalize_schedule(
-    schedule, constrain: bool = False, ramp_constraints: bool = False
-):
-    """Normalize a relax schedule into a list of (pack_frac, min_frac, constraint) tuples.
-
-    Accepts a list of schedule entries in either simple or complex format:
-
-    Simple format (float):
-        A single number used as both the pack and min fa_rep fraction and a
-        constraint weight determined by the constrain and ramp_constraints flags.
-        Example: ``0.559`` becomes ``(0.559, 0.559, 0.0)``.
-
-    Complex format (dict):
-        A dict with keys ``"fa_rep_pack_frac"``, ``"fa_rep_min_frac"``, and ``"cst_frac"``
-        specifying separate fa_rep fractions for the packing and minimization stages.
-        Example: ``{"fa_rep_pack_frac": 0.040, "fa_rep_min_frac": 0.051, "cst_frac": 0.5}``
-        becomes ``(0.040, 0.051, 0.5)``.
-
-    Both formats may be freely mixed within a single schedule list.
+    schedule: Sequence[RelaxScheduleEntry],
+    constrain: bool = False,
+    ramp_constraints: bool = False,
+) -> list[tuple[float, float, float]]:
+    """Normalize user schedule entries into pack, minimize, and constraint weights.
 
     Args:
-        schedule: List of floats and/or dicts.
+        schedule: Numbers, used for both fa_rep stages, or dictionaries with
+            ``fa_rep_pack_frac``, ``fa_rep_min_frac``, and optional ``cst_frac``.
+        constrain: Whether the score function has an active constraint term.
+        ramp_constraints: Whether to ramp its weight to zero.
 
     Returns:
-        List of (pack_frac, min_frac, cst_frac) tuples.
+        ``(pack_fraction, minimize_fraction, constraint_fraction)`` per step.
 
     Raises:
         ValueError: If an entry is neither a float/int nor a dict with the
             required keys.
     """
 
-    def constraint_fraction(step_index):
+    def constraint_fraction(step_index: int) -> float:
         """Determine the constraint fraction for a particular step.
 
         If ramping, ramp constraint frations down from 1.0 to 0.0 over
@@ -94,9 +89,8 @@ def _normalize_schedule(
             return 1.0
         n_steps = len(schedule)
         if step_index > n_steps // 2:
-            return 0
-        else:
-            return 1 - step_index / (n_steps / 2)
+            return 0.0
+        return 1 - step_index / (n_steps / 2)
 
     normalized = []
     for i, entry in enumerate(schedule):
@@ -120,7 +114,14 @@ def _normalize_schedule(
     return normalized
 
 
-def _default_kin_min_fn(pose_stack, sfxn, *, fold_forest, move_map, verbose):
+def _default_kin_min_fn(
+    pose_stack: PoseStack,
+    sfxn: ScoreFunction,
+    *,
+    fold_forest: FoldForest,
+    move_map: MoveMap | CartesianMoveMap,
+    verbose: bool,
+) -> PoseStack:
     """Default minimization function: kinematic (torsion-space) LBFGS."""
     return run_kin_min(
         pose_stack,
@@ -132,18 +133,15 @@ def _default_kin_min_fn(pose_stack, sfxn, *, fold_forest, move_map, verbose):
     )
 
 
-def _default_cart_min_fn(pose_stack, sfxn, *, fold_forest, move_map, verbose):
-    """Default Cartesian minimization function for use as fast_relax min_fn.
-
-    Extracts ``coord_mask`` from ``move_map`` if it is a
-    :class:`~tmol.kinematics._move_map.CartesianMoveMap`; otherwise all atoms
-    are free to move.  ``fold_forest`` is accepted but ignored.
-
-    Example usage with :func:`fast_relax`::
-
-        fast_relax(pose_stack, sfxn, palette, CartesianMoveMap(), fold_forest,
-                   min_fn=_default_cart_min_fn, ...)
-    """
+def _default_cart_min_fn(
+    pose_stack: PoseStack,
+    sfxn: ScoreFunction,
+    *,
+    fold_forest: FoldForest,
+    move_map: MoveMap | CartesianMoveMap,
+    verbose: bool,
+) -> PoseStack:
+    """Run Cartesian LBFGS using a Cartesian move map's coordinate mask."""
     coord_mask = move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
     return run_cart_min(
         pose_stack,
@@ -158,104 +156,48 @@ def fast_relax(  # noqa: C901
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
     packer_pallete: PackerPalette,
-    move_map: Union[MoveMap, CartesianMoveMap],
+    move_map: MoveMap | CartesianMoveMap,
     fold_forest: FoldForest,
     *,
-    task_operations=None,
-    num_repeats=2,
-    ramp_constraints: Optional[bool] = None,  # default True
-    schedule=None,
-    min_fn=None,
+    task_operations: Sequence[PackerTaskOperation] | None = None,
+    num_repeats: int = 2,
+    ramp_constraints: bool | None = None,  # default True
+    schedule: Sequence[RelaxScheduleEntry] | None = None,
+    min_fn: RelaxMinimizer | None = None,
     verbose: bool = False,
-):
-    """Run the FastRelax protocol: repeated rounds of rotamer packing and
-    gradient minimization with a ramped fa_rep weight schedule.
+) -> PoseStack:
+    """Relax poses through repeated side-chain packing and minimization.
 
-    This implements Jack Maguire's tuned MonomerRelax2019 protocol.  Each
-    repeat consists of several pack-min steps at increasing fa_rep fractions,
-    followed by an accept-to-best check.
+    Each repeat applies the MonomerRelax2019 fa_rep ramp and retains the
+    lowest-scoring conformation independently for every pose in the batch.
 
     Args:
-        pose_stack: The input poses to relax.
-        sfxn: Score function used for packing and minimization. If you wish
-            to use constraints during relax, then the weight on the "constraint"
-            score type must already have a non-zero value.
-        packer_pallete: Palette defining the residue types available to the
-            packer.
+        pose_stack: Input poses to relax.
+        sfxn: Packing and minimization score function. Constraints are active
+            only when its constraint weight is nonzero.
+        packer_pallete: Residue types available to the packer.
         move_map: Specifies which DOFs are free to move during minimization.
         fold_forest: Fold forest defining the kinematic connectivity.
-        task_operations: List of callables that configure a PackerTask.  Each
-            callable receives a PackerTask and modifies it in place (e.g. to
-            restrict to repacking or add chi samplers).  If None, a default
-            operation is created that restricts to repacking with Dunbrack
-            rotamers and includes the current rotamer.
-        ramp_constraints: If True, decrease the constraing weight over the first
-            half of the weight-ramping schedule from its starting value to 0.
-            If False, use the starting constraint weight for the entirety
-            of relax. The weight on the "constraint" term in the input sfxn
-            will be restored to its starting value at the end of relax.
-            Default: True. A warning message is printed if you specify
-            ramp_constraints=True but the "constraint" weight is 0.
-        num_repeats: Number of times to repeat the full schedule of pack-min
-            steps (default: 2).
-        schedule: The fa_rep / constraint ramp schedule — a list of per-step entries
-            controlling the fa_rep weight and constraints used during packing and
-            minimization. Each entry is either:
-
-            - A **float**: used as the fa_rep fraction for both packing and
-              minimization.  E.g. ``0.559`` means both stages run at
-              ``0.559 * fa_rep_start`` (specifying nothing for the constraints).
-            - A **dict** with keys ``"fa_rep_pack_frac"``,
-              ``"fa_rep_min_frac"`` and optionally ``"cst_frac"``:
-              allows different fractions for the two
-              stages and an optional constraint fraction.  E.g. ``{"fa_rep_pack_frac": 0.040, "fa_rep_min_frac":
-              0.051, "cst_frac": 0.5}``.
-
-            Both formats may be mixed within a single list.  All fractions are
-            multiplied by the starting ``fa_rep`` weight / ``constraint`` weight
-            from ``sfxn``.
-
-            If None, ``DEFAULT_RELAX_SCHEDULE`` is used (the 4-step ramp from
-            MonomerRelax2019).
-        min_fn: Callable used to minimize the pose at each pack-min step.
-            Must have the signature::
-
-                min_fn(pose_stack, sfxn, *, fold_forest, move_map, verbose)
-                    -> PoseStack
-
-            The ``fold_forest`` and ``move_map`` are passed as keyword
-            arguments so that Cartesian minimizers can accept and ignore them
-            via ``**kwargs``.
-
-            If None, the default Cartesian minimizer is used
-            (``run_cart_min`` via :func:`_default_cart_min_fn`).
-
-            Examples::
-
-                # Cartesian minimization:
-                min_fn=lambda ps, sfxn, **kw: run_cart_min(ps, sfxn)
-
-                # Kinematic minimization with torch's LBFGS + strong Wolfe:
-                def my_min(ps, sfxn, *, fold_forest, move_map, **kw):
-                    return run_kin_min(
-                        ps, sfxn, fold_forest, move_map,
-                        optimizer_cls=torch.optim.LBFGS,
-                        optimizer_kwargs={
-                            "line_search_fn": "strong_wolfe",
-                        },
-                    )
-
+        task_operations: In-place task configuration callbacks. By default,
+            restrict to repacking with Dunbrack, fixed-AA, and current rotamers.
+        num_repeats: Number of complete pack-minimize ramps.
+        ramp_constraints: Ramp an active constraint weight to zero. Defaults
+            to true; the input weight is restored after relaxation.
+        schedule: Numeric fa_rep fractions or dictionaries with separate pack,
+            minimize, and optional constraint fractions. Defaults to
+            ``DEFAULT_RELAX_SCHEDULE``.
+        min_fn: Minimizer called with the pose, score function, fold forest,
+            move map, and verbosity. Defaults to Cartesian minimization.
         verbose: Print timing information for each step.
 
     Returns:
-        The relaxed PoseStack (best-scoring across all repeats).
+        Best-scoring relaxed poses across all repeats.
     """
     if min_fn is None:
         min_fn = _default_cart_min_fn
     if schedule is None:
         schedule = DEFAULT_RELAX_SCHEDULE
 
-    # Logic for using / adding constraints
     constraint_weight_start = sfxn.get_weight(ScoreType.constraint)
     use_constraints = constraint_weight_start != 0
     if not use_constraints and ramp_constraints:
@@ -267,7 +209,7 @@ def fast_relax(  # noqa: C901
 
     steps = _normalize_schedule(schedule, use_constraints, ramp_constraints)
 
-    if len(steps) == 0:
+    if not steps:
         raise ValueError("Relax schedule must contain at least one step.")
 
     # Warn if the final step doesn't restore fa_rep to its full weight.
@@ -280,11 +222,6 @@ def fast_relax(  # noqa: C901
         )
 
     if task_operations is None:
-        # Create a default task operation that
-        # 1. builds rotamers using the Dunbrack rotamer library
-        # 2. restricts to repacking
-        # 3. includes the current rotamer
-
         torch_device = pose_stack.device
         from tmol.pack.rotamer.dunbrack import (
             create_dunbrack_sampler_from_database,
@@ -296,11 +233,8 @@ def fast_relax(  # noqa: C901
             default_database, torch_device
         )
 
-        def default_op(task):
+        def default_op(task: PackerTask) -> None:
             task.restrict_to_repacking()
-            # TO DO: Prove that bump_check does not worsen relax
-            # task.or_bump_check(True)
-
             fixed_sampler = FixedAAChiSampler()
             task.add_conformer_sampler(dun_sampler)
             task.add_conformer_sampler(fixed_sampler)
@@ -340,18 +274,36 @@ def fast_relax(  # noqa: C901
 
 
 def relax_pack_min_step(
-    pose_stack,
-    sfxn,
-    fold_forest,
-    move_map: Union[MoveMap, CartesianMoveMap],
-    packer_pallete,
-    fa_rep_pack_weight,
-    fa_rep_min_weight,
-    cst_weight,
-    task_operations,
-    min_fn,
-    verbose,
-):
+    pose_stack: PoseStack,
+    sfxn: ScoreFunction,
+    fold_forest: FoldForest,
+    move_map: MoveMap | CartesianMoveMap,
+    packer_pallete: PackerPalette,
+    fa_rep_pack_weight: float,
+    fa_rep_min_weight: float,
+    cst_weight: float,
+    task_operations: Sequence[PackerTaskOperation],
+    min_fn: RelaxMinimizer,
+    verbose: bool,
+) -> PoseStack:
+    """Execute one weighted packing and minimization stage.
+
+    Args:
+        pose_stack: Current poses.
+        sfxn: Score function whose repulsive and constraint weights are updated.
+        fold_forest: Connectivity passed to the minimizer.
+        move_map: Movable degrees of freedom passed to the minimizer.
+        packer_pallete: Residue types available during packing.
+        fa_rep_pack_weight: Repulsive weight for packing.
+        fa_rep_min_weight: Repulsive weight for minimization.
+        cst_weight: Constraint weight for both operations.
+        task_operations: In-place task configuration callbacks.
+        min_fn: Minimization callable.
+        verbose: Print synchronized stage timings.
+
+    Returns:
+        The minimized pose stack.
+    """
 
     if verbose and torch.cuda.is_available():
         torch.cuda.synchronize()
@@ -402,15 +354,27 @@ def relax_pack_min_step(
 def accept_best(
     sfxn: ScoreFunction,
     best_pose_stack: PoseStack,
-    best_pose_score: torch.Tensor,
+    best_pose_score: Tensor[torch.float32][:],
     candidate_pose_stack: PoseStack,
-    verbose=False,
-):
+    verbose: bool = False,
+) -> tuple[PoseStack, Tensor[torch.float32][:]]:
+    """Keep the lower-scoring conformation independently for each pose.
+
+    Args:
+        sfxn: Score function used for comparison.
+        best_pose_stack: Best poses from previous repeats.
+        best_pose_score: Best scores shaped ``[n_poses]``.
+        candidate_pose_stack: Newly minimized poses.
+        verbose: Print accepted scores.
+
+    Returns:
+        Updated best poses and scores shaped ``[n_poses]``.
+    """
     wpsm = sfxn.render_whole_pose_scoring_module(candidate_pose_stack)
     candidate_score = wpsm(candidate_pose_stack.coords)
     better_mask = candidate_score < best_pose_score
 
-    def select_better(tensor_name):
+    def select_better(tensor_name: str) -> torch.Tensor:
         tensor = getattr(best_pose_stack, tensor_name)
         new_tensor = tensor.detach().clone()
         new_tensor[better_mask] = getattr(candidate_pose_stack, tensor_name)[
@@ -440,5 +404,4 @@ def accept_best(
         new_best_pose_score = best_pose_score.detach().clone()
         new_best_pose_score[better_mask] = candidate_score[better_mask]
         return new_best_pose_stack, new_best_pose_score
-    else:  # no change
-        return best_pose_stack, best_pose_score
+    return best_pose_stack, best_pose_score

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -9,6 +9,7 @@ from tmol.types import Tensor
 from tmol.database import ParameterDatabase
 from tmol.database._yaml import safe_load
 from tmol.score import ScoreType
+from tmol.score.common import ZeroTermPoseScoringModule
 
 # force registration of the terms with the ScoreTermFactory
 from tmol.score.terms import *  # noqa: F401, F403
@@ -526,6 +527,23 @@ class BlockPairScoringModule:
     def __call__(self, coords, sum_terms=True, apply_weights=True):
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
+        if sum_terms and apply_weights:
+            active_scores = []
+            active_weights = []
+            weight_offset = 0
+            for term in self.term_modules:
+                if isinstance(term, ZeroTermPoseScoringModule):
+                    weight_offset += term.shape[0]
+                    continue
+                scores = term(coords)
+                next_offset = weight_offset + scores.shape[0]
+                active_scores.append(scores)
+                active_weights.append(self.weights[weight_offset:next_offset])
+                weight_offset = next_offset
+            if active_scores:
+                unweighted = torch.cat(active_scores, dim=0)
+                weights = torch.cat(active_weights, dim=0)
+                return unweighted.mul_(weights).sum(dim=0)
         unweighted = self.unweighted_scores(coords)
         weighted = unweighted.mul_(self.weights) if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -527,7 +527,7 @@ class BlockPairScoringModule:
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         unweighted = self.unweighted_scores(coords)
-        weighted = self.weights * unweighted if apply_weights else unweighted
+        weighted = unweighted.mul_(self.weights) if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
 
         return summed

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -417,7 +417,7 @@ class WholePoseScoringModule:
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         unweighted = self.unweighted_scores(coords)
-        weighted = self.weights * unweighted if apply_weights else unweighted
+        weighted = unweighted.mul_(self.weights) if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
 
         return summed

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -126,6 +126,11 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
 
     torch.testing.assert_close(actual, expected)
 
+    with pytest.raises(TypeError, match="integer dtype"):
+        score_utils.calculate_block_pair_ddg(
+            Pose(), block_indices.float(), sfxn=ScoreFunction(), minimize=False
+        )
+
 
 def test_build_coord_mask_and_minimize_for_first_residue(
     biotite_1ubq: struc.AtomArray, torch_device

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -68,6 +68,57 @@ def test_default_sum_is_bitwise_legacy_equivalent(torch_device):
     assert torch.equal(actual, expected)
 
 
+def test_single_block_indices_match_boolean_masks(torch_device):
+    generator = torch.Generator(device=torch_device).manual_seed(29)
+    scores = torch.randn(5, 3, 7, 7, generator=generator, device=torch_device)
+    block_indices = torch.tensor([1, 4, 2], device=torch_device)
+    mask = torch.zeros(3, 7, dtype=torch.bool, device=torch_device)
+    mask.scatter_(1, block_indices[:, None], True)
+    other = torch.tensor(
+        [
+            [True, True, False, True, False, False, True],
+            [False, True, True, False, False, True, False],
+            [True, False, False, True, True, False, True],
+        ],
+        device=torch_device,
+    )
+
+    expected = score_utils._sum_cross_block_scores(
+        scores, mask, other, memory_efficient=True
+    )
+    actual = score_utils._sum_single_block_cross_scores(scores, block_indices, other)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_calculate_ddg_accepts_single_block_indices(torch_device):
+    class Pose:
+        device = torch_device
+        n_poses = 2
+        block_type_ind = torch.zeros(2, 4, dtype=torch.int32, device=torch_device)
+        coords = torch.empty(2, 0, 3, device=torch_device)
+
+    scores = torch.arange(2 * 2 * 4 * 4, device=torch_device, dtype=torch.float32)
+    scores = scores.reshape(2, 2, 4, 4)
+
+    class ScoreFunction:
+        @staticmethod
+        def render_block_pair_scoring_module(_pose):
+            return lambda _coords, sum_terms: scores
+
+    block_indices = torch.tensor([0, 2], device=torch_device)
+    mask = torch.zeros(2, 4, dtype=torch.bool, device=torch_device)
+    mask.scatter_(1, block_indices[:, None], True)
+    expected = score_utils.calculate_block_pair_ddg(
+        Pose(), mask, sfxn=ScoreFunction(), minimize=False
+    )
+    actual = score_utils.calculate_block_pair_ddg(
+        Pose(), block_indices, sfxn=ScoreFunction(), minimize=False
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
 def test_build_coord_mask_and_minimize_for_first_residue(
     biotite_1ubq: struc.AtomArray, torch_device
 ):

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -5,8 +5,10 @@ import biotite.structure as struc
 from tmol.ops import build_coord_mask_for_mask_and_nearby_blocks
 from tmol.io import (
     pose_stack_from_biotite,
+    pose_stack_from_pdb,
     biotite_from_pose_stack,
 )
+from tmol.pose import PoseStackBuilder
 from tmol import run_cart_min, beta2016_score_function
 import tmol.ops._score_utils as score_utils
 
@@ -130,6 +132,74 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
         score_utils.calculate_block_pair_ddg(
             Pose(), block_indices.float(), sfxn=ScoreFunction(), minimize=False
         )
+
+
+def test_interacting_coord_mask_matches_per_pose_reference(
+    biotite_1ubq: struc.AtomArray, systems_bysize, torch_device, monkeypatch
+):
+    pose = pose_stack_from_biotite(biotite_1ubq, torch_device)
+    shorter_pose = pose_stack_from_pdb(systems_bysize[40], torch_device)
+    poses = PoseStackBuilder.from_poses([pose, shorter_pose, pose], torch_device)
+    block_mask = torch.zeros_like(poses.block_type_ind, dtype=torch.bool)
+    block_mask[0, 0] = True
+    block_mask[1, 5] = True
+    block_mask[2, [0, 5]] = True
+
+    residue_mask = score_utils.res_mask_to_coord_mask(poses, block_mask)
+    sidechain_mask = score_utils.build_sidechain_coord_mask(poses)
+    actual = score_utils.build_coord_mask_for_mask_and_interacting_atoms(
+        poses, block_mask
+    )
+
+    expected_residue_mask = torch.zeros_like(residue_mask)
+    expected_sidechain_mask = torch.zeros_like(sidechain_mask)
+    pbt = poses.packed_block_types
+    for pose_index in range(poses.n_poses):
+        for block_index in range(poses.max_n_blocks):
+            block_type_index = int(poses.block_type_ind64[pose_index, block_index])
+            if block_type_index < 0:
+                continue
+            residue_type = pbt.active_block_types[block_type_index]
+            block_offset = int(poses.block_coord_offset64[pose_index, block_index])
+            n_atoms = int(pbt.n_atoms[block_type_index])
+            if block_mask[pose_index, block_index]:
+                expected_residue_mask[
+                    pose_index, block_offset : block_offset + n_atoms
+                ] = True
+
+            mainchain_atoms = set(residue_type.properties.polymer.mainchain_atoms)
+            for atom_index, atom in enumerate(residue_type.atoms):
+                if atom.name not in mainchain_atoms:
+                    expected_sidechain_mask[pose_index, block_offset + atom_index] = (
+                        True
+                    )
+
+    assert torch.equal(residue_mask, expected_residue_mask)
+    assert torch.equal(sidechain_mask, expected_sidechain_mask)
+
+    expected = residue_mask.clone()
+    for pose_index in range(poses.n_poses):
+        selected_coords = poses.coords[pose_index, residue_mask[pose_index]]
+        differences = poses.coords[pose_index, :, None, :] - selected_coords[None, :, :]
+        nearby = torch.sqrt((differences**2).sum(dim=2)).amin(dim=1) <= 5.0
+        expected[pose_index] |= (
+            nearby & poses.real_atoms[pose_index] & sidechain_mask[pose_index]
+        )
+
+    assert torch.equal(actual, expected)
+    assert torch.equal(
+        actual,
+        score_utils.build_coord_mask_for_mask_and_interacting_atoms(poses, block_mask),
+    )
+
+    monkeypatch.setattr(score_utils, "_INTERACTION_DISTANCE_WORKSPACE_BYTES", 1)
+    assert torch.equal(
+        actual,
+        score_utils.build_coord_mask_for_mask_and_interacting_atoms(poses, block_mask),
+    )
+    assert not score_utils.build_coord_mask_for_mask_and_interacting_atoms(
+        poses, torch.zeros_like(block_mask)
+    ).any()
 
 
 def test_build_coord_mask_and_minimize_for_first_residue(

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -100,11 +100,19 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
 
     scores = torch.arange(2 * 2 * 4 * 4, device=torch_device, dtype=torch.float32)
     scores = scores.reshape(2, 2, 4, 4)
+    weights = torch.tensor([0.25, 1.5], device=torch_device).reshape(2, 1, 1, 1)
 
     class ScoreFunction:
         @staticmethod
         def render_block_pair_scoring_module(_pose):
-            return lambda _coords, sum_terms: scores
+            class Scorer:
+                def __init__(self):
+                    self.weights = weights
+
+                def __call__(self, _coords, sum_terms, apply_weights=True):
+                    return weights * scores if apply_weights else scores
+
+            return Scorer()
 
     block_indices = torch.tensor([0, 2], device=torch_device)
     mask = torch.zeros(2, 4, dtype=torch.bool, device=torch_device)

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -135,7 +135,7 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
 
 
 def test_interacting_coord_mask_matches_per_pose_reference(
-    biotite_1ubq: struc.AtomArray, systems_bysize, torch_device, monkeypatch
+    biotite_1ubq: struc.AtomArray, systems_bysize, torch_device
 ):
     pose = pose_stack_from_biotite(biotite_1ubq, torch_device)
     shorter_pose = pose_stack_from_pdb(systems_bysize[40], torch_device)
@@ -192,14 +192,19 @@ def test_interacting_coord_mask_matches_per_pose_reference(
         score_utils.build_coord_mask_for_mask_and_interacting_atoms(poses, block_mask),
     )
 
-    monkeypatch.setattr(score_utils, "_INTERACTION_DISTANCE_WORKSPACE_BYTES", 1)
     assert torch.equal(
         actual,
-        score_utils.build_coord_mask_for_mask_and_interacting_atoms(poses, block_mask),
+        score_utils.build_coord_mask_for_mask_and_interacting_atoms(
+            poses, block_mask, max_workspace_bytes=1
+        ),
     )
     assert not score_utils.build_coord_mask_for_mask_and_interacting_atoms(
         poses, torch.zeros_like(block_mask)
     ).any()
+    with pytest.raises(ValueError, match="max_workspace_bytes"):
+        score_utils.build_coord_mask_for_mask_and_interacting_atoms(
+            poses, block_mask, max_workspace_bytes=0
+        )
 
 
 def test_build_coord_mask_and_minimize_for_first_residue(

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 import biotite.structure as struc
@@ -11,6 +13,25 @@ from tmol.io import (
 from tmol.pose import PoseStackBuilder
 from tmol import run_cart_min, beta2016_score_function
 import tmol.ops._score_utils as score_utils
+
+
+def test_sidechain_mask_treats_missing_mainchain_as_all_sidechain(torch_device):
+    """Polymer metadata may omit main-chain atoms for ligand-like blocks."""
+    residue_type = SimpleNamespace(
+        properties=SimpleNamespace(
+            polymer=SimpleNamespace(mainchain_atoms=None),
+        ),
+        atom_to_idx={},
+    )
+    packed_block_types = SimpleNamespace(
+        atom_is_real=torch.tensor([[True, True, False]], device=torch_device),
+        active_block_types=[residue_type],
+    )
+    pose_stack = SimpleNamespace(packed_block_types=packed_block_types)
+
+    actual = score_utils._sidechain_atom_mask_for_block_type(pose_stack)
+
+    torch.testing.assert_close(actual, packed_block_types.atom_is_real)
 
 
 @pytest.mark.parametrize("einsum", [False, True])

--- a/tmol/tests/pack/rotamer/test_build_rotamers.py
+++ b/tmol/tests/pack/rotamer/test_build_rotamers.py
@@ -103,7 +103,13 @@ def test_build_rotamers_smoke(default_database, ubq_pdb, torch_device, dun_sampl
     task = SetPackerTask.from_packer_task(task)
 
     poses, rotamer_set = build_rotamers(poses, task, default_database.chemical)
-    assert rotamer_set is not None
+    _, cached_rotamer_set = build_rotamers(poses, task, default_database.chemical)
+
+    torch.testing.assert_close(cached_rotamer_set.coords, rotamer_set.coords)
+    torch.testing.assert_close(
+        cached_rotamer_set.block_type_ind_for_rot,
+        rotamer_set.block_type_ind_for_rot,
+    )
 
 
 def test_construct_scans_for_rotamers(
@@ -314,12 +320,10 @@ def test_measure_pose_dofs(default_database, ubq_pdb, torch_device, dun_sampler)
         n_atoms_offset_for_conformer,
     )
 
-    n_conformers = poses.max_n_blocks
     n_atoms_total = poses.max_n_pose_atoms
 
     rotamer_coords = calculate_rotamer_coords(
         pbt,
-        n_conformers,
         n_atoms_total,
         orig_kinforest,
         nodes,
@@ -1460,8 +1464,6 @@ def test_new_rotamer_building_logic1(
 
     gbt_for_conformer_torch = _t(gbt_for_conformer, torch.int64)
 
-    n_conformers = sampler_for_conformer.shape[0]
-
     block_type_ind_for_conformer = gbt_block_type_ind[gbt_for_conformer_np]
     block_type_ind_for_conformer_torch = _t(block_type_ind_for_conformer, torch.int64)
 
@@ -1525,7 +1527,6 @@ def test_new_rotamer_building_logic1(
 
     rotamer_coords = calculate_rotamer_coords(
         pbt,
-        n_conformers,
         n_atoms_total,
         conformer_kinforest,
         nodes,

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -1,4 +1,5 @@
 import attrs
+import pytest
 import torch
 import math
 
@@ -199,7 +200,10 @@ def get_constraints_only_sfxn(default_database, torch_device):
     return sfxn
 
 
-def test_pack_rotamers(default_database, ubq_pdb, dun_sampler, torch_device):
+@pytest.mark.parametrize("chunk_size", [8, 16])
+def test_pack_rotamers(
+    default_database, ubq_pdb, dun_sampler, torch_device, chunk_size
+):
     n_poses = 4
     p = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=76)
     pose_stack, task = setup_pose_stack_and_task(
@@ -218,7 +222,7 @@ def test_pack_rotamers(default_database, ubq_pdb, dun_sampler, torch_device):
         bc_rot_to_orig_rot,
         bg_bg_energies,
         packer_energy_tables,
-    ) = build_packer_energy_tables(pose_stack, rotamer_set, sfxn)
+    ) = build_packer_energy_tables(pose_stack, rotamer_set, sfxn, chunk_size=chunk_size)
 
     _, _ = run_pack_and_assert_scores(
         pose_stack,

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -8,7 +8,8 @@ from tmol.score import (
     ScoreFunction,
     ScoreType,
 )
-from tmol.score._score_function import WholePoseScoringModule
+from tmol.score._score_function import BlockPairScoringModule, WholePoseScoringModule
+from tmol.score.common import ZeroTermPoseScoringModule
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
     DEFAULT_ATOM_OCCUPANCY,
@@ -243,6 +244,20 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
     torch.testing.assert_close(
         full_score, torch.sum(block_score, dim=(1, 2)), atol=1e-3, rtol=1e-3
     )
+
+
+def test_block_pair_scoring_supports_only_invariant_zero_terms(torch_device):
+    scorer = BlockPairScoringModule(
+        torch.ones(2, device=torch_device),
+        [ZeroTermPoseScoringModule("zero", 2, 3, torch_device, 4)],
+    )
+    coords = torch.zeros((3, 1, 3), device=torch_device, requires_grad=True)
+
+    scores = scorer(coords)
+
+    assert scores.shape == (3, 4, 4)
+    assert torch.count_nonzero(scores) == 0
+    scores.sum().backward()
 
 
 def test_virtual_residue_scoring(ubq_pdb, torch_device):


### PR DESCRIPTION
## Summary

This PR removes measured bottlenecks from FastRelax, batched point-mutation ddG scans, and their shared packing/scoring setup while preserving scoring behavior:

- specializes the production simulated-annealing kernels for the interaction graph's 16-rotamer chunks;
- replaces annealer neighbor CSR construction and its host synchronization with one device-built fixed-stride layout, and omits best-assignment tracking during monotonic quench phases;
- removes discarded rescoring, duplicate weighting/storage, dead timing/debug buffers, an unused rotamer argument and assertion, and stale commentary;
- batches mutation-site interaction-mask construction across poses, caches immutable compact atom topology, and uses deterministic OR reductions for aliasing scatter indices;
- adds the integer-index route for one mutated block per pose, reducing only the relevant score rows/columns and applying term weights after reduction;
- batches jump-parent chi correction on the GPU and caches already-complete rotamer annotations;
- skips invariant-zero topology terms for summed block-pair output while preserving per-term output;
- adds TMol-native shaped tensor types, concise Google-style docstrings, and useful batch/layout comments around the changed public and performance-critical paths.

The full PR is a net deletion: **944 additions / 1,044 deletions** across 13 files.

## Performance

Measured on one NVIDIA H200 with an AOT sm_90 build, PyTorch 2.13.0+cu132, synchronized steady-state medians. FastRelax used one complete four-stage schedule and 10 Cartesian LBFGS iterations per stage.

| FastRelax case | master | this PR | change |
|---|---:|---:|---:|
| protein 100, batch 1 | 1211.3 ms | 1094.4 ms | 9.7% faster |
| protein 100, batch 4 | 2235.6 ms | 1873.3 ms | 16.2% faster |

In a controlled same-node isolated annealer comparison, fixed-stride neighbors plus monotonic-quench specialization reduced 191.57 ms to 184.85 ms (3.5%). Earlier Nsight attribution also showed lower aggregate high-temperature, low-temperature, and full-quench kernel time. The full FastRelax recipe packs four times.

Rotamer setup on protein 100 improved as follows:

| operation | before | this PR | change |
|---|---:|---:|---:|
| complete `build_rotamers()` | 22.917 ms | 13.656 ms | 40.4% faster |
| jump-parent chi correction | 5.856 ms | 1.455 ms | 4.0x faster |
| repeated annotation pass | 6.331 ms | 0.013 ms | cached |

For a 64-pose, one-site protein-100 mutation batch, the complete nearby-atom mask fell from 30.33 ms in the per-pose implementation to 0.729 ms on the first topology lookup and 0.484 ms when reused (41.6x and 62.7x). The calculation defaults to a configurable 256 MiB temporary-workspace cap; smaller values trade more chunks for a lower memory peak.

For the isolated single-block ddG reduction (22 terms), passing integer block indices produced:

| poses x blocks | Boolean mask | integer indices | speedup |
|---|---:|---:|---:|
| 8 x 350 | 0.1470 ms | 0.0362 ms | 4.1x |
| 64 x 350 | 0.8457 ms | 0.0411 ms | 20.6x |
| 256 x 100 | 0.3493 ms | 0.0432 ms | 8.1x |
| 512 x 100 | 0.6455 ms | 0.0656 ms | 9.8x |

Including complete block-pair scoring with a pre-rendered scorer, the indexed route improved protein-ligand batch 8 from 2.719 to 2.507 ms (7.8%) and protein-100 batch 64 from 3.268 to 3.108 ms (4.9%). Allocated-memory high-water deltas fell by 15.0 MiB and 9.2 MiB.

For ordinary summed block-pair scoring, in-place weighting plus omission of invariant-zero terms lowered:

| case | before | this PR | peak allocation before | this PR |
|---|---:|---:|---:|---:|
| protein-ligand, batch 8 | 2.566 ms | 2.527 ms | 186.9 MiB | 160.8 MiB |
| protein 100, batch 64 | 3.135 ms | 3.100 ms | 114.9 MiB | 98.8 MiB |

## Numerical behavior and verification

- With a fixed seed and identical protein-100 energy tables, all 312 returned annealer scores and all 30,264 assignment entries are bit-for-bit identical to master.
- The GPU chi correction preserves every value in the full 49,838 x 3 protein-100 rotamer coordinate tensor exactly.
- The integer ddG path matches the Boolean formulation within the documented reduction tolerance; the final in-place gather is bit-for-bit identical to its prior implementation.
- Omitting invariant-zero terms changes only floating-point reduction grouping for summed output. Across protein, protein-ligand, and DNA cases, the maximum observed score difference was `7.63e-6` and maximum coordinate-gradient difference was `3.05e-5`; per-term output is unchanged.
- The interaction-mask reference test covers CPU/CUDA, homogeneous and jagged pose lengths, deterministic repetition, forced low-workspace chunking, and empty selections.
- Broad focused suite: **48 passed, 3 skipped** across score utilities, interaction-graph construction, packing, repeated rotamer building, and FastRelax on CPU/CUDA.
- AOT sm_90 CUDA build succeeds; Black, Flake8, Ruff, clang-format, and `git diff --check` pass.


