### PR TITLE
Fix replicated constraint metadata

### DIFF
--- a/tmol/pose/_constraint_set.py
+++ b/tmol/pose/_constraint_set.py
@@ -1,25 +1,31 @@
-import torch
-import attr
+from collections.abc import Callable, Sequence
 
-from typing import Optional, Tuple
+import attr
+import torch
+
 from tmol.types import Tensor
 from tmol.utility.tensor import exclusive_cumsum1d
+
+ConstraintFunction = Callable[
+    [Tensor[torch.float32][:, :, 3], Tensor[torch.float32][:, :]],
+    Tensor[torch.float32][:],
+]
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class ConstraintSet:
-    """ """
+    """Immutable collection of geometric constraints for a batch of poses."""
 
     MAX_N_ATOMS = 4
 
     device: torch.device
     n_poses: int
-    constraint_function_inds: Tensor[torch.int][:]
-    constraint_atoms: Tensor[torch.int][:, 4, 3]
+    constraint_function_inds: Tensor[torch.int32][:]
+    constraint_atoms: Tensor[torch.int32][:, 4, 3]
     constraint_params: Tensor[torch.float32][:, :]
-    constraint_num_unique_blocks: Tensor[torch.int][:]
-    constraint_unique_blocks: Tensor[torch.int][:, :]
-    constraint_functions: Tuple
+    constraint_num_unique_blocks: Tensor[torch.int32][:]
+    constraint_unique_blocks: Tensor[torch.int32][:, 3]
+    constraint_functions: tuple[ConstraintFunction, ...]
 
     @classmethod
     def create_empty(cls, device: torch.device, n_poses: int) -> "ConstraintSet":
@@ -45,11 +51,11 @@ class ConstraintSet:
     @classmethod
     def concatenate(  # noqa: C901
         cls,
-        constraint_sets: Tuple[Optional["ConstraintSet"], ...],
+        constraint_sets: Sequence["ConstraintSet | None"],
         from_multiple_pose_stacks: bool = True,
-        n_poses: Optional[int] = None,
-        ps_offset: Optional[Tensor[torch.int64][:]] = None,
-    ) -> Optional["ConstraintSet"]:
+        n_poses: int | None = None,
+        ps_offset: Tensor[torch.int64][:] | None = None,
+    ) -> "ConstraintSet | None":
         """Concatenate multiple ConstraintSets into a single ConstraintSet.
 
         This function is particularly useful if you're creating a PoseStack from multiple
@@ -213,7 +219,7 @@ class ConstraintSet:
             constraint_unique_blocks=self.constraint_unique_blocks.to(device),
         )
 
-    def split(self, index) -> "ConstraintSet":
+    def split(self, index: int) -> "ConstraintSet":
         """Split out a single pose's worth of constraints from a batch."""
         # find the constraints that apply to this pose
         is_constraint_for_pose = self.constraint_atoms[:, :, 0] == index
@@ -252,54 +258,88 @@ class ConstraintSet:
 
     #################### PROPERTIES #####################
 
-    def count_unique_blocks(self, atom_indices):
-        # sorted_blocks_per_constraint, _ = atom_indices[:,:,1]
-        # now shift by 1 and count the differences
-        # diffs = sorted_blocks_per_constraint[:, 1:] != sorted_blocks_per_constraint[:, :-1]
+    @staticmethod
+    def count_unique_blocks(
+        atom_indices: Tensor[torch.int32][:, :, 3],
+    ) -> Tensor[torch.int32][:]:
+        """Count distinct consecutive blocks referenced by each constraint."""
         constraint_blocks = atom_indices[:, :, 1]
-        # now shift by 1 and count the differences
         diffs = constraint_blocks[:, 1:] != constraint_blocks[:, :-1]
-
-        return diffs.sum(dim=1) + 1
+        return diffs.sum(dim=1, dtype=torch.int32) + 1
 
     def add_constraints_to_all_poses(
-        self, fn, atom_indices, params=None
+        self,
+        fn: ConstraintFunction,
+        atom_indices: Tensor[torch.int32][:, :, :],
+        params: Tensor[torch.float32][:, :] | None = None,
     ) -> "ConstraintSet":
