### PR TITLE
Reduce sparse rotamer scoring memory

### DIFF
--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 # .sfxn file and checked on load.
 SFXN_FORMAT_VERSION: str = "1.0"
 
+# Exact CUDA tensor equality synchronizes with the host. Only pay that cost
+# when one duplicate sparse index layout would retain at least 16 MiB.
+_ROTAMER_LAYOUT_DEDUP_MIN_BYTES = 16 * 1024 * 1024
+
 
 class ScoreFunction:
     """Weighted collection of energy terms rendered for a pose topology.
@@ -256,14 +260,19 @@ class ScoreFunction:
         self,
         pose_stack: PoseStack,
         rotamer_set: "RotamerSet",  # noqa: F405
-    ):
-        """Create an object designed to evaluate the score a RotamerSet
-        repeatedly as the Poses change their conformation, e.g., as in
-        minimization. This object will derive from torch.nn.Module and
-        it will contain a set of objects rendered by the ScoreFunction's
-        terms that themselves are derived from torch.nn.Module. This
-        object's __call__ will return a tensor of weighted energies of
-        shape (n_poses, max_n_blocks, max_n_blocks).
+    ) -> "RotamerScoringModule":
+        """Render a weighted sparse scorer for one rotamer set.
+
+        Args:
+            pose_stack: Poses whose fixed background interacts with the
+                rotamers.
+            rotamer_set: Candidate conformers and their pose/block indexing.
+
+        Returns:
+            A callable that accepts rotamer coordinates and returns an
+            uncoalesced sparse COO tensor shaped
+            ``[n_poses, n_rotamers, n_rotamers]``. Call ``coalesce()`` before
+            reading its indices or values.
         """
         self.pre_work_initialization(pose_stack)
         term_modules = [
@@ -590,7 +599,11 @@ class BlockPairScoringModule:
 
 
 class RotamerScoringModule:
-    """Rendered energy modules that build sparse rotamer-pair energy tables."""
+    """Rendered energy modules that build sparse rotamer-pair energy tables.
+
+    Large identical index layouts are combined before sparse coalescing to
+    avoid retaining and sorting redundant block-pair indices.
+    """
 
     def __init__(
         self,
@@ -602,17 +615,18 @@ class RotamerScoringModule:
         )
         self.term_modules = term_modules
 
-    def __call__(self, coords):
+    def __call__(self, coords: torch.Tensor) -> torch.Tensor:
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         # Accumulate weighted values and their indices across all terms at the
         # dense [nnz] level.  This avoids torch.stack on sparse tensors, which
         # previously created a [n_subterms, n_poses, n_rots, n_rots] 4D sparse
         # tensor whose index storage grew as n_subterms × nnz × 4 int32.
-        all_values = []
-        all_indices = []
-        n_poses = None
-        n_rots = None
+        all_values: list[torch.Tensor] = []
+        all_indices: list[torch.Tensor] = []
+        layouts_by_nnz: dict[int, list[int]] = {}
+        n_poses: int | None = None
+        n_rots: int | None = None
         weights_offset = 0
 
         for term in self.term_modules:
@@ -623,8 +637,28 @@ class RotamerScoringModule:
             w = self.weights[weights_offset : weights_offset + n_subterms, 0, 0, 0]
             weighted_values = (w[:, None] * scores).sum(dim=0)
 
-            all_values.append(weighted_values)
-            all_indices.append(indices)
+            # Several terms share the same block-pair dispatch. Combine their
+            # values now so the sparse coalesce does not sort another copy of
+            # the same, potentially multi-gigabyte, index layout.
+            deduplicate_layout = (
+                indices.numel() * indices.element_size()
+                >= _ROTAMER_LAYOUT_DEDUP_MIN_BYTES
+            )
+            candidate_layouts = (
+                layouts_by_nnz.get(indices.shape[1], ()) if deduplicate_layout else ()
+            )
+            for layout_index in candidate_layouts:
+                if torch.equal(indices, all_indices[layout_index]):
+                    all_values[layout_index] = (
+                        all_values[layout_index] + weighted_values
+                    )
+                    break
+            else:
+                layout_index = len(all_indices)
+                all_values.append(weighted_values)
+                all_indices.append(indices)
+                if deduplicate_layout:
+                    layouts_by_nnz.setdefault(indices.shape[1], []).append(layout_index)
             weights_offset += n_subterms
 
             if n_poses is None:

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -3,12 +3,17 @@ import numpy
 import os
 import pytest
 
+from tmol.score import _score_function as score_function_module
 from tmol.score import (
     _non_memoized_beta2016,
     ScoreFunction,
     ScoreType,
 )
-from tmol.score._score_function import BlockPairScoringModule, WholePoseScoringModule
+from tmol.score._score_function import (
+    BlockPairScoringModule,
+    RotamerScoringModule,
+    WholePoseScoringModule,
+)
 from tmol.score.common import ZeroTermPoseScoringModule
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
@@ -171,6 +176,54 @@ def test_no_grad_scoring_detaches_coordinates():
     with torch.no_grad():
         scorer(coords)
     assert not term.input_requires_grad
+
+
+def test_rotamer_scorer_combines_identical_sparse_layouts(
+    torch_device: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(score_function_module, "_ROTAMER_LAYOUT_DEDUP_MIN_BYTES", 0)
+
+    class SparseTerm(torch.nn.Module):
+        def __init__(self, scores: torch.Tensor, indices: torch.Tensor) -> None:
+            super().__init__()
+            self.scores = scores
+            self.indices = indices
+            self.n_poses = 1
+            self.n_rots = 3
+
+        def forward(self, coords: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return self.scores * coords, self.indices
+
+    shared = torch.tensor(
+        [[0, 0], [0, 1], [1, 0]], dtype=torch.int32, device=torch_device
+    )
+    distinct = torch.tensor(
+        [[0, 0], [0, 2], [2, 1]], dtype=torch.int32, device=torch_device
+    )
+    terms = [
+        SparseTerm(torch.tensor([[1.0, 2.0]], device=torch_device), shared),
+        SparseTerm(torch.tensor([[3.0, 4.0]], device=torch_device), shared.clone()),
+        SparseTerm(torch.tensor([[5.0, 6.0]], device=torch_device), distinct),
+    ]
+    scorer = RotamerScoringModule(
+        torch.tensor([1.0, 2.0, 4.0], device=torch_device), terms
+    )
+    coords = torch.ones((), device=torch_device, requires_grad=True)
+
+    scores = scorer(coords)
+    dense_scores = scores.to_dense()
+
+    assert scores._nnz() == 4
+    torch.testing.assert_close(
+        dense_scores,
+        torch.tensor(
+            [[[0.0, 7.0, 20.0], [10.0, 0.0, 0.0], [0.0, 24.0, 0.0]]],
+            device=torch_device,
+        ),
+    )
+    dense_scores.sum().backward()
+    torch.testing.assert_close(coords.grad, torch.tensor(61.0, device=torch_device))
 
 
 def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):


### PR DESCRIPTION
## Summary

- combine score-term values that use exactly identical large sparse rotamer index layouts before constructing the final COO tensor
- keep layouts smaller than 16 MiB on the existing path, avoiding synchronization overhead for small packing jobs
- document the actual sparse `[n_poses, n_rotamers, n_rotamers]` return contract and add explicit scorer typing
- test identical and unequal layouts as well as coordinate gradients

The coalesced energies and gradients are unchanged. The raw uncoalesced tensor may contain fewer duplicate entries because equal layouts are precombined.

## H200 benchmark

Same H200 job, alternating candidate/baseline order. The workload repacks a 10-pose, 76-residue ubiquitin batch with expanded chi1 sampling and times five calls to the rendered rotamer scorer plus `coalesce()` after warm-up.

| implementation | median run 1 | median run 2 | peak allocation delta |
| --- | ---: | ---: | ---: |
| `master` | 1086.69 ms | 1086.95 ms | 17,302.03 MiB |
| this PR | 1050.45 ms | 1051.50 ms | 8,852.43 MiB |

That is **3.30% faster** and saves **8,449.60 MiB (48.84%)** of peak temporary allocation. In the profiler, sparse coalescing fell from 88.68 ms to 53.39 ms and concatenation allocation fell from 4.03 GiB to 2.08 GiB.

A 15-residue, one-pose check confirms the 16 MiB guard preserves the small-layout path:

| implementation | median run 1 | median run 2 |
| --- | ---: | ---: |
| `master` | 9.638 ms | 9.618 ms |
| this PR | 9.638 ms | 9.616 ms |

## Validation

- `86 passed, 1 skipped`: score-function tests, protein packing, nucleic-acid rotamer scoring, and fragmented-ligand minimize/pack on H200
- focused CPU + H200 gradient/layout test: `2 passed`
- Black 26.3.1, Flake8 7.3.0, Ruff, and `git diff --check`
