### PR TITLE
Normalize public CUDA device construction

### DIFF
--- a/tmol/pack/rotamer/_na_chi_sampler.py
+++ b/tmol/pack/rotamer/_na_chi_sampler.py
@@ -27,6 +27,7 @@ from tmol.score.na_torsion import (
     polymer_index,
     pucker_weights,
 )
+from tmol.utility._device import resolve_device
 
 # k in chi = mean + k * sdev_chi, by extra-chi sample level, mirroring Rosetta's
 # expansion of its fitted chi gaussians
@@ -84,7 +85,19 @@ class NaChiRotamerSampler(ChiSampler):
         device: torch.device,
         chi_sample_level: int = 0,
         sample_syn: bool = True,
-    ):
+    ) -> "NaChiRotamerSampler":
+        """Create a nucleic-acid chi sampler on a concrete device.
+
+        Args:
+            param_db: Source scoring and chemical parameters.
+            device: Target device. Unindexed CUDA resolves to the current GPU.
+            chi_sample_level: Number of standard-deviation expansion levels.
+            sample_syn: Include eligible syn rotamers when true.
+
+        Returns:
+            A sampler whose parameters and device metadata agree.
+        """
+        device = resolve_device(device)
         return cls(
             params=NaTorsionParams.from_database(param_db.scoring.na_torsion, device),
             element_for_atom_type={

--- a/tmol/pack/rotamer/dunbrack/_dunbrack_chi_sampler.py
+++ b/tmol/pack/rotamer/dunbrack/_dunbrack_chi_sampler.py
@@ -747,7 +747,8 @@ def create_dunbrack_sampler_from_database(
 
     Args:
         param_db: The parameter database containing Dunbrack parameters
-        device: The device to use for the sampler
+        device: The device to use for the sampler. An unindexed CUDA device
+            resolves to the current CUDA device.
 
     Returns:
         DunbrackChiSampler: Configured sampler for rotamer building

--- a/tmol/pose/_constraint_set.py
+++ b/tmol/pose/_constraint_set.py
@@ -3,12 +3,13 @@ import attr
 
 from typing import Optional, Tuple
 from tmol.types import Tensor
+from tmol.utility._device import resolve_device
 from tmol.utility.tensor import exclusive_cumsum1d
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class ConstraintSet:
-    """ """
+    """Immutable batched coordinate constraints and their tensor storage."""
 
     MAX_N_ATOMS = 4
 
@@ -23,6 +24,8 @@ class ConstraintSet:
 
     @classmethod
     def create_empty(cls, device: torch.device, n_poses: int) -> "ConstraintSet":
+        """Create an empty constraint set on a concrete device."""
+        device = resolve_device(device)
         return ConstraintSet(
             device=device,
             n_poses=n_poses,
@@ -203,6 +206,8 @@ class ConstraintSet:
         )
 
     def to(self, device: torch.device) -> "ConstraintSet":
+        """Return a copy whose tensors and metadata use ``device``."""
+        device = resolve_device(device)
         return attr.evolve(
             self,
             device=device,

--- a/tmol/pose/_packed_block_types.py
+++ b/tmol/pose/_packed_block_types.py
@@ -14,6 +14,7 @@ from tmol.chemical import (
     ResidueTypeSet,
 )
 from tmol.database import PatchedChemicalDatabase
+from tmol.utility._device import resolve_device
 from tmol.utility.tensor import join_tensors_and_report_real_entries
 
 
@@ -126,7 +127,20 @@ class PackedBlockTypes:
         restype_set: ResidueTypeSet,
         active_block_types: Sequence[RefinedResidueType],
         device: torch.device,
-    ):
+    ) -> "PackedBlockTypes":
+        """Pack residue-type metadata onto a concrete torch device.
+
+        Args:
+            chem_db: Chemical database shared by the residue types.
+            restype_set: Source residue-type collection.
+            active_block_types: Ordered residue types to pack.
+            device: Target device. An unindexed CUDA device resolves to the
+                current CUDA device.
+
+        Returns:
+            Packed residue-type tensors and their concrete device metadata.
+        """
+        device = resolve_device(device)
         max_n_atoms = cls.count_max_n_atoms(active_block_types)
         n_atoms = cls.count_n_atoms(active_block_types, device)
         atom_is_real = cls.determine_real_atoms(max_n_atoms, n_atoms, device)

--- a/tmol/pose/_pose_stack.py
+++ b/tmol/pose/_pose_stack.py
@@ -77,9 +77,11 @@ class PoseStack:
         n_poses = self.block_coord_offset.size(0)
         n_blocks = self.block_coord_offset.size(1)
 
-        block_inds = torch.zeros_like(self.block_coord_offset)
-        block_inds[:, :] = torch.arange(0, n_blocks)
-        self.block_ind_for_rot = block_inds.flatten()
+        self.block_ind_for_rot = torch.arange(
+            n_blocks,
+            dtype=self.block_coord_offset.dtype,
+            device=self.block_coord_offset.device,
+        ).repeat(n_poses)
 
         pose_inds = (
             torch.arange(0, n_poses, dtype=torch.int32, device=self.device)

--- a/tmol/pose/_pose_stack_builder.py
+++ b/tmol/pose/_pose_stack_builder.py
@@ -34,6 +34,7 @@ from tmol.utility.tensor import (
     stretch,
     stretch2,
 )
+from tmol.utility._device import resolve_device
 
 
 class PoseStackBuilder:
@@ -53,6 +54,7 @@ class PoseStackBuilder:
         Returns:
             A padded pose stack containing every input pose in order.
         """
+        device = resolve_device(device)
         pbt0 = pose_stacks[0].packed_block_types
         for ps in pose_stacks:
             # all PoseStacks must be built from the same chemical database

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -10,6 +10,7 @@ from tmol.database import ParameterDatabase
 from tmol.database._yaml import safe_load
 from tmol.score import ScoreType
 from tmol.score.common import ZeroTermPoseScoringModule
+from tmol.utility._device import resolve_device
 
 # force registration of the terms with the ScoreTermFactory
 from tmol.score.terms import *  # noqa: F401, F403
@@ -30,10 +31,12 @@ class ScoreFunction:
 
     Args:
         param_db: Chemical and scoring parameters used to construct terms.
-        device: Device on which weights and rendered scorers operate.
+        device: Device on which weights and rendered scorers operate. An
+            unindexed CUDA device resolves to the current CUDA device.
     """
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
+        device = resolve_device(device)
         self._weights = torch.zeros((ScoreType.n_score_types.value,), device=device)
 
         self._all_terms = []

--- a/tmol/score/dunbrack/_params.py
+++ b/tmol/score/dunbrack/_params.py
@@ -1,12 +1,12 @@
+import itertools
+from typing import Any
+
 import attr
 import cattr
-
 import numpy
 import pandas
 import torch
-
 import toolz.functoolz
-import itertools
 
 from tmol.types import (
     NDArray,
@@ -26,6 +26,16 @@ from tmol.utility.tensor import (
     nplus1d_tensor_from_list,
     cat_differently_sized_tensors,
 )
+from tmol.utility._device import resolve_device
+
+
+def _dunbrack_database_cache_key(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[DunbrackRotamerLibrary, str, int | None]:
+    """Key Dunbrack parameters by database and concrete device."""
+    dun_database = args[1] if len(args) > 1 else kwargs["dun_database"]
+    device = resolve_device(args[2] if len(args) > 2 else kwargs["device"])
+    return dun_database, device.type, device.index
 
 
 @attr.s(auto_attribs=True)
@@ -149,9 +159,11 @@ class DunbrackParamResolver(ValidateAttrs):
     @validate_args
     @toolz.functoolz.memoize(
         cache=_from_dun_db_cache,
-        key=lambda args, kwargs: (args[1], args[2].type, args[2].index),
+        key=_dunbrack_database_cache_key,
     )
     def from_database(cls, dun_database: DunbrackRotamerLibrary, device: torch.device):
+        """Load and cache parameters on a concrete torch device."""
+        device = resolve_device(device)
         all_rotlibs = [
             rotlib
             for rotlib in itertools.chain(

--- a/tmol/tests/pack/rotamer/dunbrack/test_dunbrack_chi_sampler.py
+++ b/tmol/tests/pack/rotamer/dunbrack/test_dunbrack_chi_sampler.py
@@ -1,5 +1,6 @@
 import cattr
 import numpy
+import pytest
 import torch
 
 import tmol.pack.rotamer.dunbrack._compiled  # noqa F401
@@ -71,6 +72,26 @@ def test_annotate_residue_type(default_database):
         tyr_restype.dun_sampler_cache.chi_defining_atom[2]
         == tyr_restype.atom_to_idx["OH"]
     )
+
+
+def test_sampler_resolves_unindexed_cuda(default_database, torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("Requires CUDA")
+
+    sampler = create_dunbrack_sampler_from_database(
+        default_database, torch.device("cuda")
+    )
+    concrete_sampler = create_dunbrack_sampler_from_database(
+        default_database, torch_device
+    )
+    keyword_resolver = DunbrackParamResolver.from_database(
+        dun_database=default_database.scoring.dun,
+        device=torch.device("cuda"),
+    )
+
+    assert sampler.device == torch_device
+    assert sampler.dun_param_resolver is concrete_sampler.dun_param_resolver
+    assert sampler.dun_param_resolver is keyword_resolver
 
 
 def test_annotate_packed_block_types(default_database, torch_device):

--- a/tmol/tests/pack/rotamer/test_na_chi_sampler.py
+++ b/tmol/tests/pack/rotamer/test_na_chi_sampler.py
@@ -46,7 +46,11 @@ def _sample(pdb_lines, default_database, torch_device, **kwargs):
 
 
 def test_na_sampler_builds_for_nucleotides_only(default_database, torch_device):
-    sampler = NaChiRotamerSampler.from_database(default_database, torch_device)
+    sampler = NaChiRotamerSampler.from_database(
+        default_database, torch.device(torch_device.type)
+    )
+    assert sampler.device == torch_device
+    assert sampler.params.chi_means.device == torch_device
     pbt = default_packed_block_types(torch_device)
     for bt in pbt.active_block_types:
         assert sampler.defines_rotamers_for_rt(bt) == (

--- a/tmol/tests/pose/test_constraint_set.py
+++ b/tmol/tests/pose/test_constraint_set.py
@@ -11,7 +11,10 @@ from tmol.io import pose_stack_from_pdb
 
 
 def test_constraint_set_empty_initialization(torch_device):
-    cs = ConstraintSet.create_empty(torch_device, 1)
+    requested_device = torch.device(torch_device.type)
+    created = ConstraintSet.create_empty(requested_device, 1)
+    assert created.device == torch_device
+    cs = created.to(requested_device)
 
     assert cs.device == torch_device
     assert cs.n_poses == 1

--- a/tmol/tests/pose/test_packed_block_types.py
+++ b/tmol/tests/pose/test_packed_block_types.py
@@ -1,4 +1,5 @@
 import numpy
+import torch
 
 from tmol.pose import PackedBlockTypes
 
@@ -90,11 +91,12 @@ def test_packed_block_types_ordered_torsions(
 def test_packed_block_types_device(
     fresh_default_restype_set, default_database, torch_device
 ):
+    requested_device = torch.device(torch_device.type)
     pbt = PackedBlockTypes.from_restype_list(
         default_database.chemical,
         fresh_default_restype_set,
         fresh_default_restype_set.residue_types,
-        torch_device,
+        requested_device,
     )
 
     assert pbt.atom_is_real.device == torch_device

--- a/tmol/tests/pose/test_pose_stack_construction.py
+++ b/tmol/tests/pose/test_pose_stack_construction.py
@@ -9,10 +9,11 @@ from tmol.pose import PoseStackBuilder
 def test_concatenate_pose_stacks_ctor(ubq_pdb, default_database, torch_device):
     p1 = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=40)
     p2 = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=60)
-    poses = PoseStackBuilder.from_poses([p1, p2], torch_device)
+    poses = PoseStackBuilder.from_poses([p1, p2], torch.device(torch_device.type))
     assert poses.block_type_ind.shape == (2, 60)
     assert poses.coords.shape == (2, 962, 3)  # fd 959->961 for nterm
     assert poses.inter_block_bondsep.shape == (2, 60, 60, 3, 3)
+    assert poses.device == torch_device
 
 
 def test_create_pose_from_sequence(fresh_default_packed_block_types, torch_device):

--- a/tmol/tests/pose/test_pose_stack_construction.py
+++ b/tmol/tests/pose/test_pose_stack_construction.py
@@ -14,6 +14,10 @@ def test_concatenate_pose_stacks_ctor(ubq_pdb, default_database, torch_device):
     assert poses.coords.shape == (2, 962, 3)  # fd 959->961 for nterm
     assert poses.inter_block_bondsep.shape == (2, 60, 60, 3, 3)
     assert poses.device == torch_device
+    torch.testing.assert_close(
+        poses.block_ind_for_rot,
+        torch.arange(60, dtype=torch.int32, device=torch_device).repeat(2),
+    )
 
 
 def test_create_pose_from_sequence(fresh_default_packed_block_types, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -41,6 +41,16 @@ def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
     assert scores is not None
 
 
+def test_score_function_resolves_unindexed_cuda(default_database, torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("Requires CUDA")
+
+    sfxn = ScoreFunction(default_database, torch.device("cuda"))
+
+    assert sfxn._device == torch_device
+    assert sfxn._weights.device == torch_device
+
+
 def test_whole_pose_gradients_respect_per_pose_upstream_weights(
     ubq_pdb, default_database, torch_device
 ):


### PR DESCRIPTION
## Summary

- resolve unindexed CUDA devices at public score-function, pose, packed-block, constraint, and nucleic-acid sampler construction boundaries
- normalize Dunbrack parameter cache keys and stored parameters to the same concrete device
- make `cuda` and `cuda:<current>` reuse one Dunbrack parameter cache entry, including keyword construction
- keep tensor storage and public `.device` metadata consistent
- construct per-pose block indices directly on their target device instead of allocating a destination and assigning CPU indices into it
- document the device behavior and reuse existing CPU/CUDA tests for regression coverage

## Bugs fixed

The documented packing tutorials construct `torch.device("cuda")`. PyTorch places tensors on a concrete device such as `cuda:0`, while several TMol constructors previously retained the unindexed spelling in metadata. The most visible failure was rotamer building rejecting a Dunbrack sampler and pose that physically occupied the same GPU. Direct pose, packed-block, constraint, and NA-sampler construction could create the same latent disagreement.

The exact H200 reproduction now reports one consistent device and completes rotamer construction:

```text
requested cuda; pose cuda:0; sampler cuda:0; score function cuda:0
rotamer coordinates: [3546, 3]
```

Explicit indexed CUDA devices and CPU devices are unchanged.

## Performance

Building flattened block indices during `PoseStack` initialization now avoids a CPU-to-CUDA assignment and an unnecessary zero-filled tensor. Isolated H200 timings (old → new) were:

- 1 × 100 blocks: 20.73 → 17.39 µs (16.1% faster)
- 64 × 100 blocks: 24.07 → 17.50 µs (27.3% faster)
- 512 × 100 blocks: 42.95 → 17.49 µs (59.3% faster)
- 64 × 350 blocks: 31.80 → 17.76 µs (44.2% faster)

## Validation

- expanded construction matrix on CPU/H200: `10 passed, 2 skipped`
- latest pose-construction test: `1 passed, 1 skipped` on CPU; `2 passed` on H200
- latest constraint/NA focused rerun: `4 passed`
- original unindexed-CUDA rotamer-build reproduction: pass
- representative pack suite: `6 passed, 1 skipped`
- Black, Ruff, and `git diff --check`: pass