### PR TITLE
Synchronize verbose timings on the workload device

### DIFF
--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -16,6 +16,7 @@ from tmol.kinematics import (
 from tmol.score import ScoreFunction
 
 from tmol.optimization import LBFGS_Armijo
+from tmol.utility._device import synchronize_device
 
 if TYPE_CHECKING:
     from tmol.optimization import CartesianSfxnNetwork, KinForestSfxnNetwork
@@ -45,25 +46,25 @@ def build_kinforest_network(
     from tmol.kinematics import PoseStackKinematicsModule
     from tmol.optimization import KinForestSfxnNetwork
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     start_time = time.perf_counter()
 
     kin_module = PoseStackKinematicsModule(pose_stack, ff)
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time1 = time.perf_counter()
 
     minimizer_map = MinimizerMap(pose_stack, kin_module.kmd, mm)
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time2 = time.perf_counter()
 
     kf_network = KinForestSfxnNetwork(
         sfxn, pose_stack, kin_module, minimizer_map.dof_mask, kin_dtype=kin_dtype
     )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time3 = time.perf_counter()
 
     if verbose:
@@ -108,8 +109,9 @@ def run_min(
     if optimizer_kwargs is None:
         optimizer_kwargs = {}
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    timing_device = next(sfxn_module.parameters()).device if verbose else None
+    if timing_device is not None:
+        synchronize_device(timing_device)
     start_time = time.perf_counter()
 
     segment_ids = getattr(sfxn_module, "segment_ids", None)
@@ -129,17 +131,17 @@ def run_min(
         E.sum().backward()
         return E if segmented else E.sum()
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if timing_device is not None:
+        synchronize_device(timing_device)
     end_time1 = time.perf_counter()
     optimizer.step(closure)
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if timing_device is not None:
+        synchronize_device(timing_device)
     end_time2 = time.perf_counter()
 
     new_pose_stack = sfxn_module.pose_stack_from_dofs()
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if timing_device is not None:
+        synchronize_device(timing_device)
     end_time3 = time.perf_counter()
 
     if verbose:

--- a/tmol/pack/_pack_rotamers.py
+++ b/tmol/pack/_pack_rotamers.py
@@ -1,5 +1,6 @@
-import torch
 import time
+
+import torch
 
 from tmol.pose import PoseStack
 from tmol.score import ScoreFunction
@@ -12,6 +13,7 @@ from tmol.pack import (
     impose_top_rotamer_assignments,
 )
 from tmol.pack.rotamer import build_rotamers
+from tmol.utility._device import synchronize_device
 
 
 def pack_rotamers(
@@ -32,16 +34,16 @@ def pack_rotamers(
         A new pose stack containing the lowest-ranked assignment per pose.
     """
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     start_time = time.perf_counter()
 
     task = SetPackerTask.from_packer_task(task)
     pbt = pose_stack.packed_block_types
 
     pose_stack, rotamer_set = build_rotamers(pose_stack, task, pbt.chem_db)
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time1 = time.perf_counter()
 
     (
@@ -54,13 +56,13 @@ def pack_rotamers(
         end_time3,
     ) = _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=verbose)
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time4 = time.perf_counter()
 
     _, rotamer_assignments = run_simulated_annealing(packer_energy_tables)
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time5 = time.perf_counter()
 
     new_pose_stack = impose_top_rotamer_assignments(
@@ -72,8 +74,8 @@ def pack_rotamers(
         bc_rot_to_orig_rot,
         rotamer_assignments,
     )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time6 = time.perf_counter()
 
     if verbose:
@@ -96,8 +98,8 @@ def _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=Fals
     energies = rotamer_scoring_module(rotamer_set.coords)
     energies = energies.coalesce()
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time2 = time.perf_counter()
 
     chunk_size = 16
@@ -132,8 +134,8 @@ def _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=Fals
         energies.values(),
         verbose,
     )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time3 = time.perf_counter()
 
     packer_energy_tables = PackerEnergyTables(

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -1,9 +1,10 @@
-import attr
-import torch
 import time
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Protocol
+
+import attr
+import torch
 
 from tmol.pose import PoseStack
 from tmol.score import (
@@ -26,6 +27,7 @@ from tmol.pack.rotamer import (
 )
 from tmol.optimization import run_cart_min, run_kin_min
 from tmol.types import Tensor
+from tmol.utility._device import synchronize_device
 
 RelaxScheduleEntry = float | int | dict[str, float]
 PackerTaskOperation = Callable[[PackerTask], None]
@@ -305,8 +307,8 @@ def relax_pack_min_step(
         The minimized pose stack.
     """
 
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     start_time = time.perf_counter()
     task = PackerTask(pose_stack, packer_pallete)
     for op in task_operations:
@@ -318,8 +320,8 @@ def relax_pack_min_step(
         print(
             f"packing with fa_rep of {fa_rep_pack_weight: .2f} and constraint weight of {cst_weight: .2f}"
         )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time1 = time.perf_counter()
     packed_pose_stack = pack_rotamers(pose_stack, sfxn, task, verbose)
 
@@ -328,8 +330,8 @@ def relax_pack_min_step(
         print(
             f"minimizing with fa_rep of {fa_rep_min_weight: .2f} and constraint weight of {cst_weight: .2f}"
         )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time2 = time.perf_counter()
     minimized_pose_stack = min_fn(
         packed_pose_stack,
@@ -338,8 +340,8 @@ def relax_pack_min_step(
         move_map=move_map,
         verbose=verbose,
     )
-    if verbose and torch.cuda.is_available():
-        torch.cuda.synchronize()
+    if verbose:
+        synchronize_device(pose_stack.device)
     end_time3 = time.perf_counter()
 
     if verbose:

--- a/tmol/tests/utility/test_device.py
+++ b/tmol/tests/utility/test_device.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+from tmol.utility._device import synchronize_device
+
+
+def test_synchronize_device_is_a_cpu_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_synchronize(device: torch.device) -> None:
+        raise AssertionError(f"unexpected CUDA synchronization on {device}")
+
+    monkeypatch.setattr(torch.cuda, "synchronize", unexpected_synchronize)
+
+    synchronize_device(torch.device("cpu"))
+
+
+def test_synchronize_device_targets_a_concrete_cuda_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    synchronized: list[torch.device] = []
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 2)
+    monkeypatch.setattr(torch.cuda, "synchronize", synchronized.append)
+
+    synchronize_device(torch.device("cuda"))
+
+    assert synchronized == [torch.device("cuda", 2)]

--- a/tmol/utility/_device.py
+++ b/tmol/utility/_device.py
@@ -2,8 +2,15 @@ import torch
 
 
 def resolve_device(device: torch.device) -> torch.device:
-    """Make device concrete; assigns user-provided device('cuda') a device number"""
+    """Resolve an unindexed CUDA device to the current device."""
     device = torch.device(device)
     if device.type == "cuda" and device.index is None:
         return torch.device("cuda", torch.cuda.current_device())
     return device
+
+
+def synchronize_device(device: torch.device) -> None:
+    """Wait for queued CUDA work on ``device``; do nothing for CPU devices."""
+    device = resolve_device(device)
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)


### PR DESCRIPTION
## Summary

- add one shared helper that synchronizes a specific CUDA device and is a no-op for CPU
- use the pose/module device for verbose timing in packing, minimization, and FastRelax
- avoid CUDA initialization and unrelated-device synchronization for CPU and multi-GPU workloads
- document the timing behavior and cover CPU and unindexed-CUDA device resolution

The scoring, packing, and minimization hot paths are unchanged when `verbose=False`.

## Bug fixed

The prior timing code guarded synchronization with `torch.cuda.is_available()` and then called `torch.cuda.synchronize()` without a device. On a CPU workload in a CUDA-capable process, that unnecessarily initialized/synchronized CUDA. On multi-GPU workloads, it could synchronize the current device rather than the device running the measured work, making the printed timings inaccurate.

## Validation

- H200 pack/minimize/FastRelax and helper suite: `110 passed, 3 skipped, 1 xfailed, 2 xpassed`
- focused latest-state helper/minimizer suite: `10 passed`
- Black check, Ruff, and `git diff --check`: pass