-        """If all Poses in the PoseStack should be constrained in the same way, then
-        this convenience function will take a list of atom indices for a single Pose
-        and replicate them across all the Poses in the PoseStack."""
-        if atom_indices.size(2) == 3:
+        """Add the same constraints to every pose in the batch.
+
+        Args:
+            fn: Function that scores coordinates and per-constraint parameters.
+            atom_indices: Integer ``[constraint, atom, block/atom]`` indices, or
+                full ``[constraint, atom, pose/block/atom]`` indices.
+            params: Optional float ``[constraint, parameter]`` values.
+
+        Returns:
+            A new constraint set containing the replicated constraints.
+        """
+        if atom_indices.ndim == 3 and atom_indices.size(2) == 3:
             # if we just drop the "which-pose-is-it-from? dimension", then
             # the normal call to add_constraints will apply it to all poses
             atom_indices = atom_indices[:, :, 1:3]
         return self.add_constraints(fn, atom_indices, params)
 
     def add_constraints(
-        self, fn, atom_indices, params=None
+        self,
+        fn: ConstraintFunction,
+        atom_indices: Tensor[torch.int32][:, :, :],
+        params: Tensor[torch.float32][:, :] | None = None,
     ) -> "ConstraintSet":  # noqa: C901
-        """
-        Create a new ConstraintSet that includes all the old constraints plus the new ones.
+        """Return a constraint set containing the existing and new constraints.
 
-        atom_indices: either (n_constraints, n_atoms, 3) or (n_constraints, n_atoms, 2)
-                      If the latter, the constraint will be applied to all poses
+        Args:
+            fn: Function that scores coordinates and per-constraint parameters.
+            atom_indices: Integer ``[constraint, atom, pose/block/atom]`` indices.
+                Omitting the pose column applies each constraint to every pose.
+            params: Optional float ``[constraint, parameter]`` values.
+
+        Returns:
+            A new constraint set containing the added constraints.
         """
+        if atom_indices.ndim != 3 or atom_indices.size(2) not in (2, 3):
+            raise ValueError("atom_indices must have shape [constraint, atom, 2 or 3]")
+        if not 0 < atom_indices.size(1) <= self.MAX_N_ATOMS:
+            raise ValueError(
+                f"constraints must contain between 1 and {self.MAX_N_ATOMS} atoms"
+            )
+        if atom_indices.dtype not in (torch.int32, torch.int64):
+            raise TypeError("atom_indices must contain 32- or 64-bit integers")
+
+        atom_indices = atom_indices.to(device=self.device, dtype=torch.int32)
+        if params is not None:
+            if params.ndim != 2 or params.size(0) != atom_indices.size(0):
+                raise ValueError(
+                    "params must have shape [constraint, parameter] with one row "
+                    "per constraint"
+                )
+            params = params.to(device=self.device, dtype=torch.float32)
+
         empty_at_start = len(self.constraint_functions) == 0
 
-        def find_or_insert(value, lst):
-            if value in lst:
-                return lst.index(value)
-            lst.append(value)
-            return lst.index(value)
-
         constraint_functions_list = list(self.constraint_functions)
-        fn_index = find_or_insert(fn, constraint_functions_list)
+        try:
+            fn_index = constraint_functions_list.index(fn)
+        except ValueError:
+            constraint_functions_list.append(fn)
+            fn_index = len(constraint_functions_list) - 1
 
         if (
             atom_indices.size(2) == 2
         ):  # The user did not input pose indices, copy to all poses
             filled_atom_indices = torch.zeros(
                 (atom_indices.size(0), atom_indices.size(1), 3),
-                dtype=torch.float32,
+                dtype=torch.int32,
                 device=self.device,
             )
             filled_atom_indices[:, :, 1:3] = atom_indices
@@ -385,7 +425,11 @@ class ConstraintSet:
         )
         if params is not None:
             new_params = params
-        max_params = max(new_params.size(1), self.constraint_params.size(1))
+        max_params = (
+            new_params.size(1)
+            if empty_at_start
+            else max(new_params.size(1), self.constraint_params.size(1))
+        )
         if not empty_at_start:
             t1 = torch.zeros(
                 (self.constraint_params.size(0), max_params),
@@ -412,14 +456,18 @@ class ConstraintSet:
             constraint_functions=tuple(constraint_functions_list),
         )
 
-    @classmethod
-    def replicate_constraints(cls, n_poses, c_atms, c_params):
+    @staticmethod
+    def replicate_constraints(
+        n_poses: int,
+        c_atms: Tensor[torch.int32][:, :, 3],
+        c_params: Tensor[torch.float32][:, :] | None,
+    ) -> tuple[Tensor[torch.int32][:, :, 3], Tensor[torch.float32][:, :] | None]:
+        """Replicate pose-independent constraints and optional parameters."""
         ncnstr = c_atms.size(0)
-        natoms = c_atms.size(1)
 
         atoms = c_atms.repeat(n_poses, 1, 1)
-        params = c_params.repeat(n_poses, 1)
-        poses = torch.arange(0, n_poses).repeat_interleave(natoms * ncnstr)
-        atoms[:, :, 0] = poses.view(n_poses * ncnstr, natoms)
+        params = None if c_params is None else c_params.repeat(n_poses, 1)
+        poses = torch.arange(n_poses, dtype=atoms.dtype, device=atoms.device)
+        atoms[:, :, 0] = poses.repeat_interleave(ncnstr).unsqueeze(1)
 
         return atoms, params

--- a/tmol/pose/_constraint_set.py
+++ b/tmol/pose/_constraint_set.py
@@ -14,7 +14,7 @@ ConstraintFunction = Callable[
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class ConstraintSet:
-    """Immutable collection of geometric constraints for a batch of poses."""
+    """ """
 
     MAX_N_ATOMS = 4
 
@@ -56,17 +56,19 @@ class ConstraintSet:
         n_poses: int | None = None,
         ps_offset: Tensor[torch.int64][:] | None = None,
     ) -> "ConstraintSet | None":
-        """Concatenate multiple ConstraintSets into a single ConstraintSet.
+        """Combine constraint sets while deduplicating their scoring functions.
 
-        This function is particularly useful if you're creating a PoseStack from multiple
-        PoseStacks, each of which has its own ConstraintSet. In that case, n_poses
-        and ps_offset will be readily available. In this use case, "from_multiple_pose_stacks"
-        should be set to True.
+        Args:
+            constraint_sets: Constraint sets to combine; ``None`` entries are
+                retained when calculating pose offsets.
+            from_multiple_pose_stacks: Shift pose indices between inputs when
+                true. When false, all inputs describe the same pose batch.
+            n_poses: Pose count for the result, inferred when omitted.
+            ps_offset: Per-input pose offsets, inferred when omitted.
 
-        The other use case is in creating multiple types of constraints for a single
-        PoseStack and then combining them in a single go. This will be more efficient
-        than repeatedly invoking add_constraints() as it skips the N^2 copy operations.
-        In this use case, "from_multiple_pose_stacks" should be set to False.
+        Returns:
+            The combined constraint set, or ``None`` when every input is
+            ``None``.
         """
 
         device = None
