### PR TITLE
Accelerate mutation-neighborhood and rotamer setup

### DIFF
--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -313,13 +313,19 @@ def build_sidechain_coord_mask(
         Mask shaped ``[n_poses, max_n_atoms]``. Non-polymers contribute all
         real atoms; polymers exclude their declared main-chain atoms.
     """
+    cache_name = "_score_utils_sidechain_coord_mask"
+    if hasattr(pose_stack, cache_name):
+        return getattr(pose_stack, cache_name)
+
     block_for_atom, atom_in_block, real_atoms = _compact_atom_layout(pose_stack)
     block_type_for_atom = pose_stack.block_type_ind64.gather(1, block_for_atom)
     sidechain_atom_mask = _sidechain_atom_mask_for_block_type(pose_stack)
-    return (
+    coord_mask = (
         sidechain_atom_mask[block_type_for_atom.clamp_min(0), atom_in_block]
         & real_atoms
     )
+    object.__setattr__(pose_stack, cache_name, coord_mask)
+    return coord_mask
 
 
 def compute_block_centroids_and_furthest_dist(
@@ -409,6 +415,9 @@ def build_coord_mask_for_mask_and_interacting_atoms(
         raise ValueError("max_workspace_bytes must be positive")
 
     coord_mask = res_mask_to_coord_mask(pose_stack, mask)
+    if interaction_distance < 0:
+        return coord_mask
+
     sidechain_mask = build_sidechain_coord_mask(pose_stack)
     n_masked_atoms = coord_mask.sum(dim=1)
     max_n_masked_atoms = int(n_masked_atoms.max().item())
@@ -435,7 +444,7 @@ def build_coord_mask_for_mask_and_interacting_atoms(
     ]
     masked_coords_are_real[masked_pose, masked_slot] = True
 
-    # Bound the temporary [chunk, n_atoms, n_masked_atoms, 3] difference tensor.
+    # Bound the temporary [chunk, n_atoms, n_masked, 3] difference tensor.
     bytes_per_pose = (
         max_n_atoms
         * max_n_masked_atoms
@@ -451,12 +460,12 @@ def build_coord_mask_for_mask_and_interacting_atoms(
             - masked_coords[first_pose:last_pose, None, :, :]
         )
         differences.square_()
-        distances = differences.sum(dim=3).sqrt_()
-        distances.masked_fill_(
+        squared_distances = differences.sum(dim=3)
+        squared_distances.masked_fill_(
             ~masked_coords_are_real[first_pose:last_pose, None, :], float("inf")
         )
-        nearby_atoms[first_pose:last_pose] = distances.amin(dim=2).le(
-            interaction_distance
+        nearby_atoms[first_pose:last_pose] = squared_distances.amin(dim=2).le(
+            interaction_distance * interaction_distance
         )
 
     return coord_mask | (nearby_atoms & pose_stack.real_atoms & sidechain_mask)

--- a/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
+++ b/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
@@ -105,10 +105,9 @@ class FixedAAChiSampler(ChiSampler):
             is_bt_faas_allowed_and_built_by, cons_bt_is_allowed
         ).to(torch.int32)
 
-        n_fixed_rots = torch.sum(n_rots_for_gbt).item()
         gbt_for_rotamer = n_rots_for_gbt.nonzero(as_tuple=True)[0].to(torch.int32)
         chi_for_rotamers = torch.zeros(
-            (n_fixed_rots, 1), dtype=torch.float32, device=poses.device
+            (gbt_for_rotamer.shape[0], 1), dtype=torch.float32, device=poses.device
         )
         chi_defining_atom_for_rotamer = torch.full_like(
             chi_for_rotamers, -1, dtype=torch.int32

--- a/tmol/pack/rotamer/_na_chi_sampler.py
+++ b/tmol/pack/rotamer/_na_chi_sampler.py
@@ -298,13 +298,18 @@ class NaChiRotamerSampler(ChiSampler):
             )
 
         counts = n_rots_for_gbt
+        # Reuse the synchronized total so these kernels need not infer it again.
         gbt_for_rotamer = torch.repeat_interleave(
-            torch.arange(n_gbt, dtype=torch.int32, device=poses.device), counts
+            torch.arange(n_gbt, dtype=torch.int32, device=poses.device),
+            counts,
+            output_size=n_rots,
         )
         # index of each rotamer within its own block
         local = torch.arange(
             n_rots, dtype=torch.int32, device=poses.device
-        ) - torch.repeat_interleave(exclusive_cumsum1d(counts), counts)
+        ) - torch.repeat_interleave(
+            exclusive_cumsum1d(counts), counts, output_size=n_rots
+        )
 
         combos_per_rot = n_combos[gbt_for_rotamer]
         chi1_slot = torch.div(local, combos_per_rot, rounding_mode="floor")

--- a/tmol/pack/rotamer/_na_chi_sampler.py
+++ b/tmol/pack/rotamer/_na_chi_sampler.py
@@ -192,26 +192,27 @@ class NaChiRotamerSampler(ChiSampler):
             chis += [SYN_MEAN + k * sdev for k in steps]
         return chis
 
-    def _pucker_for_blocks(self, poses: PoseStack, pbt: PackedBlockTypes):
-        """argmax pucker state of every block's input sugar, -1 where absent."""
+    def _pucker_for_blocks(
+        self,
+        poses: PoseStack,
+        pbt: PackedBlockTypes,
+        pose_indices: Tensor[torch.int64][:],
+        block_indices: Tensor[torch.int64][:],
+        block_type_indices: Tensor[torch.int64][:],
+    ) -> Tensor[torch.int64][:]:
+        """Return the most likely input-sugar pucker for selected blocks."""
         cache = pbt.na_chi_sampler_cache
-        bt = poses.block_type_ind64
-        real = bt >= 0
-        ring_local = cache["ring"][bt.clamp_min(0)]
-        offset = poses.block_coord_offset64.unsqueeze(-1)
-        ok = (ring_local >= 0) & real.unsqueeze(-1)
+        ring_local = cache["ring"][block_type_indices]
+        offset = poses.block_coord_offset64[pose_indices, block_indices].unsqueeze(-1)
+        ok = ring_local >= 0
         index = (offset + ring_local).clamp_min(0)
-        n_poses = bt.shape[0]
         max_n_atoms = poses.coords.shape[1]
-        flat = (
-            torch.arange(n_poses, device=poses.device).view(-1, 1, 1) * max_n_atoms
-            + index
-        )
+        flat = pose_indices.unsqueeze(-1) * max_n_atoms + index
         xyz = poses.coords.reshape(-1, 3)[flat.reshape(-1)].reshape(*index.shape, 3)
         xyz = torch.where(ok.unsqueeze(-1), xyz, torch.zeros_like(xyz))
         w = pucker_weights(
             xyz.reshape(-1, 5, 3), self.params.pucker_temperature
-        ).reshape(*bt.shape, N_PUCKER)
+        ).reshape(pose_indices.shape[0], N_PUCKER)
         pucker = w.argmax(dim=-1)
         return torch.where(ok.all(-1), pucker, torch.full_like(pucker, -1))
 
