### PR TITLE
Accelerate sparse block-pair gradients

### DIFF
--- a/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
+++ b/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
@@ -140,9 +140,11 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   } else {
     V_t = TPack<Real, 4, Dev>::zeros({2, n_poses, 1, 1});
   }
-  auto dV_dxyz_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dxyz_t = accumulate_derivs
                        ? TPack<Vec<Real, 3>, 2, Dev>::zeros({2, n_atoms})
-                       : TPack<Vec<Real, 3>, 2, Dev>::empty({2, n_atoms});
+                       : TPack<Vec<Real, 3>, 2, Dev>::empty({2, 0});
 
   auto V = V_t.view;
   auto dV_dxyz = dV_dxyz_t.view;
@@ -236,7 +238,7 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
     // accumulate rama
     if (valid_phipsi && rama_table_ind >= 0) {
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         auto rama = rama_V_dV<Dev, Real, Int>(
             phi_coords,
             psi_coords,
@@ -307,7 +309,7 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     }
 
     if (valid_phipsi && omega_table_ind >= 0) {
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         auto omega = omega_bbdep_V_dV<Dev, Real, Int>(
             phi_coords,
             psi_coords,
@@ -347,7 +349,7 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
       }
     } else {
       // if rama is undefined, fall back to old version
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         auto omega = omega_V_dV<Dev, Real, Int>(omega_coords, 32.8);
         accumulate<Dev, Real>::add(
             V[1][pose_ind][V_ind1][V_ind2], common::get<0>(omega));
@@ -490,6 +492,12 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
       // the upper neighbor is not a real residue: skip
       return;
     }
+
+    if (dTdV[0][pose_ind][block_ind1][block_ind2] == 0
+        && dTdV[1][pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
     int const block_type2 = first_rot_block_type[pose_ind][block_ind2];
     int const rot_ind2 = first_rot_for_block[pose_ind][block_ind2];
 

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -249,9 +249,11 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // Allocate the tensors to which we will write our outputs
   int const n_V = output_block_pair_energies ? max_n_blocks : 1;
   auto V_t = TPack<Real, 4, D>::zeros({5, n_poses, n_V, n_V});
-  auto dV_dx_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dx_t = accumulate_derivs
                      ? TPack<Vec<Real, 3>, 2, D>::zeros({5, n_atoms})
-                     : TPack<Vec<Real, 3>, 2, D>::empty({5, n_atoms});
+                     : TPack<Vec<Real, 3>, 2, D>::empty({5, 0});
 
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;
@@ -300,7 +302,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
       // Real score;
       switch (type) {
         case subgraph_type::length: {
-          if (compute_derivs) {
+          if (accumulate_derivs) {
             auto eval = cblength_V_dV(atom1, atom2, params[2], params[1]);
             accumulate_result<Real, Int, 2, D>(
                 length_score,
@@ -317,7 +319,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         }
         case subgraph_type::angle: {
           Vec<Real, 3> atom3 = rot_coords[atoms[2]];
-          if (compute_derivs) {
+          if (accumulate_derivs) {
             auto eval = cbangle_V_dV(atom1, atom2, atom3, params[2], params[1]);
             accumulate_result<Real, Int, 3, D>(
                 angle_score, eval, atoms.head(3), true, dV_dx[score_type], 1.0);
@@ -333,7 +335,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           Real& tor_score = (score_type == 3)   ? improper_torsion_score
                             : (score_type == 4) ? hxyl_torsion_score
                                                 : torsion_score;
-          if (compute_derivs) {
+          if (accumulate_derivs) {
             auto eval = cbtorsion_V_dV(
                 atom1,
                 atom2,
@@ -740,13 +742,16 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
       Real hxyl_torsion_score = 0.0;
       Vec<Real, 7> params = hash_values[param_index];
 
-      Vec<Real, 3> atom1 = rot_coords[atoms[0]];
-      Vec<Real, 3> atom2 = rot_coords[atoms[1]];
-
       subgraph_type type = get_subgraph_type(atoms);
 
       int score_type = params[0];
       Real block_weight = dTdV[score_type][pose_ind][block_ind1][block_ind2];
+      if (block_weight == 0) {
+        return;
+      }
+
+      Vec<Real, 3> atom1 = rot_coords[atoms[0]];
+      Vec<Real, 3> atom2 = rot_coords[atoms[1]];
 
       // Real score;
       switch (type) {

--- a/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
+++ b/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
@@ -317,6 +317,9 @@ auto DisulfidePoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
           // coincidentally handles the case when block_ind2 == -1
           continue;
         }
+        if (dTdV[0][pose_ind][block_ind1][block_ind2] == 0) {
+          continue;
+        }
         int const block_type2 = first_rot_block_type[pose_ind][block_ind2];
         int const rot_ind2 = first_rot_for_block[pose_ind][block_ind2];
         if (rot_ind2 < 0) {

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -156,9 +156,11 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
   int n_V = output_block_pair_energies ? max_n_blocks : 1;
   TPack<Real, 4, D> V_t = TPack<Real, 4, D>::zeros({3, n_poses, n_V, n_V});
-  auto dV_dx_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dx_t = accumulate_derivs
                      ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
-                     : TPack<Vec<Real, 3>, 2, D>::empty({3, n_atoms});
+                     : TPack<Vec<Real, 3>, 2, D>::empty({3, 0});
 
   auto dihedral_atom_inds_t =
       TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih});
@@ -166,10 +168,11 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dihedral_values_t = TPack<Real, 2, D>::zeros({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
   auto dihedral_deriv_t =
-      compute_derivs ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
-                           {n_rots, max_n_dih})
-                     : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
-                           {n_rots, max_n_dih});
+      accumulate_derivs
+          ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
+                {n_rots, max_n_dih})
+          : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
+                {n_rots, max_n_dih});
   auto dihedral_deriv = dihedral_deriv_t.view;
 
   auto rotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
@@ -180,18 +183,18 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
       semirotameric_rottable_assignment_t.view;
 
   auto dneglnprob_rot_dbb_xyz_t =
-      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
-                     : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
+      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
+                        : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
   auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
 
   auto drotchi_devpen_dtor_xyz_t =
-      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                     : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                        : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
 
   auto dneglnprob_nonrot_dtor_xyz_t =
-      compute_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                     : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                        : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
 
   auto V = V_t.view;
@@ -261,7 +264,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                          : (ii == 1) ? PSI_DEFAULT
                                      : 0.0;
 
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         measure_dihedral_V_dV(
             TensorAccessor<Vec<Real, 3>, 1, D>(rot_coords),
             dihedral_atom_inds[rotamer_index][ii],
@@ -301,7 +304,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           rotameric_rottable_assignment[rotamer_index],
           dneglnprob_rot_dbb_xyz[rotamer_index],
           dihedral_deriv[rotamer_index],
-          compute_derivs);
+          accumulate_derivs);
 
       if (output_block_pair_energies) {
         V[0][pose_index][block_index][block_index] = prob;
@@ -309,7 +312,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         common::accumulate<D, Real>::add(V[0][pose_index][0][0], prob);
       }
 
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         // Note that we will accumulate all of the dV_dx derivatives
         // into the phi and psi definiing atoms of the _first rotamers_
         // of residues i+1 and i-1 respectively. This is dedicedly weird
@@ -352,10 +355,10 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           // Out
           drotchi_devpen_dtor_xyz[rotamer_index],
           dihedral_deriv[rotamer_index],
-          compute_derivs);
+          accumulate_derivs);
       rotameric_chi_dev_penalty += Erotdev;
 
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         Vec<Int, DIH_N_ATOMS> tor0_ats = dihedral_atom_inds[rotamer_index][0];
         Vec<Int, DIH_N_ATOMS> tor1_ats = dihedral_atom_inds[rotamer_index][1];
         Vec<Int, DIH_N_ATOMS> tor2_ats =
@@ -405,7 +408,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
           dneglnprob_nonrot_dtor_xyz[rotamer_index],
           dihedral_deriv[rotamer_index],
-          compute_derivs);
+          accumulate_derivs);
 
       if (output_block_pair_energies) {
         V[2][pose_index][block_index][block_index] = Esemi;
@@ -413,7 +416,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         common::accumulate<D, Real>::add(V[2][pose_index][0][0], Esemi);
       }
 
-      if (compute_derivs) {
+      if (accumulate_derivs) {
         int last = block_n_chi[block_type_index] + 1;  // = +2 - 1
         Vec<Int, DIH_N_ATOMS> tor0_ats = dihedral_atom_inds[rotamer_index][0];
         Vec<Int, DIH_N_ATOMS> tor1_ats = dihedral_atom_inds[rotamer_index][1];
@@ -599,6 +602,12 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
       // in non-rotamer scoring (both whole-pose and block-pair scoring)
       // we will launch n_poses * max_n_blocks_per_pose threads
       // with some threads being launched for blocks with -1 block type.
+      return;
+    }
+
+    if (dTdV[0][pose_index][block_index][block_index] == 0
+        && dTdV[1][pose_index][block_index][block_index] == 0
+        && dTdV[2][pose_index][block_index][block_index] == 0) {
       return;
     }
 

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -503,9 +503,11 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   assert(block_type_intra_repr_path_distance.size(1) == max_n_block_atoms);
   assert(block_type_intra_repr_path_distance.size(2) == max_n_block_atoms);
 
-  auto dV_dcoords_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dcoords_t = accumulate_derivs
                           ? TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms})
-                          : TPack<Vec<Real, 3>, 2, D>::empty({1, n_atoms});
+                          : TPack<Vec<Real, 3>, 2, D>::empty({1, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
@@ -1038,6 +1040,10 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
 
     if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    if (dTdV[0][pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
 

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -438,9 +438,11 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
   // One score type: gen_torsions (index 0).
   int const n_V = output_block_pair_energies ? max_n_blocks : 1;
   auto V_t = TPack<Real, 4, D>::zeros({1, n_poses, n_V, n_V});
-  auto dV_dx_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dx_t = accumulate_derivs
                      ? TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms})
-                     : TPack<Vec<Real, 3>, 2, D>::empty({1, n_atoms});
+                     : TPack<Vec<Real, 3>, 2, D>::empty({1, 0});
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;
 
@@ -485,7 +487,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
               prm[4]   // offset
           );
           accumulate_torsion_result<Real, Int, D>(
-              score, eval, atoms, compute_derivs, dV_dx[0], 1.0);
+              score, eval, atoms, accumulate_derivs, dV_dx[0], 1.0);
         });
 
     // -----------------------------------------------------------------------
@@ -503,7 +505,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
               prm[1]   // delta
           );
           accumulate_torsion_result<Real, Int, D>(
-              score, eval, atoms, compute_derivs, dV_dx[0], 1.0);
+              score, eval, atoms, accumulate_derivs, dV_dx[0], 1.0);
         });
 
     int block_ind2 = -1;
