### PR TITLE
Clarify TMol Python API contracts for v0.1.52

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.51"
+version = "0.1.52"
 
 dependencies = [
     # Core ML framework

--- a/tmol/__init__.py
+++ b/tmol/__init__.py
@@ -1,3 +1,5 @@
+"""TMol: GPU-accelerated molecular modeling with PyTorch."""
+
 # flake8: noqa
 
 # Load pre-compiled C++/CUDA extensions (TORCH_LIBRARY ops).

--- a/tmol/_load_ext.py
+++ b/tmol/_load_ext.py
@@ -106,7 +106,6 @@ def load_module(module_name: str, file: str, sources, precompiled_path: str):
         )
 
         return load(modulename(module_name), cuda_if_available(relpaths(file, sources)))
-    else:
-        import importlib
+    import importlib
 
-        return importlib.import_module(precompiled_path)
+    return importlib.import_module(precompiled_path)

--- a/tmol/chemical/__init__.py
+++ b/tmol/chemical/__init__.py
@@ -1,3 +1,5 @@
+"""Chemical residue types, patches, and connectivity utilities."""
+
 from ._all_bonds import bonds_and_bond_ranges  # noqa: F401
 from ._constants import MAX_PATHS_FROM_CONNECTION, MAX_SIG_BOND_SEPARATION  # noqa: F401
 from ._ideal_coords import (  # noqa: F401

--- a/tmol/chemical/_ideal_coords.py
+++ b/tmol/chemical/_ideal_coords.py
@@ -1,26 +1,30 @@
+from typing import TYPE_CHECKING
+
 import numpy
 
+from tmol.types import NDArray
 
-def eye4():
-    """Create the identity homogeneous transform
-    Only necessary because numpy.eye(4, dtype=numpy.float32)
-    is strangely unsupported in numpy"""
+if TYPE_CHECKING:
+    from tmol.chemical import RefinedResidueType
+
+
+def eye4() -> NDArray[numpy.float32][4, 4]:
+    """Return a single-precision homogeneous identity transform."""
 
     return numpy.eye(4, dtype=numpy.float32)
 
-    # m = numpy.zeros((4, 4), dtype=numpy.float32)
-    # m[0, 0] = 1
-    # m[1, 1] = 1
-    # m[2, 2] = 1
-    # m[3, 3] = 1
-    # return m
 
-
-def normalize(v):
+def normalize(v: numpy.ndarray) -> numpy.ndarray:
+    """Return ``v`` scaled to unit length."""
     return v / numpy.linalg.norm(v)
 
 
-def frame_from_coords(p1, p2, p3):
+def frame_from_coords(
+    p1: NDArray[numpy.float32][3],
+    p2: NDArray[numpy.float32][3],
+    p3: NDArray[numpy.float32][3],
+) -> NDArray[numpy.float32][4, 4]:
+    """Construct a homogeneous frame from three Cartesian points."""
     ht = eye4()
     z = normalize(p3 - p2)
     v21 = normalize(p1 - p2)
@@ -34,11 +38,11 @@ def frame_from_coords(p1, p2, p3):
     return ht
 
 
-def rot_x(rot):
+def rot_x(rot: float) -> NDArray[numpy.float32][4, 4]:
+    """Return a homogeneous rotation about the x-axis."""
     ht = eye4()
     crot = numpy.cos(rot)
     srot = numpy.sin(rot)
-    # print("rot x", rot, crot, srot)
     ht[1, 1] = crot
     ht[2, 1] = srot
     ht[1, 2] = -srot
@@ -46,11 +50,11 @@ def rot_x(rot):
     return ht
 
 
-def rot_z(rot):
+def rot_z(rot: float) -> NDArray[numpy.float32][4, 4]:
+    """Return a homogeneous rotation about the z-axis."""
     ht = eye4()
     crot = numpy.cos(rot)
     srot = numpy.sin(rot)
-    # print("rot z", rot, crot, srot)
     ht[0, 0] = crot
     ht[1, 0] = srot
     ht[0, 1] = -srot
@@ -58,13 +62,18 @@ def rot_z(rot):
     return ht
 
 
-def trans_z(trans):
+def trans_z(trans: float) -> NDArray[numpy.float32][4, 4]:
+    """Return a homogeneous translation along the z-axis."""
     ht = eye4()
     ht[2, 3] = trans
     return ht
 
 
-def build_coords_from_icoors(icoors_ancestors, icoors_geom):
+def build_coords_from_icoors(
+    icoors_ancestors: NDArray[numpy.int32][:, 3],
+    icoors_geom: NDArray[numpy.float64][:, 3],
+) -> NDArray[numpy.float32][:, 3]:
+    """Build Cartesian coordinates from ancestor indices and internal geometry."""
     # start with atom 1 at the origin
     # place atom 2 along the x axis
     # place atom 3 in the x-y plane
@@ -98,7 +107,6 @@ def build_coords_from_icoors(icoors_ancestors, icoors_geom):
     coords[2, :] = ht_2[:3, 3]
 
     for i in range(3, icoors_ancestors.shape[0]):
-        # print("ancestors", i)
         ht_i = frame_from_coords(
             coords[icoors_ancestors[i, 2], :],
             coords[icoors_ancestors[i, 1], :],
@@ -116,7 +124,10 @@ def build_coords_from_icoors(icoors_ancestors, icoors_geom):
     return coords
 
 
-def build_ideal_coords(restype: "RefinedResidueType"):  # noqa F821
+def build_ideal_coords(
+    restype: "RefinedResidueType",
+) -> NDArray[numpy.float32][:, 3]:
+    """Build ideal Cartesian coordinates for a refined residue type."""
     # lets build a kinforest using not the prioritized bonds,
     # but the icoors; let's not even use the scan algorithm.
     # let's just build the coordinates directly from the

--- a/tmol/chemical/_restypes.py
+++ b/tmol/chemical/_restypes.py
@@ -319,7 +319,7 @@ class RefinedResidueType(RawResidueType):
             return self.connection_to_cidx["up"]
         return -1
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p, _cycle):
         p.text(f"RefinedResidueType(name={self.name},...)")
 
     torsion_to_uaids: Mapping[str, Tuple[UnresolvedAtomID]] = attr.ib()

--- a/tmol/chemical/_restypes.py
+++ b/tmol/chemical/_restypes.py
@@ -149,8 +149,7 @@ def get_element_from_atom_name(atom_name: str) -> str:
             if len(element) == 2:
                 if element.upper() in ["FE", "MG", "CL", "ZN", "NA", "CU"]:
                     return element.capitalize()
-                else:
-                    return element[0].upper()
+                return element[0].upper()
         else:
             break
 
@@ -310,8 +309,7 @@ class RefinedResidueType(RawResidueType):
     def _setup_down_connection_ind(self):
         if "down" in self.connection_to_cidx:
             return self.connection_to_cidx["down"]
-        else:
-            return -1
+        return -1
 
     up_connection_ind: int = attr.ib()
 
@@ -319,8 +317,7 @@ class RefinedResidueType(RawResidueType):
     def _setup_up_connection_ind(self):
         if "up" in self.connection_to_cidx:
             return self.connection_to_cidx["up"]
-        else:
-            return -1
+        return -1
 
     def _repr_pretty_(self, p, cycle):
         p.text(f"RefinedResidueType(name={self.name},...)")
@@ -471,7 +468,7 @@ class RefinedResidueType(RawResidueType):
             # create a convenient datastructure for following connections
             bondmap = {-1: []}
             for bond in self.bond_indices:
-                if bond[0] not in bondmap.keys():
+                if bond[0] not in bondmap:
                     bondmap[bond[0]] = []
                 bondmap[bond[0]].append(bond[1])
 

--- a/tmol/database/__init__.py
+++ b/tmol/database/__init__.py
@@ -1,8 +1,10 @@
+"""Chemical and scoring parameter databases used by TMol."""
+
 from __future__ import annotations
 
 import os
 import attr
-from typing import List, Optional, Mapping
+from typing import Mapping, Optional
 
 from .chemical import AtomType, ChemicalDatabase, RawResidueType  # noqa: F401
 from ._patched_chemdb import PatchedChemicalDatabase  # noqa: F401
@@ -36,6 +38,7 @@ class ParameterDatabase:
 
     @classmethod
     def from_file(cls, path: str) -> "ParameterDatabase":
+        """Load chemical and scoring parameters rooted at ``path``."""
         chemdb = ChemicalDatabase.from_file(os.path.join(path, "chemical"))
         patched_chemdb = PatchedChemicalDatabase.from_chem_db(chemdb)
         return cls(
@@ -44,7 +47,7 @@ class ParameterDatabase:
         )
 
     def create_stable_subset(
-        self, desired_names: List[str], desired_variants: List[str]
+        self, desired_names: list[str], desired_variants: list[str]
     ) -> "ParameterDatabase":
         """Create a ParameterDatabase representing a subset of the
         RefinedResidueTypes in this PD's PatchedChemicalDatabase from a list

--- a/tmol/database/_patched_chemdb.py
+++ b/tmol/database/_patched_chemdb.py
@@ -122,9 +122,7 @@ def update_icoor(res, patch, atoms_remove, namemap):
 
     # create final icoor list
     remove = [namemap[i] for i in atoms_remove]
-    icoor = (*(x for x in res if x.name not in remove), *new_icoor)
-
-    return icoor
+    return (*(x for x in res if x.name not in remove), *new_icoor)
 
 
 # get a list of atoms modified by a patch
@@ -459,11 +457,11 @@ def _validate_patch_icoors(patch, added_ats_and_conns):
 #    newreses - list of new residues produced by the patch (currently only support for 1)
 #    newmarked - updated list of modified atoms in new residue
 def do_patch(res, variant, resgraph, patchgraph, marked):  # noqa: C901
-    atoms_match = (
-        lambda x, y: ("element" not in y)
-        or ("element" not in x)
-        or x["element"] == y["element"]
-    )
+    def atoms_match(x, y):
+        return (
+            ("element" not in y) or ("element" not in x) or x["element"] == y["element"]
+        )
+
     gm = iso.GraphMatcher(resgraph, patchgraph, node_match=atoms_match)
 
     added, modded, deleted = get_modified_atoms(variant)

--- a/tmol/database/chemical/__init__.py
+++ b/tmol/database/chemical/__init__.py
@@ -14,8 +14,7 @@ _acceptor_hybridizations = {"sp2", "sp3", "ring"}
 def _parse_acceptor_hybridization(v, t):
     if v in _acceptor_hybridizations:
         return v
-    else:
-        raise ValueError(f"Invalid AcceptorHybridization value: {v}")
+    raise ValueError(f"Invalid AcceptorHybridization value: {v}")
 
 
 cattr.register_structure_hook(AcceptorHybridization, _parse_acceptor_hybridization)

--- a/tmol/database/chemical/__init__.py
+++ b/tmol/database/chemical/__init__.py
@@ -1,4 +1,6 @@
-from typing import Tuple, Optional, NewType
+"""Typed schemas for TMol chemical parameter data."""
+
+from typing import Any, NewType, Optional, Tuple
 from tmol.utility import BondAngle, DihedralAngle
 
 import attr
@@ -20,7 +22,7 @@ def _parse_acceptor_hybridization(v, t):
 cattr.register_structure_hook(AcceptorHybridization, _parse_acceptor_hybridization)
 
 
-def normalize_bond_tuples(raw):  # noqa: C901
+def normalize_bond_tuples(raw: Any) -> Any:  # noqa: C901
     """Normalize legacy 2-field bond entries to include bond order.
 
     Historically, some YAML snippets used ``[atom1, atom2]`` for bonds.
@@ -62,12 +64,16 @@ def normalize_bond_tuples(raw):  # noqa: C901
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Element:
+    """Chemical element name and atomic number."""
+
     name: str
     atomic_number: int
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class AtomType:
+    """Chemical atom-type properties used by scoring terms."""
+
     name: str
     element: str
     is_acceptor: bool = False
@@ -79,18 +85,24 @@ class AtomType:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Atom:
+    """Named residue atom and its chemical atom type."""
+
     name: str = attr.ib()
     atom_type: str = attr.ib()
 
 
 @attr.s(frozen=True, slots=True)
 class AtomAlias:
+    """Alternative input name for a residue atom."""
+
     name: str = attr.ib()
     alt_name: str = attr.ib()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Icoor:
+    """Internal-coordinate definition for one residue atom."""
+
     name: str
     phi: DihedralAngle
     theta: BondAngle
@@ -102,6 +114,8 @@ class Icoor:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Connection:
+    """Named inter-residue connection and its bond type."""
+
     name: str
     atom: str
     type: str = "SINGLE"
@@ -109,6 +123,8 @@ class Connection:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class UnresolvedAtom:
+    """Atom reference resolved from a name or residue connection."""
+
     atom: Optional[str] = None
     connection: Optional[str] = None
     bond_sep_from_conn: Optional[int] = None
@@ -116,6 +132,8 @@ class UnresolvedAtom:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Torsion:
+    """Named torsion defined by four unresolved atoms."""
+
     name: str
     a: UnresolvedAtom
     b: UnresolvedAtom
@@ -125,6 +143,8 @@ class Torsion:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ChiSamples:
+    """Discrete samples and expansions for one chi dihedral."""
+
     chi_dihedral: str
     samples: Tuple[float, ...]
     expansions: Tuple[float, ...]
@@ -132,11 +152,15 @@ class ChiSamples:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class SidechainBuilding:
+    """Side-chain construction data for one chi dihedral."""
+
     chi_samples: ChiSamples
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class PolymerProperties:
+    """Polymer identity and connectivity metadata for a residue."""
+
     is_polymer: bool
     # None for a non-polymer
     polymer_type: Optional[str]
@@ -148,6 +172,8 @@ class PolymerProperties:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ProtonationProperties:
+    """Protonation-state metadata for a residue."""
+
     protonated_atoms: Tuple[str, ...]
     protonation_state: str
     pH: float
@@ -155,6 +181,8 @@ class ProtonationProperties:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ChemicalProperties:
+    """Chemical classification metadata for a residue."""
+
     is_canonical: bool
     polymer: PolymerProperties
     chemical_modifications: Tuple[str, ...]
@@ -165,6 +193,8 @@ class ChemicalProperties:
 
 @attr.s(auto_attribs=True)
 class RawResidueType:
+    """Unpatched residue definition loaded from the chemical database."""
+
     name: str
     base_name: str
     name3: str
@@ -190,12 +220,15 @@ class RawResidueType:
     #   "a" is both DA and RA.
     one_letter_code: Optional[str] = None
 
-    def atom_name(self, index):
+    def atom_name(self, index: int) -> str:
+        """Return the name of the atom at ``index``."""
         return self.atoms[index].name
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class IcoorVariant:
+    """Patch operation that adds or modifies an internal coordinate."""
+
     name: str
     source: Optional[str] = None
     phi: Optional[DihedralAngle] = 0.0
@@ -208,11 +241,15 @@ class IcoorVariant:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class PolymerPropertiesVariant:
+    """Polymer-property changes made by a residue patch."""
+
     polymer_type: str
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ChemicalPropertiesVariant:
+    """Chemical-property changes made by a residue patch."""
+
     polymer: Optional[PolymerPropertiesVariant] = None
 
 
@@ -228,7 +265,8 @@ class VariantScope:
     backbone_types: Optional[Tuple[str, ...]] = None
     base_names: Optional[Tuple[str, ...]] = None
 
-    def matches(self, res):
+    def matches(self, res: RawResidueType) -> bool:
+        """Return whether this scope accepts ``res``."""
         if self.base_names is not None and res.base_name not in self.base_names:
             return False
         backbone = res.properties.polymer.backbone_type
@@ -237,6 +275,8 @@ class VariantScope:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class VariantType:
+    """Patch that transforms a base residue into a chemical variant."""
+
     name: str
     display_name: str
     pattern: str
@@ -254,6 +294,8 @@ class VariantType:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ChemicalDatabase:
+    """Immutable collection of chemical types, residues, and patches."""
+
     __default = None
 
     element_types: Tuple[Element, ...]
@@ -271,7 +313,8 @@ class ChemicalDatabase:
         return cls.__default
 
     @classmethod
-    def from_file(cls, path):
+    def from_file(cls, path: str | os.PathLike[str]) -> "ChemicalDatabase":
+        """Load a chemical database from a directory containing YAML data."""
         path = os.path.join(path, "chemical.yaml")
         with open(path, "r") as infile:
             raw = safe_load(infile)

--- a/tmol/database/scoring/__init__.py
+++ b/tmol/database/scoring/__init__.py
@@ -1,3 +1,5 @@
+"""Typed schemas and loaders for TMol scoring parameters."""
+
 from ._cartbonded import (  # noqa: F401
     AngleGroup,
     CartRes,
@@ -68,6 +70,8 @@ from ._ref import RefDatabase  # noqa: F401
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class ScoringDatabase:
+    """Immutable parameters for all standard TMol energy terms."""
+
     cartbonded: CartBondedDatabase
     genbonded: GenBondedDatabase
     disulfide: DisulfideDatabase
@@ -81,7 +85,10 @@ class ScoringDatabase:
     ref: RefDatabase
 
     @classmethod
-    def from_file(cls, path=os.path.dirname(__file__)):  # noqa
+    def from_file(
+        cls, path: str | os.PathLike[str] = os.path.dirname(__file__)
+    ) -> "ScoringDatabase":
+        """Load all scoring-term databases rooted at ``path``."""
 
         return cls(
             cartbonded=CartBondedDatabase.from_file(

--- a/tmol/database/scoring/_cartbonded.py
+++ b/tmol/database/scoring/_cartbonded.py
@@ -82,5 +82,4 @@ class CartBondedDatabase:
     @classmethod
     def _generate_hash(cls, resparam_dict):
         serialized = json.dumps(resparam_dict, sort_keys=True)
-        hash_value = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
-        return hash_value
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/tmol/io/__init__.py
+++ b/tmol/io/__init__.py
@@ -1,3 +1,5 @@
+"""Structure conversion between external formats and TMol poses."""
+
 import torch
 from typing import Optional, Union
 

--- a/tmol/io/_canonical_ordering.py
+++ b/tmol/io/_canonical_ordering.py
@@ -601,7 +601,7 @@ def canonical_form_from_atom_records(  # noqa: C901
     if res_not_connected is not None:
         assert res_not_connected.shape == (1, n_res, 2)
 
-    canonical_form = CanonicalForm(
+    return CanonicalForm(
         chain_id=_ti32(chain_id),
         res_types=_ti32(res_types),
         coords=_tf32(coords),
@@ -613,5 +613,3 @@ def canonical_form_from_atom_records(  # noqa: C901
         res_not_connected=res_not_connected,
         disulfides=None,
     )
-
-    return canonical_form

--- a/tmol/io/_canonical_ordering.py
+++ b/tmol/io/_canonical_ordering.py
@@ -344,12 +344,11 @@ class CanonicalOrdering:
                 cys_co_aa_ind=-1,
                 sg_atom_for_co_cys=-1,
             )
-        else:
-            cys_co_aa_ind = restype_name3s.index("CYS")
-            return CysSpecialCaseIndices(
-                cys_co_aa_ind=cys_co_aa_ind,
-                sg_atom_for_co_cys=restypes_ordered_atom_names["CYS"].index("SG"),
-            )
+        cys_co_aa_ind = restype_name3s.index("CYS")
+        return CysSpecialCaseIndices(
+            cys_co_aa_ind=cys_co_aa_ind,
+            sg_atom_for_co_cys=restypes_ordered_atom_names["CYS"].index("SG"),
+        )
 
     @classmethod
     def _init_his_special_case_indices(
@@ -367,23 +366,22 @@ class CanonicalOrdering:
                 his_NN_in_co=-1,
                 his_CG_in_co=-1,
             )
-        else:
-            his_co_aa_ind = restype_name3s.index("HIS")
+        his_co_aa_ind = restype_name3s.index("HIS")
 
-            def his_at_ind(atname):
-                return restypes_ordered_atom_names["HIS"].index(atname)
+        def his_at_ind(atname):
+            return restypes_ordered_atom_names["HIS"].index(atname)
 
-            return HisSpecialCaseIndices(
-                his_co_aa_ind=his_co_aa_ind,
-                his_ND1_in_co=his_at_ind("ND1"),
-                his_NE2_in_co=his_at_ind("NE2"),
-                his_HD1_in_co=his_at_ind("HD1"),
-                his_HE2_in_co=his_at_ind("HE2"),
-                his_HN_in_co=his_at_ind("HN"),
-                his_NH_in_co=his_at_ind("NH"),
-                his_NN_in_co=his_at_ind("NN"),
-                his_CG_in_co=his_at_ind("CG"),
-            )
+        return HisSpecialCaseIndices(
+            his_co_aa_ind=his_co_aa_ind,
+            his_ND1_in_co=his_at_ind("ND1"),
+            his_NE2_in_co=his_at_ind("NE2"),
+            his_HD1_in_co=his_at_ind("HD1"),
+            his_HE2_in_co=his_at_ind("HE2"),
+            his_HN_in_co=his_at_ind("HN"),
+            his_NH_in_co=his_at_ind("NH"),
+            his_NN_in_co=his_at_ind("NN"),
+            his_CG_in_co=his_at_ind("CG"),
+        )
 
     def create_src_2_tmol_mappings(
         self, src_aa_name3s, src_atom_names_for_name3s, device

--- a/tmol/io/_pdb_parsing.py
+++ b/tmol/io/_pdb_parsing.py
@@ -162,10 +162,6 @@ def parse_atom_lines(lines):
         lines
     )
     results["b"] = numpy.vectorize(lambda s: float(s[60:66]), otypes=[float])(lines)
-    # results["segi"]       = numpy.vectorize(lambda s: str.strip(s[72:76]), otypes = [numpy.str])(lines)
-    # results["element"]    = numpy.vectorize(lambda s: str.strip(s[76:78]), otypes = [numpy.str])(lines)
-    # results["charge"]     = numpy.vectorize(lambda s: float(s[78:80]), otypes     = [numpy.float])(lines)
-
     return results
 
 

--- a/tmol/io/_pdb_parsing.py
+++ b/tmol/io/_pdb_parsing.py
@@ -1,4 +1,3 @@
-# flake8: noqa: E2
 """Utility functions for converting pdb files to/from atom records.
 
 Atom records are DataFrames with the records:
@@ -72,20 +71,20 @@ def parse_pdb(pdb_lines) -> pandas.DataFrame:
 
     # Accumulate atom lines, flagging model/chain breaks on the
     # last atom of the model/chain
-    for l in pdb_lines:
-        if l.startswith("MODEL"):
+    for line in pdb_lines:
+        if line.startswith("MODEL"):
             if model_breaks:
                 model_breaks[-1] = True
 
             if chain_breaks:
                 chain_breaks[-1] = True
 
-            model_name = l[6:].strip()
-        elif l.startswith("TER"):
+            model_name = line[6:].strip()
+        elif line.startswith("TER"):
             if chain_breaks:
                 chain_breaks[-1] = True
-        elif l.startswith("ATOM  "):
-            atom_lines.append(l)
+        elif line.startswith("ATOM  "):
+            atom_lines.append(line)
 
             chain_breaks.append(False)
 
@@ -183,8 +182,7 @@ def format_atomn(atomn):
 
     if atomn.startswith(("H", "C", "N", "O", "S")) and len(atomn) < 4:
         return " {0:<3}".format(atomn)
-    else:
-        return "{0:<4}".format(atomn)
+    return "{0:<4}".format(atomn)
 
 
 def to_pdb_lines(atom_records):
@@ -196,8 +194,8 @@ def to_pdb_lines(atom_records):
     for model_name, records in atom_records.groupby("model"):
         yield "MODEL {}\n".format(model_name)
 
-        for l in to_atom_lines(r for _, r in records.iterrows()):
-            yield l
+        for line in to_atom_lines(r for _, r in records.iterrows()):
+            yield line
 
         yield "TER\n"
         yield "ENDMDL\n"

--- a/tmol/io/_pose_stack_construction.py
+++ b/tmol/io/_pose_stack_construction.py
@@ -403,5 +403,4 @@ def pose_stack_from_canonical_form(  # noqa: C901
 
     if len(opt_return_vals) > 0:
         return ps, opt_return_vals
-    else:
-        return ps
+    return ps

--- a/tmol/io/_pose_stack_construction.py
+++ b/tmol/io/_pose_stack_construction.py
@@ -37,115 +37,40 @@ def pose_stack_from_canonical_form(  # noqa: C901
     return_atom_mapping: bool = False,
     return_block_has_missing_atoms: bool = False,
 ):
-    """Create a PoseStack, resolving which block type is requested by the
-    presence and absence of the provided atoms for each residue type.
-    There are five required arguments and several optional arguments.
+    """Build a pose stack from tensors in canonical atom ordering.
 
-    Arguments:
-    canonical_ordering: an object that describes the set of atoms that each
-        residue type (aka block type) and all of its interchangable variants
-        contain and the order in which those atoms should appear in the
-        coords tensor
-    packed_block_types: the object that holds score-term annotations needed
-        by the score terms and which is intended to be shared between
-        multiple PoseStacks for efficiency; the PoseStack this function
-        creates will hold this packed_block_types object
-    chain_id: an n-pose x max-n-residue tensor with an index for which chain
-        each residue belongs to. Residues belonging to the same chain must be
-        consecutive.
-    res_types: an n-pose x max-n-residue tensor with the canonically
-        ordered amino acid index for each residue. A sentinel value of "-1"
-        should be used to indicate that a given position does not contain
-        a residue (perhaps because it belongs to a pose with fewer than
-        max-n-residue residues; each pose in the PoseStack is allowed to
-        have fewer than max-n-residue residues).
-    coords: an n-pose x max-n-residue x max-n-atoms-per-residue tensor
-        providing the coordinates of some or all of the atoms. The order
-        in which atoms should appear in this tensor is given by the
-        CanonicalOrdering object. Any atoms whose coordinates are not
-        being provided to this function must have their coordinates marked
-        as NaN. Any atom with a coordinate of NaN will be taken as "not
-        present" and all others (including any coordinates at the origin, e.g.)
-        will be treated as if they "are present." Note: "present" here
-        means "the coordinate is being provided" and not "this atom
-        should be modeled;" conversely, there is no way to say "do not
-        include a particular atom in tmol calculations."
+    Residue variants are selected from the atoms present in ``coords``. A NaN
+    coordinate marks an absent input atom; TMol builds missing leaf atoms, but
+    requires non-leaf atoms unless ``return_block_has_missing_atoms`` is set.
 
-        Currently, all heavy atoms must be provided to tmol except
-        leaf atoms. A "leaf atom" is one that has no atoms that use it
-        as a parent or grand parent when describing their icoors.
-        Hydrogen atoms are all leaf atoms. Backbone carbonyl oxygens
-        are also leaf atoms. Even though hydrogen atoms are optional,
-        the hydroxyl hydrogens on SER, THR, and TYR are recommended
-        as tmol will build them suboptimally: at a dihedral of 180
-        regardless of the presence of nearby hydrogen-bond acceptors
+    Args:
+        canonical_ordering: Residue and atom ordering used by the input tensors.
+        pbt: Packed residue types and score-term annotations for the new pose.
+        chain_id: Chain index for each ``[pose, residue]``; residues in a chain
+            must be consecutive.
+        res_types: Canonical residue-type index for each ``[pose, residue]``;
+            ``-1`` marks padding.
+        coords: Coordinates shaped ``[pose, residue, canonical_atom, xyz]``.
+        res_labels: Optional source residue numbers shaped ``[pose, residue]``.
+        res_ins_codes: Optional source insertion codes shaped ``[pose, residue]``.
+        chain_labels: Optional source chain labels shaped ``[pose, residue]``.
+        atom_occupancy: Optional source occupancies in canonical atom ordering.
+        atom_b_factor: Optional source B-factors in canonical atom ordering.
+        disulfides: Explicit ``[pose, cys1, cys2]`` rows. If omitted, nearby
+            cysteine SG atoms are paired geometrically.
+        res_not_connected: Flags shaped ``[pose, residue, direction]`` for
+            polymer connections absent before or after each residue.
+        find_additional_disulfides: Detect geometrically plausible disulfides
+            not included in ``disulfides``.
+        return_chain_ind: Include the left-justified ``chain_ind`` tensor.
+        return_atom_mapping: Include ``can_atom_mapping`` and
+            ``ps_atom_mapping`` tensors between canonical and pose atom order.
+        return_block_has_missing_atoms: Include a ``[pose, residue]`` mask for
+            blocks missing non-leaf input atoms instead of rejecting them.
 
-    disulfides: an optional n-total-disulfides x 3 tensor. If this argument
-        is not provided, then the coordinates of SG atoms on CYS residues
-        will be used to determine which pairs are closest to each other and
-        within a cutoff distance of 2.5A and declare those SGs as forming
-        disulfide bonds. This means that SGs slightly longer than 2.5A
-        will not be detected. If you should know which pairs of cysteines
-        form disulfide bonds, then you can provide their pairing:
-        [ [pose_ind, cys1_ind, cys2_ind], ...].
-
-    find_additional_disulfides: an optional boolean argument to control whether
-        to look for disulfide bonds between pairs of CYS residues that are
-        not listed in the "disulfides" argument. By default, this is True,
-        but if you want to skip disulfide detection or want to prevent
-        unpaired CYS from being locked into disulfides, then set this flag
-        to False
-
-    res_not_connected: an optional input used to indicate that a given (polymeric)
-        residue is not connected to either its previous or next residue; for
-        termini residues, they will not be built with their termini-variant
-        types. The purpose is to allow the user to include a subset of the
-        residues in a protein where a series of "gap" residues can be omitted
-        between i and i+1 without those two residues being treated as if they
-        are chemically bonded. This will keep the Ramachandran term from scoring
-        nonsense dihdral angles and will keep the cart-bonded term from scoring
-        nonsense bond lengths and angles.
-
-
-    Optional return values:
-        If any of the following flags are provided, this function will return a tuple
-        instead of just a pose stack, with the first argument being the pose stack and
-        the second argument being a dictionary with keys corresponding to the requested
-        values.
-
-        return_chain_ind: return the chain-index tensor as "chain_ind" that has been
-            "left-justified" from the chain
-
-        return_atom_mapping: return the mapping for atoms in the canonical-form tensor
-            to their PoseStack index; this could be used to update the coordinates
-            in a PoseStack without rebuilding it (as long as the chemical identity
-            is meant to be unchanged) or to perhaps remap derivatives to or from
-            pose stack ordering. If requested, the atom mapping will returned as two tensors
-            under the keys "ps_atom_mapping" and "can_atom_mapping" by this function:
-                ps, opt_vals = pose_stack_from_canonical_form(
-                    ...,
-                    return_atom_mapping=True
-                )
-                t1 = opt_vals["can_atom_mapping"]
-                t2 = opt_vals["ps_atom_mapping"]
-                can_ord_coords[
-                    t1[:, 0], t1[:, 1], t1[:, 2]
-                ] = ps.coords[
-                    t2[:, 0], t2[:, 1]
-                ]
-            where can_atom_mapping is a tensor nats x 3 where
-            - position [i, 0] is the pose index
-            - position [i, 1] is the residue index, and
-            - position [i, 2] is the canonical-ordering atom index
-            and ps_atom_mapping is a tensor nats x 2 where
-            - position [i, 0] is the pose index, and
-            - position [i, 1] is the pose-ordered atom index
-
-        return_block_has_missing_atoms: returns a [n_pose x max_n_res] bool
-            tensor in the dictionary under the key "block_has_missing_atoms" with
-            elements being true iff any non-leaf atoms were missing (NaN). To be used
-            with a packer to build these missing atoms. If this argument is False, an
-            exception will be thrown when these missing atoms are encountered.
+    Returns:
+        The pose stack. If any return flag is set, returns ``(pose_stack,
+        metadata)`` with the requested tensors in ``metadata``.
     """
 
     from tmol.io.details import left_justify_canonical_form

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -970,7 +970,6 @@ def biotite_from_canonical_form(  # noqa: C901
 
     if co is None:
         co = canonical_ordering_for_biotite()
-    # rts = _restype_set_for_biotite()
 
     n_poses = cf.coords.size(0)
     n_residues = cf.coords.size(1)

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -780,6 +780,8 @@ def canonical_form_from_biotite(
             where the resulting tensors should be allocated.
         co: A CanonicalForm in case you want to use a non-default database (and thus may need
             a different mapping)
+        missing_density_distance_threshold: Maximum distance in angstroms for
+            treating a polymer gap as missing density rather than a chain break.
 
     Returns:
         CanonicalForm: A data structure containing:

--- a/tmol/io/_write_pose_stack_pdb.py
+++ b/tmol/io/_write_pose_stack_pdb.py
@@ -206,7 +206,6 @@ def atom_records_from_coords(
     pose_atom_offsets = exclusive_cumsum1d(n_pose_atoms)
 
     # ok, let's move everything to the cpu/numpy from here forward
-    # chain_begin = chain_begin.cpu().numpy()
     block_types64 = block_types64.cpu().numpy()
     pose_like_coords = pose_like_coords.cpu().detach().numpy()
     block_coord_offset = block_coord_offset.cpu().numpy()

--- a/tmol/io/details/__init__.py
+++ b/tmol/io/details/__init__.py
@@ -1,3 +1,5 @@
+"""Internal canonical-form and pose-construction operations."""
+
 from ._build_missing_leaf_atoms import (  # noqa: F401
     build_missing_leaf_atoms,
     BlockTypeLeafAtomsAnnotation,

--- a/tmol/io/details/_build_missing_leaf_atoms.py
+++ b/tmol/io/details/_build_missing_leaf_atoms.py
@@ -366,10 +366,9 @@ def _annotate_packed_block_types_w_leaf_atom_icoors(pbt: PackedBlockTypes):
 def _uaid_for_at(bt, icoor_at_name):
     if icoor_at_name == "up":
         return (-1, bt.up_connection_ind, 0)
-    elif icoor_at_name == "down":
+    if icoor_at_name == "down":
         return (-1, bt.down_connection_ind, 0)
-    else:
-        return (bt.atom_to_idx[icoor_at_name], -1, -1)
+    return (bt.atom_to_idx[icoor_at_name], -1, -1)
 
 
 def _icoor_at_is_leaf(bt, icoor_at_name):

--- a/tmol/io/details/_build_missing_leaf_atoms.py
+++ b/tmol/io/details/_build_missing_leaf_atoms.py
@@ -503,7 +503,6 @@ def _determine_leaf_atom_icoors_for_block_type(bt, atom_is_hydrogen):  # noqa: C
         anc_uaids_backup=icoor_uaids_backup,
     )
     setattr(bt, "leaf_atom_icoor_ann", ann)
-    # return bt_icoor_geom, bt_icoor_uaids, bt_icoor_geom_backup, bt_icoor_uaids_backup
 
 
 # Max heavy neighbors a parent can have while still carrying a single H

--- a/tmol/io/details/_disulfide_search.py
+++ b/tmol/io/details/_disulfide_search.py
@@ -150,5 +150,4 @@ def find_disulf_numba(
             restype_variants[i_pose, i_res] = 1
             restype_variants[i_pose, closest_match_res] = 1
             n_found_dslf += 1
-    found_dslf = found_dslf[:n_found_dslf]
-    return found_dslf
+    return found_dslf[:n_found_dslf]

--- a/tmol/io/details/_disulfide_search.py
+++ b/tmol/io/details/_disulfide_search.py
@@ -109,8 +109,6 @@ def find_disulf_numba(
     #    mark the two as now paired
 
     n_cys = cys_pose_ind.shape[0]
-    # oops -- doesn't work in nopython mode
-    # already_paired = restype_variants[cys_pose_ind, cys_res_ind] == 1
     already_paired = numpy.zeros(n_cys, dtype=numpy.int32)
     for i in range(n_cys):
         already_paired[i] = restype_variants[cys_pose_ind[i], cys_res_ind[i]]

--- a/tmol/io/details/_select_from_canonical.py
+++ b/tmol/io/details/_select_from_canonical.py
@@ -652,10 +652,10 @@ def select_best_block_type_candidate(  # noqa: C901
 
             if real_candidate_should_be_excluded[cand_ind]:
                 equiv_class = cand_bt.io_equiv_class
-                for l in range(
+                for atom_ind in range(
                     len(canonical_ordering.restypes_ordered_atom_names[equiv_class])
                 ):
-                    if real_candidate_provided_atoms_absent[cand_ind, l]:
+                    if real_candidate_provided_atoms_absent[cand_ind, atom_ind]:
                         err_msg.extend(
                             [
                                 str(x)
@@ -663,7 +663,7 @@ def select_best_block_type_candidate(  # noqa: C901
                                     " atom",
                                     canonical_ordering.restypes_ordered_atom_names[
                                         equiv_class
-                                    ][l],
+                                    ][atom_ind],
                                     "provided but absent from candidate",
                                     cand_bt.name + "\n",
                                 )
@@ -672,10 +672,12 @@ def select_best_block_type_candidate(  # noqa: C901
 
             if real_candidate_canonical_atom_was_not_provided[cand_ind].any():
                 equiv_class = cand_bt.io_equiv_class
-                for l in range(
+                for atom_ind in range(
                     len(canonical_ordering.restypes_ordered_atom_names[equiv_class])
                 ):
-                    if real_candidate_canonical_atom_was_not_provided[cand_ind, l]:
+                    if real_candidate_canonical_atom_was_not_provided[
+                        cand_ind, atom_ind
+                    ]:
                         err_msg.extend(
                             [
                                 str(x)
@@ -683,7 +685,7 @@ def select_best_block_type_candidate(  # noqa: C901
                                     " atom",
                                     canonical_ordering.restypes_ordered_atom_names[
                                         equiv_class
-                                    ][l],
+                                    ][atom_ind],
                                     "missing but present in candidate",
                                     cand_bt.name + "\n",
                                 )
@@ -700,8 +702,7 @@ def select_best_block_type_candidate(  # noqa: C901
         failure_threshold = 2 * warning_threshold
         if torch.any(best_candidate_score >= failure_threshold):
             raise RuntimeError(err_msg + "Best candidate exceeds failure threshold")
-        else:
-            logger.warning(err_msg)
+        logger.warning(err_msg)
 
     block_type_ind64_2 = torch.full_like(res_types64, -1)
     block_type_ind64_2[is_real_res] = block_type_candidates[
@@ -956,11 +957,11 @@ def _collect_var_combo_candidates(
                 var_combo_n_candidates[i, j, k] = len(
                     pbt_io_equiv_class_candidates[bt_name3][j][k]
                 )
-                for l, (bt, bt_ind) in enumerate(
+                for candidate_ind, (bt, bt_ind) in enumerate(
                     pbt_io_equiv_class_candidates[bt_name3][j][k]
                 ):
-                    var_combo_candidate_bt_index[i, j, k, l] = bt_ind
-                    var_combo_is_real_candidate[i, j, k, l] = True
+                    var_combo_candidate_bt_index[i, j, k, candidate_ind] = bt_ind
+                    var_combo_is_real_candidate[i, j, k, candidate_ind] = True
     return (
         var_combo_candidate_bt_index,
         var_combo_is_real_candidate,

--- a/tmol/io/details/compiled/__init__.py
+++ b/tmol/io/details/compiled/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled kernels used by pose construction."""
+
 from ._compiled import gen_pose_leaf_atoms, resolve_his_taut  # noqa: F401

--- a/tmol/kinematics/__init__.py
+++ b/tmol/kinematics/__init__.py
@@ -1,3 +1,5 @@
+"""Kinematic trees, fold forests, move maps, and coordinate transforms."""
+
 from ._fold_forest import EdgeType, FoldForest, _build_pose_fold_forest  # noqa: F401
 from ._datatypes import (  # noqa: F401
     BTGenerationalSegScanPathSegs,

--- a/tmol/kinematics/_check_fold_forest.py
+++ b/tmol/kinematics/_check_fold_forest.py
@@ -273,7 +273,6 @@ def _append_bad_jumps_errors(
                 is_repeat_index = False
                 first_edge_w_index = -1
                 for k in range(bad_jump_numbers[i, j]):
-                    # print(f"e: {e[0]}, {e[1]}, {e[2]}, {e[3]} and k: {k} edge {edges[i, k, 0]}, {edges[i, k, 3]}")
                     if edges[i, k, 0] == EdgeType.jump and edges[i, k, 3] == e[3]:
                         is_repeat_index = True
                         first_edge_w_index = k
@@ -325,9 +324,6 @@ def validate_fold_forest(
     n_blocks: NDArray[numpy.int64][:],
     edges: NDArray[numpy.int64][:, :, 4],
 ):
-    # print("validate fold forest")
-    # print(n_blocks.shape)
-    # print(edges.shape)
     (
         good,
         bad_edges,

--- a/tmol/kinematics/_datatypes.py
+++ b/tmol/kinematics/_datatypes.py
@@ -78,10 +78,6 @@ class KinForest(TensorGroup, ConvertAttrs):
 
     Indices::
         id = the TO index in KFO; i.e. kin_forest_order_2_target_order
-        # roots = KFO index for the roots of the trees in the forest;
-        #      coordinate updates for these atoms and the path they root will
-        #      proceed in parallel in the first pass of the generational
-        #      -segmented scan. These are listed in no particular order.
         parent = KFO index of the parent, in KFO
         frame_x = KFO index of self, in KFO
         frame_y = KFO index of parent, in KFO
@@ -89,7 +85,6 @@ class KinForest(TensorGroup, ConvertAttrs):
     """
 
     id: Tensor[torch.int32][...]
-    # roots: Tensor[torch.int32][...]
     doftype: Tensor[torch.int32][...]
     parent: Tensor[torch.int32][...]
     frame_x: Tensor[torch.int32][...]
@@ -110,7 +105,6 @@ class KinForest(TensorGroup, ConvertAttrs):
         """Construct a single node from element values."""
         return cls(
             id=torch.Tensor([id]),
-            # roots=torch.Tensor([]),
             doftype=torch.Tensor([doftype]),
             parent=torch.Tensor([parent]),
             frame_x=torch.Tensor([frame_x]),

--- a/tmol/kinematics/_move_map.py
+++ b/tmol/kinematics/_move_map.py
@@ -1,7 +1,6 @@
-import torch
 import attrs
+import torch
 
-from typing import Optional, Union
 from tmol.types import Tensor
 
 from tmol.pose import PoseStack
@@ -10,6 +9,8 @@ from tmol.kinematics import (
     n_movable_bond_dof_types,
     n_movable_jump_dof_types,
 )
+
+TensorSelection = torch.Tensor | int
 
 
 @attrs.define
@@ -34,11 +35,12 @@ class CartesianMoveMap:
             :class:`~tmol.optimization._sfxn_modules.CartesianSfxnNetwork`).
     """
 
-    coord_mask: Optional[torch.Tensor] = None
+    coord_mask: torch.Tensor | None = None
 
 
 @attrs.define(slots=True, auto_attribs=True)
 class MoveMap:
+    """Hierarchical internal-coordinate degrees of freedom for a pose stack."""
 
     move_all_jumps: bool
     move_all_root_jumps: bool
@@ -80,8 +82,8 @@ class MoveMap:
     move_atom_dof_mask: Tensor[torch.bool][:, :, :, :]
 
     @classmethod
-    def from_pose_stack(cls, ps: PoseStack):
-        """Main construction utility for MoveMap."""
+    def from_pose_stack(cls, ps: PoseStack) -> "MoveMap":
+        """Construct a move map sized for ``ps`` with all movement disabled."""
         return cls(
             ps.n_poses,
             ps.max_n_blocks,
@@ -92,10 +94,10 @@ class MoveMap:
 
     def set_move_all_jump_dofs_for_jump(
         self,
-        pose_selection: Union[Tensor, int],
-        jump_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        jump_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable all jump dofs for a particular set of jumps on particular poses.
 
         If jump_selection is None, then the two dimensional settings tensor will be indexed by
@@ -106,10 +108,10 @@ class MoveMap:
 
     def set_move_all_jump_dofs_for_root_jump(
         self,
-        pose_selection: Union[Tensor, int],
-        root_jump_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        root_jump_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable all jump dofs for a particular set of root-jumps on particular poses.
 
         If root_jump_selection is None, then the two dimensional settings tensor will be indexed by
@@ -122,10 +124,10 @@ class MoveMap:
 
     def set_move_all_mc_tors_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable all DOFs for a partiular set of blocks on particular poses.
 
         If block_selection is None, then the two dimensional settings tensor will be indexed by
@@ -143,19 +145,19 @@ class MoveMap:
 
     def set_move_all_sc_tors_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         self._assert_valid_pose_block_selection(pose_selection, block_selection)
         self._set_val_and_mask_for_2dim(pose_selection, block_selection, "scs", value)
 
     def set_move_all_named_torsions_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         self._assert_valid_pose_block_selection(pose_selection, block_selection)
         self._set_val_and_mask_for_2dim(
             pose_selection, block_selection, "named_torsions", value
@@ -163,11 +165,11 @@ class MoveMap:
 
     def set_move_mc_tor_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
-        tor_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
+        tor_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable partiular main-chain torsions for a particular set of blocks on particular poses.
 
         Valid combinations of block_selection and tor_selection are:
@@ -184,11 +186,11 @@ class MoveMap:
 
     def set_move_sc_tor_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
-        dof_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
+        dof_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable partiular side-chain torsions for a particular set of blocks on particular poses."""
         self._assert_valid_pose_block_dof_selection(
             pose_selection, block_selection, dof_selection, self.max_n_named_torsions
@@ -199,11 +201,11 @@ class MoveMap:
 
     def set_move_named_torsion_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
-        tor_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
+        tor_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable partiular named-torsions for a particular set of blocks on particular poses."""
         self._assert_valid_pose_block_dof_selection(
             pose_selection, block_selection, tor_selection, self.max_n_named_torsions
@@ -214,11 +216,11 @@ class MoveMap:
 
     def set_move_jump_dof_for_jumps(
         self,
-        pose_selection: Union[Tensor, int],
-        jump_selection: Optional[Union[Tensor, int]] = None,
-        dof_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        jump_selection: TensorSelection | None = None,
+        dof_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable all jump dofs for a particular set of jumps on particular poses.
 
         If jump_selection is None, then the two dimensional settings tensor will be indexed by
@@ -234,11 +236,11 @@ class MoveMap:
 
     def set_move_jump_dof_for_root_jumps(
         self,
-        pose_selection: Union[Tensor, int],
-        root_jump_selection: Optional[Union[Tensor, int]] = None,
-        dof_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        root_jump_selection: TensorSelection | None = None,
+        dof_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable all jump dofs for a particular set of root-jumps on particular poses.
 
         If root_jump_selection is None, then the two dimensional settings tensor will be indexed by
@@ -254,12 +256,12 @@ class MoveMap:
 
     def set_move_atom_dof_for_blocks(
         self,
-        pose_selection: Union[Tensor, int],
-        block_selection: Optional[Union[Tensor, int]] = None,
-        atom_selection: Optional[Union[Tensor, int]] = None,
-        dof_selection: Optional[Union[Tensor, int]] = None,
+        pose_selection: TensorSelection,
+        block_selection: TensorSelection | None = None,
+        atom_selection: TensorSelection | None = None,
+        dof_selection: TensorSelection | None = None,
         value: bool = True,
-    ):
+    ) -> None:
         """Enable or disable partiular atom dofs for a particular set of blocks on particular poses.
 
         Either only "pose_selection" should be not None or all four "selection" variables should be
@@ -285,23 +287,23 @@ class MoveMap:
             ] = True
 
     @property
-    def n_poses(self):
+    def n_poses(self) -> int:
         return self.move_jumps.shape[0]
 
     @property
-    def max_n_jumps(self):
+    def max_n_jumps(self) -> int:
         return self.move_jumps.shape[1]
 
     @property
-    def max_n_blocks(self):
+    def max_n_blocks(self) -> int:
         return self.move_mcs.shape[1]
 
     @property
-    def max_n_named_torsions(self):
+    def max_n_named_torsions(self) -> int:
         return self.move_named_torsion.shape[2]
 
     @property
-    def max_n_atoms_per_block(self):
+    def max_n_atoms_per_block(self) -> int:
         return self.move_atom_dof.shape[2]
 
     def __init__(
@@ -310,8 +312,8 @@ class MoveMap:
         max_n_blocks: int,
         max_n_named_torsions: int,
         max_n_atoms_per_block: int,
-        device: Optional[torch.device] = None,
-    ):
+        device: torch.device | None = None,
+    ) -> None:
         if device is None:
             device = torch.device("cpu")
 
@@ -322,10 +324,10 @@ class MoveMap:
         self.move_all_named_torsions = False
         self.non_ideal = False
 
-        def z_bool(shape):
+        def z_bool(shape: tuple[int, ...]) -> torch.Tensor:
             return torch.zeros(shape, dtype=torch.bool, device=device)
 
-        def z_bool_pb(remaining_shape=tuple()):
+        def z_bool_pb(remaining_shape: tuple[int, ...] = ()) -> torch.Tensor:
             return z_bool((n_poses, max_n_blocks) + remaining_shape)
 
         # data members on a per-residue basis; plural, representing
@@ -436,12 +438,16 @@ class MoveMap:
 
 
 class MinimizerMap:
+    """Resolved per-DOF movement mask for a pose's kinematic forest."""
+
+    dof_mask: Tensor[torch.bool][:, :, :]
+
     def __init__(
         self,
         pose_stack: PoseStack,
         kmd: KinematicModuleData,
         mm: MoveMap,
-    ):
+    ) -> None:
         from tmol.kinematics.compiled import minimizer_map_from_movemap
 
         pbt = pose_stack.packed_block_types

--- a/tmol/kinematics/_script_modules.py
+++ b/tmol/kinematics/_script_modules.py
@@ -48,12 +48,10 @@ class PoseStackKinematicsModule(torch.nn.Module):
         n_blocks = torch.sum(ps.block_type_ind != -1, dim=1).cpu().numpy()
         validate_fold_forest(n_blocks, ff.edges)
 
-        # pbt_gssps = pbt.gen_seg_scan_path_segs
         ff_edges_cpu = torch.from_numpy(ff.edges).to(torch.int32)
         kmd = construct_kin_module_data_for_pose(ps, ff_edges_cpu)
 
         def _p(t):
-            # return torch.nn.Parameter(t, requires_grad=False)
             # NOTE: I don't think ANY of these should be treated as parameters
             return t
 

--- a/tmol/kinematics/compiled/__init__.py
+++ b/tmol/kinematics/compiled/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled kinematics operations."""
+
 from ._compiled_ops import (  # noqa: F401
     forward_kin_op,
     forward_only_op,

--- a/tmol/ligand/__init__.py
+++ b/tmol/ligand/__init__.py
@@ -1,3 +1,5 @@
+"""Ligand typing, preparation, fragmentation, and serialization."""
+
 from ._atom_typing import (  # noqa: F401
     AtomTypeAssignment,
     ELEMENT_SYMBOLS,

--- a/tmol/ligand/_atom_typing.py
+++ b/tmol/ligand/_atom_typing.py
@@ -285,14 +285,14 @@ def _assign_missing_hybridization(  # noqa: C901
     """Port Rosetta assign_hybridization_if_missing for hyb==0 cases."""
     conf = mol.GetConformer() if mol.GetNumConformers() > 0 else None
 
-    def _dihedral_deg(i: int, j: int, k: int, l: int) -> float:
+    def _dihedral_deg(i: int, j: int, k: int, m: int) -> float:
         """Compute dihedral angle for four atom indices.
 
         Args:
             i: First atom index.
             j: Second atom index.
             k: Third atom index.
-            l: Fourth atom index.
+            m: Fourth atom index.
 
         Returns:
             Signed dihedral angle in degrees.
@@ -302,7 +302,7 @@ def _assign_missing_hybridization(  # noqa: C901
         p1 = conf.GetAtomPosition(i)
         p2 = conf.GetAtomPosition(j)
         p3 = conf.GetAtomPosition(k)
-        p4 = conf.GetAtomPosition(l)
+        p4 = conf.GetAtomPosition(m)
 
         b0 = (float(p1.x - p2.x), float(p1.y - p2.y), float(p1.z - p2.z))
         b1 = (float(p3.x - p2.x), float(p3.y - p2.y), float(p3.z - p2.z))
@@ -660,14 +660,13 @@ def _classify_H(
         z = nbr.GetAtomicNum()
         if z == 6:
             return "HR" if _get_hyb(nbr, state) == 9 else "HC"
-        elif z == 8:
+        if z == 8:
             return "HO"
-        elif z == 7:
+        if z == 7:
             return "HN"
-        elif z == 16:
+        if z == 16:
             return "HS"
-        else:
-            return "HG"
+        return "HG"
     return "HG"
 
 
@@ -761,7 +760,7 @@ def _classify_N_hetero(  # noqa: C901
     if hyb == 3:
         if ntot <= 3 and nH >= 1:
             return "Nam2"
-        elif nH >= 1:
+        if nH >= 1:
             return "Nam"
         return "NG3"
 
@@ -1100,12 +1099,11 @@ def _classify_S(
     nC, nH, _, _, nS, ntot = _neighbor_counts(atom, state)
     if nC == 1 and nH == 1 and ntot == 2:
         return "Sth"
-    elif nC + nS == 2 and ntot == 2:
+    if nC + nS == 2 and ntot == 2:
         return "SR" if atom.GetIdx() in state.atms_aro else "Ssl"
-    elif ntot == 1:
+    if ntot == 1:
         return "SG2"
-    else:
-        return "SG5" if _get_hyb(atom, state) == 5 else "SG3"
+    return "SG5" if _get_hyb(atom, state) == 5 else "SG3"
 
 
 def _classify_P(

--- a/tmol/ligand/_conformer_generation.py
+++ b/tmol/ligand/_conformer_generation.py
@@ -86,8 +86,9 @@ def generate_conformer(
     by a very short MMFF minimization.
 
     Args:
+        smiles: Ligand SMILES to embed and minimize.
         minimize_steps: OpenBabel conjugate-gradient steps for the final min.
-        seed: Ooptional fixed RNG seed for reproducible coordinates.
+        seed: Optional fixed RNG seed for reproducible coordinates.
 
     Raises:
         ValueError: Failures in parsing or final min.
@@ -356,25 +357,25 @@ def _planar_component_distances(atoms, r0, ang, max_iters: int = 150):
     w, V = np.linalg.eigh(-0.5 * (Jc @ (Dm**2) @ Jc))
     o = np.argsort(w)[::-1]
     Y0 = V[:, o[:2]] * np.sqrt(np.clip(w[o[:2]], 0.0, None))
-    I = torch.tensor([p[0] for p in tp])
-    J = torch.tensor([p[1] for p in tp])
-    T = torch.tensor([p[2] for p in tp], dtype=torch.double)
+    pair_i = torch.tensor([p[0] for p in tp])
+    pair_j = torch.tensor([p[1] for p in tp])
+    target_distance = torch.tensor([p[2] for p in tp], dtype=torch.double)
     Y = torch.tensor(np.ascontiguousarray(Y0), dtype=torch.double, requires_grad=True)
     opt = torch.optim.LBFGS([Y], max_iter=max_iters, line_search_fn="strong_wolfe")
 
     def closure():
         opt.zero_grad()
-        d = ((Y[I] - Y[J]) ** 2).sum(1).clamp_min(1e-12).sqrt()
-        loss = ((d - T) ** 2).sum()
+        d = ((Y[pair_i] - Y[pair_j]) ** 2).sum(1).clamp_min(1e-12).sqrt()
+        loss = ((d - target_distance) ** 2).sum()
         loss.backward()
         return loss
 
     opt.step(closure)
     Yc = Y.detach().numpy()
     return {
-        (atoms[k], atoms[l]): float(np.linalg.norm(Yc[k] - Yc[l]))
+        (atoms[k], atoms[atom_j]): float(np.linalg.norm(Yc[k] - Yc[atom_j]))
         for k in range(m)
-        for l in range(k + 1, m)
+        for atom_j in range(k + 1, m)
     }
 
 

--- a/tmol/ligand/_openbabel_compat.py
+++ b/tmol/ligand/_openbabel_compat.py
@@ -137,8 +137,7 @@ def _obmol_to_rdkit_mol(obmol, *, sanitize: bool = False) -> Optional[Chem.Mol]:
     if not sdf:
         return None
 
-    mol = Chem.MolFromMolBlock(sdf, sanitize=sanitize, removeHs=False)
-    return mol
+    return Chem.MolFromMolBlock(sdf, sanitize=sanitize, removeHs=False)
 
 
 def obabel_read_mol2(path: str | Path) -> Optional[Chem.Mol]:

--- a/tmol/ligand/_params_file.py
+++ b/tmol/ligand/_params_file.py
@@ -149,25 +149,24 @@ def load_params_file(path: str | Path) -> list["LigandPreparation"]:
             f"Current format version is {TMOL_FORMAT_VERSION}. "
             f"Regenerate the file with the current version."
         )
-    else:
-        file_version = str(file_version)
-        # Compare major version numbers only (the part before the first dot).
-        file_major = file_version.split(".")[0]
-        current_major = TMOL_FORMAT_VERSION.split(".")[0]
-        if file_major != current_major:
-            raise ValueError(
-                f"{path}: .tmol format version {file_version} is incompatible "
-                f"with the current format version {TMOL_FORMAT_VERSION}. "
-                f"Regenerate the file with the current writer."
-            )
-        if file_version != TMOL_FORMAT_VERSION:
-            logger.info(
-                "%s: .tmol format version %s differs from current %s "
-                "(backward-compatible minor version change)",
-                path,
-                file_version,
-                TMOL_FORMAT_VERSION,
-            )
+    file_version = str(file_version)
+    # Compare major version numbers only (the part before the first dot).
+    file_major = file_version.split(".")[0]
+    current_major = TMOL_FORMAT_VERSION.split(".")[0]
+    if file_major != current_major:
+        raise ValueError(
+            f"{path}: .tmol format version {file_version} is incompatible "
+            f"with the current format version {TMOL_FORMAT_VERSION}. "
+            f"Regenerate the file with the current writer."
+        )
+    if file_version != TMOL_FORMAT_VERSION:
+        logger.info(
+            "%s: .tmol format version %s differs from current %s "
+            "(backward-compatible minor version change)",
+            path,
+            file_version,
+            TMOL_FORMAT_VERSION,
+        )
 
     if "chemical" not in raw and (
         "residues" in raw or "residue_params" in raw or "atom_charge_parameters" in raw

--- a/tmol/ligand/_preparation.py
+++ b/tmol/ligand/_preparation.py
@@ -758,9 +758,18 @@ def prepare_ligand_from_smiles(
     requires the optional ``openbabel`` package.
 
     Args:
+        smiles: Ligand SMILES to protonate and prepare.
+        param_db: Base parameter database; defaults to the TMol database.
+        ph: Target pH used when ``protonate`` is true.
+        strict_atom_types: Fail instead of falling back for unknown atom types.
+        res_name: Optional residue-name override.
         protonate: When ``True`` (default) Dimorphite protonates ``smiles``
             first; set ``False`` to pin an already-protonated SMILES verbatim.
+        sample_proton_chi: Emit chi samples for rotatable polar hydrogens.
         seed: Fixed RNG seed for reproducible 3D coordinates; ``None`` is random.
+
+    Returns:
+        A ``(ParameterDatabase, CanonicalOrdering)`` with the ligand injected.
     """
     lig = nonstandard_residue_info_from_smiles_via_mol2(
         smiles,

--- a/tmol/numeric/__init__.py
+++ b/tmol/numeric/__init__.py
@@ -1,3 +1,5 @@
+"""Numerical interpolation and geometry utilities."""
+
 from ._bspline import BSplineInterpolation  # noqa: F401
 from ._dihedrals import Angles, Coord64Array, coord_dihedrals  # noqa: F401
 

--- a/tmol/numeric/bspline_compiled/__init__.py
+++ b/tmol/numeric/bspline_compiled/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled B-spline interpolation operations."""
+
 from ._compiled import (  # noqa: F401
     computeCoeffs2,
     computeCoeffs3,

--- a/tmol/numeric/interpolation/__init__.py
+++ b/tmol/numeric/interpolation/__init__.py
@@ -1,3 +1,5 @@
+"""Polynomial interpolation primitives."""
+
 from ._cubic_hermite_polynomial import (  # noqa: F401
     interpolate,
     interpolate_dt,

--- a/tmol/ops/__init__.py
+++ b/tmol/ops/__init__.py
@@ -1,3 +1,5 @@
+"""High-level batched scoring operations."""
+
 from ._score_utils import (  # noqa: F401
     build_coord_mask_for_mask_and_interacting_atoms,
     build_coord_mask_for_mask_and_nearby_blocks,

--- a/tmol/optimization/__init__.py
+++ b/tmol/optimization/__init__.py
@@ -1,3 +1,5 @@
+"""Minimizers and scoring-function optimization adapters."""
+
 from ._lbfgs_armijo import (  # noqa: F401
     LBFGS_Armijo,
     armijo_linesearch_segmented,

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import time
+from typing import TYPE_CHECKING
+
 import torch
+
 from tmol.pose import PoseStack
+from tmol.types import Tensor
 
 from tmol.kinematics import (
     FoldForest,
@@ -11,15 +17,31 @@ from tmol.score import ScoreFunction
 
 from tmol.optimization import LBFGS_Armijo
 
+if TYPE_CHECKING:
+    from tmol.optimization import CartesianSfxnNetwork, KinForestSfxnNetwork
+
 
 def build_kinforest_network(
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
     ff: FoldForest,
     mm: MoveMap,
-    verbose=False,
-    kin_dtype=torch.float32,
-):
+    verbose: bool = False,
+    kin_dtype: torch.dtype = torch.float32,
+) -> KinForestSfxnNetwork:
+    """Build a differentiable kinematic scoring network for a pose stack.
+
+    Args:
+        pose_stack: Structures and topology to score.
+        sfxn: Score function to render against ``pose_stack``.
+        ff: Fold forest defining the kinematic tree.
+        mm: Internal-coordinate degrees of freedom allowed to move.
+        verbose: Print synchronized setup timings.
+        kin_dtype: Floating-point dtype for kinematic degrees of freedom.
+
+    Returns:
+        A network mapping movable kinematic degrees of freedom to pose energies.
+    """
     from tmol.kinematics import PoseStackKinematicsModule
     from tmol.optimization import KinForestSfxnNetwork
 
@@ -55,12 +77,12 @@ def build_kinforest_network(
 
 
 def run_min(
-    sfxn_module,
-    optimizer_cls=LBFGS_Armijo,
-    optimizer_kwargs=None,
-    verbose=False,
-    per_pose=True,
-):
+    sfxn_module: CartesianSfxnNetwork | KinForestSfxnNetwork,
+    optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
+    optimizer_kwargs: dict[str, object] | None = None,
+    verbose: bool = False,
+    per_pose: bool = True,
+) -> PoseStack:
     """Run minimization on any sfxn module (Cartesian or KinForest).
 
     The sfxn_module must be a torch.nn.Module whose forward() returns
@@ -101,7 +123,7 @@ def run_min(
 
     optimizer = optimizer_cls(sfxn_module.parameters(), **optimizer_kwargs)
 
-    def closure():
+    def closure() -> torch.Tensor:
         optimizer.zero_grad()
         E = sfxn_module()
         E.sum().backward()
@@ -134,14 +156,27 @@ def run_kin_min(
     sfxn: ScoreFunction,
     ff: FoldForest,
     mm: MoveMap,
-    optimizer_cls=LBFGS_Armijo,
-    optimizer_kwargs=None,
-    verbose=False,
-    kin_dtype=torch.float32,
-):
+    optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
+    optimizer_kwargs: dict[str, object] | None = None,
+    verbose: bool = False,
+    kin_dtype: torch.dtype = torch.float32,
+) -> PoseStack:
     """Run minimization on a PoseStack in internal DOF space.
 
-    Builds a KinForestSfxnNetwork and delegates to run_min().
+    Builds a ``KinForestSfxnNetwork`` and delegates to :func:`run_min`.
+
+    Args:
+        pose_stack: Structures and coordinates to minimize.
+        sfxn: Score function defining the objective.
+        ff: Fold forest defining the kinematic tree.
+        mm: Internal-coordinate degrees of freedom allowed to move.
+        optimizer_cls: Closure-based PyTorch optimizer class.
+        optimizer_kwargs: Optional optimizer constructor arguments.
+        verbose: Print synchronized setup and minimization timings.
+        kin_dtype: Floating-point dtype for kinematic degrees of freedom.
+
+    Returns:
+        A new pose stack containing the minimized coordinates.
     """
     kf_network = build_kinforest_network(
         pose_stack, sfxn, ff, mm, verbose, kin_dtype=kin_dtype
@@ -157,14 +192,25 @@ def run_kin_min(
 def run_cart_min(
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
-    coord_mask=None,
-    optimizer_cls=LBFGS_Armijo,
-    optimizer_kwargs=None,
-    verbose=False,
-):
+    coord_mask: Tensor[torch.bool][:, :] | None = None,
+    optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
+    optimizer_kwargs: dict[str, object] | None = None,
+    verbose: bool = False,
+) -> PoseStack:
     """Run minimization on a PoseStack in Cartesian coordinate space.
 
-    Builds a CartesianSfxnNetwork and delegates to run_min().
+    Builds a ``CartesianSfxnNetwork`` and delegates to :func:`run_min`.
+
+    Args:
+        pose_stack: Structures and coordinates to minimize.
+        sfxn: Score function defining the objective.
+        coord_mask: Movable atoms shaped ``[pose, atom]``; ``None`` moves all.
+        optimizer_cls: Closure-based PyTorch optimizer class.
+        optimizer_kwargs: Optional optimizer constructor arguments.
+        verbose: Print synchronized setup and minimization timings.
+
+    Returns:
+        A new pose stack containing the minimized coordinates.
     """
     from tmol.optimization import CartesianSfxnNetwork
 

--- a/tmol/pack/__init__.py
+++ b/tmol/pack/__init__.py
@@ -1,3 +1,5 @@
+"""Side-chain packing tasks, energy tables, and annealing."""
+
 from ._datatypes import PackerEnergyTables  # noqa: F401
 from ._packer_task import (  # noqa: F401
     PackerPalette,

--- a/tmol/pack/_impose_rotamers.py
+++ b/tmol/pack/_impose_rotamers.py
@@ -274,7 +274,7 @@ def impose_top_rotamer_assignments(
         new_pdb_info = orig_pose_stack.pdb_info
 
     # now construct the new PoseStack
-    new_pose_stack = PoseStack(
+    return PoseStack(
         packed_block_types=pbt,
         coords=new_coords,
         block_coord_offset=new_n_atoms_offset32,
@@ -292,4 +292,3 @@ def impose_top_rotamer_assignments(
         device=device,
         split_block_mapping=orig_pose_stack.split_block_mapping,
     )
-    return new_pose_stack

--- a/tmol/pack/_impose_rotamers.py
+++ b/tmol/pack/_impose_rotamers.py
@@ -45,8 +45,6 @@ def impose_top_rotamer_assignments(
     max_n_atoms_per_block = orig_pose_stack.max_n_atoms
     max_n_molten_blocks = bc_assignment.shape[2]
     bc_assignment = bc_assignment[:, 0, :]
-    # n_assignments = bc_assignment.shape[1]
-    # print("bc_assignment", bc_assignment.shape, bc_assignment.dtype)
 
     # map from the subset of blocks and bump-checked rotamer
     # to an assignment in the original rotamer-set indexing
@@ -60,10 +58,6 @@ def impose_top_rotamer_assignments(
     is_molten_block = torch.logical_and(
         rotamer_for_nonmolten_block == -1, is_real_block
     )
-    # print("is_molten_block.unsqueeze(1).expand(-1, n_assignments, -1)", is_molten_block.unsqueeze(1).expand(-1, n_assignments, -1).shape)
-    # print("bc_assignment[is_molten_block.unsqueeze(1).expand(-1, n_assignments, -1)]", bc_assignment[is_molten_block.unsqueeze(1).expand(-1, n_assignments, -1)].shape)
-    # print("assignment[is_molten_block, :]", assignment[is_molten_block, :].shape)
-
     molten_block_arange = (
         torch.arange(max_n_molten_blocks, dtype=torch.int64, device=device)
         .unsqueeze(0)
@@ -77,16 +71,10 @@ def impose_top_rotamer_assignments(
 
     assignment[is_molten_block] = bc_rot_to_orig_rot[bc_assignment_global].reshape(-1)
 
-    # print("assignment", assignment.shape)
-    # print("assignment", assignment)
-
     # lets figure out how many atoms per pose
     new_block_type_ind64 = torch.full(
         (n_poses, max_n_blocks), -1, dtype=torch.int64, device=device
     )
-    # new_rot_for_block64 = (
-    #     assignment[:, 0, :].to(torch.int64) + rotamer_set.rot_offset_for_block
-    # )
     new_rot_for_block64 = assignment
 
     is_real_block = orig_pose_stack.block_type_ind64 != -1

--- a/tmol/pack/_packer_task.py
+++ b/tmol/pack/_packer_task.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# import numpy
 import torch
 import attr
 

--- a/tmol/pack/compiled/__init__.py
+++ b/tmol/pack/compiled/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled packing and annealing operations."""
+
 from ._compiled import (  # noqa: F401
     build_interaction_graph,
     pack_anneal,

--- a/tmol/pack/rotamer/__init__.py
+++ b/tmol/pack/rotamer/__init__.py
@@ -1,6 +1,6 @@
 # Import in topological order: dependencies before dependents.
 from ._bfs_sidechain import bfs_sidechain_atoms, bfs_sidechain_atoms_jit  # noqa: F401
-from ._conformer_sampler import ConformerSampler  # noqa: F401
+from ._conformer_sampler import ConformerSample, ConformerSampler  # noqa: F401
 from ._rotamer_set import RotamerSet  # noqa: F401
 from ._single_residue_kinforest import (  # noqa: F401
     PackedRotamerKintree,
@@ -63,6 +63,7 @@ from ._build_rotamers import (  # noqa: F401
 __all__ = [
     "AtomFingerprint",
     "ChiSampler",
+    "ConformerSample",
     "ConformerSampler",
     "FallbackSampler",
     "FixedAAChiSampler",

--- a/tmol/pack/rotamer/__init__.py
+++ b/tmol/pack/rotamer/__init__.py
@@ -1,3 +1,5 @@
+"""Rotamer sampling, construction, and coordinate transfer."""
+
 # Import in topological order: dependencies before dependents.
 from ._bfs_sidechain import bfs_sidechain_atoms, bfs_sidechain_atoms_jit  # noqa: F401
 from ._conformer_sampler import ConformerSample, ConformerSampler  # noqa: F401

--- a/tmol/pack/rotamer/_chi_sampler.py
+++ b/tmol/pack/rotamer/_chi_sampler.py
@@ -1,7 +1,7 @@
 import torch
 import attr
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Any
 
 from tmol.types import (
     Tensor,
@@ -14,40 +14,47 @@ from tmol.pose import (
     PoseStack,
 )
 from tmol.kinematics import KinForest
-from tmol.pack.rotamer import ConformerSampler
+from tmol.pack.rotamer import ConformerSample, ConformerSampler
+
+if TYPE_CHECKING:
+    from tmol.pack import PackerTask
 
 
 @attr.s(auto_attribs=True)
 class ChiSampler(ConformerSampler):
+    """Base class for samplers that define conformers through chi angles."""
+
     @classmethod
-    def sampler_name(cls):
+    def sampler_name(cls) -> str:
+        """Return the stable name used for chi-sampler annotations."""
         raise NotImplementedError()
 
     @validate_args
-    def annotate_residue_type(self, rt: RefinedResidueType):
+    def annotate_residue_type(self, rt: RefinedResidueType) -> None:
+        """Attach optional sampler metadata to one residue type."""
         pass
 
     @validate_args
-    def annotate_packed_block_types(self, packed_block_types: PackedBlockTypes):
+    def annotate_packed_block_types(self, packed_block_types: PackedBlockTypes) -> None:
+        """Attach optional sampler metadata to packed block types."""
         pass
 
     @validate_args
-    def defines_rotamers_for_rt(self, rt: RefinedResidueType):
+    def defines_rotamers_for_rt(self, rt: RefinedResidueType) -> bool:
+        """Return whether this sampler supports a residue type."""
         raise NotImplementedError()
 
     @validate_args
-    def first_sc_atoms_for_rt(self, rt_name: str) -> Tuple[str, ...]:
+    def first_sc_atoms_for_rt(self, rt_name: str) -> tuple[str, ...]:
+        """Return side-chain roots used to transfer main-chain geometry."""
         raise NotImplementedError()
 
     def create_samples_for_poses(
         self,
         pose_stack: PoseStack,
-        task: "PackerTask",  # noqa: 821
-    ) -> Tuple[  # noqa F821
-        Tensor[torch.int32][:],  # n_rots_for_gbt
-        Tensor[torch.int32][:],  # bt_for_rotamer
-        dict,  # anything else the sampler wants to save for later
-    ]:
+        task: "PackerTask",
+    ) -> ConformerSample:
+        """Create chi samples and preserve their defining atoms and angles."""
         (
             n_rots_for_gbt,
             gbt_for_rotamer,
@@ -64,8 +71,8 @@ class ChiSampler(ConformerSampler):
         )
 
     def sample_chi_for_poses(
-        self, systems: PoseStack, task: "PackerTask"  # noqa F821
-    ) -> Tuple[
+        self, systems: PoseStack, task: "PackerTask"
+    ) -> tuple[
         Tensor[torch.int32][:, :, :],  # n_rots_for_rt
         Tensor[torch.int32][:],  # rt_for_rotamer
         Tensor[torch.int32][:, :],  # chi_defining_atom_for_rotamer
@@ -76,7 +83,7 @@ class ChiSampler(ConformerSampler):
     def fill_dofs_for_samples(
         self,
         pose_stack: PoseStack,
-        task: "PackerTask",  # noqa: 821
+        task: "PackerTask",
         orig_kinforest: KinForest,
         orig_dofs_kto: Tensor[torch.float32][:, 9],
         gbt_for_conformer: Tensor[torch.int64][:],
@@ -88,9 +95,9 @@ class ChiSampler(ConformerSampler):
         conf_inds_for_sampler: Tensor[torch.int64][:],
         sampler_n_rots_for_gbt: Tensor[torch.int32][:],
         sampler_gbt_for_rotamer: Tensor[torch.int32][:],
-        sample_dict: dict,
+        sample_dict: dict[str, Any],
         conf_dofs_kto: Tensor[torch.float32][:, 9],
-    ):
+    ) -> None:
         copy_dofs_from_orig_to_rotamers_for_sampler(
             pose_stack,
             task,

--- a/tmol/pack/rotamer/_conformer_sampler.py
+++ b/tmol/pack/rotamer/_conformer_sampler.py
@@ -1,7 +1,7 @@
 import torch
 import attr
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Any
 
 from tmol.types import (
     Tensor,
@@ -14,23 +14,39 @@ from tmol.pose import (
 )
 from tmol.kinematics import KinForest
 
+if TYPE_CHECKING:
+    from tmol.pack import PackerTask
+
+
+ConformerSample = tuple[
+    Tensor[torch.int32][:],
+    Tensor[torch.int32][:],
+    dict[str, Any],
+]
+
 
 @attr.s(auto_attribs=True)
 class ConformerSampler:
+    """Interface for creating and applying packing conformer samples."""
+
     @classmethod
-    def sampler_name(cls):
+    def sampler_name(cls) -> str:
+        """Return the stable name used for sampler-specific annotations."""
         raise NotImplementedError()
 
     @validate_args
-    def annotate_residue_type(self, rt: RefinedResidueType):
+    def annotate_residue_type(self, rt: RefinedResidueType) -> None:
+        """Attach optional sampler metadata to one residue type."""
         pass
 
     @validate_args
-    def annotate_packed_block_types(self, packed_block_types: PackedBlockTypes):
+    def annotate_packed_block_types(self, packed_block_types: PackedBlockTypes) -> None:
+        """Attach optional sampler metadata to packed block types."""
         pass
 
     @validate_args
-    def defines_rotamers_for_rt(self, rt: RefinedResidueType):
+    def defines_rotamers_for_rt(self, rt: RefinedResidueType) -> bool:
+        """Return whether this sampler supports a residue type."""
         raise NotImplementedError()
 
     def defines_rotamers_for_bts(
@@ -39,24 +55,22 @@ class ConformerSampler:
         raise NotImplementedError()
 
     @validate_args
-    def first_sc_atoms_for_rt(self, rt: RefinedResidueType) -> Tuple[str, ...]:
+    def first_sc_atoms_for_rt(self, rt: RefinedResidueType) -> tuple[str, ...]:
+        """Return side-chain roots used to transfer main-chain geometry."""
         raise NotImplementedError()
 
     def create_samples_for_poses(
         self,
         pose_stack: PoseStack,
-        task: "PackerTask",  # noqa: 821
-    ) -> Tuple[  # noqa F821
-        Tensor[torch.int32][:],  # n_rots_for_bt
-        Tensor[torch.int32][:],  # bt_for_rotamer
-        dict,  # anything else the sampler wants to save for later
-    ]:
+        task: "PackerTask",
+    ) -> ConformerSample:
+        """Create per-block sample counts, block indices, and metadata."""
         raise NotImplementedError()
 
     def fill_dofs_for_samples(
         self,
         pose_stack: PoseStack,
-        task: "PackerTask",  # noqa: 821
+        task: "PackerTask",
         orig_kinforest: KinForest,
         orig_dofs_kto: Tensor[torch.float32][:, 9],
         gbt_for_conformer: Tensor[torch.int64][:],
@@ -68,7 +82,8 @@ class ConformerSampler:
         conf_inds_for_sampler: Tensor[torch.int64][:],
         sampler_n_rots_for_gbt: Tensor[torch.int32][:],
         sampler_gbt_for_rotamer: Tensor[torch.int32][:],
-        sample_dict: dict,
+        sample_dict: dict[str, Any],
         conf_dofs_kto: Tensor[torch.float32][:, 9],
-    ):
+    ) -> None:
+        """Write this sampler's conformer degrees of freedom in place."""
         raise NotImplementedError

--- a/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
+++ b/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
@@ -53,7 +53,7 @@ class FixedAAChiSampler(ChiSampler):
     def first_sc_atoms_for_rt(self, rt: RefinedResidueType) -> Tuple[str, ...]:
         if rt.base_name == "GLY":
             return ("HA3",)
-        elif rt.base_name == "ALA":
+        if rt.base_name == "ALA":
             return ("CB",)
 
     def annotate_residue_type(self, block_type):

--- a/tmol/pack/rotamer/_mainchain_fingerprint.py
+++ b/tmol/pack/rotamer/_mainchain_fingerprint.py
@@ -169,8 +169,6 @@ def create_non_sidechain_fingerprint(  # noqa: C901
         n_bonds[rt.bond_indices[i, 0]] += 1
         n_nonh_bonds[rt.connection_to_idx[conn]] += 1
 
-    # mc_ancestors = numpy.full(rt.n_atoms, -1, dtype=numpy.int32)
-    # chiralities = numpy.full(rt.n_atoms, -1, dtype=numpy.int32)
     non_sc_atom_fingerprints = []
     at_for_fingerprint = {}
     fp_seen_count = {}

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -606,12 +606,6 @@ class OptHSampler(ConformerSampler):
         # where we will measure the chi dihedrals for the flip. Then we will
         # count the number of rotamers for each block as well as the number
         # of chi columns.
-        # We will return:
-        # n_rots_for_gbt, max_n_chi_cols, pos_flip_chi
-        # n_rots_for_gbt: tensor[n_gbt]
-        # max_n_chi_cols: int
-        # pos_flip_chi: tensor[n_poses, max_n_blocks]
-
         pbt = pose_stack.packed_block_types
         optH_cache = pbt.opth_sample_cache
 

--- a/tmol/pack/rotamer/_rotamer_set.py
+++ b/tmol/pack/rotamer/_rotamer_set.py
@@ -48,8 +48,7 @@ class RotamerSet(ValidateAttrs):
         pifa = torch.zeros((n_atoms,), dtype=torch.int64, device=self.coords.device)
         # mark the first atom for the first rotamer in each pose after pose 0
         pifa[self.coord_offset_for_rot[self.rot_offset_for_pose[1:]]] = 1
-        pifa = torch.cumsum(pifa, dim=0)
-        return pifa
+        return torch.cumsum(pifa, dim=0)
 
     @property
     def n_rotamers_total(self):

--- a/tmol/pack/rotamer/dunbrack/__init__.py
+++ b/tmol/pack/rotamer/dunbrack/__init__.py
@@ -1,3 +1,5 @@
+"""Dunbrack backbone-dependent rotamer sampling."""
+
 from ._compiled import dun_sample_chi  # noqa: F401
 from ._dunbrack_chi_sampler import (  # noqa: F401
     DunSamplerPBTCache,

--- a/tmol/pose/__init__.py
+++ b/tmol/pose/__init__.py
@@ -1,3 +1,5 @@
+"""Pose stacks, packed residue types, and structural metadata."""
+
 from ._constraint_set import ConstraintSet  # noqa: F401
 from ._split_block_mapping import SplitBlockEntry, SplitBlockMapping  # noqa: F401
 from ._packed_block_types import PackedBlockTypes  # noqa: F401

--- a/tmol/pose/_constraint_set.py
+++ b/tmol/pose/_constraint_set.py
@@ -260,8 +260,7 @@ class ConstraintSet:
         # now shift by 1 and count the differences
         diffs = constraint_blocks[:, 1:] != constraint_blocks[:, :-1]
 
-        temp = diffs.sum(dim=1) + 1
-        return temp
+        return diffs.sum(dim=1) + 1
 
     def add_constraints_to_all_poses(
         self, fn, atom_indices, params=None

--- a/tmol/pose/_pose_stack.py
+++ b/tmol/pose/_pose_stack.py
@@ -1,6 +1,7 @@
+from typing import TYPE_CHECKING
+
 import attr
 import torch
-from typing import Optional, TYPE_CHECKING
 
 from tmol.types import Tensor
 from tmol.chemical import RefinedResidueType
@@ -16,73 +17,30 @@ if TYPE_CHECKING:
 
 @attr.s(auto_attribs=True)
 class PoseStack:
-    """The PoseStack class defines a batch (a stack) of molecular systems
+    """Batch of molecular systems with shared residue-type definitions.
 
-    The PoseStack defines the per-residue chemistry, inter-residue
-    connectivity, and coordinates of a set of molecular systems.
-    The per-residue chemistry and the connectivity are meant to be
-    constant over its lifetime; however, its coordinates are allowed
-    to change. That is, a PoseStack may have its coords tensor written
-    to without any negative consequences. Thus, you can minimize the
-    coordinates in a PoseStack. The main way to change the chemistry or
-    connectivity or even the ConstraintSet of a PoseStack is to use
-    attr.evolve to return a completely new PoseStack but replacing
-    the datamember(s) that you want to change. Such a PoseStack will be
-    a shallow copy of the original PoseStack, so the coordinates tensor
-    must always be cloned / replaced when evolving a PoseStack, or two
-    PoseStacks may point to the same coordinates tensor, and then
-    changes to the coordinates in one PoseStack would affect the other.
+    Chemistry and connectivity are fixed after construction, while ``coords``
+    may be updated in place during minimization. Use :func:`attr.evolve` for
+    structural metadata changes and replace or clone ``coords`` to avoid sharing
+    mutable coordinate storage between pose stacks.
 
-    Datamembers:
-    packed_block_types: a representation of the chemical space that this
-    PoseStack can contain. The PackedBlockTypes object aggregates a set
-    of residue-types objects (RefinedResidueTypes) and holds annotations
-    for this aggregate that must be made by the terms in the ScoreFunction
-    in order for them to efficiently perform their calculations.
-
-    coords: a tensor of [n_poses x max_n_atoms_per_pose x 3] holding the
-    cartesian coordinates of the atoms in the system. The coordinates
-    of the atoms are held in a contiguous array so that mixing very
-    large residue types (e.g. heme) and very small residue types
-    (e.g. water) does not waste memory / GPU cache.
-
-    block_coord_offset: a tensor of [n_poses x max_n_residues] holding
-    the starting indices in the coords tensor for the residues; offsets
-    for custom kernels are 32-bit integers, offset for torch functions
-    are 64-bit integers. We keep around both for performance reasons.
-
-    inter_residue_connections: a tensor of
-    [n_poses x max_n_residues x max_n_conn x 2] representing for each
-    inter-residue connection point on each residue the 1) index of
-    the residue it is connected to (sentinel of -1 for "no connection
-    defined) and the connection-point index it is connected to
-    (sentinel of -1, also).
-
-    inter_block_bondsep: a integer tensor of shape
-    [n_poses x max_n_residues x max_n_residues x max_n_conn x max_n_conn]
-    stating the number of chemical bonds that separate every pair of
-    inter-residue connections for every pair of residues -- up to a
-    maximum inter-residue separation of
-    tmol.chemical.MAX_SIG_BOND_SEPARATION (6 as of March 2024) --
-    so that the number of chemical bonds separating arbitrary
-    atom pairs may be rapidly computed for the interatomic energy
-    calculations
-
-    block_type_ind: the integer index for each block type (residue type)
-    referring to the order in which that block type appears in the
-    PoseStack's PackedBlockTypes object. A sentinel of -1 for positions
-    where there is no block type.
-
-    chain_id: the integer chain identifier for each residue
-
-    pdb_info: a PDBInfo object holding the PDB-level information that's needed
-    for writing out PDB / mmCIF files and keeping the original author labels
-    for the chains and residues + occupancy and B-factor information for the atoms;
-    none of these things are necessary for any structural manipulations or energy
-    calculations, but they are invaluable for working with structures in any kind
-    of pipeline.
-
-    device: the torch.device that this collection of structures lives on
+    Args:
+        packed_block_types: Residue types and their score-term annotations.
+        coords: Cartesian coordinates shaped ``[pose, atom, xyz]``.
+        block_coord_offset: Per-residue atom offsets shaped ``[pose, residue]``.
+        block_coord_offset64: 64-bit copy of ``block_coord_offset`` for PyTorch.
+        inter_residue_connections: Connected residue and connection indices.
+        inter_residue_connections64: 64-bit connection-index copy.
+        inter_block_bondsep: Capped bond separation between residue connections.
+        inter_block_bondsep64: 64-bit bond-separation copy.
+        block_type_ind: Packed block-type index for each residue; ``-1`` is padding.
+        block_type_ind64: 64-bit block-type-index copy.
+        chain_id: Chain index for each residue.
+        chain_id64: 64-bit chain-index copy.
+        pdb_info: Source labels, occupancy, and B-factor metadata.
+        constraint_set: Optional geometric constraints.
+        device: Device holding all pose tensors.
+        split_block_mapping: Optional mapping back to pre-split residue blocks.
     """
 
     packed_block_types: PackedBlockTypes
@@ -108,14 +66,14 @@ class PoseStack:
     chain_id64: Tensor[torch.int64][:, :]
 
     pdb_info: PDBInfo
-    constraint_set: Optional[ConstraintSet]
+    constraint_set: ConstraintSet | None
 
     device: torch.device
-    split_block_mapping: Optional["SplitBlockMapping"] = None
+    split_block_mapping: "SplitBlockMapping | None" = None
 
     #################### INIT #####################
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         n_poses = self.block_coord_offset.size(0)
         n_blocks = self.block_coord_offset.size(1)
 
@@ -170,30 +128,30 @@ class PoseStack:
 
     #################### PROPERTIES #####################
 
-    def __len__(self):
-        """return the number of PoseStack held in this stack"""
+    def __len__(self) -> int:
+        """Return the number of poses in this stack."""
         return self.coords.shape[0]
 
     @property
-    def n_poses(self):
+    def n_poses(self) -> int:
         return self.coords.shape[0]
 
     @property
-    def max_n_blocks(self):
+    def max_n_blocks(self) -> int:
         return self.block_coord_offset.shape[1]
 
     @property
-    def max_n_atoms(self):
+    def max_n_atoms(self) -> int:
         return self.packed_block_types.max_n_atoms
 
     @property
-    def max_n_block_atoms(self):
-        """Same thing as max_n_atoms"""
+    def max_n_block_atoms(self) -> int:
+        """Return the maximum atoms in any packed residue type."""
         return self.packed_block_types.max_n_atoms
 
     @property
-    def max_n_pose_atoms(self):
-        """The largest number of atoms in any pose"""
+    def max_n_pose_atoms(self) -> int:
+        """Return the padded atom dimension of each pose."""
         return self.coords.shape[1]
 
     @property
@@ -209,8 +167,8 @@ class PoseStack:
         return n_ats_per_block
 
     @property
-    def real_atoms(self):
-        """return the boolean vector of the real atoms in the coords tensor"""
+    def real_atoms(self) -> Tensor[torch.bool][:, :]:
+        """Return the mask of real, non-padding atoms in ``coords``."""
         # get the list of real atoms to read out of pose coords
         n_ats_per_pose_arange_expanded = (
             torch.arange(self.max_n_pose_atoms, dtype=torch.int64, device=self.device)
@@ -244,8 +202,8 @@ class PoseStack:
             split_block_mapping=self.split_block_mapping,
         )
 
-    def split(self, index) -> "PoseStack":
-        """Return a single PoseStack from one containing many"""
+    def split(self, index: int) -> "PoseStack":
+        """Copy one pose into a new single-pose stack."""
         return PoseStack(
             packed_block_types=self.packed_block_types,
             coords=self.coords[index : index + 1].detach().clone(),
@@ -287,11 +245,14 @@ class PoseStack:
             ),
         )
 
-    def expand_coords(self):
-        """Load the coordinates into a 4D tensor:
-        n_poses x max_n_blocks x max_n_atoms_per_block x 3
-        making it possible to perform simple operations on the
-        per-block level in python/torch
+    def expand_coords(
+        self,
+    ) -> tuple[Tensor[torch.float32][:, :, :, 3], Tensor[torch.bool][:, :, :]]:
+        """Expand packed coordinates into residue-major layout.
+
+        Returns:
+            Coordinates shaped ``[pose, residue, residue_atom, xyz]`` and the
+            corresponding real-atom mask shaped ``[pose, residue, residue_atom]``.
         """
 
         # get the list of real atoms that we will be writing to in the 4D tensor
@@ -314,13 +275,11 @@ class PoseStack:
         return expanded_coords, real_expanded_pose_ats
 
     @property
-    def n_res_per_pose(self):
+    def n_res_per_pose(self) -> Tensor[torch.int64][:]:
         return torch.sum(self.block_type_ind >= 0, dim=1)
 
-    def is_real_block(self, pose_ind: int, block_ind: int) -> bool:
-        """Report whether a particular block on a particular pose is
-        real or just filler
-        """
+    def is_real_block(self, pose_ind: int, block_ind: int) -> torch.Tensor:
+        """Return a scalar boolean tensor indicating whether a block is real."""
         return self.block_type_ind[pose_ind, block_ind] >= 0
 
     def block_type(self, pose_ind: int, block_ind: int) -> RefinedResidueType:
@@ -330,10 +289,12 @@ class PoseStack:
             self.block_type_ind[pose_ind, block_ind]
         ]
 
-    def get_constraint_set(self):
+    def get_constraint_set(self) -> ConstraintSet | None:
+        """Return the optional constraint set associated with this pose stack."""
         return self.constraint_set
 
-    def block_identity_map(self):
+    def block_identity_map(self) -> Tensor[torch.int32][:, :]:
+        """Return each residue's padded block index for every pose."""
         identity_map = torch.zeros_like(self.block_coord_offset)
         identity_map[:, :] = torch.arange(
             self.block_coord_offset.size(1), device=self.device

--- a/tmol/pose/_pose_stack_builder.py
+++ b/tmol/pose/_pose_stack_builder.py
@@ -1055,10 +1055,10 @@ class PoseStackBuilder:
                 (n_poses, max_n_chains_minus1), -1, dtype=torch.int64
             )
             for i, c_lens in enumerate(chain_lengths):
-                for j, l in enumerate(c_lens):
+                for j, chain_length in enumerate(c_lens):
                     if j != len(c_lens) - 1:
                         # we will leave off the last chain from each pose
-                        chain_lengths_t[i, j] = l
+                        chain_lengths_t[i, j] = chain_length
             chain_lengths_t = chain_lengths_t.to(device)
             cl_real = chain_lengths_t != -1
             cl_offsets = torch.cumsum(chain_lengths_t, dim=1)
@@ -1255,9 +1255,7 @@ class PoseStackBuilder:
         inter_block_bondsep[bconn_pair_real] = pconn_matrix[pconn_pair_real]
 
         # now reorder so it's pose-ind x r1 x r2 x c1 x c2
-        inter_block_bondsep = torch.transpose(inter_block_bondsep, 2, 3)
-
-        return inter_block_bondsep
+        return torch.transpose(inter_block_bondsep, 2, 3)
 
     @classmethod
     @validate_args

--- a/tmol/pose/compiled/__init__.py
+++ b/tmol/pose/compiled/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled pose topology operations."""
+
 from ._apsp_ops import stacked_apsp  # noqa: F401

--- a/tmol/relax/__init__.py
+++ b/tmol/relax/__init__.py
@@ -1,3 +1,5 @@
+"""Packing and minimization protocols for structural relaxation."""
+
 from ._fast_relax import (  # noqa: F401
     DEFAULT_RELAX_SCHEDULE,
     _default_cart_min_fn,

--- a/tmol/score/__init__.py
+++ b/tmol/score/__init__.py
@@ -1,3 +1,5 @@
+"""Score functions, energy terms, and standard weight sets."""
+
 from __future__ import annotations
 
 import toolz.functoolz

--- a/tmol/score/backbone_torsion/__init__.py
+++ b/tmol/score/backbone_torsion/__init__.py
@@ -1,3 +1,5 @@
+"""Backbone torsion parameter resolution and scoring."""
+
 from ._params import (  # noqa: F401
     BackboneTorsionParamResolver,
     PackedOmegaDatabase,

--- a/tmol/score/backbone_torsion/potentials/__init__.py
+++ b/tmol/score/backbone_torsion/potentials/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled backbone-torsion potentials."""
+
 from ._compiled import (  # noqa: F401
     backbone_torsion_pose_score,
     backbone_torsion_rotamer_score,

--- a/tmol/score/cartbonded/__init__.py
+++ b/tmol/score/cartbonded/__init__.py
@@ -1,3 +1,5 @@
+"""Cartesian bonded geometry scoring."""
+
 from ._cartbonded_energy_term import (  # noqa: F401
     CROSS_RES_PREFIX,
     CartBondedEnergyTerm,

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -85,18 +85,18 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         # create a convenient datastructure for following connections
         bondmap = {}
         for bond in bonds:
-            if bond[0] not in bondmap.keys():
+            if bond[0] not in bondmap:
                 bondmap[bond[0]] = set()
             bondmap[bond[0]].add(bond[1])
 
         # get lengths
-        for atom1 in bondmap.keys():
+        for atom1 in bondmap:
             for atom2 in bondmap[atom1]:
                 if atom1 < atom2:
                     lengths.append((atom1, atom2, -1, -1))
 
         # get angles
-        for atom1 in bondmap.keys():
+        for atom1 in bondmap:
             for atom2 in bondmap[atom1]:
                 for atom3 in bondmap[atom2]:
                     if atom1 >= atom3:
@@ -104,7 +104,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
                     angles.append((atom1, atom2, atom3, -1))
 
         # get torsions
-        for atom1 in bondmap.keys():
+        for atom1 in bondmap:
             for atom2 in bondmap[atom1]:
                 for atom3 in bondmap[atom2]:
                     if atom1 == atom3:
@@ -140,8 +140,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
                 + self.cart_database.residue_params[res].improper_parameters
                 + self.cart_database.residue_params[res].hxltorsion_parameters
             )
-        else:
-            return []
+        return []
 
     def get_formatted_atoms_and_params(self, raw_params):
         fields = ["atm1", "atm2", "atm3", "atm4"]

--- a/tmol/score/cartbonded/potentials/__init__.py
+++ b/tmol/score/cartbonded/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled Cartesian bonded potentials."""
+
 from ._compiled import cartbonded_pose_scores, cartbonded_rotamer_scores  # noqa: F401

--- a/tmol/score/common/__init__.py
+++ b/tmol/score/common/__init__.py
@@ -1,3 +1,5 @@
+"""Shared score-term interfaces and numerical helpers."""
+
 from ._convert_float64 import convert_float64  # noqa: F401
 from ._cubic_hermite_polynomial import (  # noqa: F401
     interpolate,

--- a/tmol/score/constraint/__init__.py
+++ b/tmol/score/constraint/__init__.py
@@ -1,3 +1,5 @@
+"""Coordinate, distance, angle, and dihedral constraints."""
+
 from ._constraint_energy_term import HiddenPrints, ConstraintEnergyTerm  # noqa: F401
 from ._utility import (  # noqa: F401
     constrain_all_ca,

--- a/tmol/score/constraint/potentials/__init__.py
+++ b/tmol/score/constraint/potentials/__init__.py
@@ -1,2 +1,4 @@
+"""Compiled constraint potentials."""
+
 # get_torsion_angle is not re-exported here: callers import from .compiled directly
 # so that monkeypatching sys.modules['...compiled'] in tests still works.

--- a/tmol/score/disulfide/__init__.py
+++ b/tmol/score/disulfide/__init__.py
@@ -1,2 +1,4 @@
+"""Disulfide geometry scoring."""
+
 from ._params import DisulfideGlobalParams  # noqa: F401
 from ._disulfide_energy_term import DisulfideEnergyTerm  # noqa: F401

--- a/tmol/score/disulfide/_params.py
+++ b/tmol/score/disulfide/_params.py
@@ -47,7 +47,7 @@ class DisulfideGlobalParams(TensorGroup):
     @classmethod
     @validate_args
     def from_database(cls, disulfide_database: DisulfideDatabase, device: torch.device):
-        global_params = DisulfideGlobalParams(
+        return DisulfideGlobalParams(
             **{
                 n: torch.tensor(v, device=device).expand((1,))
                 for n, v in cattr.unstructure(
@@ -55,5 +55,3 @@ class DisulfideGlobalParams(TensorGroup):
                 ).items()
             }
         )
-
-        return global_params

--- a/tmol/score/disulfide/potentials/__init__.py
+++ b/tmol/score/disulfide/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled disulfide potentials."""
+
 from ._compiled import disulfide_pose_scores, disulfide_rotamer_scores  # noqa: F401

--- a/tmol/score/dunbrack/__init__.py
+++ b/tmol/score/dunbrack/__init__.py
@@ -1,3 +1,5 @@
+"""Dunbrack rotamer-probability scoring."""
+
 from ._params import (  # noqa: F401
     DunbrackParamResolver,
     DunbrackParams,

--- a/tmol/score/dunbrack/potentials/__init__.py
+++ b/tmol/score/dunbrack/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled Dunbrack potentials."""
+
 from ._compiled import dunbrack_pose_scores, dunbrack_rotamer_scores  # noqa: F401

--- a/tmol/score/elec/__init__.py
+++ b/tmol/score/elec/__init__.py
@@ -1,2 +1,4 @@
+"""Distance-dependent electrostatic scoring."""
+
 from ._params import ElecGlobalParams, ElecParamResolver  # noqa: F401
 from ._elec_energy_term import ElecEnergyTerm  # noqa: F401

--- a/tmol/score/elec/_params.py
+++ b/tmol/score/elec/_params.py
@@ -65,11 +65,7 @@ class ElecParamResolver(ValidateAttrs):
                 if vi in self.partial_charges[res][atm.name]:
                     return self.partial_charges[res][atm.name][vi]
 
-        partial_charge = numpy.vectorize(lookup_charge, otypes=[numpy.float32])(
-            block_type.atoms
-        )
-
-        return partial_charge
+        return numpy.vectorize(lookup_charge, otypes=[numpy.float32])(block_type.atoms)
 
     def get_bonded_path_length_mapping_for_block(self, block_type: RefinedResidueType):
         """remap bonded path length for a residue block"""

--- a/tmol/score/elec/potentials/__init__.py
+++ b/tmol/score/elec/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled electrostatic potentials."""
+
 from ._compiled import elec_pose_scores, elec_rotamer_scores  # noqa: F401

--- a/tmol/score/genbonded/__init__.py
+++ b/tmol/score/genbonded/__init__.py
@@ -1,3 +1,5 @@
+"""General bonded geometry scoring for arbitrary chemistry."""
+
 from ._genbonded_energy_term import (  # noqa: F401
     BOND_CHAR_TO_INT,
     BOND_TYPE_TO_CHAR,

--- a/tmol/score/genbonded/potentials/__init__.py
+++ b/tmol/score/genbonded/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled general-bonded potentials."""
+
 from ._compiled import genbonded_pose_scores, genbonded_rotamer_scores  # noqa: F401

--- a/tmol/score/hbond/__init__.py
+++ b/tmol/score/hbond/__init__.py
@@ -1,3 +1,5 @@
+"""Hydrogen-bond parameter resolution and scoring."""
+
 from ._params import (  # noqa: F401
     CompactedHBondDatabase,
     HBondPairParams,

--- a/tmol/score/hbond/potentials/__init__.py
+++ b/tmol/score/hbond/potentials/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled hydrogen-bond potentials."""
+
 from ._compiled import (  # noqa: F401
     gen_hbond_bases,
     hbond_pose_scores,

--- a/tmol/score/ljlk/__init__.py
+++ b/tmol/score/ljlk/__init__.py
@@ -1,2 +1,4 @@
+"""Lennard-Jones and Lazaridis-Karplus solvation scoring."""
+
 from ._params import LJLKGlobalParams, LJLKParamResolver, LJLKTypeParams  # noqa: F401
 from ._ljlk_energy_term import LJLKEnergyTerm  # noqa: F401

--- a/tmol/score/ljlk/_params.py
+++ b/tmol/score/ljlk/_params.py
@@ -108,8 +108,7 @@ class LJLKParamResolver(ValidateAttrs):
         def at_least_1d(t):
             if t.dim() == 0:
                 return t.expand((1,))
-            else:
-                return t
+            return t
 
         global_params = LJLKGlobalParams(
             **{

--- a/tmol/score/ljlk/potentials/__init__.py
+++ b/tmol/score/ljlk/potentials/__init__.py
@@ -1,1 +1,3 @@
+"""Compiled Lennard-Jones and isotropic solvation potentials."""
+
 from ._compiled import ljlk_pose_scores, ljlk_rotamer_scores  # noqa: F401

--- a/tmol/score/lk_ball/__init__.py
+++ b/tmol/score/lk_ball/__init__.py
@@ -1,2 +1,4 @@
+"""Orientation-dependent LK-ball solvation scoring."""
+
 from ._params import LKBallBlockTypeParams, LKBallPackedBlockTypesParams  # noqa: F401
 from ._lk_ball_energy_term import LKBallEnergyTerm  # noqa: F401

--- a/tmol/score/lk_ball/potentials/__init__.py
+++ b/tmol/score/lk_ball/potentials/__init__.py
@@ -1,3 +1,5 @@
+"""Compiled LK-ball solvation potentials."""
+
 from ._compiled import (  # noqa: F401
     gen_pose_waters,
     lk_ball_pose_score,

--- a/tmol/score/na_torsion/__init__.py
+++ b/tmol/score/na_torsion/__init__.py
@@ -1,3 +1,5 @@
+"""Nucleic-acid torsion parameter resolution and scoring."""
+
 from ._params import (  # noqa: F401
     BACKBONE_TORSIONS,
     BASES,

--- a/tmol/score/ref/__init__.py
+++ b/tmol/score/ref/__init__.py
@@ -1,3 +1,5 @@
+"""Residue reference-energy scoring."""
+
 from ._ref_energy_term import (  # noqa: F401
     RefEnergyTerm,
     eval_ref_energy_for_pose,

--- a/tmol/score/terms/__init__.py
+++ b/tmol/score/terms/__init__.py
@@ -1,3 +1,5 @@
+"""Factories for constructing standard score terms."""
+
 from ._score_term_factory import ScoreTermFactory  # noqa: F401
 from ._term_creator import TermCreator, score_term_creator  # noqa: F401
 from ._backbone_torsion_creator import BackboneTorsionTermCreator  # noqa: F401

--- a/tmol/support/__init__.py
+++ b/tmol/support/__init__.py
@@ -1,0 +1,1 @@
+"""Parameter-conversion and compatibility support tools."""

--- a/tmol/support/rosetta/__init__.py
+++ b/tmol/support/rosetta/__init__.py
@@ -1,0 +1,1 @@
+"""Rosetta data-conversion helpers."""

--- a/tmol/support/scoring/__init__.py
+++ b/tmol/support/scoring/__init__.py
@@ -1,3 +1,5 @@
+"""Utilities for importing and converting scoring parameters."""
+
 from ._hbond_param_import import (  # noqa: F401
     RawParams,
     RosettaHBParams,

--- a/tmol/support/scoring/_hbond_param_import.py
+++ b/tmol/support/scoring/_hbond_param_import.py
@@ -315,8 +315,7 @@ class RosettaHBParams:
 
         if not outfile:
             return obuf.getvalue()
-        else:
-            return None
+        return None
 
 
 basetype_for_dtype = {

--- a/tmol/support/scoring/_rewrite_rama_binary.py
+++ b/tmol/support/scoring/_rewrite_rama_binary.py
@@ -47,7 +47,7 @@ def parse_lines_as_ndarrays(lines, aacol=0, phipsicol=1, probcol=3):
         if cols[0][0] == "#":
             continue
         curaa = cols[aacol]
-        if curaa not in prob_tables.keys():
+        if curaa not in prob_tables:
             prob_tables[curaa] = numpy.zeros((36, 36), dtype=float)
         phi_ind, psi_ind = (
             int(float(x)) // 10 + 18 for x in cols[phipsicol : (phipsicol + 2)]

--- a/tmol/tests/types/test_shape.py
+++ b/tmol/tests/types/test_shape.py
@@ -76,6 +76,11 @@ class testShape(unittest.TestCase):
             for v in e["invalid"]:
                 self.assertInvalid(spec, v)
 
+        # Equal dimensions must compare by value, including integers outside
+        # CPython's small-integer cache.
+        large_dim = int("1000")
+        self.assertValid(s[large_dim], (int("1000"),))
+
     def assertValid(self, spec, array, msg=None):
         spec.validate(array)
 

--- a/tmol/types/_attrs.py
+++ b/tmol/types/_attrs.py
@@ -5,7 +5,9 @@ from ._validators import get_validator
 
 
 class ConvertAttrs:
-    def __attrs_post_init__(self):
+    """Convert attrs fields according to their declared annotations."""
+
+    def __attrs_post_init__(self) -> None:
         for a in self.__attrs_attrs__:
             if not a.converter:
                 object.__setattr__(
@@ -14,7 +16,9 @@ class ConvertAttrs:
 
 
 class ValidateAttrs:
-    def __attrs_post_init__(self):
+    """Validate attrs fields according to their declared annotations."""
+
+    def __attrs_post_init__(self) -> None:
         for a in self.__attrs_attrs__:
             if not a.validator:
                 try:

--- a/tmol/types/_converters.py
+++ b/tmol/types/_converters.py
@@ -51,7 +51,7 @@ def union_convert(union_annotation, value):
             errors.append(ex)
 
     raise TypeError(
-        "Unable to convert to any union subtype: {union_annotaion} value: {value}"
+        f"Unable to convert to any union subtype: {union_annotation} value: {value!r}"
     )
 
 

--- a/tmol/types/_converters.py
+++ b/tmol/types/_converters.py
@@ -23,8 +23,7 @@ def get_converter(type_annotation):
 def constructor_convert(type_annotation, value):
     if isinstance(value, type_annotation):
         return value
-    else:
-        return type_annotation(value)
+    return type_annotation(value)
 
 
 @toolz.curry

--- a/tmol/types/_converters.py
+++ b/tmol/types/_converters.py
@@ -45,8 +45,7 @@ def union_convert(union_annotation, value):
     errors = []
     for subtype in union_annotation.__args__:
         try:
-            result = get_converter(subtype)(value)
-            return result
+            return get_converter(subtype)(value)
         except (TypeError, ValueError) as ex:
             errors.append(ex)
 

--- a/tmol/types/_shape.py
+++ b/tmol/types/_shape.py
@@ -58,11 +58,16 @@ Or a standard, ordering/density:
 - ``[:,4,4].dense(2).order('c')`` - ndim 3, shape (n, 4,4), 2-dense, c-contiguous
 """
 
+from collections.abc import Sequence
+from typing import Any
+
 import attr
 
 
 @attr.s(frozen=True, slots=True)
 class Dim:
+    """One dimension in a runtime-validated tensor shape."""
+
     @staticmethod
     def _to_size(size):
         if size in (None, Ellipsis):
@@ -86,7 +91,7 @@ class Dim:
         if not isinstance(size, int) or size < 1:
             raise ValueError("size must be None, Ellipsis, or >1", size)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.size is Ellipsis:
             return "..."
         if self.size is None:
@@ -96,9 +101,13 @@ class Dim:
 
 @attr.s(slots=True, frozen=True)
 class Shape:
-    class Factory(object):
+    """Runtime-validatable tensor shape specification."""
+
+    class Factory:
+        """Construct ``Shape`` objects through subscription syntax."""
+
         @staticmethod
-        def __getitem__(args):
+        def __getitem__(args: Any) -> "Shape":
             if not isinstance(args, tuple):
                 args = (args,)
 
@@ -119,14 +128,8 @@ class Shape:
         if any(e.size is Ellipsis for e in dims[1:]):
             raise ValueError("Invalid dims", dims)
 
-    @classmethod
-    def create(cls, dims):
-        cls(dims=list(map(Dim, dims)))
-
-    def __init__(self, dims):
-        dims = list(map(Dim, dims))
-
-    def validate(self, shape):
+    def validate(self, shape: Sequence[int]) -> bool:
+        """Validate concrete dimensions against this specification."""
         dims = list(self.dims)
         adims = list(shape)
 
@@ -154,7 +157,7 @@ class Shape:
         assert len(dims) == len(adims)
 
         for d, a in zip(dims, adims):
-            if d.size and d.size is not Ellipsis and d.size is not a:
+            if d.size and d.size is not Ellipsis and d.size != a:
                 raise ValueError(
                     f"Invalid dimension size. "
                     f"expected: {self!s} received: {adims} dim: {d} size: {a}"
@@ -162,7 +165,7 @@ class Shape:
 
         return True
 
-    def __call__(self, trait, value):
+    def __call__(self, _trait: Any, value: Any) -> Any:
         """Validate shape for given array."""
         try:
             self.validate(value.shape)
@@ -170,10 +173,10 @@ class Shape:
         except ValueError as vex:
             raise ValueError(f"Invalid shape: {value.shape} expected: {self}") from vex
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "[{}]".format(",".join(map(str, self.dims)))
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         assert not cycle
 
         p.text(str(self))

--- a/tmol/types/_shape.py
+++ b/tmol/types/_shape.py
@@ -67,14 +67,13 @@ class Dim:
     def _to_size(size):
         if size in (None, Ellipsis):
             return size
-        elif isinstance(size, slice):
+        if isinstance(size, slice):
             if size.start is not None:
                 raise ValueError("Invalid slice.", size)
             if size.step is not None:
                 raise ValueError("Invalid slice.", size)
             return size.stop
-        else:
-            return int(size)
+        return int(size)
 
     size = attr.ib(converter=_to_size.__func__)
 
@@ -82,19 +81,17 @@ class Dim:
     def _valid_size(self, _, size):
         if size is None:
             return
-        elif size is Ellipsis:
+        if size is Ellipsis:
             return
-        else:
-            if not isinstance(size, int) or size < 1:
-                raise ValueError("size must be None, Ellipsis, or >1", size)
+        if not isinstance(size, int) or size < 1:
+            raise ValueError("size must be None, Ellipsis, or >1", size)
 
     def __str__(self):
         if self.size is Ellipsis:
             return "..."
-        elif self.size is None:
+        if self.size is None:
             return ":"
-        else:
-            return str(self.size)
+        return str(self.size)
 
 
 @attr.s(slots=True, frozen=True)
@@ -147,7 +144,7 @@ class Shape:
                     f"Fewer than expected dims in shape. "
                     f"expected: {self!s} received: {adims}"
                 )
-            elif not dims[0].size is Ellipsis:
+            if dims[0].size is not Ellipsis:
                 raise ValueError(
                     f"No implied broadcast to shape. "
                     f"expected: {self!s} received: {adims}"

--- a/tmol/types/_subscriptable.py
+++ b/tmol/types/_subscriptable.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class _SubscribedType(type):
     """
     This class is a placeholder to let the IDE know the attributes of the
@@ -22,7 +25,7 @@ class SubscriptableType(type):
     'SomeType'
     """
 
-    def __init_subclass__(mcs, **kwargs):
+    def __init_subclass__(mcs, **kwargs: Any) -> None:
         mcs._hash = None
         mcs.__args__ = None
         mcs.__origin__ = None
@@ -40,7 +43,7 @@ class SubscriptableType(type):
             result._after_subscription(item)
         return result
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         self_module = getattr(self, "__module__", None)
         self_qualname = getattr(self, "__qualname__", None)
         self_origin = getattr(self, "__origin__", None)
@@ -58,7 +61,7 @@ class SubscriptableType(type):
             and self_origin == other_origin
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if not getattr(self, "_hash", None):
             self_module = getattr(self, "__module__", None)
             self_qualname = getattr(self, "__qualname__", None)

--- a/tmol/types/_tensor.py
+++ b/tmol/types/_tensor.py
@@ -114,9 +114,8 @@ class _TensorType(metaclass=_TensorTypeMeta):
         instance_shape = instance.shape
         if not subshape:
             return instance.shape
-        else:
-            assert len(instance_shape) >= len(subshape)
-            return instance_shape[: -len(subshape)]
+        assert len(instance_shape) >= len(subshape)
+        return instance_shape[: -len(subshape)]
 
 
 class TensorGroup:
@@ -230,8 +229,7 @@ class TensorGroup:
         diff = set(n for n in components if components[n] is not to_components[n])
         if not diff:
             return self
-        else:
-            return attr.evolve(self, **to_components)
+        return attr.evolve(self, **to_components)
 
 
 def cat(seq, dim=0, out=None):

--- a/tmol/types/_validators.py
+++ b/tmol/types/_validators.py
@@ -2,7 +2,7 @@
 
 from functools import singledispatch
 
-from typing import List, get_args
+from typing import List, get_args, get_origin
 from typing_inspect import is_tuple_type, is_union_type
 import toolz
 
@@ -26,34 +26,7 @@ def is_list_type(tp):
         get_origin(tp) is list  # Tuple prior to Python 3.7
     """
 
-    from typing_inspect import NEW_TYPING
-
-    if NEW_TYPING:
-        import sys
-        from typing import Generic, _GenericAlias
-
-        if sys.version_info[:3] >= (3, 9, 0):
-            from typing import _SpecialGenericAlias
-            from types import GenericAlias
-
-            typingGenericAlias = (_GenericAlias, _SpecialGenericAlias, GenericAlias)
-        else:
-            typingGenericAlias = (_GenericAlias,)
-
-        return (
-            tp is List
-            or isinstance(tp, typingGenericAlias)
-            and tp.__origin__ is list
-            or isinstance(tp, type)
-            and issubclass(tp, Generic)
-            and issubclass(tp, list)
-        )
-
-    # only attempt to import if we have an old version of python?
-    # is this needed? We are targetting tmol for python3.7+
-    from typing import ListMeta
-
-    return type(tp) is ListMeta
+    return tp is List or get_origin(tp) is list
 
 
 @singledispatch
@@ -61,8 +34,7 @@ def get_validator(type_annotation):
     for pred, val in _validators:
         if pred(type_annotation):
             return val(type_annotation)
-    else:
-        return validate_isinstance(type_annotation)
+    return validate_isinstance(type_annotation)
 
 
 @toolz.curry

--- a/tmol/utility/__init__.py
+++ b/tmol/utility/__init__.py
@@ -1,3 +1,5 @@
+"""General-purpose helpers used throughout TMol."""
+
 from ._args import _signature, bind_to_args, ignore_unused_kwargs  # noqa: F401
 from ._attr import AttrMapping, AttrMutableMapping  # noqa: F401
 from ._auto_number import AutoNumber  # noqa: F401

--- a/tmol/utility/_args.py
+++ b/tmol/utility/_args.py
@@ -92,8 +92,7 @@ def _builtin_signature(f):
 
     if getattr(f, "__text_signature__", None):
         return inspect.signature(f)
-    else:
-        return _pybind11_signature(f)
+    return _pybind11_signature(f)
 
 
 def _pybind11_doc_signatures(f):

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -156,8 +156,7 @@ def cuda_if_available(sources):
     """Filter cuda sources if cuda is not available."""
     if torch.cuda.is_available():
         return sources
-    else:
-        return [s for s in sources if not _is_cuda_file(s)]
+    return [s for s in sources if not _is_cuda_file(s)]
 
 
 @wraps(torch.utils.cpp_extension.load)

--- a/tmol/utility/_dicttoolz.py
+++ b/tmol/utility/_dicttoolz.py
@@ -87,6 +87,5 @@ def update_inplace(d, keys, func, default=None, factory=dict):
             d[k] = factory()
         update_inplace(d[k], ks, func, default, factory)
         return d
-    else:
-        d[k] = func(d[k]) if (k in d) else func(default)
-        return d
+    d[k] = func(d[k]) if (k in d) else func(default)
+    return d

--- a/tmol/utility/ndarray/__init__.py
+++ b/tmol/utility/ndarray/__init__.py
@@ -1,3 +1,5 @@
+"""NumPy array utility operations."""
+
 from ._common_operations import (  # noqa: F401
     exclusive_cumsum1d,
     exclusive_cumsum2d,

--- a/tmol/utility/tensor/__init__.py
+++ b/tmol/utility/tensor/__init__.py
@@ -1,3 +1,5 @@
+"""PyTorch tensor utility operations."""
+
 from ._common_operations import (  # noqa: F401
     cat_differently_sized_tensors,
     exclusive_cumsum1d,

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -175,20 +175,6 @@ def cat_differently_sized_tensors(
     return newt, sizes, strides
 
 
-# def real_elements_of_differently_sized_tensors(tensors: List):
-#     assert len(tensors) > 0
-#     for tensor in tensors:
-#         assert len(tensor.shape) == len(tensors[0].shape)
-#         assert tensor.dtype == tensors[0].dtype
-#         assert tensor.device == tensor[0].device
-#
-#     device = tensors[0].device
-#     new_sizes = [
-#         max(t.shape[i] for t in tensors) for i in range(len(tensors[0].shape))
-#     ]
-#     arange_inds = torch.arange(new_sizes.shape[-1], dtype=torch.int64, device=device)
-
-
 def join_tensors_and_report_real_entries(tensors: List, sentinel: int = -1):
     """Concatenate a bunch of N-dimensional tensors into a single N+1-D tensor
     and report which elements out of the new tensor are real.


### PR DESCRIPTION
## Summary

This is a deliberately behavior-preserving cleanup of TMol's Python surface, kept separate from the performance work in #441.

- adds concise Google-style documentation to important public APIs, database schemas, and previously empty product package boundaries
- applies TMol's native shape-aware `Tensor[dtype][shape]` and `NDArray[dtype][shape]` annotations to high-value I/O, pose, kinematics, minimization, rotamer, and coordinate-building interfaces
- removes stale commented implementations, obsolete pre-Python-3.9 compatibility code, redundant temporaries, and low-risk control-flow noise
- tightens runtime shape/type utilities, including fixing integer dimension validation to compare by value rather than object identity and adding a regression for large dimensions
- documents tensor layouts where batch/block/atom dimensions are not obvious

No new typing dependency is introduced, no scoring kernel behavior is changed, and dynamic/private implementation code was not mass-annotated merely to satisfy a metric. The diff spans 105 files because 51 package initializers receive one-line module documentation; overall it is +655/-631 (net +24 lines).

## Validation

- repository-wide Black check: 481 non-vendored Python files clean
- repository-wide Flake8 check: 481 non-vendored Python files clean
- Ruff and `git diff --check`: clean
- exact-revision AOT wheel built successfully (CPython 3.12, CUDA/H200)
- 67 exact-AOT I/O and minimization tests passed on CPU/GPU
- focused subsystem runs passed for chemical schemas, pose stacks, move maps, optimizer internals, type utilities, conformer samplers, coordinate construction, and the low-risk simplifications
- 55 product packages imported successfully and expose non-empty module documentation

The cleanup branch is based directly on current `master`; #441 has only one overlapping file, with independent changes on separate lines.
