### PR TITLE
Build ABI-qualified CPU wheels for Linux and Apple Silicon

### DIFF
--- a/.github/scripts/test_colab_release_config.py
+++ b/.github/scripts/test_colab_release_config.py
@@ -93,7 +93,7 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
         if step.get("name") == "Validate release wheel manifest"
     )
     assert "--gpu-count 25" in manifest_step["run"]
-    assert "--cpu-count 8" in manifest_step["run"]
+    assert "--cpu-count 12" in manifest_step["run"]
     assert "--require cu128torch2.11:cp312:x86_64" in manifest_step["run"]
     assert "--require cu128torch2.8:cp312:x86_64" not in manifest_step["run"]
 
@@ -108,6 +108,15 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
     assert any(row.get("local-tag") == "cu128torch2.11" for row in test_rows)
     assert any(row.get("local-tag") == "cu129torch2.8" for row in build_rows)
     assert any(row.get("local-tag") == "cu129torch2.8" for row in test_rows)
+    assert smoke["jobs"]["build-macos-cpu"]["strategy"]["matrix"]["python-version"] == [
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ]
+    assert len(smoke["jobs"]["test-macos-cpu"]["strategy"]["matrix"]["include"]) == 4
+    assert len(smoke["jobs"]["build-linux-cpu"]["strategy"]["matrix"]["include"]) == 2
+    assert len(smoke["jobs"]["test-linux-cpu"]["strategy"]["matrix"]["include"]) == 2
 
 
 def test_docs_workflow_uses_hosted_cpu_and_gpu_ci_executes_gpu_cells():