@@ -113,36 +115,29 @@ class ConstraintSet:
             )
         )
 
-        constraint_functions_list = []
-        constraint_function_inds = []
-        for i, cs in enumerate(constraint_sets):
-            if cs is not None:
-                constraint_function_inds.append([])
-                for j, func in enumerate(cs.constraint_functions):
-                    found_existing = False
-                    for k, func_existing in enumerate(constraint_functions_list):
-                        if func_existing == func:
-                            constraint_function_inds[-1].append(k)
-                            found_existing = True
-                            break
-                    if not found_existing:
-                        constraint_functions_list.append(func)
-                        constraint_function_inds[-1].append(
-                            len(constraint_functions_list) - 1
-                        )
+        constraint_functions_list: list[ConstraintFunction] = []
+        remapped_function_inds: list[Tensor[torch.int32][:]] = []
+        for cs in constraint_sets:
+            if cs is None:
+                continue
+            # Remap each source set at once on-device. Indexing this Python
+            # mapping with CUDA scalars would synchronize once per constraint.
+            function_remap: list[int] = []
+            for function in cs.constraint_functions:
+                try:
+                    function_index = constraint_functions_list.index(function)
+                except ValueError:
+                    constraint_functions_list.append(function)
+                    function_index = len(constraint_functions_list) - 1
+                function_remap.append(function_index)
+            function_remap_tensor = torch.tensor(
+                function_remap, dtype=torch.int32, device=device
+            )
+            remapped_function_inds.append(
+                function_remap_tensor[cs.constraint_function_inds]
+            )
 
-        # now let's figure out the new contraint_function_inds
-        # for the combined set
-        new_constraint_function_inds = torch.tensor(
-            [
-                constraint_function_inds[i][cs.constraint_function_inds[j]]
-                for i, cs in enumerate(constraint_sets)
-                if cs is not None
-                for j in range(cs.constraint_function_inds.size(0))
-            ],
-            device=device,
-            dtype=torch.int32,
-        )
+        new_constraint_function_inds = torch.cat(remapped_function_inds)
         n_constraints = new_constraint_function_inds.size(0)
         new_constraint_atoms = torch.full(
             (n_constraints, cls.MAX_N_ATOMS, 3), -1, dtype=torch.int32, device=device
@@ -199,6 +194,7 @@ class ConstraintSet:
         )
 
     def clone(self) -> "ConstraintSet":
