### PR TITLE
Clarify public API documentation and test compatibility

### DIFF
--- a/.github/scripts/smoke_tutorial_notebooks.py
+++ b/.github/scripts/smoke_tutorial_notebooks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import copy
 import os
+import re
 from pathlib import Path
 
 import nbformat
@@ -23,6 +24,10 @@ TUTORIAL_NOTEBOOKS = (
 )
 TUTORIAL_REF = "master"
 KERNEL_STARTUP_TIMEOUT = 180
+CPU_CUDA_RUNTIME_NOISE = re.compile(
+    r"^W\d{4} .* torch/utils/cpp_extension\.py:\d+\] "
+    r"No CUDA runtime is found, using CUDA_HOME='[^']*'\n?$"
+)
 
 
 def _validate_tutorial_entrypoints(notebook, path: Path) -> None:
@@ -63,6 +68,27 @@ def _without_gpu_cells(notebook):
     return notebook
 
 
+def _remove_expected_cpu_cuda_noise(notebook) -> None:
+    """Remove PyTorch's expected no-CUDA warning from published CPU outputs."""
+    for cell in notebook.cells:
+        if cell.cell_type != "code":
+            continue
+        retained = []
+        for output in cell.outputs:
+            if output.output_type != "stream":
+                retained.append(output)
+                continue
+            text = "".join(
+                line
+                for line in output.text.splitlines(keepends=True)
+                if not CPU_CUDA_RUNTIME_NOISE.fullmatch(line)
+            )
+            if text:
+                output.text = text
+                retained.append(output)
+        cell.outputs = retained
+
+
 def execute_notebook(
     path: Path,
     timeout: int,
@@ -85,6 +111,8 @@ def execute_notebook(
         resources={"metadata": {"path": str(path.parent.resolve())}},
     )
     client.execute()
+    if not include_gpu_cells:
+        _remove_expected_cpu_cuda_noise(executed)
     if write:
         # Preserve the authored source (including GPU examples), but copy the
         # CPU execution results used by nbsphinx into the CI workspace.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -218,13 +218,12 @@ tail -f /net/scratch/kdidi/actions-runner/runner.log
 ## Releasing
 
 The version in a development checkout is not proof that a release has been
-published. As of 2026-07-17, GitHub Releases and PyPI contain v0.1.40; v0.1.42
-is the next validated release candidate. Check the GitHub Releases page before
-using a versioned wheel URL.
+published. Check both GitHub Releases and PyPI before choosing the next version
+or using a versioned wheel URL; published versions and artifacts are immutable.
 
 1. Bump `project.version` in `pyproject.toml`.
 2. Commit the version bump and ensure both `CI` and `Wheel smoke test` pass.
-3. Create and push the matching version tag (for example `v0.1.42`):
+3. Create and push the matching version tag (for example `vX.Y.Z`):
    - `publish.yml` triggers only from a pushed `v*` tag.
    - The workflow rejects tags that do not match `project.version`.
 4. Wait for workflow completion:
@@ -235,7 +234,7 @@ using a versioned wheel URL.
    - `upload`
 5. Verify release artifacts:
    - PyPI sdist upload succeeds.
-   - GitHub prerelease `vX.Y.Z` exists and contains exactly 32 manylinux wheel files: 24 GPU and 8 CPU.
+   - GitHub prerelease `vX.Y.Z` exists and contains exactly 33 manylinux wheel files: 25 GPU and 8 CPU.
 6. Install using explicit wheel files (recommended):
    - Install matching PyTorch/CUDA first.
    - Install from GitHub release wheel URL (or pinned `tmol==X.Y.Z+...` with `--find-links`).
@@ -269,4 +268,3 @@ Pre-commit runs `clang-format` (C++) and `black` (Python) on staged files. If fo
 ### Pull requests
 
 All changes to master go through pull requests. PRs are merged via squash or rebase to keep a linear history. Each PR should be an atomic unit of work.
-

--- a/docs/api/analysis.rst
+++ b/docs/api/analysis.rst
@@ -8,5 +8,4 @@ metadata, use :func:`tmol.score.calculate_fragment_interactions`.
 .. automodule:: tmol.ops
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/chemical.rst
+++ b/docs/api/chemical.rst
@@ -6,7 +6,6 @@ Public chemical database and residue-type objects.
 .. automodule:: tmol.chemical
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 Public constants and aliases

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -7,5 +7,4 @@ parameters used to construct poses and score functions.
 .. automodule:: tmol.database
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -9,5 +9,4 @@ mmCIF structures, including nucleic acids and ligands.
 .. automodule:: tmol.io
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/kinematics.rst
+++ b/docs/api/kinematics.rst
@@ -6,5 +6,4 @@ Fold forests, move maps, and kinematic coordinate operations.
 .. automodule:: tmol.kinematics
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/ligand.rst
+++ b/docs/api/ligand.rst
@@ -7,7 +7,6 @@ from the public :mod:`tmol.ligand` package.
 .. automodule:: tmol.ligand
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 Public constants

--- a/docs/api/numeric.rst
+++ b/docs/api/numeric.rst
@@ -4,5 +4,4 @@ Numerical Utilities
 .. automodule:: tmol.numeric
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/optimization.rst
+++ b/docs/api/optimization.rst
@@ -6,5 +6,4 @@ Cartesian and kinematic minimization entry points.
 .. automodule:: tmol.optimization
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/pack.rst
+++ b/docs/api/pack.rst
@@ -7,7 +7,6 @@ the conformations considered by the packer.
 .. automodule:: tmol.pack
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 Rotamer sampling
@@ -16,11 +15,9 @@ Rotamer sampling
 .. automodule:: tmol.pack.rotamer
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: tmol.pack.rotamer.dunbrack
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/pose.rst
+++ b/docs/api/pose.rst
@@ -9,7 +9,6 @@ stored in ``ConstraintSet``.
 .. automodule:: tmol.pose
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 Public defaults

--- a/docs/api/relax.rst
+++ b/docs/api/relax.rst
@@ -7,5 +7,4 @@ and acceptance behavior are TMol-specific.
 .. automodule:: tmol.relax
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/score.rst
+++ b/docs/api/score.rst
@@ -8,7 +8,6 @@ individual :class:`tmol.score.ScoreType` weights.
 .. automodule:: tmol.score
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 .. currentmodule:: tmol.score

--- a/docs/api/score_terms.rst
+++ b/docs/api/score_terms.rst
@@ -107,6 +107,7 @@ Nucleic-acid term
 .. automodule:: tmol.score.na_torsion
    :members:
    :imported-members:
+   :exclude-members: NaTorsionEnergyTerm
    :show-inheritance:
 
 The public parameter aliases and fitted-model constants are also available
@@ -140,6 +141,7 @@ Constraints
 .. automodule:: tmol.score.constraint
    :members:
    :imported-members:
+   :exclude-members: ConstraintEnergyTerm
    :show-inheritance:
 
 .. currentmodule:: tmol.score.constraint
@@ -161,5 +163,4 @@ a :class:`tmol.score.ScoreFunction` rather than instantiate creators directly.
 .. automodule:: tmol.score.terms
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -4,5 +4,4 @@ Types
 .. automodule:: tmol.types
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -4,7 +4,6 @@ Utilities
 .. automodule:: tmol.utility
    :members:
    :imported-members:
-   :undoc-members:
    :show-inheritance:
 
 Public aliases and units

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.52"
+version = "0.1.53"
 
 dependencies = [
     # Core ML framework

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.53"
+version = "0.1.52"
 
 dependencies = [
     # Core ML framework

--- a/tmol/chemical/_restypes.py
+++ b/tmol/chemical/_restypes.py
@@ -30,6 +30,8 @@ BondCount = NewType("BondCount", int)
 
 
 class BondType(IntEnum):
+    """Supported covalent bond orders for residue-type topology."""
+
     SINGLE = 1
     DOUBLE = 2
     TRIPLE = 3
@@ -158,6 +160,8 @@ def get_element_from_atom_name(atom_name: str) -> str:
 
 @attr.s
 class RefinedResidueType(RawResidueType):
+    """Residue type augmented with indexed atoms, bonds, and kinematic metadata."""
+
     @property
     def n_atoms(self):
         return len(self.atoms)
@@ -626,6 +630,8 @@ class RefinedResidueType(RawResidueType):
 
 @attr.s(auto_attribs=True)
 class ResidueTypeSet:
+    """Collection of residue types refined from one chemical database."""
+
     __default = None
     __refined_cache = None
 

--- a/tmol/database/_patched_chemdb.py
+++ b/tmol/database/_patched_chemdb.py
@@ -602,6 +602,8 @@ def do_patch(res, variant, resgraph, patchgraph, marked):  # noqa: C901
 # returns PatchedChemicalDatabase containing only Tuple[RawResidueType]
 @attr.s(auto_attribs=True)
 class PatchedChemicalDatabase:
+    """Chemical database containing residue types after variant application."""
+
     element_types: Tuple[Element, ...]
     atom_types: Tuple[AtomType, ...]
     residues: Tuple[RawResidueType, ...]

--- a/tmol/io/_extern.py
+++ b/tmol/io/_extern.py
@@ -2,6 +2,7 @@ import requests
 
 
 def fetch_pdb(pdbid):
+    """Download a PDB-format structure from the RCSB Protein Data Bank."""
     return requests.get(
         "https://files.rcsb.org/download/%s.pdb" % str.upper(pdbid)
     ).text

--- a/tmol/io/_generic.py
+++ b/tmol/io/_generic.py
@@ -5,6 +5,7 @@ from functools import singledispatch
 
 @singledispatch
 def to_pdb(system):
+    """Serialize a supported molecular system to PDB text."""
     raise NotImplementedError(f"Unknown system: {system}")
 
 

--- a/tmol/io/_pose_stack_deconstruction.py
+++ b/tmol/io/_pose_stack_deconstruction.py
@@ -20,6 +20,16 @@ from tmol.io.details import (
 def canonical_form_from_pose_stack(
     canonical_ordering: CanonicalOrdering, pose_stack: PoseStack, chain_id=None
 ):
+    """Convert a pose stack to canonical residue and atom tensors.
+
+    Args:
+        canonical_ordering: Residue and atom ordering for the output tensors.
+        pose_stack: Poses to deconstruct.
+        chain_id: Optional integer chain identifiers shaped ``[pose, residue]``.
+
+    Returns:
+        Canonical form containing coordinates, residue metadata, and connectivity.
+    """
     pbt = pose_stack.packed_block_types
     co = canonical_ordering
     _annotate_packed_block_types_w_canonical_res_order(co, pbt)

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -966,6 +966,18 @@ def biotite_from_canonical_form(  # noqa: C901
     cf: CanonicalForm,
     co: CanonicalOrdering | None = None,
 ) -> biotite.structure.AtomArray | biotite.structure.AtomArrayStack:
+    """Convert canonical TMol tensors to a Biotite atom array.
+
+    Args:
+        cf: Canonical coordinates, residue identities, and metadata.
+        co: Canonical atom ordering. Defaults to the Biotite ordering.
+
+    Returns:
+        One atom array, or an atom-array stack for multiple coordinate sets.
+
+    Raises:
+        ValueError: If poses in a multi-pose input have different metadata.
+    """
     import biotite.structure as struc
 
     if co is None:

--- a/tmol/kinematics/_check_fold_forest.py
+++ b/tmol/kinematics/_check_fold_forest.py
@@ -324,6 +324,16 @@ def validate_fold_forest(
     n_blocks: NDArray[numpy.int64][:],
     edges: NDArray[numpy.int64][:, :, 4],
 ):
+    """Validate batched fold-forest edges and raise with pose-specific details.
+
+    Args:
+        n_blocks: Number of real blocks in each pose, shaped ``[pose]``.
+        edges: Fold-forest edges shaped ``[pose, edge, 4]``.
+
+    Raises:
+        ValueError: If an edge is invalid, connectivity is incomplete or cyclic,
+            or jump numbering is inconsistent.
+    """
     (
         good,
         bad_edges,

--- a/tmol/kinematics/_datatypes.py
+++ b/tmol/kinematics/_datatypes.py
@@ -122,6 +122,8 @@ class KinForest(TensorGroup, ConvertAttrs):
 
 @attrs.define(auto_attribs=True, frozen=True)
 class KinForestScanData(TensorGroup, ConvertAttrs):
+    """Node, scan-start, and generation-start tensors for a kinematic scan."""
+
     nodes: Tensor[torch.int]
     scans: Tensor[torch.int]
     gens: Tensor[torch.int]
@@ -129,6 +131,8 @@ class KinForestScanData(TensorGroup, ConvertAttrs):
 
 @attrs.define(auto_attribs=True, frozen=True)
 class KinematicModuleData:
+    """Topology and traversal tensors required by a pose kinematics module."""
+
     forest: KinForest
     scan_data_fw: KinForestScanData
     scan_data_bw: KinForestScanData

--- a/tmol/kinematics/_fold_forest.py
+++ b/tmol/kinematics/_fold_forest.py
@@ -7,6 +7,8 @@ from tmol.pose import PoseStack
 
 
 class EdgeType(enum.IntEnum):
+    """Kinds of directed connections represented in a fold forest."""
+
     polymer = 0
     jump = enum.auto()
     root_jump = enum.auto()
@@ -228,7 +230,16 @@ class FoldForest:
         return cls(max_n_edges=max_n_edges, n_edges=n_edges, edges=edges)
 
     @classmethod
-    def from_edges(cls, edges: NDArray[int][:, :, 4]):
+    def from_edges(cls, edges: NDArray[int][:, :, 4]) -> "FoldForest":
+        """Construct a fold forest from a padded edge array.
+
+        Args:
+            edges: Edge records shaped ``[pose, edge, 4]``. Unused entries
+                have ``-1`` in their edge-type column.
+
+        Returns:
+            A fold forest with per-pose edge counts inferred from ``edges``.
+        """
         return cls(
             max_n_edges=edges.shape[1],
             n_edges=numpy.sum(edges[:, :, 0] != -1, axis=1),

--- a/tmol/kinematics/_scan_ordering.py
+++ b/tmol/kinematics/_scan_ordering.py
@@ -334,6 +334,15 @@ def construct_kin_module_data_for_pose(
     pose_stack: PoseStack,
     fold_forest_edges: Tensor[torch.int32][:, :, 4],
 ):
+    """Construct the indexed forest and scan order for batched poses.
+
+    Args:
+        pose_stack: Poses whose atoms will form the kinematic forest.
+        fold_forest_edges: Fold-forest edges shaped ``[pose, edge, 4]``.
+
+    Returns:
+        Immutable topology and traversal data for forward and backward scans.
+    """
     from tmol.kinematics.compiled import (
         calculate_ff_edge_delays,
         get_children,

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -13,6 +13,8 @@ from tmol.kinematics.compiled import inverse_kin
 
 
 class CartesianSfxnNetwork(torch.nn.Module):
+    """Differentiable score network over selected Cartesian coordinates."""
+
     def __init__(
         self, score_function: ScoreFunction, pose_stack: PoseStack, coord_mask=None
     ):
@@ -79,6 +81,8 @@ class CartesianSfxnNetwork(torch.nn.Module):
 
 
 class KinForestSfxnNetwork(torch.nn.Module):
+    """Differentiable score network over selected kinematic degrees of freedom."""
+
     def __init__(
         self,
         score_function: ScoreFunction,

--- a/tmol/pack/_datatypes.py
+++ b/tmol/pack/_datatypes.py
@@ -10,6 +10,8 @@ from tmol.types import (
 
 @attr.s(auto_attribs=True, frozen=True)
 class PackerEnergyTables(TensorGroup, ConvertAttrs):
+    """One- and two-body energy tables plus their packed rotamer indexing."""
+
     max_n_rotamers_per_pose: int
     pose_n_res: Tensor[torch.int32][:]  # [n-poses]
     pose_n_rotamers: Tensor[torch.int32][:]  # [n-poses]

--- a/tmol/pack/_packer_task.py
+++ b/tmol/pack/_packer_task.py
@@ -53,6 +53,8 @@ def set_compare(x, y):
 
 @attr.define(slots=True, frozen=True)
 class PackerPalleteAnnotation:
+    """Cached residue-type compatibility tensors for a packer palette."""
+
     max_n_allowed: int
     n_allowed_block_types_for_block_type: Tensor[torch.int64][:]
     allowed_block_types_for_block_type: Tensor[torch.bool][:, :]
@@ -61,6 +63,8 @@ class PackerPalleteAnnotation:
 
 
 class PackerPalette:
+    """Define which residue types may replace each original residue type."""
+
     def __init__(self):
         pass
 
@@ -71,6 +75,16 @@ class PackerPalette:
         Tensor[torch.int64][:, :, :],
         Tensor[torch.bool][:, :, :],
     ]:
+        """Return residue-type choices allowed by the default palette.
+
+        Args:
+            pbt: Packed residue-type collection shared by the poses.
+            orig: Original residue-type index for each pose and block.
+
+        Returns:
+            The number of choices, padded choice indices, and a mask marking
+            each original residue type.
+        """
         # initialize the list of allowed block types for a PoseStack based on the
         # original block types; the logic of which block types are allowed given
         # the original block type is pre-computed and cached in the PackedBlockTypes
@@ -113,7 +127,8 @@ class PackerPalette:
 
     def create_restrict_to_repacking_mask(
         self, pbt: PackedBlockTypes, orig: Tensor[torch.int64][:, :]
-    ):
+    ) -> Tensor[torch.bool][:, :, :]:
+        """Return choices that preserve each block's original residue name."""
         # initialize the restrict-to-repacking mask for a PoseStack based on the
         # original block types; the logic of which block types are allowed for each
         # starting block type can be pre-computed and cached in the PackedBlockTypes
@@ -261,6 +276,7 @@ def _annotate_packed_block_types_for_default_packer_palette(pbt: PackedBlockType
 
 
 class PackerTask:
+    """Configure residue identities, conformers, and movable sites for packing."""
 
     def __init__(self, systems: PoseStack, palette: PackerPalette):
         self.pbt = systems.packed_block_types
@@ -355,7 +371,8 @@ class PackerTask:
             self.per_block_is_block_type_allowed, restriction
         )
 
-    def add_conformer_sampler(self, sampler: ConformerSampler):
+    def add_conformer_sampler(self, sampler: ConformerSampler) -> None:
+        """Enable a conformer sampler at every block."""
         self.conformer_samplers.append(sampler)
         self.conformer_sampler_index[id(sampler)] = len(self.conformer_samplers) - 1
         self.per_block_conformer_sampler_allowed = torch.cat(
@@ -376,7 +393,8 @@ class PackerTask:
 
     def add_conformer_sampler_by_block_mask(
         self, sampler: ConformerSampler, block_type_mask: Tensor[torch.bool][:, :]
-    ):
+    ) -> None:
+        """Enable a conformer sampler only at selected pose/block entries."""
         assert (
             block_type_mask.shape == self.per_block_n_considered_block_types.shape[:2]
         )
@@ -392,23 +410,29 @@ class PackerTask:
             dim=-1,
         )
 
-    def or_expand_chi(self, chi_ind: int):
+    def or_expand_chi(self, chi_ind: int) -> None:
+        """Request one extra standard-deviation sample for a chi torsion."""
         self.per_block_chi_expansion[:, :, :, chi_ind] = 1
 
-    def or_expand_chi_to(self, chi_ind: int, sample_level: int):
+    def or_expand_chi_to(self, chi_ind: int, sample_level: int) -> None:
+        """Raise a chi torsion's expansion level without lowering it."""
         # max over the current sample level and the new sample level.
         self.per_block_chi_expansion[:, :, :, chi_ind] = torch.max(
             self.per_block_chi_expansion[:, :, :, chi_ind], sample_level
         )
 
-    def disable_packing_by_block_mask(self, block_type_mask: Tensor[torch.bool][:, :]):
+    def disable_packing_by_block_mask(
+        self, block_type_mask: Tensor[torch.bool][:, :]
+    ) -> None:
+        """Disable packing at selected pose/block entries."""
         assert block_type_mask.device == self.device
         assert block_type_mask.shape == self.per_block_is_block_type_allowed.shape[:2]
         self.per_block_is_block_type_allowed = torch.logical_and(
             self.per_block_is_block_type_allowed, ~block_type_mask.unsqueeze(-1)
         )
 
-    def or_bump_check(self, setting=True):
+    def or_bump_check(self, setting: bool = True) -> None:
+        """Enable bump checking without allowing later calls to disable it."""
         self._bump_check |= setting
 
     @property

--- a/tmol/pack/rotamer/_build_rotamers.py
+++ b/tmol/pack/rotamer/_build_rotamers.py
@@ -588,6 +588,14 @@ def measure_dofs_from_orig_coords(
 def measure_pose_dofs(
     poses: PoseStack,
 ) -> tuple[KinForest, Tensor[torch.float32][:, 9]]:
+    """Measure the internal coordinates of every real residue in a pose stack.
+
+    Args:
+        poses: Poses providing residue topology and Cartesian coordinates.
+
+    Returns:
+        A residue-local kinematic forest and its measured degrees of freedom.
+    """
     # measure the DOFs for the original residues
     # -- first build kinforests for the original residues,
     # -- then call measure_dofs_from_orig_coords

--- a/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
+++ b/tmol/pack/rotamer/_fixed_aa_chi_sampler.py
@@ -25,6 +25,8 @@ from tmol.pack.rotamer import ChiSampler
 
 @attr.s(auto_attribs=True, frozen=True)
 class FixedAAChiSampler(ChiSampler):
+    """Generate one ideal side-chain conformer for fixed amino acids."""
+
     @classmethod
     def sampler_name(cls):
         return "FixedAAChiSampler"

--- a/tmol/pack/rotamer/_include_current_sampler.py
+++ b/tmol/pack/rotamer/_include_current_sampler.py
@@ -19,6 +19,7 @@ from tmol.pack.rotamer import ConformerSampler
 
 @attr.s(auto_attribs=True, frozen=True)
 class IncludeCurrentSampler(ConformerSampler):
+    """Add each packable residue's current conformation to its rotamer set."""
 
     @classmethod
     def sampler_name(cls):

--- a/tmol/pack/rotamer/_mainchain_fingerprint.py
+++ b/tmol/pack/rotamer/_mainchain_fingerprint.py
@@ -82,6 +82,8 @@ from tmol.pack.rotamer import (
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class AtomFingerprint:
+    """Topology signature locating an atom relative to the main chain."""
+
     mc_ind: int
     mc_bond_dist: int
     chirality: int
@@ -91,6 +93,8 @@ class AtomFingerprint:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class MCFingerprint:
+    """Main-chain atom fingerprint and its residue-local atom mapping."""
+
     mc_ats: NDArray[numpy.int32][:]
     mc_at_fingerprints: Tuple[AtomFingerprint, ...]
     fingerprint: Tuple[AtomFingerprint, ...]
@@ -99,6 +103,8 @@ class MCFingerprint:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class MCFingerprints:
+    """Packed main-chain fingerprint mappings indexed by conformer sampler."""
+
     atom_mapping: Tensor[torch.int32][:, :, :, :]  # make int64
     sampler_mapping: Mapping[str, int]
     max_sampler: Tensor[torch.int32][:]

--- a/tmol/pack/rotamer/_rotamer_set.py
+++ b/tmol/pack/rotamer/_rotamer_set.py
@@ -9,6 +9,8 @@ from tmol.types import (
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class RotamerSet(ValidateAttrs):
+    """Packed coordinates and pose/block indexing for generated rotamers."""
+
     n_rots_for_pose: Tensor[torch.int64][:]
     rot_offset_for_pose: Tensor[torch.int64][:]
     n_rots_for_block: Tensor[torch.int64][:, :]

--- a/tmol/pack/rotamer/_single_residue_kinforest.py
+++ b/tmol/pack/rotamer/_single_residue_kinforest.py
@@ -19,6 +19,8 @@ from tmol.pose import PackedBlockTypes
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class RotamerKintree:
+    """Residue-local kinematic tree and scan ordering in NumPy form."""
+
     kinforest_idx: NDArray[numpy.int32][
         :
     ]  # mapping from restype order to kinforest order
@@ -39,6 +41,8 @@ class RotamerKintree:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class PackedRotamerKintree:
+    """Padded batch of residue-local kinematic trees."""
+
     kinforest_idx: NDArray[numpy.int32][
         :, :
     ]  # mapping from restype order to kinforest order
@@ -60,9 +64,6 @@ class PackedRotamerKintree:
 
 @validate_args
 def construct_single_residue_kinforest(restype: RefinedResidueType):
-    from tmol.kinematics.compiled import inverse_kin
-    from tmol.utility.ndarray import invert_mapping
-
     """Create a kinforest for a single residue and its associated
     scan ordering data.
 
@@ -74,6 +75,9 @@ def construct_single_residue_kinforest(restype: RefinedResidueType):
 
     Also create the backbone fingerprint
     """
+    from tmol.kinematics.compiled import inverse_kin
+    from tmol.utility.ndarray import invert_mapping
+
     if hasattr(restype, "rotamer_kinforest"):
         return
 

--- a/tmol/pack/rotamer/dunbrack/_dunbrack_chi_sampler.py
+++ b/tmol/pack/rotamer/dunbrack/_dunbrack_chi_sampler.py
@@ -64,6 +64,8 @@ class DunSamplerPBTCache:
 # ParamResolver.
 # @attr.s(auto_attribs=True, slots=True, frozen=True)
 class DunbrackChiSampler(ChiSampler):
+    """Sample amino-acid side-chain conformers from Dunbrack libraries."""
+
     dun_param_resolver: DunbrackParamResolver
 
     def __eq__(self, other):

--- a/tmol/pose/_pose_stack.py
+++ b/tmol/pose/_pose_stack.py
@@ -134,14 +134,17 @@ class PoseStack:
 
     @property
     def n_poses(self) -> int:
+        """Return the number of poses in the stack."""
         return self.coords.shape[0]
 
     @property
     def max_n_blocks(self) -> int:
+        """Return the padded residue count per pose."""
         return self.block_coord_offset.shape[1]
 
     @property
     def max_n_atoms(self) -> int:
+        """Return the maximum atom count among packed residue types."""
         return self.packed_block_types.max_n_atoms
 
     @property
@@ -276,6 +279,7 @@ class PoseStack:
 
     @property
     def n_res_per_pose(self) -> Tensor[torch.int64][:]:
+        """Return the number of real residues in each pose."""
         return torch.sum(self.block_type_ind >= 0, dim=1)
 
     def is_real_block(self, pose_ind: int, block_ind: int) -> torch.Tensor:

--- a/tmol/pose/_pose_stack_builder.py
+++ b/tmol/pose/_pose_stack_builder.py
@@ -37,12 +37,22 @@ from tmol.utility.tensor import (
 
 
 class PoseStackBuilder:
+    """Build heterogeneous pose stacks while preserving chemical-database identity."""
 
     @classmethod
     @validate_args
     def from_poses(
         cls, pose_stacks: List[PoseStack], device: torch.device
     ) -> PoseStack:
+        """Combine one or more pose stacks on a common device.
+
+        Args:
+            pose_stacks: Pose stacks built from the same chemical database.
+            device: Device for the combined tensors.
+
+        Returns:
+            A padded pose stack containing every input pose in order.
+        """
         pbt0 = pose_stacks[0].packed_block_types
         for ps in pose_stacks:
             # all PoseStacks must be built from the same chemical database

--- a/tmol/score/_bonded_atom.py
+++ b/tmol/score/_bonded_atom.py
@@ -9,6 +9,8 @@ from tmol.types import Tensor
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class IndexedBonds:
+    """Sorted atom bonds with per-atom spans for efficient neighborhood lookup."""
+
     # bonds = [ nstacks x nbonds x 2 ]
     #   with 2 = (atom1ind atom2ind)
     # bond_spans = [ nstacks x max-natoms x 2 ]

--- a/tmol/score/_chemical_database.py
+++ b/tmol/score/_chemical_database.py
@@ -21,6 +21,8 @@ from enum import IntEnum
 
 
 class AcceptorHybridization(IntEnum):
+    """Hydrogen-bond acceptor hybridization categories."""
+
     none = 0
     sp2 = 1
     sp3 = 2
@@ -34,6 +36,8 @@ AcceptorHybridization._index = pandas.Index([None, "sp2", "sp3", "ring"])
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class AtomTypeParams(TensorGroup, ValidateAttrs):
+    """Packed donor, acceptor, hydrogen, and hybridization atom-type flags."""
+
     is_acceptor: Tensor[bool][...]
     acceptor_hybridization: Tensor[torch.int32][...]
 

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
 
 
 class EnergyTerm:
+    """Base protocol for topology setup and rendering of one energy term.
+
+    Subclasses describe their score types and body order, cache topology-only
+    annotations through the ``setup_*`` hooks, and provide callable scoring
+    implementations for whole-pose and rotamer evaluation.
+    """
+
     def __init__(self, **kwargs):
         pass
 
@@ -42,18 +49,15 @@ class EnergyTerm:
         raise NotImplementedError()
 
     def setup_block_type(self, block_type: RefinedResidueType):
-        """
-        Make a one-time annotation on the block type. These annotations will
-        probably require string comparison and may be slow; they should be
+        """Make a one-time CPU annotation on a block type.
+
+        These annotations may require slow string comparisons; they should be
         performed only once, so the EnergyTerm must check that its annotation
         is not already present in the block type. Annotations should be in
         numpy data structures (and stored on the CPU).
 
-        If the annotation requires more than one array, then the EnergyTerm
-        should use a python class to store those arrays. E.g.,
-        class FooSet:
-            foo_array1: NDArray[numpy.int32][:]
-            foo_array2: NDArray[numpy.int32][:, :]
+        If the annotation requires more than one array, use a Python class to
+        store those arrays.
 
         If the kind of annotation made depends on data that may change
         between different instances of the same term, then the annotation
@@ -67,28 +71,15 @@ class EnergyTerm:
         pass
 
     def setup_packed_block_types(self, packed_block_types: PackedBlockTypes):
-        """
-        Make a one-time annotation of the packed-block types. This annotation
-        should mostly involve concatenating the previously-made numpy annotations
-        on the block types that the packed-block types contains. E.g. if the
-        EnergyTerm annotates the block types with an i-dimensional array "foo,"
-        then it should also annotate the PackedBlockTypes with an (i+1)-dimensional
-        tensor "foo" where the first dimension will index across the different
-        block types in foo in the order that those block types appear in the
-        PackedBlockTypes' list of active block types. Sometimes the size of the
-        i-dimensional arrays will differ between block types; the (i+1)-dimensional
-        tensor should be dimensioned to the maximal size for each of the i dimensions
-        among the set of dimensions of the various block types. The extra padding
-        in such cases is recommended to be filled with a sentinel value of -1.
+        """Make a one-time device annotation of the packed block types.
 
-        As with the block type annotation, if more than one tensor is required,
-        then the annotation should be a class. If the annotation is based on
-        data that might differ between instances, then the annotation should be
-        a map whose keys are determined by the data.
-
-        The EnergyMethod should begin by checking that it has not already made
-        this annotation. Any array data in the annotation should be torch
-        tensors and should live on the PackedBlockTypes' device.
+        Implementations generally pack the residue-type NumPy annotations into
+        tensors whose first dimension follows ``active_block_types``. Pad
+        variable residue dimensions with a sentinel such as ``-1`` and cache
+        all tensors on the packed block types' device. If setup depends on
+        instance-specific parameters, key the cached annotation by those
+        immutable parameters so distinct term instances cannot reuse
+        incompatible data.
         """
         pass
 

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -26,6 +26,13 @@ SFXN_FORMAT_VERSION: str = "1.0"
 
 
 class ScoreFunction:
+    """Weighted collection of energy terms rendered for a pose topology.
+
+    Args:
+        param_db: Chemical and scoring parameters used to construct terms.
+        device: Device on which weights and rendered scorers operate.
+    """
+
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
         self._weights = torch.zeros((ScoreType.n_score_types.value,), device=device)
 
@@ -61,7 +68,16 @@ class ScoreFunction:
 
         self.term_options = {}
 
-    def set_weight(self, st: ScoreType, weight: float):
+    def set_weight(self, st: ScoreType, weight: float) -> None:
+        """Set the weight for one score type.
+
+        The energy term that implements ``st`` is created lazily when the
+        requested weight is nonzero.
+
+        Args:
+            st: Score type to update.
+            weight: New scalar weight.
+        """
         # Do not construct an energy term merely to assign it a zero weight.
         # FastRelax updates its (usually disabled) constraint weight at every
         # schedule step; constructing that term adds a device-to-host sync to
@@ -77,10 +93,12 @@ class ScoreFunction:
         self._weights[st.value] = weight
         self._weights_tensor_out_of_date = True
 
-    def get_weight(self, st: ScoreType):
+    def get_weight(self, st: ScoreType) -> torch.Tensor:
+        """Return the scalar weight for ``st`` on the score-function device."""
         return self._weights[st.value]
 
-    def score_type_covered_by_contained_term(self, st: ScoreType):
+    def score_type_covered_by_contained_term(self, st: ScoreType) -> bool:
+        """Return whether a constructed energy term implements ``st``."""
         # `_all_terms` is a lazily refreshed sorted cache; consulting it while
         # weights are being populated can miss a term already present in the
         # unordered source lists and construct duplicate term objects.
@@ -154,7 +172,8 @@ class ScoreFunction:
 
         return self._all_terms
 
-    def all_score_types(self):
+    def all_score_types(self) -> list[ScoreType]:
+        """Return score types in the same order as :meth:`all_terms`."""
         if self._all_terms_out_of_date:
             self._all_terms, self._all_score_types = self.get_sorted_terms(
                 self._all_terms_unordered
@@ -164,6 +183,7 @@ class ScoreFunction:
         return self._all_score_types
 
     def one_body_terms(self):
+        """Return the active one-body energy terms in score-type order."""
         if self._one_body_terms_out_of_date:
             self._one_body_terms, _ = self.get_sorted_terms(
                 self._one_body_terms_unordered
@@ -173,6 +193,7 @@ class ScoreFunction:
         return self._one_body_terms
 
     def two_body_terms(self):
+        """Return the active two-body energy terms in score-type order."""
         if self._two_body_terms_out_of_date:
             self._two_body_terms, _ = self.get_sorted_terms(
                 self._two_body_terms_unordered
@@ -182,6 +203,7 @@ class ScoreFunction:
         return self._two_body_terms
 
     def multi_body_terms(self):
+        """Return the active multi-body energy terms in score-type order."""
         if self._multi_body_terms_out_of_date:
             self._multi_body_terms, _ = self.get_sorted_terms(
                 self._multi_body_terms_unordered
@@ -250,7 +272,15 @@ class ScoreFunction:
         ]
         return RotamerScoringModule(self.weights_tensor(), term_modules)
 
-    def pre_work_initialization(self, pose_stack: PoseStack):
+    def pre_work_initialization(self, pose_stack: PoseStack) -> None:
+        """Prepare active energy terms for a pose topology.
+
+        Repeated calls reuse topology-dependent setup when neither the terms,
+        their options, nor the packed block types have changed.
+
+        Args:
+            pose_stack: Poses whose topology will be scored.
+        """
         # set_options must be first, since some of the logic that follows it
         # may depend on the options
         terms = self.all_terms()
@@ -280,7 +310,7 @@ class ScoreFunction:
         for energy_term in terms:
             energy_term.setup_poses(pose_stack)
 
-    def set_option(self, key: str, value):
+    def set_option(self, key: str, value) -> None:
         """Set an option for all energy terms.
 
         Options are passed to each energy term's set_options method
@@ -289,7 +319,7 @@ class ScoreFunction:
         self.term_options[key] = value
         self._options_version += 1
 
-    def set_options(self, options: Dict):
+    def set_options(self, options: Dict) -> None:
         """Set the score function options by a dict.
 
         This replaces the options dict entirely - any previous values
@@ -298,7 +328,8 @@ class ScoreFunction:
         self.term_options = options
         self._options_version += 1
 
-    def weights_tensor(self):
+    def weights_tensor(self) -> Tensor[torch.float32][:]:
+        """Return weights aligned with the rendered term/subterm order."""
         if self._weights_tensor_out_of_date:
             # Keep weight collection on-device. Constructing a tensor from a
             # Python list of CUDA scalar tensors calls ``item()`` on every
@@ -396,6 +427,8 @@ class ScoreFunction:
 
 
 class WholePoseScoringModule:
+    """Rendered energy modules that score complete poses."""
+
     def __init__(
         self,
         weights: Tensor[torch.float32][:],
@@ -514,6 +547,8 @@ class _InferenceCUDAGraph:
 
 
 class BlockPairScoringModule:
+    """Rendered energy modules that retain per-block-pair scores."""
+
     def __init__(
         self,
         weights: Tensor[torch.float32][:],
@@ -555,6 +590,8 @@ class BlockPairScoringModule:
 
 
 class RotamerScoringModule:
+    """Rendered energy modules that build sparse rotamer-pair energy tables."""
+
     def __init__(
         self,
         weights: Tensor[torch.float32][:],

--- a/tmol/score/_score_types.py
+++ b/tmol/score/_score_types.py
@@ -2,6 +2,8 @@ from tmol.utility import AutoNumber
 
 
 class ScoreType(AutoNumber):
+    """Stable indices for energy terms in score-function weight tensors."""
+
     fa_ljatr = ()
     fa_ljrep = ()
     fa_lk = ()

--- a/tmol/score/constraint/_constraint_energy_term.py
+++ b/tmol/score/constraint/_constraint_energy_term.py
@@ -24,6 +24,8 @@ class HiddenPrints:
 
 
 class ConstraintEnergyTerm(EnergyTerm):
+    """Score coordinate and geometric constraints attached to a pose stack."""
+
     device: torch.device  # = attr.ib()
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):

--- a/tmol/score/constraint/_utility.py
+++ b/tmol/score/constraint/_utility.py
@@ -7,6 +7,7 @@ from tmol.pose._pose_stack import PoseStack
 
 
 def constrain_all_ca(pose_stack: PoseStack) -> PoseStack:
+    """Add coordinate constraints at every available protein CA atom."""
     from tmol.pose._constraint_set import ConstraintSet
     from tmol.score.constraint._constraint_energy_term import ConstraintEnergyTerm
 
@@ -58,6 +59,8 @@ def constrain_all_ca(pose_stack: PoseStack) -> PoseStack:
 
 @attrs.define
 class MCAtomIndices:
+    """Padded main-chain atom indices for every packed block type."""
+
     max_n_mainchain_atoms: int
     n_mainchain_atoms: Tensor[torch.int64][:]
     mainchain_atoms: Tensor[torch.int64][:, :]
@@ -112,6 +115,7 @@ def _annotate_mainchain_atom_indices(packed_block_types: PackedBlockTypes) -> No
 
 
 def create_mainchain_coordinate_constraints(pose_stack: PoseStack) -> PoseStack:
+    """Add coordinate constraints for every declared polymer main-chain atom."""
     from tmol.pose._constraint_set import ConstraintSet
     from tmol.score.constraint._constraint_energy_term import ConstraintEnergyTerm
 

--- a/tmol/score/na_torsion/_na_torsion_energy_term.py
+++ b/tmol/score/na_torsion/_na_torsion_energy_term.py
@@ -34,6 +34,8 @@ SUGAR_SLOTS = (DELTA, TORSION_IND["nu4"], TORSION_IND["nu0"], TORSION_IND["nu1"]
 
 
 class NaTorsionEnergyTerm(EnergyTerm):
+    """Score nucleic-acid backbone, sugar-pucker, and glycosidic torsions."""
+
     device: torch.device
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
@@ -281,6 +283,7 @@ def eval_na_torsion_for_pose(
     weight_sugar,
     output_block_pair_energies: bool,
 ):
+    """Evaluate nucleic-acid torsion energies for packed rotamer coordinates."""
     if not has_na:
         n_poses, max_n_blocks = block_coord_offset.shape
         zero = torch.zeros(

--- a/tmol/score/na_torsion/_params.py
+++ b/tmol/score/na_torsion/_params.py
@@ -102,6 +102,8 @@ def polymer_index(base):
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class NaTorsionParams(ValidateAttrs):
+    """Device-resident nucleic-acid torsion distributions and well energies."""
+
     # means in degrees; 3 bins for alpha/gamma, 2 for beta/epsilon/zeta
     backbone_means: Tensor[torch.float32][2, 6, 3]
     backbone_n_bins: Tensor[torch.int32][2, 6]

--- a/tmol/score/terms/_backbone_torsion_creator.py
+++ b/tmol/score/terms/_backbone_torsion_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class BackboneTorsionTermCreator(TermCreator):
+    """Create the protein backbone torsion energy term."""
+
     _score_types = [ScoreType.rama, ScoreType.omega]
 
     @classmethod

--- a/tmol/score/terms/_cartbonded_creator.py
+++ b/tmol/score/terms/_cartbonded_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class CartBondedTermCreator(TermCreator):
+    """Create the Cartesian bonded-geometry energy term."""
+
     _score_types = [
         ScoreType.cart_lengths,
         ScoreType.cart_angles,

--- a/tmol/score/terms/_constraint_creator.py
+++ b/tmol/score/terms/_constraint_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class ConstraintTermCreator(TermCreator):
+    """Create the pose-constraint energy term."""
+
     _score_types = [ScoreType.constraint]
 
     @classmethod

--- a/tmol/score/terms/_disulfide_creator.py
+++ b/tmol/score/terms/_disulfide_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class DisulfideTermCreator(TermCreator):
+    """Create the disulfide-geometry energy term."""
+
     _score_types = [ScoreType.disulfide]
 
     @classmethod

--- a/tmol/score/terms/_dunbrack_creator.py
+++ b/tmol/score/terms/_dunbrack_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class DunbrackTermCreator(TermCreator):
+    """Create the Dunbrack rotamer energy term."""
+
     _score_types = [
         ScoreType.dunbrack_rot,
         ScoreType.dunbrack_rotdev,

--- a/tmol/score/terms/_elec_creator.py
+++ b/tmol/score/terms/_elec_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class ElecTermCreator(TermCreator):
+    """Create the electrostatic energy term."""
+
     _score_types = [ScoreType.fa_elec]
 
     @classmethod

--- a/tmol/score/terms/_genbonded_creator.py
+++ b/tmol/score/terms/_genbonded_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class GenBondedTermCreator(TermCreator):
+    """Create the general bonded-torsion energy term."""
+
     _score_types = [
         ScoreType.gen_torsions,
     ]

--- a/tmol/score/terms/_hbond_creator.py
+++ b/tmol/score/terms/_hbond_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class HBondTermCreator(TermCreator):
+    """Create the hydrogen-bond energy term."""
+
     _score_types = [ScoreType.hbond]
 
     @classmethod

--- a/tmol/score/terms/_ljlk_creator.py
+++ b/tmol/score/terms/_ljlk_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class LJLKTermCreator(TermCreator):
+    """Create the Lennard-Jones and Lazaridis-Karplus energy term."""
+
     _score_types = [ScoreType.fa_ljatr, ScoreType.fa_ljrep, ScoreType.fa_lk]
 
     @classmethod

--- a/tmol/score/terms/_lk_ball_creator.py
+++ b/tmol/score/terms/_lk_ball_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class LKBallTermCreator(TermCreator):
+    """Create the orientation-dependent LK-ball solvation energy term."""
+
     _score_types = [
         ScoreType.lk_ball_iso,
         ScoreType.lk_ball,

--- a/tmol/score/terms/_na_torsion_creator.py
+++ b/tmol/score/terms/_na_torsion_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class NaTorsionTermCreator(TermCreator):
+    """Create the nucleic-acid torsion energy term."""
+
     _score_types = [ScoreType.na_torsion, ScoreType.na_torsion_well]
 
     @classmethod

--- a/tmol/score/terms/_ref_creator.py
+++ b/tmol/score/terms/_ref_creator.py
@@ -6,6 +6,8 @@ import torch
 
 @score_term_creator
 class RefTermCreator(TermCreator):
+    """Create the residue reference-energy term."""
+
     _score_types = [ScoreType.ref]
 
     @classmethod

--- a/tmol/score/terms/_term_creator.py
+++ b/tmol/score/terms/_term_creator.py
@@ -30,5 +30,6 @@ class TermCreator:
 
 
 def score_term_creator(cls):
+    """Register a term-creator class with the global score-term factory."""
     ScoreTermFactory.factory_register(cls)
     return cls

--- a/tmol/tests/_benchmark.py
+++ b/tmol/tests/_benchmark.py
@@ -91,8 +91,6 @@ def make_fixture(
         cprofile=cprofile,
         cprofile_loops=cprofile_loops,
         cprofile_dump=cprofile_dump,
-        precision=3,
-        confidence=0.95,
     )
 
     benchmark.extra_info.update(extra_info)
@@ -135,8 +133,6 @@ def make_subfixture(
         cprofile=parent.cprofile,
         cprofile_loops=parent.cprofile_loops,
         cprofile_dump=parent.cprofile_dump,
-        precision=3,
-        confidence=0.95,
     )
 
     benchmark.extra_info.update(parent.extra_info)

--- a/tmol/tests/_benchmark.py
+++ b/tmol/tests/_benchmark.py
@@ -30,8 +30,9 @@ Example:
             assert mult == add
 """
 
-import types
+import inspect
 import logging
+import types
 import warnings
 
 from functools import singledispatch
@@ -41,6 +42,13 @@ import toolz
 
 import pytest_benchmark
 from pytest_benchmark.fixture import BenchmarkFixture
+
+
+def _new_benchmark_fixture(**kwargs) -> BenchmarkFixture:
+    """Construct a fixture across supported pytest-benchmark releases."""
+    if "precision" in inspect.signature(BenchmarkFixture).parameters:
+        kwargs.update(precision=3, confidence=0.95)
+    return BenchmarkFixture(**kwargs)
 
 
 def make_fixture(
@@ -74,7 +82,7 @@ def make_fixture(
 
     node = types.SimpleNamespace(name=name, _nodeid=name)
 
-    benchmark = pytest_benchmark.fixture.BenchmarkFixture(
+    benchmark = _new_benchmark_fixture(
         node=node,
         add_stats=add_stats if add_stats is not None else lambda s: None,
         min_rounds=min_rounds,
@@ -116,7 +124,7 @@ def make_subfixture(
         name=parent.name + name_suffix, _nodeid=parent.fullname + name_suffix
     )
 
-    benchmark = pytest_benchmark.fixture.BenchmarkFixture(
+    benchmark = _new_benchmark_fixture(
         node=node,
         disable_gc=parent._disable_gc,
         timer=pytest_benchmark.utils.NameWrapper(parent._timer),

--- a/tmol/tests/test_benchmark.py
+++ b/tmol/tests/test_benchmark.py
@@ -1,6 +1,11 @@
 import pytest
 
-from ._benchmark import subfixture
+from ._benchmark import make_fixture, subfixture
+
+
+def test_make_fixture():
+    benchmark = make_fixture(max_time=0.001)
+    assert benchmark(lambda: "value") == "value"
 
 
 def test_str_join_method(benchmark):

--- a/tmol/types/_array.py
+++ b/tmol/types/_array.py
@@ -20,6 +20,8 @@ class Casting(enum.Enum):
 
 
 class NDArray(_TensorType):
+    """Runtime-checkable NumPy array annotation with dtype and shape metadata."""
+
     _module: typing.ClassVar = numpy
     _tensortype: typing.ClassVar = numpy.ndarray
 

--- a/tmol/types/_converters.py
+++ b/tmol/types/_converters.py
@@ -12,6 +12,7 @@ _converters = []
 
 @singledispatch
 def get_converter(type_annotation):
+    """Return the registered value converter for a type annotation."""
     for pred, conv in _converters:
         if pred(type_annotation):
             return conv(type_annotation)
@@ -21,6 +22,7 @@ def get_converter(type_annotation):
 
 @toolz.curry
 def constructor_convert(type_annotation, value):
+    """Convert a value by calling the annotated type when necessary."""
     if isinstance(value, type_annotation):
         return value
     return type_annotation(value)
@@ -28,6 +30,7 @@ def constructor_convert(type_annotation, value):
 
 @toolz.curry
 def validate_convert(type_annotation, value):
+    """Validate a value against an annotation and return it unchanged."""
     validators.get_validator(type_annotation)(value)
 
     return value
@@ -35,6 +38,7 @@ def validate_convert(type_annotation, value):
 
 @toolz.curry
 def union_convert(union_annotation, value):
+    """Convert a value using the first compatible member of a union."""
     for subtype in union_annotation.__args__:
         try:
             validators.get_validator(subtype)(value)
@@ -55,6 +59,7 @@ def union_convert(union_annotation, value):
 
 
 def register_converter(type_predicate, converter):
+    """Register a converter factory for annotations matching a predicate."""
     _converters.append((type_predicate, converter))
 
 

--- a/tmol/types/_functional.py
+++ b/tmol/types/_functional.py
@@ -9,6 +9,7 @@ from ._converters import get_converter
 
 
 def validate_args(f):
+    """Decorate a callable with runtime validation of annotated values."""
     f._signature = inspect.signature(f)
     f._validators = {n: get_validator(v) for n, v in typing.get_type_hints(f).items()}
 
@@ -39,6 +40,7 @@ def validate_args(f):
 
 
 def convert_args(f):
+    """Decorate a callable with runtime conversion of annotated values."""
     f._signature = inspect.signature(f)
     f._converters = {n: get_converter(v) for n, v in typing.get_type_hints(f).items()}
 

--- a/tmol/types/_tensor.py
+++ b/tmol/types/_tensor.py
@@ -119,6 +119,8 @@ class _TensorType(metaclass=_TensorTypeMeta):
 
 
 class TensorGroup:
+    """Mixin for immutable structures whose fields are tensors or tensor groups."""
+
     @property
     def _pure_tensor(self):
         return all(
@@ -233,6 +235,7 @@ class TensorGroup:
 
 
 def cat(seq, dim=0, out=None):
+    """Concatenate tensors or compatible tensor groups along a dimension."""
     first, *rest = seq
     return _cat_internal(first, rest, dim=dim, out=out)
 

--- a/tmol/types/_torch.py
+++ b/tmol/types/_torch.py
@@ -53,6 +53,8 @@ def like_kwargs(t: torch.Tensor):
 
 
 class Tensor(_TensorType):
+    """Runtime-checkable PyTorch tensor annotation with dtype and shape metadata."""
+
     _module: typing.ClassVar = torch
     _tensortype: typing.ClassVar = torch.Tensor
 

--- a/tmol/types/_validators.py
+++ b/tmol/types/_validators.py
@@ -31,6 +31,7 @@ def is_list_type(tp):
 
 @singledispatch
 def get_validator(type_annotation):
+    """Return the registered runtime validator for a type annotation."""
     for pred, val in _validators:
         if pred(type_annotation):
             return val(type_annotation)
@@ -106,11 +107,13 @@ def validate_union(union, value):
 
 @toolz.curry
 def validate_isinstance(type_annotation, value):
+    """Require a value to be an instance of the annotated type."""
     if not isinstance(value, type_annotation):
         raise TypeError(f"expected {type_annotation}, received {type(value)!r}")
 
 
 def register_validator(type_predicate, validator):
+    """Register a validator factory for annotations matching a predicate."""
     _validators.append((type_predicate, validator))
 
 

--- a/tmol/utility/_auto_number.py
+++ b/tmol/utility/_auto_number.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 
 class AutoNumber(Enum):
+    """Enum base that assigns consecutive integer values in declaration order."""
+
     def __new__(cls):
         value = len(cls.__members__)
         obj = object.__new__(cls)

--- a/tmol/utility/_biotite_util.py
+++ b/tmol/utility/_biotite_util.py
@@ -3,8 +3,7 @@ from biotite.structure import get_residue_starts
 
 
 def get_all_segment_positions(starts, length):
-    # backported function from biotite, since it is not available in
-    # the version of biotite that is available for python 3.10
+    """Return the segment index of each position from exclusive segment starts."""
 
     segment_changes = np.zeros(length, dtype=int)
     segment_changes[starts[1:-1]] = 1
@@ -12,8 +11,7 @@ def get_all_segment_positions(starts, length):
 
 
 def get_all_residue_positions(array):
-    # backported function from biotite, since it is not available in
-    # the version of biotite that is available for python 3.10
+    """Return the residue index of each atom in a Biotite atom array."""
 
     starts = get_residue_starts(array, add_exclusive_stop=True)
     return get_all_segment_positions(starts, array.array_length())

--- a/tmol/utility/_cumsum.py
+++ b/tmol/utility/_cumsum.py
@@ -19,6 +19,7 @@ def exclusive_cumsum(inds: NDArray[int][:]) -> NDArray[int][:]:
 def exclusive_cumsum1d(
     inds: Union[Tensor[torch.int32][:], Tensor[torch.int64][:]],
 ) -> Union[Tensor[torch.int32][:], Tensor[torch.int64][:]]:
+    """Compute a one-dimensional exclusive cumulative sum."""
     return torch.cat(
         (
             torch.tensor([0], dtype=inds.dtype, device=inds.device),
@@ -31,6 +32,7 @@ def exclusive_cumsum1d(
 def exclusive_cumsum2d(
     inds: Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]],
 ) -> Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]]:
+    """Compute an exclusive cumulative sum along the second dimension."""
     return torch.cat(
         (
             torch.zeros((inds.shape[0], 1), dtype=inds.dtype, device=inds.device),
@@ -47,6 +49,7 @@ def exclusive_cumsum2d_w_totals(
     Tuple[Tensor[torch.int32][:, :], Tensor[torch.int32][:]],
     Union[Tensor[torch.int64][:, :], Tensor[torch.int64][:]],
 ]:
+    """Return row-wise exclusive cumulative sums and inclusive row totals."""
     cumsum = torch.cumsum(inds, dim=1, dtype=inds.dtype)
     return (
         torch.cat(

--- a/tmol/utility/_log.py
+++ b/tmol/utility/_log.py
@@ -21,6 +21,8 @@ ClassLogger = attr.ib(
 
 
 class LoggerMixin:
+    """Provide a lazily constructed logger named for the concrete class."""
+
     @property
     def logger(self) -> logging.Logger:
         logger = getattr(self, "_logger", None)

--- a/tmol/utility/_nvtx.py
+++ b/tmol/utility/_nvtx.py
@@ -6,6 +6,7 @@ from torch.cuda.nvtx import range_push, range_pop
 
 @contextlib.contextmanager
 def nvtx_range(name):
+    """Annotate a CUDA operation range when CUDA is available."""
     if torch.cuda.is_available():
         try:
             range_push(name)


### PR DESCRIPTION
## Summary

Make the generated API reference concise and complete without changing TMol scoring behavior:

- document public classes and functions that previously rendered as empty entries;
- add focused Google-style Args, Returns, and Raises sections to core I/O, scoring, packing, kinematics, and type utilities;
- retain documented public methods while removing undoc-members noise from API pages;
- remove duplicate energy-term entries from the score-term reference;
- suppress only the expected no-CUDA extension warning in published CPU notebook output, preserving every other warning and all authored GPU cells;
- support the pytest-benchmark APIs used by both the declared dependency and current CI, with direct fixture coverage;
- make release guidance timeless and correct the release manifest to 33 wheels: 25 GPU and 8 CPU.

The workflow/example structure remains intentionally distinct: workflows are concise task recipes, while examples are executable notebooks with interactive py3Dmol and ITables output. No URLs or interactive visualization behavior are changed. The package remains at version 0.1.52; this PR does not create a release.

## Rendered result

A clean local build with warnings as errors reports zero empty definitions across all 16 API pages. The scoring, pose, packing, kinematics, and score-term pages retain important public methods while dropping undocumented implementation fields.

## Validation

- clean sphinx-build -E -a -W --keep-going build, including notebook execution
- exact combined performance/docs tree: 1,472 passed, 913 skipped, 5 expected xfails, 1 expected xpass, zero failures
- final benchmark utility module: 2 passed and 1 expected xfail under pytest-benchmark 5.2.3; isolated fixture and subfixture smoke passed under 5.3.0
- 38 focused runtime tests passed; 31 CUDA-only cases skipped on CPU
- Black 26.3.1 clean across all 58 changed Python files
- Flake8 7.3.0 and git diff checks clean
- rendered HTML visually inspected at desktop width
- GitHub complete CPU/CUDA/benchmark CI and strict docs build are final merge gates