@@ -237,8 +238,27 @@ class NaChiRotamerSampler(ChiSampler):
         ]
         active = allowed_for_cons & builds & bt_allowed
 
-        pucker_for_block = self._pucker_for_blocks(poses, pbt)
-        pucker = pucker_for_block[task.cons_bt_pose, task.cons_bt_block]
+        active_gbt = torch.nonzero(active, as_tuple=True)[0]
+        pucker = torch.full_like(task.cons_bt_pose, -1)
+        if active_gbt.numel() > 0:
+            active_pose = task.cons_bt_pose[active_gbt]
+            active_block = task.cons_bt_block[active_gbt]
+            active_global_block = active_pose * poses.max_n_blocks + active_block
+            unique_global_block, inverse = torch.unique_consecutive(
+                active_global_block, return_inverse=True
+            )
+            unique_pose = torch.div(
+                unique_global_block, poses.max_n_blocks, rounding_mode="floor"
+            )
+            unique_block = unique_global_block % poses.max_n_blocks
+            unique_pucker = self._pucker_for_blocks(
+                poses,
+                pbt,
+                unique_pose,
+                unique_block,
+                poses.block_type_ind64[unique_pose, unique_block],
+            )
+            pucker[active_gbt] = unique_pucker[inverse]
         base = cache["base"][task.cons_bt_block_type]
         active = active & (pucker >= 0)
 
@@ -277,13 +297,13 @@ class NaChiRotamerSampler(ChiSampler):
                 torch.zeros((0, n_chi), dtype=torch.float32, device=poses.device),
             )
 