+        """Return a copy with independent tensor storage."""
         return attr.evolve(
             self,
             constraint_function_inds=self.constraint_function_inds.clone(),

--- a/tmol/score/constraint/__init__.py
+++ b/tmol/score/constraint/__init__.py
@@ -1,6 +1,6 @@
 """Coordinate, distance, angle, and dihedral constraints."""
 
-from ._constraint_energy_term import HiddenPrints, ConstraintEnergyTerm  # noqa: F401
+from ._constraint_energy_term import ConstraintEnergyTerm  # noqa: F401
 from ._utility import (  # noqa: F401
     constrain_all_ca,
     MCAtomIndices,

--- a/tmol/score/constraint/_constraint_energy_term.py
+++ b/tmol/score/constraint/_constraint_energy_term.py
@@ -1,7 +1,6 @@
-import torch
 import math
-import os
-import sys
+
+import torch
 
 from .._energy_term import EnergyTerm
 
@@ -11,16 +10,6 @@ from tmol.pose import (
     PackedBlockTypes,
     PoseStack,
 )
-
-
-class HiddenPrints:
-    def __enter__(self):
-        self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, "w")
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        sys.stdout.close()
-        sys.stdout = self._original_stdout
 
 
 class ConstraintEnergyTerm(EnergyTerm):

--- a/tmol/tests/pose/test_constraint_set.py
+++ b/tmol/tests/pose/test_constraint_set.py
@@ -17,6 +17,12 @@ def _zero_constraint(atoms: torch.Tensor, params: torch.Tensor) -> torch.Tensor:
     return torch.zeros(atoms.shape[0], dtype=atoms.dtype, device=atoms.device)
 
 
+def _one_constraint(atoms: torch.Tensor, params: torch.Tensor) -> torch.Tensor:
+    """Return unit energy for a constraint with no parameters."""
+    assert params.shape[1] == 0
+    return torch.ones(atoms.shape[0], dtype=atoms.dtype, device=atoms.device)
+
+
 def test_constraint_set_empty_initialization(torch_device):
     cs = ConstraintSet.create_empty(torch_device, 1)
 
@@ -58,6 +64,27 @@ def test_constraint_set_replicates_parameterless_constraints(torch_device):
     torch.testing.assert_close(
         result.constraint_unique_blocks,
         torch.tensor([[0, 0, 1], [1, 0, 1]], dtype=torch.int32, device=torch_device),
+    )
+
+
+def test_constraint_set_concatenation_remaps_functions_on_device(torch_device):
+    atom_indices = torch.tensor([[[0, 0, 0]]], dtype=torch.int32, device=torch_device)
+    first = ConstraintSet.create_empty(torch_device, n_poses=1)
+    first = first.add_constraints(_zero_constraint, atom_indices)
+    first = first.add_constraints(_one_constraint, atom_indices)
+    second = ConstraintSet.create_empty(torch_device, n_poses=1)
+    second = second.add_constraints(_one_constraint, atom_indices)
+    second = second.add_constraints(_zero_constraint, atom_indices)
+
+    combined = ConstraintSet.concatenate(
+        [first, second], from_multiple_pose_stacks=False
+    )
+
+    assert combined is not None
+    assert combined.constraint_functions == (_zero_constraint, _one_constraint)
+    torch.testing.assert_close(
+        combined.constraint_function_inds,
+        torch.tensor([0, 1, 1, 0], dtype=torch.int32, device=torch_device),
     )
 
 

--- a/tmol/tests/pose/test_constraint_set.py
+++ b/tmol/tests/pose/test_constraint_set.py
@@ -1,4 +1,5 @@
 import attr
+import pytest
 import torch
 
 from tmol.pose import (
@@ -8,6 +9,12 @@ from tmol.pose import (
 from tmol.score.constraint import ConstraintEnergyTerm
 
 from tmol.io import pose_stack_from_pdb
+
+
+def _zero_constraint(atoms: torch.Tensor, params: torch.Tensor) -> torch.Tensor:
+    """Return zero energy for a constraint with no parameters."""
+    assert params.shape[1] == 0
+    return torch.zeros(atoms.shape[0], dtype=atoms.dtype, device=atoms.device)
 
 
 def test_constraint_set_empty_initialization(torch_device):
@@ -21,6 +28,56 @@ def test_constraint_set_empty_initialization(torch_device):
     assert cs.constraint_num_unique_blocks.shape == (0,)
     assert cs.constraint_unique_blocks.shape == (0, 3)
     assert len(cs.constraint_functions) == 0
+
+
+def test_constraint_set_replicates_parameterless_constraints(torch_device):
+    cs = ConstraintSet.create_empty(torch_device, n_poses=2)
+    atom_indices = torch.tensor(
+        [[[0, 1], [1, 2]]], dtype=torch.int64, device=torch_device
+    )
+
+    result = cs.add_constraints_to_all_poses(_zero_constraint, atom_indices)
+
+    expected_atoms = torch.tensor(
+        [
+            [[0, 0, 1], [0, 1, 2]],
+            [[1, 0, 1], [1, 1, 2]],
+        ],
+        dtype=torch.int32,
+        device=torch_device,
+    )
+    torch.testing.assert_close(result.constraint_atoms[:, :2], expected_atoms)
+    assert result.constraint_atoms.dtype == torch.int32
+    assert result.constraint_atoms.device == torch.device(torch_device)
+    assert result.constraint_params.shape == (2, 0)
+    assert result.constraint_num_unique_blocks.dtype == torch.int32
+    torch.testing.assert_close(
+        result.constraint_num_unique_blocks,
+        torch.tensor([2, 2], dtype=torch.int32, device=torch_device),
+    )
+    torch.testing.assert_close(
+        result.constraint_unique_blocks,
+        torch.tensor([[0, 0, 1], [1, 0, 1]], dtype=torch.int32, device=torch_device),
+    )
+
+
+def test_constraint_set_validates_inputs():
+    cs = ConstraintSet.create_empty(torch.device("cpu"), n_poses=1)
+
+    with pytest.raises(ValueError, match="atom_indices must have shape"):
+        cs.add_constraints(_zero_constraint, torch.zeros((1, 2), dtype=torch.int32))
+    with pytest.raises(ValueError, match="between 1 and 4 atoms"):
+        cs.add_constraints(_zero_constraint, torch.zeros((1, 0, 3), dtype=torch.int32))
+    with pytest.raises(TypeError, match="must contain 32- or 64-bit integers"):
+        cs.add_constraints(
+            _zero_constraint, torch.zeros((1, 2, 3), dtype=torch.float32)
+        )
+    with pytest.raises(ValueError, match="params must have shape"):
+        cs.add_constraints(
+            _zero_constraint,
+            torch.zeros((1, 2, 3), dtype=torch.int32),
+            torch.zeros((2, 0), dtype=torch.float32),
+        )
 
 
 def test_constraint_set_add_constraints(torch_device, ubq_pdb):
@@ -214,7 +271,6 @@ def test_split_constraint_set(default_database, ubq_pdb, torch_device):
             (poses[i].max_n_blocks - 1, 2), 0, dtype=torch.float32, device=torch_device
         )
         for j in range(poses[i].max_n_blocks - 1):
-
             ij_res1_type = poses[i].block_type(0, j)
             ij_res2_type = poses[i].block_type(0, j + 1)
             cnstr_atoms1[j, 0] = torch.tensor([0, j, ij_res1_type.atom_to_idx["C"]])


### PR DESCRIPTION
## Summary

- replicate constraints without parameters across pose batches
- keep atom, pose, and block metadata on the target device with a consistent `int32` representation
- validate public constraint input shapes and dtypes at the construction boundary
- remap deduplicated constraint-function indices in one on-device operation per input set instead of reading one CUDA scalar per constraint
- clarify the changed callable and tensor contracts with concise typing and Google-style docstrings
- remove the unused, non-public `HiddenPrints` output suppressor and its `os`/`sys` dependencies

## Why

`add_constraints_to_all_poses(..., params=None)` previously called `.repeat()` on `None`. The same path created atom indices as `float32`, produced block counts as `int64`, and built pose indices on CPU even for CUDA constraint sets.

Concatenation also indexed a Python list with every CUDA-resident function index, forcing one device-to-host synchronization per constraint. The new implementation constructs the small function map once and applies it to the complete index tensor on-device.

## H200 function-index remapping

This isolates the remapping phase used by `ConstraintSet.concatenate`.

| Constraints | Original | Batched | Speedup |
|---:|---:|---:|---:|
| 32 | 0.352 ms | 0.052 ms | 6.7× |
| 512 | 5.391 ms | 0.054 ms | 99.7× |
| 8,192 | 85.720 ms | 0.055 ms | 1,567.8× |

## Verification

- focused CPU constraint suite: `8 passed, 7 skipped`
- focused H200 constraint suite: `15 passed`
- combined H200 regression with PRs #448-#454: `357 passed, 6 skipped, 1 xfailed, 2 xpassed`
- merge-tree audit against #452 confirms the two branches auto-merge without conflict
- forced clean Sphinx HTML build with warnings as errors
- Black 26.3.1: clean
- Ruff: clean
- `git diff --check`: clean