@@ -763,6 +765,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
                                        int bblock_ind1,
                                        int bblock_ind2) {
       Real const block_weight = dTdV[0][bpose_ind][bblock_ind1][bblock_ind2];
+      if (block_weight == 0) return;
       auto eval = gbtorsion_V_dV(
           rot_coords[atoms[0]],
           rot_coords[atoms[1]],
@@ -786,6 +789,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
                                         int bblock_ind1,
                                         int bblock_ind2) {
       Real const block_weight = dTdV[0][bpose_ind][bblock_ind1][bblock_ind2];
+      if (block_weight == 0) return;
       auto eval = gbimproper_V_dV(
           rot_coords[atoms[0]],
           rot_coords[atoms[1]],

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -77,7 +77,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
     if (cp_separation < 5) {                                   \
       return Real(0.0);                                        \
     }                                                          \
-    if (compute_derivs) {                                      \
+    if (accumulate_derivs) {                                   \
       Real val = hbond_atom_energy_and_derivs_full<TILE_SIZE>( \
           don_ind,                                             \
           acc_ind,                                             \
@@ -585,9 +585,11 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
   assert(max_n_interblock_bonds <= MAX_N_CONN);
 
-  auto dV_dcoords_t = compute_derivs
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs = compute_derivs && !output_block_pair_energies;
+  auto dV_dcoords_t = accumulate_derivs
                           ? TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms})
-                          : TPack<Vec<Real, 3>, 2, Dev>::empty({1, n_atoms});
+                          : TPack<Vec<Real, 3>, 2, Dev>::empty({1, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
@@ -926,6 +928,10 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
       return;
     }
 
+    if (dTdV[0][pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
     int const block_type1 = block_type_ind_for_rot[rot_ind1];
     int const block_type2 = block_type_ind_for_rot[rot_ind2];
 
@@ -1223,6 +1229,7 @@ auto HBondRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
   assert(max_n_interblock_bonds <= MAX_N_CONN);
 
+  bool const accumulate_derivs = compute_derivs;
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -813,9 +813,12 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   assert(block_type_path_distance.size(1) == max_n_block_atoms);
   assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-  auto dV_dcoords_t = require_gradient
+  // Block-pair autograd recomputes coordinate derivatives in backward.
+  bool const accumulate_derivs =
+      require_gradient && !output_block_pair_energies;
+  auto dV_dcoords_t = accumulate_derivs
                           ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
-                          : TPack<Vec<Real, 3>, 2, D>::empty({3, n_atoms});
+                          : TPack<Vec<Real, 3>, 2, D>::empty({3, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
@@ -1400,6 +1403,12 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::backward(
     int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
 
     if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      return;
+    }
+
+    if (dTdV[0][pose_ind][block_ind1][block_ind2] == 0
+        && dTdV[1][pose_ind][block_ind1][block_ind2] == 0
+        && dTdV[2][pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
 

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -811,6 +811,10 @@ class LKBallPoseScoreDispatch {
       for (int i = 0; i < 4; ++i) {
         local_dTdV[i] = dTdV[i][pose_ind][weight_block1][weight_block2];
       }
+      if (block_pair_scoring && local_dTdV[0] == 0 && local_dTdV[1] == 0
+          && local_dTdV[2] == 0 && local_dTdV[3] == 0) {
+        return;
+      }
 
       auto lk_ball_atom_derivs =
           ([=] TMOL_DEVICE_FUNC(

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -246,6 +246,36 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
     )
 
 
+def test_block_pair_gradients_respect_sparse_upstream_weights(
+    ubq_pdb, default_database, torch_device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    scorer = beta2016_score_function(
+        torch_device, default_database
+    ).render_block_pair_scoring_module(pose_stack)
+
+    n_blocks = pose_stack.max_n_blocks
+    split = n_blocks // 2
+    cross_mask = torch.zeros(
+        (1, n_blocks, n_blocks), device=torch_device, dtype=pose_stack.coords.dtype
+    )
+    cross_mask[:, :split, split:] = 1
+    cross_mask[:, split:, :split] = 1
+    all_pairs = torch.ones_like(cross_mask)
+
+    def gradient(upstream: torch.Tensor) -> torch.Tensor:
+        coords = pose_stack.coords.detach().clone().requires_grad_(True)
+        score = (scorer(coords) * upstream).sum()
+        return torch.autograd.grad(score, coords)[0]
+
+    sparse_gradient = gradient(cross_mask)
+    reference_gradient = gradient(all_pairs) - gradient(all_pairs - cross_mask)
+
+    torch.testing.assert_close(
+        sparse_gradient, reference_gradient, atol=2e-3, rtol=2e-3
+    )
+
+
 def test_block_pair_scoring_supports_only_invariant_zero_terms(torch_device):
     scorer = BlockPairScoringModule(
         torch.ones(2, device=torch_device),


### PR DESCRIPTION
## Summary

- avoid calculating and zero-initializing forward derivative buffers for block-pair scorers whose custom backward pass already recomputes derivatives
- skip block-pair backward work when every upstream weight for that pair is zero across LJ/LK, electrostatics, hydrogen bonds, LKBall, backbone torsions, Dunbrack, Cartesian/general bonded, and disulfide scoring
- add a regression test comparing a sparse interface gradient with an equivalent dense-gradient decomposition

This targets RFD4-style differentiable interface guidance, where a dense block-pair score tensor is multiplied by a sparse protein–DNA, antibody, or protein–ligand interaction mask. There are no Python API changes, and whole-pose scoring is unchanged.

## H200 benchmark

Median of three alternating baseline/optimized runs on one H200. Both revisions were built from source in the same Python 3.12, Torch 2.13, CUDA 13.2 image for SM90; each timing uses 10 warmups and 100 measured iterations.

| workload | operation | v0.1.52 | this PR | change |
|---|---:|---:|---:|---:|
| protein–DNA, batch 32 | forward with grad | 4.035 ms | 3.908 ms | 3.1% faster |
| protein–DNA, batch 32 | sparse forward + backward | 9.765 ms | 8.647 ms | 11.5% faster |
| antibody, batch 8 | forward with grad | 12.889 ms | 12.758 ms | 1.0% faster |
| antibody, batch 8 | sparse forward + backward | 25.230 ms | 23.791 ms | 5.7% faster |
| protein–ligand, batch 1 | forward with grad | 1.413 ms | 1.347 ms | 4.7% faster |
| protein–ligand, batch 1 | sparse forward + backward | 2.923 ms | 2.439 ms | 16.6% faster |
| protein–ligand, batch 8 | forward with grad | 5.408 ms | 5.297 ms | 2.0% faster |
| protein–ligand, batch 8 | sparse forward + backward | 11.305 ms | 9.606 ms | 15.0% faster |

Dense forward/backward changed by less than 2% in every case. The existing no-gradient point-mutation interface scorer remained approximately 1.33 ms, so this PR does not claim a speedup for that already-indexed v0.1.52 path. I also tested CUDA-graphing Cartesian minimization; warm FastRelax medians were 2.261 s eager and 2.250 s graphed, so that higher-risk/noise-level experiment is intentionally not included.

## Validation

- `146 passed` across the changed score-term CPU/CUDA suites, including finite-difference and reweighted block-pair gradchecks
- `29 passed, 1 skipped` in `tmol/tests/score/test_score_function.py`
- protein–DNA and protein–ligand sparse workload gradients agree with dense decompositions within `1e-5` maximum absolute error
- AOT CUDA wheel build succeeds
- pre-commit `clang-format`, `black`, and `flake8` hooks pass