-        counts = n_rots_for_gbt.to(torch.int64)
+        counts = n_rots_for_gbt
         gbt_for_rotamer = torch.repeat_interleave(
-            torch.arange(n_gbt, dtype=torch.int64, device=poses.device), counts
+            torch.arange(n_gbt, dtype=torch.int32, device=poses.device), counts
         )
         # index of each rotamer within its own block
         local = torch.arange(
-            n_rots, dtype=torch.int64, device=poses.device
+            n_rots, dtype=torch.int32, device=poses.device
         ) - torch.repeat_interleave(exclusive_cumsum1d(counts), counts)
 
         combos_per_rot = n_combos[gbt_for_rotamer]
@@ -308,7 +328,7 @@ class NaChiRotamerSampler(ChiSampler):
         )
         return (
             n_rots_for_gbt,
-            gbt_for_rotamer.to(torch.int32),
+            gbt_for_rotamer,
             cache["chi_atom"][rot_bt],
             chi,
         )

--- a/tmol/pack/rotamer/_opth_sampler.py
+++ b/tmol/pack/rotamer/_opth_sampler.py
@@ -888,11 +888,13 @@ class OptHSampler(ConformerSampler):
                 ),
             )
         rot_offset_for_gbt = exclusive_cumsum1d(n_rots_for_gbt)
+        # Reuse the synchronized total and keep the existing int32 indices.
         gbt_for_rotamer = torch.repeat_interleave(
             torch.arange(
                 n_rots_for_gbt.shape[0], dtype=torch.int32, device=pose_stack.device
             ),
-            n_rots_for_gbt.to(torch.int64),
+            n_rots_for_gbt,
+            output_size=n_rots_total,
         )
         chi_defining_atom_for_rotamer = torch.full(
             (n_rots_total, max_n_chi_cols),

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -65,7 +65,7 @@ class TermScoringModule(torch.nn.Module):
 
         self.term_score_poses = term_score_poses
 
-    def _build_static_tails(self, block_pair_scoring):
+    def _build_static_tails(self, block_pair_scoring: bool) -> None:
         # Pre-build the non-coordinate argument list used by every forward.
         # Float64 scoring is mainly used by gradcheck, so defer those copies
         # until a float64 input actually arrives.
@@ -73,7 +73,7 @@ class TermScoringModule(torch.nn.Module):
         self._static_tail_f32 = tuple(tail) + (block_pair_scoring,)
         self._static_tail_f64 = None
 
-    def _static_tail_for_coords(self, coords):
+    def _static_tail_for_coords(self, coords: torch.Tensor) -> tuple[object, ...]:
         if coords.dtype != torch.float64:
             return self._static_tail_f32
         if self._static_tail_f64 is None:

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -66,16 +66,21 @@ class TermScoringModule(torch.nn.Module):
         self.term_score_poses = term_score_poses
 
     def _build_static_tails(self, block_pair_scoring):
-        # Pre-build the (non-coords) portion of the arg list once,
-        #    for both float32 and float64 coord dtypes.
-        # Reused across every forward call to eliminat repeated cats/conversions
-        # (fd) if f32+f64 is too wasteful, make this a ScoringModule input?
+        # Pre-build the non-coordinate argument list used by every forward.
+        # Float64 scoring is mainly used by gradcheck, so defer those copies
+        # until a float64 input actually arrives.
         tail = list(self.common_parameters) + list(self.term_parameters)
         self._static_tail_f32 = tuple(tail) + (block_pair_scoring,)
+        self._static_tail_f64 = None
 
-        tail_f64 = list(tail)
-        convert_float64(tail_f64)
-        self._static_tail_f64 = tuple(tail_f64) + (block_pair_scoring,)
+    def _static_tail_for_coords(self, coords):
+        if coords.dtype != torch.float64:
+            return self._static_tail_f32
+        if self._static_tail_f64 is None:
+            tail_f64 = list(self._static_tail_f32[:-1])
+            convert_float64(tail_f64)
+            self._static_tail_f64 = tuple(tail_f64) + (self._static_tail_f32[-1],)
+        return self._static_tail_f64
 
     def add_parameters(self, table, params):
         def _p(t):
@@ -139,11 +144,7 @@ class TermWholePoseScoringModule(TermPoseScoringModule):
         coords,
     ):
         flat = coords.flatten(start_dim=0, end_dim=-2)
-        tail = (
-            self._static_tail_f64
-            if coords.dtype == torch.float64
-            else self._static_tail_f32
-        )
+        tail = self._static_tail_for_coords(coords)
         # ignore the dispatch_indices return tensor
         scores, _ = self.term_score_poses(flat, *tail)
         return scores
