### PR TITLE
Accelerate batched fragment interaction scoring

### DIFF
--- a/docs/user_guide/scoring.md
+++ b/docs/user_guide/scoring.md
@@ -106,3 +106,32 @@ binding free energy or delta-delta G.
 any requested minimization. Use `return_pose_stack=True` when the refined
 coordinates are part of the result, and `sum_terms=False` to inspect score
 terms separately.
+
+## Fragmented-ligand attribution
+
+For a ligand represented by connected fragment blocks, attribute its
+interaction with an explicit partner mask in one connected-pose score:
+
+```python
+from tmol.score import calculate_fragment_interactions
+
+fragment_scores = calculate_fragment_interactions(
+    pose_stack,
+    protein_block_mask,
+    sfxn=sfxn,
+    sum_terms=False,
+)
+```
+
+`fragment_scores.scores` has shape
+`[n_terms, n_poses, n_fragments]`; set `sum_terms=True` for
+`[n_poses, n_fragments]`. The fragment columns follow
+`fragment_scores.mapping`. Every pose in the stack must use the same fragment
+block layout, and the partner mask must exclude those fragment blocks.
+
+Keep the fragments in one `PoseStack` and call this function once. It renders
+one block-pair scorer and reduces all fragment columns together, preserving
+autograd through the connected complex. Calling a complete scoring workflow
+once per fragment repeats scorer and kernel-launch overhead. Rebuilding
+separated fragment poses additionally changes the physical system by removing
+the connected multi-block context.

--- a/tmol/pose/_pose_stack_builder.py
+++ b/tmol/pose/_pose_stack_builder.py
@@ -1,6 +1,7 @@
 import copy
 
 import itertools
+from dataclasses import replace
 
 import numpy
 import torch
