### PR TITLE
Fix and accelerate tensor utility device contracts

### DIFF
--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -19,3 +19,10 @@ Public aliases and units
    ClassLogger
    DihedralAngle
    ureg
+
+Tensor utilities
+----------------
+
+.. automodule:: tmol.utility.tensor
+   :members:
+   :imported-members:

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -214,6 +214,18 @@ def test_join_tensors_preserves_gradients_and_empty_entries(torch_device):
     assert all(torch.all(tensor.grad == 1) for tensor in tensors)
 
 
+def test_join_tensors_preserves_large_integer_sentinel(torch_device):
+    sentinel = 2**60 + 1
+    tensors = [
+        torch.tensor([1], dtype=torch.int64, device=torch_device),
+        torch.tensor([2, 3], dtype=torch.int64, device=torch_device),
+    ]
+
+    _, _, joined = join_tensors_and_report_real_entries(tensors, sentinel=sentinel)
+
+    assert joined[0, 1] == sentinel
+
+
 def test_invert_mapping(torch_device):
     a_2_b = torch.tensor([5, 4, 7, 1, 2, 0], dtype=torch.int32, device=torch_device)
     b_2_a = invert_mapping(a_2_b, 8)

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -7,6 +7,8 @@ from tmol.utility.tensor import (
     stretch,
     stretch2,
     exclusive_cumsum1d,
+    exclusive_cumsum2d,
+    exclusive_cumsum2d_and_totals,
     nplus1d_tensor_from_list,
     cat_differently_sized_tensors,
     join_tensors_and_report_real_entries,
@@ -59,6 +61,21 @@ def test_exclusive_cumsum():
     excumsum = exclusive_cumsum1d(t)
     gold = numpy.arange(50, dtype=numpy.int64)
     numpy.testing.assert_equal(excumsum, gold)
+
+
+@pytest.mark.parametrize("dtype", (torch.int32, torch.int64))
+def test_exclusive_cumsums_preserve_empty_shapes(torch_device, dtype):
+    one_dim = torch.empty(0, dtype=dtype, device=torch_device)
+    two_dim = torch.empty((3, 0), dtype=dtype, device=torch_device)
+
+    one_dim_result = exclusive_cumsum1d(one_dim)
+    two_dim_result = exclusive_cumsum2d(two_dim)
+    two_dim_with_totals, totals = exclusive_cumsum2d_and_totals(two_dim)
+
+    assert one_dim_result.shape == one_dim.shape
+    assert two_dim_result.shape == two_dim.shape
+    assert two_dim_with_totals.shape == two_dim.shape
+    torch.testing.assert_close(totals, torch.zeros(3, dtype=dtype, device=torch_device))
 
 
 @pytest.mark.parametrize(

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -190,6 +190,30 @@ def test_join_tensors_and_report_real_entries(torch_device):
     numpy.testing.assert_equal(joined_elements_gold, joined_elements.cpu().numpy())
 
 
+def test_join_tensors_preserves_gradients_and_empty_entries(torch_device):
+    tensors = [
+        torch.randn((length, 2), device=torch_device, requires_grad=True)
+        for length in (0, 3, 1)
+    ]
+
+    n_elements, real, joined = join_tensors_and_report_real_entries(tensors)
+    joined.sum().backward()
+
+    torch.testing.assert_close(
+        n_elements,
+        torch.tensor([0, 3, 1], dtype=torch.int32, device=torch_device),
+    )
+    torch.testing.assert_close(
+        real,
+        torch.tensor(
+            [[False, False, False], [True, True, True], [True, False, False]],
+            device=torch_device,
+        ),
+    )
+    assert all(tensor.grad is not None for tensor in tensors)
+    assert all(torch.all(tensor.grad == 1) for tensor in tensors)
+
+
 def test_invert_mapping(torch_device):
     a_2_b = torch.tensor([5, 4, 7, 1, 2, 0], dtype=torch.int32, device=torch_device)
     b_2_a = invert_mapping(a_2_b, 8)

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -1,6 +1,8 @@
 import torch
 import numpy
+import pytest
 
+from tmol.tests import requires_cuda
 from tmol.utility.tensor import (
     stretch,
     stretch2,
@@ -9,6 +11,7 @@ from tmol.utility.tensor import (
     cat_differently_sized_tensors,
     join_tensors_and_report_real_entries,
     invert_mapping,
+    print_row_numbered_tensor,
 )
 
 
@@ -41,6 +44,44 @@ def test_exclusive_cumsum():
     excumsum = exclusive_cumsum1d(t)
     gold = numpy.arange(50, dtype=numpy.int64)
     numpy.testing.assert_equal(excumsum, gold)
+
+
+@pytest.mark.parametrize(
+    ("values", "first_row"),
+    (([5, 6], "tensor([[0, 5]"), ([[5, 6], [7, 8]], "tensor([[0, 5, 6]")),
+)
+def test_print_row_numbered_tensor(values, first_row, torch_device, capsys):
+    tensor = torch.tensor(values, dtype=torch.int32, device=torch_device)
+
+    print_row_numbered_tensor(tensor)
+
+    output = capsys.readouterr().out
+    assert first_row in output
+
+
+def test_tensor_sequence_validation():
+    one_dim = torch.zeros((1,), dtype=torch.float32)
+    two_dim = torch.zeros((1, 1), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="one- or two-dimensional"):
+        print_row_numbered_tensor(torch.zeros((1, 1, 1)))
+    with pytest.raises(ValueError, match="at least one tensor"):
+        nplus1d_tensor_from_list([])
+    with pytest.raises(ValueError, match="same number of dimensions"):
+        nplus1d_tensor_from_list([one_dim, two_dim])
+    with pytest.raises(ValueError, match="same dtype"):
+        cat_differently_sized_tensors([one_dim, one_dim.to(torch.float64)])
+    with pytest.raises(ValueError, match="same shape after dimension zero"):
+        join_tensors_and_report_real_entries([torch.zeros((1, 2)), torch.zeros((2, 3))])
+
+
+@requires_cuda
+def test_tensor_sequence_validation_rejects_mixed_devices():
+    cpu = torch.zeros((1, 2))
+    cuda = cpu.to("cuda")
+
+    with pytest.raises(ValueError, match="same device"):
+        cat_differently_sized_tensors([cpu, cuda])
 
 
 def test_nplus1d_tensor_from_list():
@@ -112,10 +153,10 @@ def test_cat_diff_sized_tensors_w_diff_sizes():
 
 
 def test_join_tensors_and_report_real_entries(torch_device):
-    t1 = torch.full((2, 4, 3), 1, dtype=torch.int32)
-    t2 = torch.full((3, 4, 3), 2, dtype=torch.int32)
-    t3 = torch.full((4, 4, 3), 3, dtype=torch.int32)
-    t4 = torch.full((5, 4, 3), 4, dtype=torch.int32)
+    t1 = torch.full((2, 4, 3), 1, dtype=torch.int32, device=torch_device)
+    t2 = torch.full((3, 4, 3), 2, dtype=torch.int32, device=torch_device)
+    t3 = torch.full((4, 4, 3), 3, dtype=torch.int32, device=torch_device)
+    t4 = torch.full((5, 4, 3), 4, dtype=torch.int32, device=torch_device)
     tensors = [t1, t2, t3, t4]
 
     n_elem, real_elem, joined_elements = join_tensors_and_report_real_entries(tensors)
@@ -142,3 +183,14 @@ def test_invert_mapping(torch_device):
     assert b_2_a.device == torch_device
     b_2_a_gold = numpy.array([5, 3, 4, -1, 1, 0, -1, 2], dtype=numpy.int32)
     numpy.testing.assert_equal(b_2_a_gold, b_2_a.cpu().numpy())
+
+
+def test_invert_mapping_infers_output_size(torch_device):
+    a_2_b = torch.tensor([2, 0], dtype=torch.int64, device=torch_device)
+
+    b_2_a = invert_mapping(a_2_b)
+
+    torch.testing.assert_close(
+        b_2_a, torch.tensor([1, -1, 0], dtype=torch.int64, device=torch_device)
+    )
+    assert invert_mapping.__doc__ is not None

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -78,6 +78,20 @@ def test_exclusive_cumsums_preserve_empty_shapes(torch_device, dtype):
     torch.testing.assert_close(totals, torch.zeros(3, dtype=dtype, device=torch_device))
 
 
+@pytest.mark.parametrize("dtype", (torch.int32, torch.int64))
+def test_exclusive_cumsums_preserve_values_and_dtype(torch_device, dtype):
+    values = torch.tensor([[3, -1, 4], [0, 2, 5]], dtype=dtype, device=torch_device)
+    expected = torch.tensor([[0, 3, 2], [0, 0, 2]], dtype=dtype, device=torch_device)
+    expected_totals = torch.tensor([6, 7], dtype=dtype, device=torch_device)
+
+    torch.testing.assert_close(exclusive_cumsum2d(values), expected)
+    actual, totals = exclusive_cumsum2d_and_totals(values)
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(totals, expected_totals)
+    assert actual.dtype == dtype
+    assert totals.dtype == dtype
+
+
 @pytest.mark.parametrize(
     ("values", "first_row"),
     (([5, 6], "tensor([[0, 5]"), ([[5, 6], [7, 8]], "tensor([[0, 5, 6]")),

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -39,6 +39,21 @@ def test_stretch2_i32(torch_device):
     assert t2.device == torch_device
 
 
+def test_stretch_accepts_scalar_tensor_count(torch_device):
+    count = torch.tensor(2, dtype=torch.int32, device=torch_device)
+    one_dim = torch.tensor([1, 2], dtype=torch.int32, device=torch_device)
+    two_dim = one_dim.reshape(1, 2)
+
+    torch.testing.assert_close(
+        stretch(one_dim, count),
+        torch.tensor([1, 1, 2, 2], dtype=torch.int32, device=torch_device),
+    )
+    torch.testing.assert_close(
+        stretch2(two_dim, count),
+        torch.tensor([[1, 1, 2, 2]], dtype=torch.int32, device=torch_device),
+    )
+
+
 def test_exclusive_cumsum():
     t = torch.ones((50,), dtype=torch.long)
     excumsum = exclusive_cumsum1d(t)

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 import torch
+from torch.nn.utils.rnn import pad_sequence
 
 from tmol.types import (
     Tensor,
@@ -198,20 +199,14 @@ def join_tensors_and_report_real_entries(
         raise ValueError("all tensors must have the same shape after dimension zero")
 
     device = first.device
-    dtype = first.dtype
-
-    max_d0 = max(t.shape[0] for t in tensors)
-    new_shape = (len(tensors), max_d0) + first.shape[1:]
 
     n_elements = torch.tensor(
         [t.shape[0] for t in tensors], dtype=torch.int32, device=device
     )
-
-    combo = torch.full(new_shape, sentinel, dtype=dtype, device=device)
-    real = torch.full((len(tensors), max_d0), False, dtype=torch.bool, device=device)
-    for i, t in enumerate(tensors):
-        combo[i, : t.shape[0]] = t
-        real[i, : t.shape[0]] = True
+    combo = pad_sequence(tensors, batch_first=True, padding_value=sentinel)
+    real = torch.arange(
+        combo.shape[1], dtype=n_elements.dtype, device=device
+    ).unsqueeze(0) < n_elements.unsqueeze(1)
 
     return n_elements, real, combo
 

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -9,24 +9,33 @@ from tmol.types import (
 
 IntTensor1D = Tensor[torch.int32][:] | Tensor[torch.int64][:]
 IntTensor2D = Tensor[torch.int32][:, :] | Tensor[torch.int64][:, :]
+RepeatCount = int | torch.Tensor
 
 
 @validate_args
-def stretch(t: IntTensor1D, count: int) -> IntTensor1D:
-    """take an input tensor and "repeat" each element count times.
-    stretch(tensor([0, 1, 2, 3]), 3) returns:
-         tensor([0 0 0 1 1 1 2 2 2 3 3 3]
-    this is equivalent to numpy's repeat
+def stretch(t: IntTensor1D, count: RepeatCount) -> IntTensor1D:
+    """Repeat each element of a one-dimensional integer tensor.
+
+    Args:
+        t: Values to repeat.
+        count: Number of repeats, as an integer or scalar integer tensor.
+
+    Returns:
+        A flattened tensor with each input element repeated ``count`` times.
     """
     return t.repeat(count).view(count, -1).permute(1, 0).contiguous().view(-1)
 
 
 @validate_args
-def stretch2(t: IntTensor2D, count: int) -> IntTensor2D:
-    """take an input 2D tensor and "repeat" each element count times.
-    stretch2(tensor([[0, 1, 2, 3], [4, 5, 6, 7]]), 3) returns:
-         tensor([[0 0 0 1 1 1 2 2 2 3 3 3],[4 4 4 5 5 5 6 6 6 7 7 7]])
-    this is equivalent to numpy's repeat
+def stretch2(t: IntTensor2D, count: RepeatCount) -> IntTensor2D:
+    """Repeat each element along the second dimension of an integer tensor.
+
+    Args:
+        t: Two-dimensional values to repeat.
+        count: Number of repeats, as an integer or scalar integer tensor.
+
+    Returns:
+        A tensor with each row element repeated ``count`` times.
     """
     return (
         t.repeat(1, count)
@@ -209,12 +218,12 @@ def join_tensors_and_report_real_entries(
 
 def invert_mapping(
     a_2_b: IntTensor1D,
-    n_elements_b: int | None = None,
+    n_elements_b: int | torch.Tensor | None = None,
     sentinel: int = -1,
 ) -> IntTensor1D:
     """Create the inverse mapping ``b_2_a`` for an input mapping ``a_2_b``."""
     if n_elements_b is None:
-        n_elements_b = int(torch.max(a_2_b).item()) + 1
+        n_elements_b = torch.max(a_2_b) + 1
 
     b_2_a = torch.full(
         (n_elements_b,), sentinel, dtype=a_2_b.dtype, device=a_2_b.device

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -244,10 +244,23 @@ def join_tensors_and_report_real_entries(
     n_elements = torch.tensor(
         [t.shape[0] for t in tensors], dtype=torch.int32, device=device
     )
-    combo = pad_sequence(tensors, batch_first=True, padding_value=sentinel)
+    padding_value = float(sentinel)
+    padding_is_exact = (
+        first.is_floating_point()
+        or first.is_complex()
+        or int(padding_value) == sentinel
+    )
+    combo = pad_sequence(
+        tensors,
+        batch_first=True,
+        padding_value=padding_value if padding_is_exact else 0.0,
+    )
     real = torch.arange(
         combo.shape[1], dtype=n_elements.dtype, device=device
     ).unsqueeze(0) < n_elements.unsqueeze(1)
+    if not padding_is_exact:
+        padding_mask = (~real).reshape(real.shape + (1,) * (combo.ndim - 2))
+        combo.masked_fill_(padding_mask, sentinel)
 
     return n_elements, real, combo
 

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -55,14 +55,10 @@ def exclusive_cumsum1d(inds: IntTensor1D) -> IntTensor1D:
         inds: Values to accumulate.
 
     Returns:
-        Prefix sums with a zero in the first position.
+        Same-shaped prefix sums where each value is the sum of preceding
+        elements. An empty input remains empty.
     """
-    return torch.cat(
-        (
-            torch.tensor([0], dtype=inds.dtype, device=inds.device),
-            torch.cumsum(inds, 0, dtype=inds.dtype).narrow(0, 0, inds.shape[0] - 1),
-        )
-    )
+    return torch.cumsum(inds, dim=0, dtype=inds.dtype) - inds
 
 
 @validate_args
@@ -73,15 +69,10 @@ def exclusive_cumsum2d(inds: IntTensor2D) -> IntTensor2D:
         inds: Values to accumulate along dimension one.
 
     Returns:
-        Row-wise prefix sums with zeros in the first column.
+        Same-shaped row-wise prefix sums where each value is the sum of
+        preceding columns. Zero-width inputs remain zero-width.
     """
-    return torch.cat(
-        (
-            torch.zeros((inds.shape[0], 1), dtype=inds.dtype, device=inds.device),
-            torch.cumsum(inds, dim=1, dtype=inds.dtype)[:, :-1],
-        ),
-        dim=1,
-    )
+    return torch.cumsum(inds, dim=1, dtype=inds.dtype) - inds
 
 
 @validate_args
@@ -97,19 +88,16 @@ def exclusive_cumsum2d_and_totals(
         inds: Values to accumulate along dimension one.
 
     Returns:
-        The exclusive prefix sums and the sum of each row.
+        The same-shaped exclusive prefix sums and the sum of each row. A
+        zero-width row has a total of zero.
     """
     cs = torch.cumsum(inds, dim=1, dtype=inds.dtype)
-    return (
-        torch.cat(
-            (
-                torch.zeros((inds.shape[0], 1), dtype=inds.dtype, device=inds.device),
-                cs[:, :-1],
-            ),
-            dim=1,
-        ),
-        cs[:, -1],
+    totals = (
+        cs[:, -1]
+        if inds.shape[1]
+        else torch.zeros(inds.shape[0], dtype=inds.dtype, device=inds.device)
     )
+    return cs - inds, totals
 
 
 def print_row_numbered_tensor(tensor: torch.Tensor) -> None:

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -1,13 +1,18 @@
+from collections.abc import Sequence
+
 import torch
-from typing import List, Tuple, Union, Optional
+
 from tmol.types import (
     Tensor,
     validate_args,
 )
 
+IntTensor1D = Tensor[torch.int32][:] | Tensor[torch.int64][:]
+IntTensor2D = Tensor[torch.int32][:, :] | Tensor[torch.int64][:, :]
+
 
 @validate_args
-def stretch(t: Union[Tensor[torch.int32][:], Tensor[torch.int64][:]], count):
+def stretch(t: IntTensor1D, count: int) -> IntTensor1D:
     """take an input tensor and "repeat" each element count times.
     stretch(tensor([0, 1, 2, 3]), 3) returns:
          tensor([0 0 0 1 1 1 2 2 2 3 3 3]
@@ -17,7 +22,7 @@ def stretch(t: Union[Tensor[torch.int32][:], Tensor[torch.int64][:]], count):
 
 
 @validate_args
-def stretch2(t: Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]], count):
+def stretch2(t: IntTensor2D, count: int) -> IntTensor2D:
     """take an input 2D tensor and "repeat" each element count times.
     stretch2(tensor([[0, 1, 2, 3], [4, 5, 6, 7]]), 3) returns:
          tensor([[0 0 0 1 1 1 2 2 2 3 3 3],[4 4 4 5 5 5 6 6 6 7 7 7]])
@@ -33,9 +38,7 @@ def stretch2(t: Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]], cou
 
 
 @validate_args
-def exclusive_cumsum1d(
-    inds: Union[Tensor[torch.int32][:], Tensor[torch.int64][:]],
-) -> Union[Tensor[torch.int32][:], Tensor[torch.int64][:]]:
+def exclusive_cumsum1d(inds: IntTensor1D) -> IntTensor1D:
     return torch.cat(
         (
             torch.tensor([0], dtype=inds.dtype, device=inds.device),
@@ -45,9 +48,7 @@ def exclusive_cumsum1d(
 
 
 @validate_args
-def exclusive_cumsum2d(
-    inds: Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]],
-) -> Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]]:
+def exclusive_cumsum2d(inds: IntTensor2D) -> IntTensor2D:
     return torch.cat(
         (
             torch.zeros((inds.shape[0], 1), dtype=inds.dtype, device=inds.device),
@@ -59,11 +60,11 @@ def exclusive_cumsum2d(
 
 @validate_args
 def exclusive_cumsum2d_and_totals(
-    inds: Union[Tensor[torch.int32][:, :], Tensor[torch.int64][:, :]],
-) -> Union[
-    Tuple[Tensor[torch.int32][:, :], Tensor[torch.int32][:]],
-    Tuple[Tensor[torch.int64][:, :], Tensor[torch.int64][:]],
-]:
+    inds: IntTensor2D,
+) -> (
+    tuple[Tensor[torch.int32][:, :], Tensor[torch.int32][:]]
+    | tuple[Tensor[torch.int64][:, :], Tensor[torch.int64][:]]
+):
     cs = torch.cumsum(inds, dim=1, dtype=inds.dtype)
     return (
         torch.cat(
@@ -77,49 +78,50 @@ def exclusive_cumsum2d_and_totals(
     )
 
 
-def print_row_numbered_tensor(tensor):
+def print_row_numbered_tensor(tensor: torch.Tensor) -> None:
+    """Print a one- or two-dimensional tensor with zero-based row indices."""
+    if tensor.ndim not in (1, 2):
+        raise ValueError("tensor must be one- or two-dimensional")
+    row_numbers = torch.arange(
+        tensor.shape[0], dtype=tensor.dtype, device=tensor.device
+    ).reshape(-1, 1)
     if len(tensor.shape) == 1:
-        print(
-            torch.cat(
-                (
-                    torch.arange(tensor.shape[0], dtype=tensor.dtype).reshape(-1, 1),
-                    tensor.reshape(-1, 1),
-                ),
-                1,
-            )
-        )
+        print(torch.cat((row_numbers, tensor.reshape(-1, 1)), dim=1))
     else:
-        print(
-            torch.cat(
-                (
-                    torch.arange(tensor.shape[0], dtype=tensor.dtype).reshape(-1, 1),
-                    tensor,
-                ),
-                1,
-            )
-        )
+        print(torch.cat((row_numbers, tensor), dim=1))
 
 
-# @validate_args
+def _validate_tensor_sequence(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
+    """Return the first tensor after validating shared structural metadata."""
+    if not tensors:
+        raise ValueError("at least one tensor is required")
+
+    first = tensors[0]
+    for tensor in tensors[1:]:
+        if tensor.ndim != first.ndim:
+            raise ValueError("all tensors must have the same number of dimensions")
+        if tensor.dtype != first.dtype:
+            raise ValueError("all tensors must have the same dtype")
+        if tensor.device != first.device:
+            raise ValueError("all tensors must be on the same device")
+    return first
+
+
 def nplus1d_tensor_from_list(
-    tensors: List,
-):  # -> Tuple[Tensor, Tensor[torch.long][:,:], Tensor[torch.long][:,:]] :
-    assert len(tensors) > 0
+    tensors: Sequence[torch.Tensor],
+) -> tuple[torch.Tensor, Tensor[torch.int64][:, :], Tensor[torch.int64][:, :]]:
+    """Pad tensors into a new leading dimension and report shape metadata."""
+    first = _validate_tensor_sequence(tensors)
 
-    for tensor in tensors:
-        assert len(tensor.shape) == len(tensors[0].shape)
-        assert tensor.dtype == tensors[0].dtype
-        assert tensor.device == tensors[0].device
-
-    max_sizes = [max(t.shape[i] for t in tensors) for i in range(len(tensors[0].shape))]
+    max_sizes = [max(t.shape[i] for t in tensors) for i in range(first.ndim)]
     newdimsizes = [len(tensors)] + max_sizes
 
-    newt = torch.zeros(newdimsizes, dtype=tensors[0].dtype, device=tensors[0].device)
+    newt = torch.zeros(newdimsizes, dtype=first.dtype, device=first.device)
     sizes = torch.zeros(
-        (len(tensors), tensors[0].dim()), dtype=torch.int64, device=tensors[0].device
+        (len(tensors), first.dim()), dtype=torch.int64, device=first.device
     )
     strides = torch.zeros(
-        (len(tensors), tensors[0].dim()), dtype=torch.int64, device=tensors[0].device
+        (len(tensors), first.dim()), dtype=torch.int64, device=first.device
     )
 
     for i, t in enumerate(tensors):
@@ -133,28 +135,25 @@ def nplus1d_tensor_from_list(
 
 
 def cat_differently_sized_tensors(
-    tensors: List,
-):
-    assert len(tensors) > 0
-    for tensor in tensors:
-        assert len(tensor.shape) == len(tensors[0].shape)
-        assert tensor.dtype == tensors[0].dtype
-        assert tensor.device == tensor[0].device
+    tensors: Sequence[torch.Tensor],
+) -> tuple[torch.Tensor, Tensor[torch.int64][:, :], Tensor[torch.int64][:, :]]:
+    """Concatenate padded tensors along dimension zero and report metadata."""
+    first = _validate_tensor_sequence(tensors)
 
-    new_sizes = [max(t.shape[i] for t in tensors) for i in range(len(tensors[0].shape))]
+    new_sizes = [max(t.shape[i] for t in tensors) for i in range(first.ndim)]
     catdim_sizes = [t.shape[0] for t in tensors]
     n_entries_for_catdim = sum(catdim_sizes)
     new_sizes[0] = n_entries_for_catdim
 
-    device = tensors[0].device
+    device = first.device
 
-    newt = torch.zeros(new_sizes, dtype=tensors[0].dtype, device=device)
+    newt = torch.zeros(new_sizes, dtype=first.dtype, device=device)
 
     sizes = torch.zeros(
-        (n_entries_for_catdim, tensors[0].dim() - 1), dtype=torch.int64, device=device
+        (n_entries_for_catdim, first.dim() - 1), dtype=torch.int64, device=device
     )
     strides = torch.zeros(
-        (n_entries_for_catdim, tensors[0].dim() - 1), dtype=torch.int64, device=device
+        (n_entries_for_catdim, first.dim() - 1), dtype=torch.int64, device=device
     )
     strides[:] = torch.unsqueeze(
         torch.tensor(newt.stride()[1:], dtype=torch.int64, device=device), dim=0
@@ -175,7 +174,9 @@ def cat_differently_sized_tensors(
     return newt, sizes, strides
 
 
-def join_tensors_and_report_real_entries(tensors: List, sentinel: int = -1):
+def join_tensors_and_report_real_entries(
+    tensors: Sequence[torch.Tensor], sentinel: int = -1
+) -> tuple[Tensor[torch.int32][:], Tensor[torch.bool][:, :], torch.Tensor]:
     """Concatenate a bunch of N-dimensional tensors into a single N+1-D tensor
     and report which elements out of the new tensor are real.
     The tensors may have different sizes for dimension 0 but should have the
@@ -183,17 +184,15 @@ def join_tensors_and_report_real_entries(tensors: List, sentinel: int = -1):
     dtype and live on the same device.
     """
 
-    assert len(tensors) > 0
-    for t in tensors:
-        assert t.device == tensors[0].device
-        assert t.dtype == tensors[0].dtype
-        assert t.shape[1:] == tensors[0].shape[1:]
+    first = _validate_tensor_sequence(tensors)
+    if any(t.shape[1:] != first.shape[1:] for t in tensors[1:]):
+        raise ValueError("all tensors must have the same shape after dimension zero")
 
-    device = tensors[0].device
-    dtype = tensors[0].dtype
+    device = first.device
+    dtype = first.dtype
 
     max_d0 = max(t.shape[0] for t in tensors)
-    new_shape = (len(tensors), max_d0) + tensors[0].shape[1:]
+    new_shape = (len(tensors), max_d0) + first.shape[1:]
 
     n_elements = torch.tensor(
         [t.shape[0] for t in tensors], dtype=torch.int32, device=device
@@ -202,21 +201,20 @@ def join_tensors_and_report_real_entries(tensors: List, sentinel: int = -1):
     combo = torch.full(new_shape, sentinel, dtype=dtype, device=device)
     real = torch.full((len(tensors), max_d0), False, dtype=torch.bool, device=device)
     for i, t in enumerate(tensors):
-        combo[i, : n_elements[i]] = t
-        real[i, : n_elements[i]] = True
+        combo[i, : t.shape[0]] = t
+        real[i, : t.shape[0]] = True
 
     return n_elements, real, combo
 
 
 def invert_mapping(
-    a_2_b: Union[Tensor[torch.int32][:], Tensor[torch.int64][:]],
-    n_elements_b: Optional[int] = None,
-    sentinel: Optional[int] = -1,
-):
-    Union[Tensor[torch.int32][:], Tensor[torch.int64][:]]
-    """Create the inverse mapping, b_2_a, given the input mapping, a_2_b"""
+    a_2_b: IntTensor1D,
+    n_elements_b: int | None = None,
+    sentinel: int = -1,
+) -> IntTensor1D:
+    """Create the inverse mapping ``b_2_a`` for an input mapping ``a_2_b``."""
     if n_elements_b is None:
-        n_elements_b = torch.max(a_2_b) + 1
+        n_elements_b = int(torch.max(a_2_b).item()) + 1
 
     b_2_a = torch.full(
         (n_elements_b,), sentinel, dtype=a_2_b.dtype, device=a_2_b.device

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -120,7 +120,14 @@ def _validate_tensor_sequence(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
 def nplus1d_tensor_from_list(
     tensors: Sequence[torch.Tensor],
 ) -> tuple[torch.Tensor, Tensor[torch.int64][:, :], Tensor[torch.int64][:, :]]:
-    """Pad tensors into a new leading dimension and report shape metadata."""
+    """Pad tensors into a new leading dimension and report shape metadata.
+
+    Args:
+        tensors: Same-rank tensors with a shared dtype and device.
+
+    Returns:
+        The padded tensor, original sizes, and strides into the padded tensor.
+    """
     first = _validate_tensor_sequence(tensors)
 
     max_sizes = [max(t.shape[i] for t in tensors) for i in range(first.ndim)]
@@ -147,7 +154,14 @@ def nplus1d_tensor_from_list(
 def cat_differently_sized_tensors(
     tensors: Sequence[torch.Tensor],
 ) -> tuple[torch.Tensor, Tensor[torch.int64][:, :], Tensor[torch.int64][:, :]]:
-    """Concatenate padded tensors along dimension zero and report metadata."""
+    """Concatenate padded tensors along dimension zero and report metadata.
+
+    Args:
+        tensors: Same-rank tensors with a shared dtype and device.
+
+    Returns:
+        The padded concatenation, original trailing sizes, and output strides.
+    """
     first = _validate_tensor_sequence(tensors)
 
     new_sizes = [max(t.shape[i] for t in tensors) for i in range(first.ndim)]
@@ -187,11 +201,14 @@ def cat_differently_sized_tensors(
 def join_tensors_and_report_real_entries(
     tensors: Sequence[torch.Tensor], sentinel: int = -1
 ) -> tuple[Tensor[torch.int32][:], Tensor[torch.bool][:, :], torch.Tensor]:
-    """Concatenate a bunch of N-dimensional tensors into a single N+1-D tensor
-    and report which elements out of the new tensor are real.
-    The tensors may have different sizes for dimension 0 but should have the
-    same size for all other dimensions. They must all have the same
-    dtype and live on the same device.
+    """Pad tensors along dimension zero and identify their real entries.
+
+    Args:
+        tensors: Tensors with matching trailing dimensions, dtype, and device.
+        sentinel: Value used to pad missing entries.
+
+    Returns:
+        Per-tensor lengths, a validity mask, and the padded tensor batch.
     """
 
     first = _validate_tensor_sequence(tensors)
@@ -216,7 +233,16 @@ def invert_mapping(
     n_elements_b: int | torch.Tensor | None = None,
     sentinel: int = -1,
 ) -> IntTensor1D:
-    """Create the inverse mapping ``b_2_a`` for an input mapping ``a_2_b``."""
+    """Create the inverse mapping ``b_2_a`` for an input mapping ``a_2_b``.
+
+    Args:
+        a_2_b: One-dimensional integer mapping from A indices to B indices.
+        n_elements_b: Output size, inferred from ``a_2_b`` when omitted.
+        sentinel: Value assigned to B indices without a corresponding A index.
+
+    Returns:
+        A mapping from B indices back to A indices.
+    """
     if n_elements_b is None:
         n_elements_b = torch.max(a_2_b) + 1
 

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -49,6 +49,14 @@ def stretch2(t: IntTensor2D, count: RepeatCount) -> IntTensor2D:
 
 @validate_args
 def exclusive_cumsum1d(inds: IntTensor1D) -> IntTensor1D:
+    """Compute an exclusive prefix sum over a one-dimensional integer tensor.
+
+    Args:
+        inds: Values to accumulate.
+
+    Returns:
+        Prefix sums with a zero in the first position.
+    """
     return torch.cat(
         (
             torch.tensor([0], dtype=inds.dtype, device=inds.device),
@@ -59,6 +67,14 @@ def exclusive_cumsum1d(inds: IntTensor1D) -> IntTensor1D:
 
 @validate_args
 def exclusive_cumsum2d(inds: IntTensor2D) -> IntTensor2D:
+    """Compute exclusive prefix sums along each row of an integer tensor.
+
+    Args:
+        inds: Values to accumulate along dimension one.
+
+    Returns:
+        Row-wise prefix sums with zeros in the first column.
+    """
     return torch.cat(
         (
             torch.zeros((inds.shape[0], 1), dtype=inds.dtype, device=inds.device),
@@ -75,6 +91,14 @@ def exclusive_cumsum2d_and_totals(
     tuple[Tensor[torch.int32][:, :], Tensor[torch.int32][:]]
     | tuple[Tensor[torch.int64][:, :], Tensor[torch.int64][:]]
 ):
+    """Compute row-wise exclusive prefix sums and inclusive row totals.
+
+    Args:
+        inds: Values to accumulate along dimension one.
+
+    Returns:
+        The exclusive prefix sums and the sum of each row.
+    """
     cs = torch.cumsum(inds, dim=1, dtype=inds.dtype)
     return (
         torch.cat(


### PR DESCRIPTION
## Summary

- validate non-empty tensor sequences and shared rank, dtype, and device through one reusable helper
- fix the mixed-device guard in `cat_differently_sized_tensors`, which previously compared every tensor with itself
- keep row-number indices on the input tensor device
- remove per-input CUDA-to-host synchronization from differently sized tensor joins
- replace per-input CUDA slice assignments with native `pad_sequence` and one broadcasted validity mask
- retain exact large-integer padding through a fallback used only when float conversion would be lossy
- preserve the established Python-integer and scalar-tensor repeat-count contract under runtime type validation
- make all exclusive-prefix helpers preserve empty shapes and return zero totals for zero-width rows
- replace prefix concatenation with same-shaped `cumsum - input`, improving both correctness and speed
- repair and modernize integer tensor annotations, including the misplaced `invert_mapping` return annotation/docstring, without introducing a new `.item()` synchronization
- expose all ten public `tmol.utility.tensor` helpers in the API reference with concise contracts

## H200 performance

The synchronized tensor-join benchmark includes allocation, padding, and validity-mask construction and uses the normal exact `-1` sentinel path.

| Input tensors | Original | Final | Speedup |
|---:|---:|---:|---:|
| 4 | 156.53 µs | 52.44 µs | 2.99× |
| 16 | 555.53 µs | 115.42 µs | 4.81× |
| 64 | 2158.24 µs | 364.99 µs | 5.91× |

The final route preserves gradients, handles empty entries, and retains exact `int64` sentinels above `2**53`.

The like-for-like exclusive-prefix benchmark excludes the shared runtime-validation wrapper from both sides.

| Shape | Original | Final | Speedup |
|---:|---:|---:|---:|
| 1,000 | 26.783 µs | 12.275 µs | 2.18× |
| 100,000 | 26.985 µs | 12.421 µs | 2.17× |
| 64 × 100 | 17.134 µs | 8.559 µs | 2.00× |
| 512 × 1,000 | 24.079 µs | 20.940 µs | 1.15× |

## Verification

- focused CPU utility suite: `19 passed, 15 skipped`
- focused H200 utility suite: `34 passed`
- combined H200 regression with PRs #448-#454, including pose construction, packed block types, Dunbrack, packing, scoring, minimization, FastRelax, constraints, and tensor utilities: `357 passed, 6 skipped, 1 xfailed, 2 xpassed`
- combined native CUDA 13.0/sm90 build: all 98 targets built successfully
- forced clean Sphinx HTML build with warnings as errors; all ten tensor helpers render in the utility API page
- Black 26.3.1: clean
- Ruff: clean
- `git diff --check`: clean