--- a/.github/workflows/_build_macos_wheel.yml
+++ b/.github/workflows/_build_macos_wheel.yml
@@ -1,0 +1,97 @@
+name: ~Build Apple Silicon wheel template
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      torch-package-version:
+        required: true
+        type: string
+      label:
+        required: true
+        type: string
+
+jobs:
+  build-wheel:
+    name: ${{ inputs.label }}
+    runs-on: macos-15
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Verify native Apple Silicon runner
+        run: test "$(uname -m)" = arm64
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "torch==${{ inputs.torch-package-version }}" \
+            'cmake>=3.18,<4' 'scikit-build-core>=0.10' ninja \
+            'packaging>=24.2' 'pybind11>=2.12' delocate
+
+      - name: Set ABI-qualified wheel version
+        run: |
+          torch_minor=$(python -c \
+            'import torch; print(".".join(torch.__version__.split(".")[:2]))')
+          python scripts/set_release_wheel_version.py "cputorch${torch_minor}"
+          echo "WHEEL_LOCAL_TAG=cputorch${torch_minor}" >> "$GITHUB_ENV"
+
+      - name: Build CPU-only wheel
+        env:
+          MAX_JOBS: 2
+        run: |
+          export CMAKE_PREFIX_PATH
+          CMAKE_PREFIX_PATH=$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')
+          python -m pip wheel . --no-build-isolation --no-deps -w dist \
+            -Ccmake.define.TMOL_ENABLE_CUDA=OFF
+
+      - name: Validate and repair native dependencies
+        run: |
+          export DYLD_LIBRARY_PATH
+          DYLD_LIBRARY_PATH=$(python -c \
+            'from pathlib import Path; import torch; print(Path(torch.__file__).parent / "lib")')
+          mkdir repaired
+          delocate-wheel \
+            --check-archs \
+            --require-archs arm64 \
+            --exclude libtorch \
+            --exclude libc10 \
+            --exclude libshm \
+            --exclude libomp \
+            --wheel-dir repaired \
+            dist/*.whl
+          rm dist/*.whl
+          mv repaired/*.whl dist/
+
+      - name: Validate ABI-qualified CPU local version
+        run: |
+          set -- dist/*.whl
+          test "$#" -eq 1
+          wheel="$1"
+          wheel_name=$(basename "$wheel")
+          case "$wheel_name" in
+            tmol-*+${WHEEL_LOCAL_TAG}-*-macosx_14_0_arm64.whl) ;;
+            *)
+              echo "Unexpected Apple Silicon wheel tag: $wheel_name"
+              exit 1
+              ;;
+          esac
+          python_tag=$(python -c \
+            'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+          echo "PYTHON_TAG=${python_tag}" >> "$GITHUB_ENV"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ env.PYTHON_TAG }}-${{ env.WHEEL_LOCAL_TAG }}-arm64
+          path: dist/*.whl

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -6,7 +6,6 @@ on:
       runs-on:
         required: true
         type: string
-        default: ubuntu-22.04
       container-image:
         required: true
         type: string
@@ -24,7 +23,6 @@ on:
       python-version:
         required: true
         type: string
-        default: "3.12"
       label:
         required: true
         type: string
@@ -273,7 +271,7 @@ jobs:
             echo "WHEEL_LOCAL_TAG=cu${CUDA_VERSION}torch${TORCH_VERSION}" >> "$GITHUB_ENV"
           else
             echo "WHEEL_CUDA_VERSION=cpu" >> "$GITHUB_ENV"
-            echo "WHEEL_LOCAL_TAG=cpu" >> "$GITHUB_ENV"
+            echo "WHEEL_LOCAL_TAG=cputorch${TORCH_VERSION}" >> "$GITHUB_ENV"
           fi
 
           if [ "${{ inputs.enable-cuda }}" != "true" ]; then
@@ -343,6 +341,12 @@ jobs:
               'cmake>=3.18,<4' 'scikit-build-core>=0.10' ninja 'packaging>=24.2' 'pybind11>=2.12' auditwheel
           "
 
+      - name: Set ABI-qualified wheel version
+        run: |
+          docker exec "$BUILDER" \
+            "${TARGET_VENV}/bin/python" \
+            scripts/set_release_wheel_version.py "$WHEEL_LOCAL_TAG"
+
       - name: Build wheel
         run: |
           docker exec \
@@ -407,12 +411,17 @@ jobs:
             scripts/repair_linux_wheel.sh dist
           '
 
-      - name: Rename wheel with local tag
+      - name: Record wheel name
         run: |
           docker exec "$BUILDER" bash -c "
             cd /workspace
-            wheel_name=\$(ls dist/*whl | xargs -n 1 basename | sed \"s/-/+${WHEEL_LOCAL_TAG}-/2\")
-            ls dist/*whl | xargs -I {} mv {} dist/\${wheel_name}
+            set -- dist/*.whl
+            test \"\$#\" -eq 1
+            wheel_name=\$(basename \"\$1\")
+            case \"\${wheel_name}\" in
+              tmol-*+${WHEEL_LOCAL_TAG}-*.whl) ;;
+              *) echo \"Unexpected wheel name: \${wheel_name}\"; exit 1 ;;
+            esac
             echo \${wheel_name}
           " | tail -1 > /tmp/wheel_name.txt
           wheel_name=$(cat /tmp/wheel_name.txt)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,8 @@ jobs:
       SLURM_CPUS_PER_TASK: 16
       SLURM_MEM: 128G
       SLURM_TIME: 06:00:00
-      # Exclude the node with a known uncorrectable ECC fault until repaired.
-      SLURM_EXCLUDE: g2548
+      # Exclude nodes with known uncorrectable ECC faults until repaired.
+      SLURM_EXCLUDE: g2547,g2548
       SRUN_GPU_MAX_ATTEMPTS: 5
       SRUN_GPU_RETRY_SLEEP: 10
       # PR tests need only the architecture of the allocated DIGS GPU.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -325,6 +325,20 @@ jobs:
       use-manylinux-build: true
       target-arch: ${{ matrix.arch }}
 
+  # ── Apple Silicon CPU-only wheel ───────────────────────────────────
+  build_macos_cpu_wheel:
+    name: "py${{ matrix.python-version }} CPU-only macOS arm64"
+    needs: verify_release_version
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    uses: ./.github/workflows/_build_macos_wheel.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      torch-package-version: "2.13.0"
+      label: "py${{ matrix.python-version }} CPU-only macOS arm64"
+
   # ── sdist ──────────────────────────────────────────────────────────
   build_sdist:
     name: Build sdist
@@ -362,7 +376,7 @@ jobs:
   # If this job fails you can RE-RUN just this job from the Actions UI.
   upload:
     name: Upload sdist to PyPI + wheels to GitHub Release
-    needs: [build_wheels, build_cpu_wheel, build_sdist]
+    needs: [build_wheels, build_cpu_wheel, build_macos_cpu_wheel, build_sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -398,9 +412,10 @@ jobs:
         run: |
           python scripts/validate_release_manifest.py wheels \
             --gpu-count 25 \
-            --cpu-count 8 \
+            --cpu-count 12 \
             --platform manylinux_2_28_x86_64 \
             --platform manylinux_2_28_aarch64 \
+            --platform macosx_14_0_arm64 \
             --require cu132torch2.12:cp311:x86_64 \
             --require cu129torch2.8:cp312:x86_64 \
             --require cu128torch2.11:cp312:x86_64 \
@@ -426,14 +441,18 @@ jobs:
             --require cu130torch2.13:cp313:aarch64 \
             --require cu132torch2.12:cp314:aarch64 \
             --require cu130torch2.13:cp314:aarch64 \
-            --require cpu:cp311:x86_64 \
-            --require cpu:cp312:x86_64 \
-            --require cpu:cp313:x86_64 \
-            --require cpu:cp314:x86_64 \
-            --require cpu:cp311:aarch64 \
-            --require cpu:cp312:aarch64 \
-            --require cpu:cp313:aarch64 \
-            --require cpu:cp314:aarch64
+            --require cputorch2.13:cp311:x86_64 \
+            --require cputorch2.13:cp312:x86_64 \
+            --require cputorch2.13:cp313:x86_64 \
+            --require cputorch2.13:cp314:x86_64 \
+            --require cputorch2.13:cp311:aarch64 \
+            --require cputorch2.13:cp312:aarch64 \
+            --require cputorch2.13:cp313:aarch64 \
+            --require cputorch2.13:cp314:aarch64 \
+            --require cputorch2.13:cp311:arm64 \
+            --require cputorch2.13:cp312:arm64 \
+            --require cputorch2.13:cp313:arm64 \
+            --require cputorch2.13:cp314:arm64
 
       - name: Upload sdist to PyPI
         env:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -2,10 +2,22 @@ name: Wheel smoke test
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - .github/workflows/_build_macos_wheel.yml
+      - .github/workflows/_build_wheel.yml
+      - .github/workflows/publish.yml
+      - .github/workflows/wheel-smoke.yml
+      - scripts/validate_release_manifest.py
+      - scripts/set_release_wheel_version.py
+      - tmol_build_backend.py
+      - tmol/tests/test_build_backend.py
   push:
     branches:
       - fix/torch-2.13-wheels
       - fix/manylinux-wheels
+      - fix/cpu-release-matrix
 
 concurrency:
   group: wheel-smoke-${{ github.ref }}
@@ -14,6 +26,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.label }}
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -291,7 +304,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-22.04
@@ -302,7 +315,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-22.04
@@ -314,7 +327,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-22.04
@@ -325,7 +338,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-22.04
@@ -336,7 +349,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-24.04-arm
@@ -347,7 +360,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-24.04-arm
@@ -359,7 +372,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-24.04-arm
@@ -370,7 +383,7 @@ jobs:
             torch-version: "2.13"
             torch-package-version: "2.13.0"
             torch-index-url: "https://download.pytorch.org/whl/cpu"
-            local-tag: "cpu"
+            local-tag: "cputorch2.13"
             enable-cuda: false
             container-image: unused-for-manylinux-cpu
             runs-on: ubuntu-24.04-arm
@@ -390,9 +403,163 @@ jobs:
       use-manylinux-build: true
       target-arch: ${{ matrix.arch }}
 
+  build-linux-cpu:
+    name: "smoke py3.12 CPU ${{ matrix.arch }}"
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-22.04
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    uses: ./.github/workflows/_build_wheel.yml
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      container-image: unused-for-manylinux-cpu
+      torch-version: "2.13"
+      torch-package-version: "2.13.0"
+      python-version: "3.12"
+      label: "smoke py3.12 CPU ${{ matrix.arch }}"
+      pip-torch-cuda-url: "https://download.pytorch.org/whl/cpu"
+      enable-cuda: false
+      use-manylinux-build: true
+      target-arch: ${{ matrix.arch }}
+
+  test-linux-cpu:
+    name: "install cp312 cputorch2.13 ${{ matrix.arch }}"
+    needs: build-linux-cpu
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-22.04
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-cp312-cputorch2.13-${{ matrix.arch }}
+          path: wheels
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install wheel with its PyTorch ABI
+        run: |
+          set -euo pipefail
+          set -- wheels/*.whl
+          test "$#" -eq 1
+          expected="tmol-*+cputorch2.13-cp312-cp312-manylinux_2_28_${{ matrix.arch }}.whl"
+          case "$(basename "$1")" in
+            $expected) ;;
+            *)
+              echo "Unexpected Linux CPU wheel: $1"
+              exit 1
+              ;;
+          esac
+          python -m pip install --upgrade pip
+          python -m pip install 'torch==2.13.0' \
+            --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install "$1"
+
+      - name: Load native extensions
+        working-directory: /tmp
+        run: |
+          python - <<'PY'
+          from importlib.metadata import version
+
+          import torch
+          import tmol
+          from tmol._cpp_lib import _ensure_loaded
+
+          assert torch.__version__.startswith("2.13.")
+          assert torch.version.cuda is None
+          assert version("tmol").endswith("+cputorch2.13")
+          _ensure_loaded()
+          print("tmol", tmol.__version__)
+          print("torch", torch.__version__)
+          PY
+
+  build-macos-cpu:
+    name: "smoke py${{ matrix.python-version }} CPU macOS arm64"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    uses: ./.github/workflows/_build_macos_wheel.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      torch-package-version: "2.13.0"
+      label: "smoke py${{ matrix.python-version }} CPU macOS arm64"
+
+  test-macos-cpu:
+    name: "install cp${{ matrix.python-tag }} cputorch2.13 macOS arm64"
+    needs: build-macos-cpu
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { python-version: "3.11", python-tag: "311" }
+          - { python-version: "3.12", python-tag: "312" }
+          - { python-version: "3.13", python-tag: "313" }
+          - { python-version: "3.14", python-tag: "314" }
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-cp${{ matrix.python-tag }}-cputorch2.13-arm64
+          path: wheels
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install wheel with its PyTorch ABI
+        run: |
+          set -euo pipefail
+          set -- wheels/*.whl
+          test "$#" -eq 1
+          case "$(basename "$1")" in
+            tmol-*+cputorch2.13-cp${{ matrix.python-tag }}-cp${{ matrix.python-tag }}-macosx_14_0_arm64.whl) ;;
+            *)
+              echo "Unexpected Apple Silicon wheel: $1"
+              exit 1
+              ;;
+          esac
+          python -m pip install --upgrade pip
+          python -m pip install 'torch==2.13.0'
+          python -m pip install "$1"
+
+      - name: Load native extensions
+        working-directory: /tmp
+        run: |
+          python - <<'PY'
+          import platform
+          from importlib.metadata import version
+
+          import torch
+          import tmol
+          from tmol._cpp_lib import _ensure_loaded
+
+          assert platform.machine() == "arm64"
+          assert torch.__version__.startswith("2.13.")
+          assert torch.version.cuda is None
+          assert version("tmol").endswith("+cputorch2.13")
+          _ensure_loaded()
+          print("tmol", tmol.__version__)
+          print("torch", torch.__version__)
+          PY
+
   test:
     name: "install cp${{ matrix.python-tag }} ${{ matrix.local-tag }} ${{ matrix.arch }}"
     needs: build
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -421,14 +588,14 @@ jobs:
           - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cu130", local-tag: "cu130torch2.13", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
           - { python-version: "3.14", python-tag: "314", torch-package-version: "2.12.0", torch-minor: "2.12", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.12", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
           - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cu130", local-tag: "cu130torch2.13", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
-          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
-          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64, portability: true }
-          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
-          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
-          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
-          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64, portability: true }
-          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
-          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cpu", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v5
@@ -501,10 +668,13 @@ jobs:
 
           expected_torch = os.environ["EXPECTED_TORCH"]
           expected_local_tag = os.environ["EXPECTED_LOCAL_TAG"]
+          assert importlib.metadata.version("tmol").endswith(
+              f"+{expected_local_tag}"
+          )
           actual_torch = ".".join(torch.__version__.split(".")[:2])
           assert actual_torch == expected_torch, (actual_torch, expected_torch)
 
-          if expected_local_tag != "cpu":
+          if not expected_local_tag.startswith("cpu"):
               expected_cuda = re.search(r"cu(\d+)torch", expected_local_tag).group(1)
               actual_cuda = re.sub(r"[^0-9]", "", torch.version.cuda or "")[:3]
               assert actual_cuda == expected_cuda, (actual_cuda, expected_cuda)
@@ -559,6 +729,7 @@ jobs:
   gpu-runtime-smoke:
     name: "self-hosted gpu runtime wheel smoke"
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, gpu]
     env:
       SIF: /home/bench/git_ci_apptainer/tmol.sif

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,15 @@ pip install "torch==2.12.*" --index-url https://download.pytorch.org/whl/cu132
 
 Wheel tags select Python, PyTorch, and CUDA compatibility. For example,
 `cp313` selects Python 3.13 and `+cu130torch2.13` selects the CUDA/PyTorch lane.
-They do not replace the host C++ runtime.
+CPU wheels are also PyTorch-minor-specific: `+cputorch2.13` selects the CPU
+extension built against PyTorch 2.13. They do not replace the host C++ runtime.
+
+Release builds provide CPU wheels for Linux x86-64, Linux aarch64, and Apple
+Silicon. For example, after installing PyTorch 2.13, an Apple Silicon wheel is:
+
+```bash
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/vX.Y.Z/tmol-X.Y.Z+cputorch2.13-cp313-cp313-macosx_14_0_arm64.whl"
+```
 
 ## PyPI Source Distribution
 
@@ -83,15 +91,17 @@ The same CPU-only path is the normal macOS source install:
 pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF
 ```
 
-CPU source builds are tested on Linux x86-64, Linux aarch64, and Apple
-Silicon. Native Windows is not currently supported; use a Linux environment
-such as WSL2.
+CPU source builds and release wheels are tested on Linux x86-64, Linux
+aarch64, and Apple Silicon. Native Windows is not currently supported; use a
+Linux environment such as WSL2.
 
 ## Linux Runtime Notes
 
-Release wheels use `manylinux_2_28` platform tags on `x86_64` and `aarch64`.
-They require glibc 2.28 or newer. PyTorch supplies the matching CUDA shared
-libraries; TMol wheels do not bundle the PyTorch or NVIDIA runtime libraries.
+Linux release wheels use `manylinux_2_28` platform tags on `x86_64` and
+`aarch64`. They require glibc 2.28 or newer. Apple Silicon wheels use
+`macosx_14_0_arm64`, matching the PyTorch 2.13 deployment target. PyTorch
+supplies the matching shared libraries; TMol wheels do not bundle the PyTorch
+or NVIDIA runtime libraries.
 
 If `import tmol` fails with a `GLIBCXX_* not found` error, the host
 `libstdc++` is too old for the wheel. Use one of these paths:

--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -125,7 +125,9 @@ publish previews under the Pages site.
 
 ## Releasing
 
-Versioned wheel and sdist publication happens from `v*` tags. The tag version
+Versioned wheel and sdist publication happens from `v*` tags. Linux x86-64,
+Linux aarch64, and Apple Silicon CPU wheels are built for each supported
+CPython version and qualified by their PyTorch minor. The tag version
 must match `[project].version` in `pyproject.toml`.
 
 Before using a versioned wheel URL, check the GitHub Releases page. The version

--- a/scripts/set_release_wheel_version.py
+++ b/scripts/set_release_wheel_version.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Add an ABI qualifier to the static project version for a wheel build."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from packaging.version import Version
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+VERSION_RE = re.compile(r'(?m)^version = "([^"]+)"$')
+
+
+def main() -> None:
+    """Write the release wheel's PEP 440 local version into pyproject.toml."""
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} LOCAL_TAG")
+
+    text = PYPROJECT.read_text(encoding="utf-8")
+    matches = VERSION_RE.findall(text)
+    if len(matches) != 1:
+        raise SystemExit(f"expected one project version in {PYPROJECT}")
+
+    base_version = Version(matches[0])
+    if base_version.local is not None:
+        raise SystemExit(f"project version already has a local tag: {base_version}")
+    wheel_version = Version(f"{base_version}+{sys.argv[1]}")
+
+    PYPROJECT.write_text(
+        VERSION_RE.sub(f'version = "{wheel_version}"', text), encoding="utf-8"
+    )
+    print(wheel_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_release_manifest.py
+++ b/scripts/validate_release_manifest.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 WHEEL_RE = re.compile(
     r"^tmol-(?P<version>[^+]+)\+"
-    r"(?P<local>cpu|cu\d+torch\d+\.\d+)-"
+    r"(?P<local>cputorch\d+\.\d+|cu\d+torch\d+\.\d+)-"
     r"cp(?P<python>\d+)-cp(?P=python)-"
     r"(?P<platform>[^.]+)\.whl$"
 )
@@ -26,6 +26,8 @@ class Wheel:
 
     @property
     def arch(self) -> str:
+        if self.platform.endswith("_arm64"):
+            return "arm64"
         if self.platform.endswith("_x86_64"):
             return "x86_64"
         if self.platform.endswith("_aarch64"):
@@ -74,8 +76,8 @@ def main() -> None:
     if len(versions) != 1:
         raise SystemExit(f"expected one release version, found: {sorted(versions)}")
 
-    gpu = [wheel for wheel in wheels if wheel.local != "cpu"]
-    cpu = [wheel for wheel in wheels if wheel.local == "cpu"]
+    gpu = [wheel for wheel in wheels if not wheel.local.startswith("cpu")]
+    cpu = [wheel for wheel in wheels if wheel.local.startswith("cpu")]
     if len(gpu) != args.gpu_count:
         raise SystemExit(f"expected {args.gpu_count} GPU wheels, found {len(gpu)}")
     if len(cpu) != args.cpu_count:

--- a/tmol/tests/test_build_backend.py
+++ b/tmol/tests/test_build_backend.py
@@ -51,6 +51,33 @@ def test_candidate_wheels_include_stable_torch_210_variants(monkeypatch):
     assert any("+cu128torch2.10-" in filename for filename in filenames)
 
 
+def test_candidate_wheels_include_torch_qualified_linux_cpu(monkeypatch):
+    monkeypatch.setattr(backend.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(backend, "_linux_arch_tag", lambda: "x86_64")
+    monkeypatch.setattr(backend, "_read_project_version", lambda: "0.1.42")
+    monkeypatch.setattr(backend, "_python_tag", lambda: "cp312")
+    monkeypatch.setattr(backend, "_torch_major_minor", lambda: "2.13")
+    monkeypatch.setattr(backend, "_torch_cuda_tag", lambda: None)
+
+    assert backend._candidate_wheel_filenames() == [
+        "tmol-0.1.42+cputorch2.13-cp312-cp312-manylinux_2_28_x86_64.whl",
+        "tmol-0.1.42+cputorch2.13-cp312-cp312-linux_x86_64.whl",
+    ]
+
+
+def test_candidate_wheels_include_apple_silicon_cpu(monkeypatch):
+    monkeypatch.setattr(backend.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(backend.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(backend, "_read_project_version", lambda: "0.1.42")
+    monkeypatch.setattr(backend, "_python_tag", lambda: "cp314")
+    monkeypatch.setattr(backend, "_torch_major_minor", lambda: "2.13")
+    monkeypatch.setattr(backend, "_torch_cuda_tag", lambda: None)
+
+    assert backend._candidate_wheel_filenames() == [
+        "tmol-0.1.42+cputorch2.13-cp314-cp314-macosx_14_0_arm64.whl"
+    ]
+
+
 def test_build_wheel_uses_downloaded_wheel_when_available(monkeypatch, tmp_path):
     monkeypatch.setattr(backend, "_is_repo_checkout", lambda: False)
     monkeypatch.setattr(backend, "_is_isolated_build_environment", lambda: False)

--- a/tmol_build_backend.py
+++ b/tmol_build_backend.py
@@ -63,13 +63,16 @@ except ModuleNotFoundError as _import_error:
 _PROJECT_ROOT = Path(__file__).resolve().parent
 _DEFAULT_RELEASE_BASE_URL = "https://github.com/uw-ipd/tmol/releases/download"
 _PYPROJECT_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"\s*$')
-_SUPPORTED_ARCHES = {"x86_64": "x86_64", "amd64": "x86_64", "aarch64": "aarch64"}
+_SUPPORTED_LINUX_ARCHES = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "aarch64": "aarch64",
+}
 _RELEASE_URL_ENV = "TMOL_WHEEL_RELEASE_BASE_URL"
 _RELEASE_TAG_ENV = "TMOL_WHEEL_RELEASE_TAG"
 _LOCAL_TAG_ENV = "TMOL_WHEEL_LOCAL_TAG"
 _FORCE_BUILD_ENV = "TMOL_FORCE_BUILD"
 _DISABLE_FETCH_ENV = "TMOL_DISABLE_WHEEL_FETCH"
-_ALLOW_CPU_FALLBACK_ENV = "TMOL_WHEEL_ALLOW_CPU_FALLBACK"
 _ENABLE_LOCAL_FETCH_ENV = "TMOL_ENABLE_LOCAL_FETCH"
 _FETCH_TIMEOUT_ENV = "TMOL_WHEEL_FETCH_TIMEOUT_S"
 _FETCH_RETRIES_ENV = "TMOL_WHEEL_FETCH_RETRIES"
@@ -122,7 +125,19 @@ def _python_tag() -> str:
 
 def _linux_arch_tag() -> str | None:
     machine = platform.machine().lower()
-    return _SUPPORTED_ARCHES.get(machine)
+    return _SUPPORTED_LINUX_ARCHES.get(machine)
+
+
+def _wheel_platform_tags() -> list[str]:
+    system = platform.system().lower()
+    if system == "linux":
+        arch = _linux_arch_tag()
+        if arch is None:
+            return []
+        return [f"manylinux_2_28_{arch}", f"linux_{arch}"]
+    if system == "darwin" and platform.machine().lower() in {"arm64", "aarch64"}:
+        return ["macosx_14_0_arm64"]
+    return []
 
 
 def _torch_major_minor() -> str | None:
@@ -179,27 +194,15 @@ def _candidate_local_tags() -> list[str]:
             # matrix uses stable cu130 wheels on both architectures.
             candidates.extend(["cu128torch2.10", "cu130torch2.10"])
     elif torch_mm and not cuda_tag:
-        candidates.append("cpu")
-    elif _env_true(_ALLOW_CPU_FALLBACK_ENV):
-        candidates.append("cpu")
+        candidates.append(f"cputorch{torch_mm}")
 
     return _dedupe_keep_order(candidates)
 
 
 def _candidate_wheel_filenames() -> list[str]:
-    if platform.system().lower() != "linux":
-        return []
-    arch = _linux_arch_tag()
-    if not arch:
-        return []
-
     version = _read_project_version()
     py_tag = _python_tag()
-    platform_tags: list[str]
-    if arch == "x86_64":
-        platform_tags = ["manylinux_2_28_x86_64", "linux_x86_64"]
-    else:
-        platform_tags = ["manylinux_2_28_aarch64", "linux_aarch64"]
+    platform_tags = _wheel_platform_tags()
 
     candidates: list[str] = []
     for local_tag in _candidate_local_tags():


### PR DESCRIPTION
## Summary

Make the CPU release artifacts explicit, platform-complete, and ABI-safe.

- qualify CPU wheel versions and filenames with the PyTorch minor (`+cputorch2.13`) instead of the ambiguous `+cpu`
- keep each wheel's filename, `.dist-info` directory, and package METADATA version consistent
- build native Apple Silicon wheels for CPython 3.11-3.14 alongside the existing Linux x86-64 and aarch64 wheels
- teach the source-build backend to select Apple Silicon wheels and exact CPU/PyTorch lanes
- validate the complete 12-wheel CPU release matrix
- build, install, and load every macOS wheel plus representative Linux wheels in pull-request CI
- keep the PyPI artifact as the source distribution; ABI-specific wheels remain GitHub Release assets

The macOS wheels use `macosx_14_0_arm64`, matching the minimum platform tag of PyTorch 2.13. The workflow resolves but excludes PyTorch shared libraries during delocation so TMol does not vendor its runtime dependency.

## Validation

- wheel smoke CI: all six representative builds and all six clean-environment install/native-load tests passed (CPython 3.11-3.14 on Apple Silicon; CPython 3.12 on Linux x86-64 and aarch64)
- inspected the built CPython 3.13 Apple artifact: matching `+cputorch2.13` filename, `.dist-info`, and METADATA; no vendored PyTorch libraries
- 11 build-backend tests pass
- 4 release-workflow static tests pass
- representative three-platform release manifest passes
- all workflow YAML parses
- pre-commit and `git diff --check` pass

No version bump or release is included.