@@ -26,6 +27,7 @@ from tmol.pose import (
     DEFAULT_ATOM_OCCUPANCY,
     PoseStack,
     ConstraintSet,
+    SplitBlockMapping,
 )
 from tmol.utility.tensor import (
     exclusive_cumsum1d,
@@ -51,7 +53,8 @@ class PoseStackBuilder:
             device: Device for the combined tensors.
 
         Returns:
-            A padded pose stack containing every input pose in order.
+            A padded pose stack containing every input pose in order. Split-
+            block mappings are concatenated when present.
         """
         pbt0 = pose_stacks[0].packed_block_types
         for ps in pose_stacks:
@@ -113,6 +116,9 @@ class PoseStackBuilder:
             n_poses=n_poses,
             ps_offset=ps_offset,
         )
+        split_block_mapping = cls._split_block_mapping_from_pose_stacks(
+            packed_block_types, pose_stacks
+        )
 
         def i64(t):
             return t.to(torch.int64)
@@ -132,8 +138,46 @@ class PoseStackBuilder:
             chain_id64=i64(chain_id),
             pdb_info=pdb_info,
             constraint_set=constraint_set,
-            device=device,
+            device=coords.device,
+            split_block_mapping=split_block_mapping,
         )
+
+    @staticmethod
+    def _split_block_mapping_from_pose_stacks(
+        packed_block_types: PackedBlockTypes,
+        pose_stacks: List[PoseStack],
+    ) -> SplitBlockMapping | None:
+        """Concatenate split-block metadata and remap original block types."""
+        if not any(
+            pose_stack.split_block_mapping is not None
+            and pose_stack.split_block_mapping.entries
+            for pose_stack in pose_stacks
+        ):
+            return None
+
+        block_type_index_by_name = {
+            block_type.name: index
+            for index, block_type in enumerate(packed_block_types.active_block_types)
+        }
+        combined_entries = []
+        pose_offset = 0
+        for pose_stack in pose_stacks:
+            mapping = pose_stack.split_block_mapping
+            if mapping is not None:
+                source_block_types = pose_stack.packed_block_types.active_block_types
+                combined_entries.extend(
+                    replace(
+                        entry,
+                        pose_ind=pose_offset + entry.pose_ind,
+                        orig_block_type_ind=block_type_index_by_name[
+                            source_block_types[entry.orig_block_type_ind].name
+                        ],
+                    )
+                    for entry in mapping.entries
+                )
+            pose_offset += pose_stack.n_poses
+
+        return SplitBlockMapping(entries=tuple(combined_entries))
 
     @classmethod
     @validate_args

--- a/tmol/score/_fragment_interactions.py
+++ b/tmol/score/_fragment_interactions.py
@@ -55,7 +55,7 @@ class _NormalizedFragmentRecord:
 class _FragmentMappingData:
     """Validated mapping indices cached on one pose topology."""
 
-    source_mapping: object
+    source_mapping: SplitBlockMapping | _LegacyFragmentMapping
     fragment_records: tuple[FragmentRecord, ...]
     record_linear_indices: Tensor[torch.int64][:]
     fragment_block_indices: Tensor[torch.int64][:]
@@ -102,6 +102,14 @@ def _fragment_mapping_data(
         [] for _ in range(pose_stack.n_poses)
     ]
     for record in records:
+        if not (
+            0 <= record.pose_index < pose_stack.n_poses
+            and 0 <= record.block_index < pose_stack.max_n_blocks
+        ):
+            raise ValueError(
+                "Fragment mapping entry is outside the pose stack: "
+                f"pose {record.pose_index}, block {record.block_index}"
+            )
         records_by_pose[record.pose_index].append(record)
 
     pose_zero_records = tuple(
@@ -113,6 +121,8 @@ def _fragment_mapping_data(
     expected_columns = {record.column_key for record in pose_zero_records}
     for pose_records in records_by_pose:
         pose_columns = {record.column_key for record in pose_records}
+        if len(pose_columns) != len(pose_records):
+            raise ValueError("Fragment mapping contains duplicate columns in one pose")
         if pose_columns != expected_columns:
             raise ValueError(
                 "Fragment mappings must use identical block topology in every pose"

--- a/tmol/score/_fragment_interactions.py
+++ b/tmol/score/_fragment_interactions.py
@@ -1,6 +1,36 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Protocol, TYPE_CHECKING
 
 import torch
+
+from tmol.pose._split_block_mapping import SplitBlockEntry, SplitBlockMapping
+from tmol.types import Tensor
+
+if TYPE_CHECKING:
+    from tmol.pose import PoseStack
+    from tmol.score._score_function import ScoreFunction
+
+
+class _LegacyFragmentRecord(Protocol):
+    """Fields consumed from the compatibility ligand mapping."""
+
+    pose_index: int
+    block_index: int
+    pose_residue_label: int
+
+
+class _LegacyFragmentMapping(Protocol):
+    """Structural type for the compatibility fragmented-ligand mapping."""
+
+    blocks: tuple[_LegacyFragmentRecord, ...]
+
+
+FragmentRecord = SplitBlockEntry | _LegacyFragmentRecord
+
+
+_FRAGMENT_REDUCTION_WORKSPACE_BYTES = 256 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -8,43 +38,192 @@ class FragmentInteractionScores:
     """Per-fragment interactions with an explicitly selected partner."""
 
     scores: torch.Tensor
-    mapping: tuple
+    mapping: tuple[FragmentRecord, ...]
 
 
-def calculate_fragment_interactions(  # noqa: C901
-    pose_stack,
-    partner_mask,
+@dataclass(frozen=True)
+class _NormalizedFragmentRecord:
+    """Common indexing fields for current and compatibility mappings."""
+
+    pose_index: int
+    block_index: int
+    column_key: tuple[int, ...]
+    source: FragmentRecord
+
+
+@dataclass(frozen=True)
+class _FragmentMappingData:
+    """Validated mapping indices cached on one pose topology."""
+
+    source_mapping: object
+    fragment_records: tuple[FragmentRecord, ...]
+    record_linear_indices: Tensor[torch.int64][:]
+    fragment_block_indices: Tensor[torch.int64][:]
+
+
+def _fragment_mapping_data(
+    pose_stack: PoseStack,
+    mapping: SplitBlockMapping | _LegacyFragmentMapping,
+) -> _FragmentMappingData:
+    """Normalize and cache current or compatibility mapping records."""
+    cached = getattr(pose_stack, "_fragment_interaction_mapping_data", None)
+    tensor_device = pose_stack.block_type_ind.device
+    if (
+        isinstance(cached, _FragmentMappingData)
+        and cached.source_mapping is mapping
+        and cached.record_linear_indices.device == tensor_device
+    ):
+        return cached
+
+    if isinstance(mapping, SplitBlockMapping):
+        records = tuple(
+            _NormalizedFragmentRecord(
+                pose_index=entry.pose_ind,
+                block_index=entry.block_ind,
+                column_key=(entry.block_ind,),
+                source=entry,
+            )
+            for entry in mapping.entries
+        )
+        require_pose_zero_record = True
+    else:
+        records = tuple(
+            _NormalizedFragmentRecord(
+                pose_index=record.pose_index,
+                block_index=record.block_index,
+                column_key=(record.pose_residue_label, record.block_index),
+                source=record,
+            )
+            for record in mapping.blocks
+        )
+        require_pose_zero_record = False
+
+    records_by_pose: list[list[_NormalizedFragmentRecord]] = [
+        [] for _ in range(pose_stack.n_poses)
+    ]
+    for record in records:
+        records_by_pose[record.pose_index].append(record)
+
+    pose_zero_records = tuple(
+        sorted(records_by_pose[0], key=lambda record: record.block_index)
+    )
+    if require_pose_zero_record and not pose_zero_records:
+        raise ValueError("split_block_mapping has no entries for pose 0")
+
+    expected_columns = {record.column_key for record in pose_zero_records}
+    for pose_records in records_by_pose:
+        pose_columns = {record.column_key for record in pose_records}
+        if pose_columns != expected_columns:
+            raise ValueError(
+                "Fragment mappings must use identical block topology in every pose"
+            )
+
+    data = _FragmentMappingData(
+        source_mapping=mapping,
+        fragment_records=tuple(record.source for record in pose_zero_records),
+        record_linear_indices=torch.tensor(
+            [
+                record.pose_index * pose_stack.max_n_blocks + record.block_index
+                for record in records
+            ],
+            dtype=torch.int64,
+            device=tensor_device,
+        ),
+        fragment_block_indices=torch.tensor(
+            [record.block_index for record in pose_zero_records],
+            dtype=torch.int64,
+            device=tensor_device,
+        ),
+    )
+    pose_stack._fragment_interaction_mapping_data = data
+    return data
+
+
+def _sum_fragment_partner_scores(
+    block_pair_scores: torch.Tensor,
+    partner_mask: Tensor[torch.bool][:, :],
+    fragment_block_indices: Tensor[torch.int64][:],
     *,
-    sfxn,
-    mapping=None,
-    sum_terms=False,
-):
+    max_workspace_bytes: int = _FRAGMENT_REDUCTION_WORKSPACE_BYTES,
+) -> torch.Tensor:
+    """Reduce both block-matrix orientations for many fragments at once.
+
+    The gathered rows and columns are chunked so that their combined temporary
+    storage stays near ``max_workspace_bytes``. This keeps the number of CUDA
+    launches independent of the number of fragments within each chunk.
+
+    Args:
+        block_pair_scores: Weighted scores shaped
+            ``[n_terms, n_poses, n_blocks, n_blocks]``.
+        partner_mask: Selected partner blocks shaped ``[n_poses, n_blocks]``.
+        fragment_block_indices: Fragment block columns shared by every pose,
+            shaped ``[n_fragments]``.
+        max_workspace_bytes: Target upper bound for the two gathered score
+            tensors in one reduction chunk.
+
+    Returns:
+        Scores shaped ``[n_terms, n_poses, n_fragments]``.
+    """
+    n_terms, n_poses, n_blocks, _ = block_pair_scores.shape
+    n_fragments = fragment_block_indices.numel()
+    if n_fragments == 0 or n_terms == 0 or n_poses == 0 or n_blocks == 0:
+        zero_scores = block_pair_scores.sum(dim=(-2, -1)).unsqueeze(-1)
+        return zero_scores.expand(n_terms, n_poses, n_fragments)
+
+    bytes_per_fragment = (
+        2 * n_terms * n_poses * n_blocks * block_pair_scores.element_size()
+    )
+    fragments_per_chunk = max(1, max_workspace_bytes // bytes_per_fragment)
+    partner_weights = partner_mask.to(dtype=block_pair_scores.dtype)
+
+    partials = []
+    for fragment_indices in fragment_block_indices.split(fragments_per_chunk):
+        selected_scores = torch.index_select(block_pair_scores, 2, fragment_indices)
+        selected_scores.add_(
+            torch.index_select(block_pair_scores, 3, fragment_indices).transpose(-1, -2)
+        )
+        partials.append(torch.einsum("tpfb,pb->tpf", selected_scores, partner_weights))
+    return partials[0] if len(partials) == 1 else torch.cat(partials, dim=2)
+
+
+def calculate_fragment_interactions(
+    pose_stack: PoseStack,
+    partner_mask: Tensor[torch.bool][:, :],
+    *,
+    sfxn: ScoreFunction,
+    mapping: SplitBlockMapping | _LegacyFragmentMapping | None = None,
+    sum_terms: bool = False,
+) -> FragmentInteractionScores:
     """Return each ligand fragment's interaction with ``partner_mask``.
 
     The connected multi-block pose is scored once. Fragment-fragment entries
     remain in the block-pair matrix and are not silently assigned to either
-    fragment.
+    fragment. ``sfxn`` must use the same ligand-extended parameter database as
+    ``pose_stack``.
 
-    ``sfxn`` is required and must be built from the same ligand-extended
-    parameter database used to construct ``pose_stack``.
+    Args:
+        pose_stack: Connected poses with identical fragment block layouts.
+        partner_mask: Partner blocks shaped ``[n_poses, max_n_blocks]``. The
+            mask must exclude every ligand fragment block.
+        sfxn: Score function built from the pose's parameter database.
+        mapping: Optional split-block mapping. By default the mapping attached
+            to ``pose_stack`` is used. Legacy fragmented-ligand mappings remain
+            accepted for compatibility.
+        sum_terms: Sum the score-term dimension when true.
 
     Returns:
-        :class:`FragmentInteractionScores`. ``scores`` has shape
-        ``[n_terms, n_poses, n_fragments]`` or ``[n_poses, n_fragments]`` when
-        ``sum_terms`` is true.
+        Fragment scores shaped ``[n_terms, n_poses, n_fragments]``, or
+        ``[n_poses, n_fragments]`` when ``sum_terms`` is true, plus the pose-zero
+        mapping records that define the fragment columns.
+
+    Raises:
+        TypeError: If ``partner_mask`` is not Boolean.
+        ValueError: If the mask, score function, or mapping is incompatible
+            with the poses.
     """
-
-    from tmol.pose._split_block_mapping import SplitBlockMapping
-
     if mapping is None:
-        sbm = getattr(pose_stack, "split_block_mapping", None)
-    elif isinstance(mapping, SplitBlockMapping):
-        sbm = mapping
-        mapping = None  # use new path
-    else:
-        sbm = None  # use legacy path with the provided FragmentedLigandPoseMapping
-
-    if sbm is None and mapping is None:
+        mapping = getattr(pose_stack, "split_block_mapping", None)
+    if mapping is None:
         raise ValueError("No split-block mapping was supplied or attached to the pose")
     if partner_mask.shape != pose_stack.block_type_ind.shape:
         raise ValueError(
@@ -60,90 +239,20 @@ def calculate_fragment_interactions(  # noqa: C901
             "sfxn is required and must use the ligand-extended parameter database"
         )
 
-    # Use split_block_mapping when no explicit mapping was provided.
-    # Fragment block indices are the same across all poses (topology is canonical),
-    # so pose-0 entries define the column layout for every pose.
-    if sbm is not None:
-        pose0_entries = sorted(
-            (e for e in sbm.entries if e.pose_ind == 0),
-            key=lambda e: e.block_ind,
-        )
-        if not pose0_entries:
-            raise ValueError("split_block_mapping has no entries for pose 0")
-        expected_block_inds = {e.block_ind for e in pose0_entries}
-        for pose_index in range(pose_stack.n_poses):
-            pose_block_inds = {
-                e.block_ind for e in sbm.entries if e.pose_ind == pose_index
-            }
-            if pose_block_inds != expected_block_inds:
-                raise ValueError(
-                    "Fragment mappings must use identical block topology in every pose"
-                )
-        for entry in sbm.entries:
-            if bool(partner_mask[entry.pose_ind, entry.block_ind]):
-                raise ValueError("partner_mask must not include ligand fragment blocks")
+    mapping_data = _fragment_mapping_data(pose_stack, mapping)
+    if bool(partner_mask.flatten()[mapping_data.record_linear_indices].any()):
+        raise ValueError("partner_mask must not include ligand fragment blocks")
 
-        scorer = sfxn.render_block_pair_scoring_module(pose_stack)
-        block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
-        n_terms, n_poses, _, _ = block_pair_scores.shape
-        result = torch.zeros(
-            (n_terms, n_poses, len(pose0_entries)),
-            dtype=block_pair_scores.dtype,
-            device=block_pair_scores.device,
-        )
-        for frag_idx, entry in enumerate(pose0_entries):
-            b = entry.block_ind
-            result[:, :, frag_idx] = (
-                block_pair_scores[:, :, b, :] * partner_mask.unsqueeze(0)
-            ).sum(dim=2) + (
-                block_pair_scores[:, :, :, b] * partner_mask.unsqueeze(0)
-            ).sum(
-                dim=2
-            )
-        if sum_terms:
-            result = result.sum(dim=0)
-        return FragmentInteractionScores(scores=result, mapping=tuple(pose0_entries))
-
-    # Legacy path: explicit FragmentedLigandPoseMapping passed as mapping=
-    fragment_records = tuple(
-        sorted(
-            (record for record in mapping.blocks if record.pose_index == 0),
-            key=lambda record: record.block_index,
-        )
-    )
-    expected_columns = {
-        (record.pose_residue_label, record.block_index) for record in fragment_records
-    }
-    for pose_index in range(pose_stack.n_poses):
-        pose_columns = {
-            (record.pose_residue_label, record.block_index)
-            for record in mapping.blocks
-            if record.pose_index == pose_index
-        }
-        if pose_columns != expected_columns:
-            raise ValueError(
-                "Fragment mappings must use identical block topology in every pose"
-            )
-    for record in mapping.blocks:
-        if bool(partner_mask[record.pose_index, record.block_index]):
-            raise ValueError("partner_mask must not include ligand fragment blocks")
     scorer = sfxn.render_block_pair_scoring_module(pose_stack)
     block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
-    n_terms, n_poses, _, _ = block_pair_scores.shape
-    result = torch.zeros(
-        (n_terms, n_poses, len(fragment_records)),
-        dtype=block_pair_scores.dtype,
-        device=block_pair_scores.device,
+    result = _sum_fragment_partner_scores(
+        block_pair_scores,
+        partner_mask,
+        mapping_data.fragment_block_indices,
     )
-    for fragment_index, record in enumerate(fragment_records):
-        block_index = record.block_index
-        result[:, :, fragment_index] = (
-            block_pair_scores[:, :, block_index, :] * partner_mask.unsqueeze(0)
-        ).sum(dim=2) + (
-            block_pair_scores[:, :, :, block_index] * partner_mask.unsqueeze(0)
-        ).sum(
-            dim=2
-        )
     if sum_terms:
         result = result.sum(dim=0)
-    return FragmentInteractionScores(scores=result, mapping=fragment_records)
+    return FragmentInteractionScores(
+        scores=result,
+        mapping=mapping_data.fragment_records,
+    )

--- a/tmol/tests/ligand/test_fragmented_ligand_scoring.py
+++ b/tmol/tests/ligand/test_fragmented_ligand_scoring.py
@@ -24,7 +24,7 @@ from tmol.ligand._fragmentation import (
     _unsplit_old_to_new,
     _unsplit_per_pose_blocks,
 )
-from tmol.pose import SplitBlockEntry, SplitBlockMapping
+from tmol.pose import PoseStackBuilder, SplitBlockEntry, SplitBlockMapping
 
 DATA_DIR = Path(__file__).parent.parent / "data" / "protein_ligand_test"
 TARGET = "ace"
@@ -438,6 +438,59 @@ def test_fragment_mapping_is_stable_for_atom_array_stack(torch_device):
     assert len(split_mapping.entries) == 2
     assert {e.pose_ind for e in split_mapping.entries} == {0}
     assert len({e.block_ind for e in split_mapping.entries}) == 2
+
+
+def test_pose_stack_builder_preserves_fragment_mapping(torch_device):
+    from tmol.score import (
+        beta2016_score_function,
+        calculate_fragment_interactions,
+    )
+
+    structure, params_path, preparation = _load_fixture()
+    annotated = _annotate_at_bridge(structure, preparation)
+    pose, context, mapping = _build(
+        annotated, params_path, torch_device, fragmented=True
+    )
+
+    # A generic ``cuda`` request must still record the concrete tensor device.
+    builder_device = torch.device(torch_device.type)
+    batched = PoseStackBuilder.from_poses([pose, pose], builder_device)
+    assert batched.device == batched.coords.device
+    batched_mapping = batched.split_block_mapping
+    assert batched_mapping is not None
+    assert len(batched_mapping.entries) == 2 * len(mapping.entries)
+    assert {entry.pose_ind for entry in batched_mapping.entries} == {0, 1}
+    source_orig_names = {
+        pose.packed_block_types.active_block_types[entry.orig_block_type_ind].name
+        for entry in mapping.entries
+    }
+    combined_orig_names = {
+        batched.packed_block_types.active_block_types[entry.orig_block_type_ind].name
+        for entry in batched_mapping.entries
+    }
+    assert combined_orig_names == source_orig_names
+
+    fragment_mask = _fragment_block_mask(batched, batched_mapping)
+    partner_mask = ~fragment_mask & (batched.block_type_ind >= 0)
+    sfxn = beta2016_score_function(torch_device, param_db=context.parameter_database)
+    interactions = calculate_fragment_interactions(
+        batched,
+        partner_mask,
+        sfxn=sfxn,
+        sum_terms=False,
+    ).scores
+
+    torch.testing.assert_close(interactions[:, 0], interactions[:, 1])
+
+    invalid_partner_mask = partner_mask.clone()
+    first_fragment = batched_mapping.entries[0]
+    invalid_partner_mask[first_fragment.pose_ind, first_fragment.block_ind] = True
+    with pytest.raises(ValueError, match="must not include ligand fragment"):
+        calculate_fragment_interactions(
+            batched,
+            invalid_partner_mask,
+            sfxn=sfxn,
+        )
 
 
 def test_fragmented_ligand_minimize_and_pack_e2e():

--- a/tmol/tests/score/test_fragment_interactions.py
+++ b/tmol/tests/score/test_fragment_interactions.py
@@ -1,0 +1,87 @@
+import pytest
+import torch
+
+from tmol.score._fragment_interactions import _sum_fragment_partner_scores
+
+
+def _reference_fragment_partner_scores(
+    block_pair_scores: torch.Tensor,
+    partner_mask: torch.Tensor,
+    fragment_block_indices: torch.Tensor,
+) -> torch.Tensor:
+    partner = partner_mask.unsqueeze(0)
+    return torch.stack(
+        [
+            (block_pair_scores[:, :, block_index, :] * partner).sum(dim=2)
+            + (block_pair_scores[:, :, :, block_index] * partner).sum(dim=2)
+            for block_index in fragment_block_indices.tolist()
+        ],
+        dim=2,
+    )
+
+
+@pytest.mark.parametrize("n_fragments", [1, 5])
+def test_fragment_partner_reduction_matches_loop(
+    torch_device: torch.device, n_fragments: int
+) -> None:
+    generator = torch.Generator(device=torch_device).manual_seed(17)
+    scores = torch.randn(
+        (3, 2, 9, 9),
+        generator=generator,
+        device=torch_device,
+        requires_grad=True,
+    )
+    partner_mask = torch.rand((2, 9), generator=generator, device=torch_device) > 0.3
+    fragment_indices = torch.arange(n_fragments, device=torch_device)
+
+    expected = _reference_fragment_partner_scores(
+        scores, partner_mask, fragment_indices
+    )
+    bytes_per_fragment = 2 * 3 * 2 * 9 * scores.element_size()
+    actual = _sum_fragment_partner_scores(
+        scores,
+        partner_mask,
+        fragment_indices,
+        max_workspace_bytes=2 * bytes_per_fragment,
+    )
+    torch.testing.assert_close(actual, expected)
+
+    expected_gradient = torch.autograd.grad(expected.sum(), scores, retain_graph=True)[
+        0
+    ]
+    actual_gradient = torch.autograd.grad(actual.sum(), scores)[0]
+    torch.testing.assert_close(actual_gradient, expected_gradient)
+
+
+def test_fragment_partner_reduction_accepts_no_fragments(
+    torch_device: torch.device,
+) -> None:
+    scores = torch.zeros((3, 2, 9, 9), device=torch_device, requires_grad=True)
+    partner_mask = torch.zeros((2, 9), dtype=torch.bool, device=torch_device)
+    fragment_indices = torch.empty((0,), dtype=torch.int64, device=torch_device)
+
+    result = _sum_fragment_partner_scores(scores, partner_mask, fragment_indices)
+
+    assert result.shape == (3, 2, 0)
+    assert result.dtype == scores.dtype
+    assert result.device == scores.device
+    assert result.requires_grad
+
+
+@pytest.mark.benchmark(group="fragment_partner_reduction")
+def test_fragment_partner_reduction_benchmark(
+    benchmark, torch_device: torch.device
+) -> None:
+    generator = torch.Generator(device=torch_device).manual_seed(17)
+    scores = torch.randn((22, 8, 100, 100), generator=generator, device=torch_device)
+    partner_mask = torch.rand((8, 100), generator=generator, device=torch_device) > 0.2
+    fragment_indices = torch.arange(7, device=torch_device)
+
+    def reduce_fragment_scores() -> torch.Tensor:
+        result = _sum_fragment_partner_scores(scores, partner_mask, fragment_indices)
+        if torch_device.type == "cuda":
+            torch.cuda.synchronize(torch_device)
+        return result
+
+    reduce_fragment_scores()  # Warm up the CUDA reduction before timing.
+    benchmark(reduce_fragment_scores)

--- a/tmol/tests/score/test_fragment_interactions.py
+++ b/tmol/tests/score/test_fragment_interactions.py
@@ -1,7 +1,90 @@
+from types import SimpleNamespace
+from typing import cast
+
 import pytest
 import torch
 
-from tmol.score._fragment_interactions import _sum_fragment_partner_scores
+from tmol.pose import PoseStack, SplitBlockMapping
+from tmol.score._fragment_interactions import (
+    _LegacyFragmentMapping,
+    _fragment_mapping_data,
+    _sum_fragment_partner_scores,
+)
+
+
+def _pose_topology(torch_device: torch.device) -> PoseStack:
+    return cast(
+        PoseStack,
+        SimpleNamespace(
+            n_poses=2,
+            max_n_blocks=4,
+            block_type_ind=torch.zeros((2, 4), dtype=torch.int32, device=torch_device),
+        ),
+    )
+
+
+def _legacy_mapping(*records: tuple[int, int, int]) -> _LegacyFragmentMapping:
+    return cast(
+        _LegacyFragmentMapping,
+        SimpleNamespace(
+            blocks=tuple(
+                SimpleNamespace(
+                    pose_index=pose_index,
+                    block_index=block_index,
+                    pose_residue_label=residue_label,
+                )
+                for pose_index, block_index, residue_label in records
+            )
+        ),
+    )
+
+
+def test_fragment_mapping_normalizes_legacy_records(
+    torch_device: torch.device,
+) -> None:
+    pose_stack = _pose_topology(torch_device)
+    mapping = _legacy_mapping(
+        (0, 3, 8),
+        (0, 1, 7),
+        (1, 3, 8),
+        (1, 1, 7),
+    )
+
+    data = _fragment_mapping_data(pose_stack, mapping)
+
+    assert [record.block_index for record in data.fragment_records] == [1, 3]
+    torch.testing.assert_close(
+        data.record_linear_indices,
+        torch.tensor([3, 1, 7, 5], dtype=torch.int64, device=torch_device),
+    )
+    assert _fragment_mapping_data(pose_stack, mapping) is data
+
+
+@pytest.mark.parametrize(
+    ("mapping", "message"),
+    [
+        (SplitBlockMapping(entries=()), "no entries for pose 0"),
+        (
+            _legacy_mapping((0, 1, 7), (1, 2, 7)),
+            "identical block topology",
+        ),
+        (
+            _legacy_mapping((0, 4, 7), (1, 4, 7)),
+            "outside the pose stack",
+        ),
+        (
+            _legacy_mapping((0, 1, 7), (0, 1, 7), (1, 1, 7)),
+            "duplicate columns",
+        ),
+    ],
+)
+def test_fragment_mapping_rejects_invalid_topology(
+    torch_device: torch.device,
+    mapping: SplitBlockMapping | _LegacyFragmentMapping,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _fragment_mapping_data(_pose_topology(torch_device), mapping)
 
 
 def _reference_fragment_partner_scores(


### PR DESCRIPTION
## Summary

- normalize current and compatibility fragment mappings once, cache immutable topology indices on the pose, and validate the partner mask with one device synchronization instead of one per mapping entry
- replace the per-fragment Python reduction with a vectorized, autograd-preserving gather/einsum reduction chunked to a 256 MiB temporary-workspace target
- preserve split-block mappings when PoseStackBuilder batches poses and record the concrete tensor device
- document the connected-pose fragment-attribution workflow and add correctness, gradient, batching, cache-validation, and benchmark coverage

## NVIDIA H200 performance

For the isolated 22-term reduction, the representative 8-pose, 100-block, 7-fragment case fell from 0.2782 ms to 0.0563 ms (4.94x). The speedup was 5.00x for 64 poses and 16.55x for 32 fragments. The checked-in synchronized benchmark measures 60.2 us on an H200.

Including scorer rendering, complete block-pair scoring, validation, and reduction for the six-fragment ACE workflow:

| Batch | Forward | Forward + backward |
| ---: | ---: | ---: |
| 1 | 2.290 to 2.142 ms (1.07x) | 4.175 to 3.769 ms (1.11x) |
| 8 | 6.957 to 6.343 ms (1.10x) | 15.824 to 12.633 ms (1.25x) |
| 64 | 44.848 to 40.309 ms (1.11x) | 108.455 to 85.069 ms (1.27x) |

## Validation

- CPU regression set: 66 passed, 47 device skips
- focused H200 suite: 14 passed
- synchronized H200 pytest benchmark: 60.228 us mean
- Sphinx HTML build with warnings treated as errors
- Black, Flake8, Ruff, and git diff checks