### PR TITLE
Parallelize independent CPU pose scoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,9 @@ endif()
 
 find_package(Torch REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
+# Linux Torch wheels require OpenMP compiler flags for at::parallel_for;
+# platforms using Torch's native thread pool do not.
+find_package(OpenMP COMPONENTS CXX QUIET)
 
 find_library(TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib" NO_DEFAULT_PATH)
 message(STATUS "tmol: TORCH_PYTHON_LIBRARY = ${TORCH_PYTHON_LIBRARY}")
@@ -402,6 +405,9 @@ if(TMOL_HAS_CUDA)
   tmol_set_cuda_flags(_C)
 else()
   tmol_set_cpp_flags(_C)
+endif()
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(_C PRIVATE OpenMP::OpenMP_CXX)
 endif()
 install(TARGETS _C DESTINATION tmol)
 

--- a/docs/user_guide/scoring.md
+++ b/docs/user_guide/scoring.md
@@ -49,6 +49,20 @@ score = scorer(coords).sum()
 score.backward()
 ```
 
+## CPU batch throughput
+
+Whole-pose CPU scoring parallelizes independent poses through PyTorch's
+intra-op thread pool. Set the pool from the cores actually allocated to the
+process, and normally do not assign more scoring threads than poses:
+
+```python
+torch.set_num_threads(min(n_poses, allocated_physical_cores))
+```
+
+The pose boundary keeps gradients race-free, so a one-pose batch does not gain
+intra-pose parallelism. When several processes or data-loader workers score at
+once, divide the available cores between them to avoid oversubscription.
+
 ## Ligand-aware Scoring
 
 When a structure introduces ligand residue types at load time, the score

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -59,6 +59,21 @@ for _ in range(repeats):
 Measure total batch latency and throughput separately. First-call compilation
 time should not be mixed into steady-state kernel timing.
 
+For repeated default weighted scoring with a fixed coordinate shape, dtype,
+and device, capture the launches once and replay them:
+
+```python
+graphed_scorer = sfxn.render_whole_pose_scoring_module(
+    batch, cuda_graph="forward"
+)
+with torch.no_grad():
+    scores = graphed_scorer(batch.coords)
+```
+
+Forward-only replay reuses its output buffer. Clone `scores` when it must remain
+unchanged across the next call. CUDA graphs mainly reduce launch overhead; they
+do not replace batching or improve kernels that already dominate runtime.
+
 ## Chunk larger workloads
 
 Batch size is limited by padding and operation-specific intermediates. Choose a

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -608,9 +608,10 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     });
     DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
   });
-  DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+  DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
       mgr,
-      n_poses * max_n_blocks * (max_n_conns + 1),
+      n_poses,
+      max_n_blocks * (max_n_conns + 1),
       eval_subgraphs_for_interaction);
 
   return {V_t, dV_dx_t};
@@ -988,9 +989,10 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     // we are only computing derivatives in this pass and don't need the score
     // a second time
   });
-  DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+  DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
       mgr,
-      n_poses * max_n_blocks * (max_n_conns + 1),
+      n_poses,
+      max_n_blocks * (max_n_conns + 1),
       eval_subgraphs_for_interaction);
 
   return dV_dx_t;

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -136,7 +136,6 @@ class TermWholePoseScoringModule(TermPoseScoringModule):
         super(TermWholePoseScoringModule, self).__init__(
             classname, pose_stack, term_parameters, term_score_poses
         )
-        self.count = 0
         self._build_static_tails(False)
 
     def forward(

--- a/tmol/score/common/accumulate.hh
+++ b/tmol/score/common/accumulate.hh
@@ -117,7 +117,7 @@ struct accumulate<
   }
 
   // All threads must write to the same ind1; threads may write to different
-  // ind0s. The CPU version is safe as long as there's only one thread.
+  // ind0s.
   template <class A>
   static def add_two_dim_one_dst(A& target, int ind0, int ind1, const T& val)
       -> void {

--- a/tmol/score/common/accumulate.hh
+++ b/tmol/score/common/accumulate.hh
@@ -69,9 +69,6 @@ struct accumulate<
 
 #ifdef __CUDACC__
 
-template <tmol::Device D, typename T, class Enable = void>
-struct reduce {};
-
 template <typename T>
 struct accumulate<
     tmol::Device::CUDA,

--- a/tmol/score/common/accumulate.hh
+++ b/tmol/score/common/accumulate.hh
@@ -23,34 +23,19 @@ struct accumulate<
     tmol::Device::CPU,
     T,
     typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+  // CPU accumulation is intentionally non-atomic. Parallel callers must write
+  // to disjoint output elements, as pose-parallel scoring does.
   static def add(T& target, const T& val) -> T {
-    //  // Try the atomic-add solution from stack overflow:
-    //  //
-    //  https://stackoverflow.com/questions/48746540/are-there-any-more-efficient-ways-for-atomically-adding-two-floats
-    //  int *ip_x= reinterpret_cast<int*>( &target ); //1
-    //  int expected= __atomic_load_n( ip_x, __ATOMIC_SEQ_CST ); //2
-    //  int desired;
-    //  do  {
-    //    float sum= *reinterpret_cast<T*>( &expected ) + val; //3
-    //    desired=   *reinterpret_cast<int*>( &sum );
-    //  } while( ! __atomic_compare_exchange_n( ip_x, &expected, desired, //4
-    //                                          /* weak = */ true,
-    //                                          __ATOMIC_SEQ_CST,
-    //                                          __ATOMIC_SEQ_CST ) );
-    //
     T old_target = target;
     target += val;
     return old_target;
   }
 
-  // This is safe to use when all threads are going to write to the same address
   template <class A>
   static def add_one_dst(A& target, int ind, const T& val) -> void {
     target[ind] += val;
   }
 
-  // All threads must write to the same ind1; threads may write to different
-  // ind0s. The CPU version is safe as long as there's only one thread.
   template <class A>
   static def add_two_dim_one_dst(A& target, int ind0, int ind1, const T& val)
       -> void {
@@ -80,60 +65,12 @@ struct accumulate<
       accumulate<D, T>::add_two_dim_one_dst(target, ind, i, val[i]);
     }
   }
-
-  template <class A>
-  static def add_two_dim_one_dst(A& target, int ind0, int ind1, const V& val)
-      -> void {
-    // ???
-  }
 };
 
-#ifndef __CUDACC__
-// Compile this reduction class only for CPU
+#ifdef __CUDACC__
 
 template <tmol::Device D, typename T, class Enable = void>
 struct reduce {};
-
-template <typename T>
-struct reduce<
-    tmol::Device::CPU,
-    T,
-    typename std::enable_if<std::is_arithmetic<T>::value>::type> {
-  template <class G, class OP>
-  static def reduce_to_head(G&, const T& val, OP) -> T {
-    T retval = val;
-    return retval;
-  }
-
-  template <class G, class OP>
-  static def reduce_to_all(G&, const T& val, OP) -> T {
-    T retval = val;
-    return retval;
-  }
-};
-
-template <tmol::Device D, int N, typename T>
-struct reduce<
-    D,
-    Eigen::Matrix<T, N, 1>,
-    typename std::enable_if<std::is_arithmetic<T>::value>::type> {
-  typedef Eigen::Matrix<T, N, 1> V;
-  template <class G, class OP>
-  static def reduce_to_head(G&, const V& val, OP) -> T {
-    V retval = val;
-    return retval;
-  }
-
-  template <class G, class OP>
-  static def reduce_to_all(G&, const V& val, OP) -> T {
-    V retval = val;
-    return retval;
-  }
-};
-
-#endif
-
-#ifdef __CUDACC__
 
 template <typename T>
 struct accumulate<

--- a/tmol/score/common/device_operations.cpu.impl.hh
+++ b/tmol/score/common/device_operations.cpu.impl.hh
@@ -4,6 +4,8 @@
 error_this_should_not_be_compiled();  // nvcc should not include this file
 #endif
 
+#include <ATen/Parallel.h>
+
 #include "device_operations.hh"
 #include <tmol/utility/tensor/context_manager.hh>
 
@@ -46,6 +48,24 @@ struct DeviceOperations<tmol::Device::CPU> {
     for (int i = 0; i < n_workgroups; ++i) {
       f(i);
     }
+  }
+
+  template <typename launch_t, typename Func>
+  static void foreach_pose_workgroup(
+      ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f) {
+    if (n_poses <= 1) {
+      foreach_workgroup<launch_t>(mgr, n_poses * workgroups_per_pose, f);
+      return;
+    }
+
+    at::parallel_for(0, n_poses, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t pose = begin; pose < end; ++pose) {
+        int const first_workgroup = pose * workgroups_per_pose;
+        for (int i = 0; i < workgroups_per_pose; ++i) {
+          f(first_workgroup + i);
+        }
+      }
+    });
   }
 
   template <mgpu::scan_type_t scan_type, typename T, typename OP>

--- a/tmol/score/common/device_operations.cuda.impl.cuh
+++ b/tmol/score/common/device_operations.cuda.impl.cuh
@@ -79,6 +79,12 @@ struct DeviceOperations<tmol::Device::CUDA> {
     mgpu::cta_launch<launch_t>(wrapper, n_workgroups, *context);
   }
 
+  template <typename launch_t, typename Func>
+  static void foreach_pose_workgroup(
+      ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f) {
+    foreach_workgroup<launch_t>(mgr, n_poses * workgroups_per_pose, f);
+  }
+
   template <mgpu::scan_type_t scan_type, typename T, typename OP>
   static void scan(ContextManager& mgr, T* src, T* dst, int n, OP op) {
     // mgpu::standard_context_t context;

--- a/tmol/score/common/device_operations.hh
+++ b/tmol/score/common/device_operations.hh
@@ -26,6 +26,13 @@ struct DeviceOperations {
   template <typename launch_t, typename Func>
   static void foreach_workgroup(ContextManager& mgr, int n_workgroups, Func f);
 
+  /// Run pose-grouped workgroups, parallelizing independent poses on CPU.
+  /// The callback receives a flattened pose-major workgroup index; workgroups
+  /// from different poses must not write to shared output elements.
+  template <typename launch_t, typename Func>
+  static void foreach_pose_workgroup(
+      ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f);
+
   // Note that dst[0] should be initialized to the identity value (e.g. 0) if
   // scan_type is exclusive.
   template <mgpu::scan_type_t scan_type, typename T, typename OP>

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -844,11 +844,11 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
   // 3
   if (output_block_pair_energies || !compute_derivs) {
-    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_energies_by_block);
+    DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
+        mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
   } else {
-    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_energies);
+    DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
+        mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
   }
 
   return {output_t, dV_dcoords_t, scratch_rot_neighbors_t};
@@ -1121,8 +1121,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
 
   // Since we have the sphere overlap results from the forward pass,
   // there's only a single kernel launch here
-  DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-      mgr, n_poses * max_n_upper_triangle_inds, eval_derivs);
+  DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
+      mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
 
   return dV_dcoords_t;
 }

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -685,9 +685,10 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
     DeviceOps<D>::template for_each_in_workgroup<nt>(reduce_and_write);
   });
 
-  DeviceOps<D>::template foreach_workgroup<launch_t>(
+  DeviceOps<D>::template foreach_pose_workgroup<launch_t>(
       mgr,
-      n_poses * max_n_blocks * (max_n_conns + 1),
+      n_poses,
+      max_n_blocks * (max_n_conns + 1),
       eval_torsions_for_interaction);
 
   return {V_t, dV_dx_t};
@@ -941,9 +942,10 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
     // add.
   });
 
-  DeviceOps<D>::template foreach_workgroup<launch_t>(
+  DeviceOps<D>::template foreach_pose_workgroup<launch_t>(
       mgr,
-      n_poses * max_n_blocks * (max_n_conns + 1),
+      n_poses,
+      max_n_blocks * (max_n_conns + 1),
       eval_torsions_for_interaction);
 
   return dV_dx_t;

--- a/tmol/score/hbond/potentials/hbond.hh
+++ b/tmol/score/hbond/potentials/hbond.hh
@@ -20,7 +20,6 @@ class HBondSingleResData {
   int block_ind;
   int block_type;
   int rot_coord_offset;
-  int block_coord_offset;  // TODO: delete
   int n_atoms;
   int n_conn;
   Real* coords;

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -783,8 +783,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
           scratch_rot_neighbors,
           Real(5.5));
 
-  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-      mgr, n_poses * max_n_upper_triangle_inds, eval_energies);
+  DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
+      mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
 
   // DeviceDispatch<Dev>::synchronize_device();
   return {output_t, dV_dcoords_t, scratch_rot_neighbors_t};
@@ -1050,8 +1050,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
         store_calculated_energies);
   });
 
-  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-      mgr, n_poses * max_n_upper_triangle_inds, eval_derivs);
+  DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
+      mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
 
   return dV_dcoords_t;
 }

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -1156,22 +1156,24 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
           max_dis);
 
   if (output_block_pair_energies) {
-    DeviceOperations<D>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_energies_by_block);
+    DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
+        mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
   } else {
     int const n_workgroups = n_poses * max_n_upper_triangle_inds;
     if (!require_gradient && n_workgroups >= min_high_occupancy_workgroups) {
-      DeviceOperations<D>::template foreach_workgroup<launch_t_high_occupancy>(
-          mgr, n_workgroups, eval_energies_by_block);
+      DeviceOperations<D>::template foreach_pose_workgroup<
+          launch_t_high_occupancy>(
+          mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
     } else if (!require_gradient) {
-      DeviceOperations<D>::template foreach_workgroup<launch_t>(
-          mgr, n_workgroups, eval_energies_by_block);
+      DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
+          mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
     } else if (n_workgroups >= min_high_occupancy_workgroups) {
-      DeviceOperations<D>::template foreach_workgroup<launch_t_high_occupancy>(
-          mgr, n_workgroups, eval_energies);
+      DeviceOperations<D>::template foreach_pose_workgroup<
+          launch_t_high_occupancy>(
+          mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
     } else {
-      DeviceOperations<D>::template foreach_workgroup<launch_t>(
-          mgr, n_workgroups, eval_energies);
+      DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
+          mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
     }
   }
 
@@ -1494,8 +1496,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::backward(
   // 3: launch a kernel to evaluate lj/lk between pairs of blocks
   // within striking distance
 
-  DeviceOperations<D>::template foreach_workgroup<launch_t>(
-      mgr, n_poses * max_n_upper_triangle_inds, eval_derivs);
+  DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
+      mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
 
   return dV_dcoords_t;
 }

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -674,8 +674,8 @@ class LKBallPoseScoreDispatch {
             scratch_rot_neighbors,
             max_dis);
     // 3 Only the forward pass in this calculation
-    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_energies_by_block);
+    DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
+        mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
 
     return {output_t, scratch_rot_neighbors_t};
   }
@@ -981,8 +981,8 @@ class LKBallPoseScoreDispatch {
 
     // Since we have the sphere overlap results from the forward pass,
     // there's only a single kernel launch here
-    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_upper_triangle_inds, eval_derivs);
+    DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
+        mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
 
     return {dV_d_pose_coords_t, dV_d_water_coords_t};
   }

--- a/tmol/tests/score/common/device_operations/test.hh
+++ b/tmol/tests/score/common/device_operations/test.hh
@@ -27,6 +27,10 @@ struct DevOpsTests {
   static auto test_foreach_workgroup(TView<int32_t, 1, D> src)
       -> TPack<int32_t, 1, D>;
 
+  // dst[pose][wg] = src[pose][wg] + flattened workgroup index
+  static auto test_foreach_pose_workgroup(TView<int32_t, 2, D> src)
+      -> TPack<int32_t, 2, D>;
+
   static auto test_scan_inclusive(TView<int32_t, 1, D> src)
       -> TPack<int32_t, 1, D>;
 

--- a/tmol/tests/score/common/device_operations/test.impl.hh
+++ b/tmol/tests/score/common/device_operations/test.impl.hh
@@ -78,6 +78,23 @@ auto DevOpsTests<D>::test_foreach_workgroup(TView<int32_t, 1, D> src)
 }
 
 template <tmol::Device D>
+auto DevOpsTests<D>::test_foreach_pose_workgroup(TView<int32_t, 2, D> src)
+    -> TPack<int32_t, 2, D> {
+  ContextManager mgr;
+  int const n_poses = src.size(0);
+  int const workgroups_per_pose = src.size(1);
+  auto dst_t = TPack<int32_t, 2, D>::empty({n_poses, workgroups_per_pose});
+  auto dst = dst_t.view;
+  DO<D>::template foreach_pose_workgroup<launch_t>(
+      mgr, n_poses, workgroups_per_pose, [=] EIGEN_DEVICE_FUNC(int wg) {
+        int const pose = wg / workgroups_per_pose;
+        int const pose_wg = wg % workgroups_per_pose;
+        dst[pose][pose_wg] = src[pose][pose_wg] + wg;
+      });
+  return dst_t;
+}
+
+template <tmol::Device D>
 auto DevOpsTests<D>::test_scan_inclusive(TView<int32_t, 1, D> src)
     -> TPack<int32_t, 1, D> {
   ContextManager mgr;

--- a/tmol/tests/score/common/device_operations/test.pybind.cpp
+++ b/tmol/tests/score/common/device_operations/test.pybind.cpp
@@ -15,6 +15,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       &CPU::test_foreach_combination_triple,
       "src"_a);
   m.def("test_foreach_workgroup", &CPU::test_foreach_workgroup, "src"_a);
+  m.def(
+      "test_foreach_pose_workgroup",
+      &CPU::test_foreach_pose_workgroup,
+      "src"_a);
   m.def("test_scan_inclusive", &CPU::test_scan_inclusive, "src"_a);
   m.def("test_scan_exclusive", &CPU::test_scan_exclusive, "src"_a);
   m.def(
@@ -54,6 +58,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       &CUDA::test_foreach_combination_triple,
       "src"_a);
   m.def("test_foreach_workgroup", &CUDA::test_foreach_workgroup, "src"_a);
+  m.def(
+      "test_foreach_pose_workgroup",
+      &CUDA::test_foreach_pose_workgroup,
+      "src"_a);
   m.def("test_scan_inclusive", &CUDA::test_scan_inclusive, "src"_a);
   m.def("test_scan_exclusive", &CUDA::test_scan_exclusive, "src"_a);
   m.def(

--- a/tmol/tests/score/common/device_operations/test_device_operations.py
+++ b/tmol/tests/score/common/device_operations/test_device_operations.py
@@ -100,6 +100,13 @@ def test_foreach_workgroup_large(ext, torch_device):
     assert torch.equal(result.cpu(), expected)
 
 
+def test_foreach_pose_workgroup(ext, torch_device):
+    src = torch.zeros(8, 17, dtype=torch.int32, device=torch_device)
+    result = ext.test_foreach_pose_workgroup(src)
+    expected = torch.arange(8 * 17, dtype=torch.int32).reshape(8, 17)
+    assert torch.equal(result.cpu(), expected)
+
+
 # ---------------------------------------------------------------------------
 # scan inclusive: cumulative prefix sum (inclusive)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Parallelize independent poses inside the CPU implementations of the six dominant whole-pose scorers: LJ/LK, electrostatics, LKBall, hydrogen bonding, cart-bonded, and generic-bonded.

- add one pose-grouped workgroup primitive
- use PyTorch CPU parallelism only across poses, while keeping each pose serial and race-free
- activate OpenMP only for the monolithic scoring extension when the installed PyTorch uses that backend
- keep the CUDA implementation as a direct call to the existing flattened workgroup launcher
- leave generic workgroups and all rotamer-scoring kernels unchanged
- document CPU thread-pool sizing and existing CUDA graph replay
- remove unreferenced scoring state and dead CPU reduction stubs

This is aimed at batched mutation scans and other CPU workloads with several independent poses. The existing one-pose path bypasses parallel dispatch.

## Performance

Controlled benchmark on 8 pinned AMD EPYC cores, using the 76-residue ubiquitin benchmark and the combined beta2016 terms:

| workload | master | this PR | speedup |
|---|---:|---:|---:|
| forward, 10 poses | 96.85 ms | 24.14 ms | 4.0x |
| forward, 30 poses | 279.73 ms | 52.10 ms | 5.4x |
| forward + backward, 10 poses | 160.78 ms | 38.85 ms | 4.1x |
| forward + backward, 30 poses | 466.98 ms | 81.93 ms | 5.7x |

With one CPU thread, the 10-pose forward benchmark was unchanged within noise (93.16 ms on master, 92.93 ms here). Single-pose dispatch also remained within noise (9.59 vs. 9.74 ms). On one 8-core DIGS node, the threaded path helped even at two poses (19.01 to 16.35 ms) and reached 3.8x at eight poses (73.88 to 19.59 ms).

On an H200 with identical CUDA 13.0/PyTorch 2.13 builds, 30-pose GPU scoring was also unchanged within noise: forward was 1.257 ms on master vs. 1.260 ms here (+0.2%), and forward + backward was 2.168 ms vs. 2.163 ms (-0.2%).

Parallelism follows `torch.set_num_threads()` / the PyTorch thread environment, so applications retain control over CPU allocation. On an isolated 30-pose run, scaling was strong through 8 cores (270.14 ms at 1 thread, 48.40 ms at 8) and then tapered (44.51 ms at 24), so the docs recommend bounding threads by both poses and allocated physical cores.

I also tested compiler-wide SIMD tuning rather than assuming an MMseqs-style AVX2 benefit. On repeated AMD runs, x86-64-v3 was 0.8% slower for forward and 1.8% faster for forward + backward. A same-node Intel Xeon comparison was also flat: portable was 74.55/107.96 ms versus 74.81/108.00 ms with `-march=native`. No nonportable ISA flag or runtime-dispatch complexity was added for that marginal result.

The existing forward CUDA-graph option was 1.07x faster for one pose, 1.03x for 30, and 1.01x for 100 on H200. The workflow docs now show it for repeated fixed-shape inference; batching remains the main GPU throughput optimization.

## RFD4 block-pair performance

The same pose-parallel dispatch covers per-term block-pair output used by RFD4 interface guidance and mutation-ddG reporting. On 8 pinned AMD EPYC cores with full 76-residue ubiquitin poses and `sum_terms=False`:

| workload | master | this PR | speedup |
|---|---:|---:|---:|
| forward, 8 poses | 79.96 ms | 20.17 ms | 4.0x |
| forward, 32 poses | 302.82 ms | 76.59 ms | 4.0x |
| forward + backward, 8 poses | 203.57 ms | 49.00 ms | 4.2x |
| forward + backward, 32 poses | 774.29 ms | 187.24 ms | 4.1x |

Both benchmark orders produced the same result within about 1%. The focused block-pair score and sparse-upstream-gradient tests pass.

## Safety

Work is partitioned only at pose boundaries. Different workers write to disjoint pose energies, coordinate gradients, and water gradients. The helper documents this invariant. CUDA receives the same pose-major flattened workgroup count and callback as before; no CUDA kernel body, launch parameters, or rotamer path changes.

## Validation

- clean CPU-only and CUDA 13.0 `sm_90` AOT builds with PyTorch 2.13
- hosted integration with #456 on Linux x86-64, Linux aarch64, and Apple Silicon: each 1,509 passed, 48 skipped, 5 xfailed, 1 xpassed
- focused eight-thread score/gradient/ligand/DNA suite: 62 passed
- latest H200 CUDA dispatch and affected-term suite: 231 passed, 2 skipped, 2 xfailed
- CPU/CUDA workgroup mapping test added
- fresh CPU AOT build and 18 high-level score-function tests after cleanup
- warning-as-error Sphinx build of all 50 documentation sources
- `pre-commit run --all-files --show-diff-on-failure`