### PR TITLE
Handle empty poses in CUDA annealing

### DIFF
--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -612,6 +612,13 @@ struct Annealer {
         segment_heads_lotemp[pose] = pose * n_lotemp_simA_traj;
         segment_heads_fullquench[pose] = pose * n_fullquench_traj;
       }
+      // A fully frozen pose has no valid random-rotamer domain.
+      if (n_res == 0) {
+        if (g.thread_rank() == 0) {
+          scores_hitemp[pose][traj_id] = 0.0f;
+        }
+        return;
+      }
 
       // Random initial assignment
       for (int i = g.thread_rank(); i < n_res; i += 32) {
@@ -691,6 +698,12 @@ struct Annealer {
       if (g.thread_rank() == 0) {
         sorted_lotemp_traj[pose][traj_id] = traj_id;
       }
+      if (n_res == 0) {
+        if (g.thread_rank() == 0) {
+          scores_lotemp[pose][traj_id] = 0.0f;
+        }
+        return;
+      }
 
       // Seed from the selected hitemp trajectory's best state
       for (int i = g.thread_rank(); i < n_res; i += 32) {
@@ -761,6 +774,12 @@ struct Annealer {
 
       if (g.thread_rank() == 0) {
         sorted_fullquench_traj[pose][traj_id] = traj_id;
+      }
+      if (n_res == 0) {
+        if (g.thread_rank() == 0) {
+          scores_fullquench[pose][traj_id] = 0.0f;
+        }
+        return;
       }
 
       for (int i = g.thread_rank(); i < n_res; i += 32) {

--- a/tmol/tests/pack/test_build_missing_sidechains.py
+++ b/tmol/tests/pack/test_build_missing_sidechains.py
@@ -44,13 +44,15 @@ def test_build_missing_sidechains_no_optH(ubq_pdb, torch_device, dun_sampler):
     block_has_missing_atoms[0, 40:60] = True
     block_has_missing_atoms[2, 10:20] = True
     sfxn = beta2016_score_function(torch_device)
-    build_missing_sidechains(
-        pose_stack=pn,
-        sfxn=sfxn,
-        dunbrack_sampler=dun_sampler,
-        no_optH=True,
-        block_has_missing_atoms=block_has_missing_atoms,
-    )
+    # A fully frozen middle pose must remain safe across repeated anneals.
+    for _ in range(2):
+        build_missing_sidechains(
+            pose_stack=pn,
+            sfxn=sfxn,
+            dunbrack_sampler=dun_sampler,
+            no_optH=True,
+            block_has_missing_atoms=block_has_missing_atoms,
+        )
 
 
 def test_build_missing_sidechains_skips_na_sampler_for_complete_pose(


### PR DESCRIPTION
## Summary

- skip simulated-annealing phases for fully frozen poses with no candidate residues
- retain zero scores and valid segmented ranking/output shapes for those poses
- exercise the empty middle-pose path twice to catch latent CUDA errors across repeated packing calls

This fixes the current master failure where a `no_optH` batch with `pose_n_res=[17, 0, 9]` enters random-rotamer arithmetic for the empty pose and leaves an illegal CUDA access that surfaces on the next pack call. Empty poses now return before random selection, which also avoids unnecessary annealing work for them.

## Validation

- H200 exact repeated regression: 2 passed with `CUDA_LAUNCH_BLOCKING=1`
- H200/CPU packing suite (`test_build_missing_sidechains.py`, `test_load_ig.py`, `test_pack_rotamers.py`): 33 passed
- Black, Flake8, and `git diff --check`: pass

This PR is intentionally separate from #448 so the fragment-scoring optimization remains narrowly scoped.