@@ -167,11 +168,7 @@ class TermBlockPairScoringModule(TermPoseScoringModule):
         coords,
     ):
         flat = coords.flatten(start_dim=0, end_dim=-2)
-        tail = (
-            self._static_tail_f64
-            if coords.dtype == torch.float64
-            else self._static_tail_f32
-        )
+        tail = self._static_tail_for_coords(coords)
         scores, _ = self.term_score_poses(flat, *tail)
         return scores
 
@@ -224,11 +221,7 @@ class TermRotamerScoringModule(TermScoringModule):
         indices: [3, nnz]          int32  (pose, rot_i, rot_j in global rot numbering)
         """
         flat = coords.flatten(start_dim=0, end_dim=-2)
-        tail = (
-            self._static_tail_f64
-            if coords.dtype == torch.float64
-            else self._static_tail_f32
-        )
+        tail = self._static_tail_for_coords(coords)
         scores, indices = self.term_score_poses(flat, *tail)
         return scores, indices
 

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -197,6 +197,7 @@ def test_interacting_coord_mask_matches_per_pose_reference(
 
     assert torch.equal(residue_mask, expected_residue_mask)
     assert torch.equal(sidechain_mask, expected_sidechain_mask)
+    assert score_utils.build_sidechain_coord_mask(poses) is sidechain_mask
 
     expected = residue_mask.clone()
     for pose_index in range(poses.n_poses):
@@ -222,6 +223,12 @@ def test_interacting_coord_mask_matches_per_pose_reference(
     assert not score_utils.build_coord_mask_for_mask_and_interacting_atoms(
         poses, torch.zeros_like(block_mask)
     ).any()
+    assert torch.equal(
+        score_utils.build_coord_mask_for_mask_and_interacting_atoms(
+            poses, block_mask, interaction_distance=-1
+        ),
+        residue_mask,
+    )
     with pytest.raises(ValueError, match="max_workspace_bytes"):
         score_utils.build_coord_mask_for_mask_and_interacting_atoms(
             poses, block_mask, max_workspace_bytes=0

--- a/tmol/tests/pack/rotamer/test_na_chi_sampler.py
+++ b/tmol/tests/pack/rotamer/test_na_chi_sampler.py
@@ -3,6 +3,8 @@
 import torch
 import pytest
 
+import tmol.pack.rotamer._na_chi_sampler as na_chi_sampler_module
+
 from tmol.io import (
     default_canonical_ordering,
     default_packed_block_types,
@@ -69,6 +71,7 @@ def test_na_sampler_chi_sit_at_scored_minima(
     assert chi.shape[0] > 0
     assert int(n_rots.sum()) == gbt_for_rot.shape[0]
     assert chi.shape[0] == gbt_for_rot.shape[0]
+    assert gbt_for_rot.dtype == torch.int32
 
     allowed = torch.cat(
         (
@@ -127,6 +130,43 @@ def test_na_sampler_chi_level_widens_the_rotamer_set(
         rna_pdb, default_database, torch_device, chi_sample_level=1
     )
     assert int(n_rots_1.sum()) == 3 * int(n_rots_0.sum())
+
+
+def test_na_sampler_measures_only_enabled_na_puckers(
+    protein_dna_pdb, default_database, torch_device, monkeypatch
+):
+    """Protein blocks in a mixed complex must not enter the sugar-pucker kernel."""
+    poses = _pose_stack(protein_dna_pdb, torch_device)
+    sampler = NaChiRotamerSampler.from_database(default_database, torch_device)
+    task = _set_task(poses, sampler)
+    sampler.annotate_packed_block_types(poses.packed_block_types)
+    sampler_index = task.conformer_sampler_index[id(sampler)]
+    allowed = task.per_block_conformer_sampler_allowed[
+        task.cons_bt_pose, task.cons_bt_block, sampler_index
+    ]
+    builds = poses.packed_block_types.na_chi_sampler_cache["builds_bt"][
+        task.cons_bt_block_type
+    ]
+    block_type_allowed = task.per_block_is_block_type_allowed[
+        task.cons_bt_pose, task.cons_bt_block, task.cons_bt_which_block_type
+    ]
+    active = allowed & builds & block_type_allowed
+    active_pose = task.cons_bt_pose[active]
+    active_block = task.cons_bt_block[active]
+    expected = torch.unique(active_pose * poses.max_n_blocks + active_block).numel()
+    assert 0 < expected < task.cons_bt_block_type.shape[0]
+
+    calls = []
+    original = na_chi_sampler_module.pucker_weights
+
+    def record_pucker_count(xyz, temperature):
+        calls.append(xyz.shape[0])
+        return original(xyz, temperature)
+
+    monkeypatch.setattr(na_chi_sampler_module, "pucker_weights", record_pucker_count)
+    sampler.sample_chi_for_poses(poses, task)
+
+    assert calls == [expected]
 
 
 @pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb"])

--- a/tmol/tests/score/common/test_scoring_module.py
+++ b/tmol/tests/score/common/test_scoring_module.py
@@ -1,0 +1,27 @@
+"""Tests for shared rendered-scoring module behavior."""
+
+import torch
+
+from tmol.score.common import TermScoringModule
+
+
+def test_float64_static_parameters_are_built_lazily() -> None:
+    module = TermScoringModule(
+        "test",
+        [torch.tensor([1.0], dtype=torch.float32)],
+        lambda *args: args,
+    )
+    module.common_parameters = []
+    module._build_static_tails(False)
+
+    assert module._static_tail_f64 is None
+
+    tail_f32 = module._static_tail_for_coords(torch.zeros(1))
+    assert tail_f32[0].dtype == torch.float32
+    assert module._static_tail_f64 is None
+
+    tail_f64 = module._static_tail_for_coords(torch.zeros(1, dtype=torch.float64))
+    assert tail_f64[0].dtype == torch.float64
+    assert (
+        module._static_tail_for_coords(torch.zeros(1, dtype=torch.float64)) is tail_f64
+    )


### PR DESCRIPTION
## Summary

Accelerate topology/setup work that dominates repeated mutation scans without changing scoring semantics:

- cache the topology-only side-chain atom mask on each pose stack;
- compare squared distances in the nearby-atom search and retain the 256 MiB temporary-workspace cap;
- evaluate sugar puckers only for enabled nucleic-acid pose/block entries;
- produce nucleic-acid rotamer indices directly as int32 and remove a duplicate fixed-rotamer count synchronization;
- reuse already-known expansion sizes in nucleic-acid and antibody OptH setup, avoiding redundant stream synchronizations and an OptH int64 count copy;
- defer float64 scorer-parameter copies until float64 scoring is actually requested.

The implementation keeps the existing dense atom layout because a compact candidate representation regressed protein-ligand workloads. The 256 MiB value is a temporary-allocation target, not reserved GPU memory; chunk sizes still adapt to each input shape and dtype.

## Measured performance

CPU benchmarks on representative repeated-workflow paths:

| Workload | Before | This PR | Change |
|---|---:|---:|---:|
| Protein-100 nearby-atom mask, batch 64 | 3.922 ms | 2.873 ms | 26.7% faster |
| Protein-ligand nearby-atom mask, batch 8 | 1.515 ms | 1.425 ms | 5.9% faster |
| DNA full NA sampler | 637.2 us | 625.1 us | 1.9% faster |
| RNA full NA sampler | 927.2 us | 857.9 us | 7.5% faster |
| Protein-DNA full NA sampler | 835.9 us | 791.8 us | 5.3% faster |
| Protein-DNA pucker calculation | 393.3 us | 254.4 us | 35.3% faster |
| Protein-400 repeated scorer render | 6.604 ms | 0.481 ms | 13.72x faster |
| NA repeat expansion, 100 considered types | 7.21 us | 3.88 us | 1.86x faster |
| OptH repeat expansion, 100 considered types | 8.20 us | 4.89 us | 1.68x faster |

The antibody nearby-mask case is neutral within benchmark noise. At 10,000 considered types, the isolated known-size expansions remain 1.27x faster for NA and 1.36x faster for OptH.

## Correctness and validation

- DNA, RNA, and protein-DNA sampler outputs are byte-identical to master across every returned tensor
- PyTorch 2.13 int32/known-size repeat expansions are exactly equal to the prior int64/inferred-size outputs
- 19 targeted score-utils and NA-sampler tests passed; 19 CUDA-only cases skipped on CPU
- 27 fixed/current/build-rotamer tests passed; 24 CUDA-only cases skipped on CPU
- whole-pose and block-pair float64 gradchecks passed
- lazy float64 cache regression test passed
- combined performance/docs tree before the final output-size-only refinement: 1,472 passed, 913 skipped, 5 expected xfails, 1 expected xpass, zero failures
- Black, Flake8, and git diff checks clean
- GitHub complete CPU/CUDA/benchmark CI and strict docs build on the rebased head are final merge gates
