### PR TITLE
Speed up batched CPU scoring and pose construction

### DIFF
--- a/tmol/io/details/_select_from_canonical.py
+++ b/tmol/io/details/_select_from_canonical.py
@@ -198,7 +198,7 @@ def assign_block_types(
         pconn_matrix,
         pconn_offsets,
         block_n_conn,
-        pose_n_pconn,
+        _,
     ) = PoseStackBuilder._take_real_conn_conn_intrablock_pairs(
         pbt, block_type_ind64, is_real_res
     )
@@ -212,7 +212,7 @@ def assign_block_types(
     # bad naming because python indentation- and line-wrapping rules are annoying:
     # inter_block_bondsep64 == ibb64
     ibb64 = PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph(
-        pbt, block_n_conn, pose_n_pconn, pconn_matrix
+        pbt, pconn_offsets, block_n_conn, pconn_matrix
     )
 
     return (block_type_ind64, inter_residue_connections64, ibb64)

--- a/tmol/ligand/_fragmentation.py
+++ b/tmol/ligand/_fragmentation.py
@@ -845,7 +845,7 @@ def apply_fragment_connections(pose_stack, mapping: FragmentedLigandPoseMapping)
         pconn_matrix,
         pconn_offsets,
         block_n_conn,
-        pose_n_pconn,
+        _,
     ) = PoseStackBuilder._take_real_conn_conn_intrablock_pairs(
         pbt, pose_stack.block_type_ind64, real_res
     )
@@ -854,7 +854,7 @@ def apply_fragment_connections(pose_stack, mapping: FragmentedLigandPoseMapping)
     )
     inter_block_bondsep64 = (
         PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph(
-            pbt, block_n_conn, pose_n_pconn, pconn_matrix
+            pbt, pconn_offsets, block_n_conn, pconn_matrix
         )
     )
     result = attr.evolve(
@@ -1237,14 +1237,14 @@ def unsplit_pose_stack(pose_stack):
         device,
     )
 
-    pconn_matrix, pconn_offsets, block_n_conn, pose_n_pconn = (
+    pconn_matrix, pconn_offsets, block_n_conn, _ = (
         PoseStackBuilder._take_real_conn_conn_intrablock_pairs(pbt, new_bt64, real_new)
     )
     PoseStackBuilder._incorporate_inter_residue_connections_into_connectivity_graph(
         new_irc64, pconn_offsets, pconn_matrix
     )
     new_ibs64 = PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph(
-        pbt, block_n_conn, pose_n_pconn, pconn_matrix
+        pbt, pconn_offsets, block_n_conn, pconn_matrix
     )
 
     new_chain_id, new_pdb_info = _unsplit_chain_and_pdb(

--- a/tmol/pose/_pose_stack_builder.py
+++ b/tmol/pose/_pose_stack_builder.py
@@ -34,7 +34,6 @@ from tmol.utility.tensor import (
     exclusive_cumsum2d,
     exclusive_cumsum2d_and_totals,
     stretch,
-    stretch2,
 )
 from tmol.utility._device import resolve_device
 
@@ -268,7 +267,7 @@ class PoseStackBuilder:
             pconn_matrix,
             pconn_offsets,
             block_n_conn,
-            pose_n_pconn,
+            _,
         ) = cls._take_real_conn_conn_intrablock_pairs(pbt, block_type_ind64, real_res)
 
         # 3b
@@ -279,7 +278,7 @@ class PoseStackBuilder:
         # 4
         inter_block_bondsep64 = (
             cls._calculate_interblock_bondsep_from_connectivity_graph(
-                pbt, block_n_conn, pose_n_pconn, pconn_matrix
+                pbt, pconn_offsets, block_n_conn, pconn_matrix
             )
         )
 
@@ -517,49 +516,18 @@ class PoseStackBuilder:
             pbt_conn_at_intrablock_bond_sep, block_types64, real_blocks
         )
 
-        local_ind_for_bconn1 = (
-            torch.arange(pbt_max_n_conn, dtype=torch.int64, device=pbt_device)
-            .repeat(n_poses * max_n_blocks * pbt_max_n_conn)
-            .reshape(n_poses, max_n_blocks, pbt_max_n_conn, pbt_max_n_conn)
-        )
-        local_ind_for_bconn2 = torch.transpose(local_ind_for_bconn1, 2, 3)
-
-        # n_conn_for_bconn:
-        # [n_poses x max_n_blockx x max_n_conn x max_n_conn] tensor stating
-        # for entry [i, j, k, l] the number of connections on pose i
-        # block j; then we can figure out if any individual pair (k,l)
-        # represents a valid intra-block pair or whether k, e.g., exceeds
-        # the number of connections for block j.
-        n_conn_for_bconn = stretch2(
-            n_conn_for_block, pbt_max_n_conn * pbt_max_n_conn
-        ).reshape(n_poses, max_n_blocks, pbt_max_n_conn, pbt_max_n_conn)
-
+        bconn_inds = torch.arange(pbt_max_n_conn, dtype=torch.int64, device=pbt_device)
         valid_local_bconn_pair = torch.logical_and(
-            local_ind_for_bconn1 < n_conn_for_bconn,
-            local_ind_for_bconn2 < n_conn_for_bconn,
+            bconn_inds[None, None, None, :] < n_conn_for_block[:, :, None, None],
+            bconn_inds[None, None, :, None] < n_conn_for_block[:, :, None, None],
         )
 
-        # pose_ind_for_pconn1
-        # [n_poses x max_n_pose_conn x max_n_pose_conn] tensor where
-        # entry [i, j, k] is j;
-        # pose_ind_for_pconn2, on the otherhand, gives [i, j, k] as k
-        # useful to know if both j and k are less than the maximum
-        # number of inter-residue connection points for the pose
-        pose_ind_for_pconn1 = (
+        # Exclude padded pose-connection rows and columns.
+        pconn_real = (
             torch.arange(max_n_pose_conn, dtype=torch.int64, device=pbt_device)
-            .repeat(n_poses * max_n_pose_conn)
-            .reshape(n_poses, max_n_pose_conn, max_n_pose_conn)
+            < n_conn_totals[:, None]
         )
-        pose_ind_for_pconn2 = torch.transpose(pose_ind_for_pconn1, 1, 2)
-
-        n_pose_conn_for_pconn = stretch(
-            n_conn_totals, max_n_pose_conn * max_n_pose_conn
-        ).reshape(n_poses, max_n_pose_conn, max_n_pose_conn)
-
-        valid_pconn_pair = torch.logical_and(
-            pose_ind_for_pconn1 < n_pose_conn_for_pconn,
-            pose_ind_for_pconn2 < n_pose_conn_for_pconn,
-        )
+        valid_pconn_pair = pconn_real[:, :, None] & pconn_real[:, None, :]
 
         real_pconns_from_same_block = torch.logical_and(
             are_pconns_from_same_block, valid_pconn_pair
@@ -1232,86 +1200,93 @@ class PoseStackBuilder:
     @validate_args
     def _calculate_interblock_bondsep_from_connectivity_graph(
         cls,
-        pbt,
+        pbt: PackedBlockTypes,
+        pconn_offsets: Tensor[torch.int64][:, :],
         block_n_conn: Tensor[torch.int32][:, :],
-        pose_n_pconn: Tensor[torch.int32][:],
         pconn_matrix: Tensor[torch.int32][:, :, :],
-    ):
+    ) -> Tensor[torch.int32][:, :, :, :, :]:
         return cls._calculate_interblock_bondsep_from_connectivity_graph_heavy(
-            pbt.max_n_conn, pbt.device, block_n_conn, pose_n_pconn, pconn_matrix
+            pbt.max_n_conn, pconn_offsets, block_n_conn, pconn_matrix
         )
 
     @classmethod
     @validate_args
     def _calculate_interblock_bondsep_from_connectivity_graph_heavy(
         cls,
-        pbt_max_n_conn,
-        pbt_device,
+        pbt_max_n_conn: int,
+        pconn_offsets: Tensor[torch.int64][:, :],
         block_n_conn: Tensor[torch.int32][:, :],
-        pose_n_pconn: Tensor[torch.int32][:],
         pconn_matrix: Tensor[torch.int32][:, :, :],
-    ):
+    ) -> Tensor[torch.int32][:, :, :, :, :]:
+        """Map shortest paths between pose connections onto block pairs.
+
+        Args:
+            pbt_max_n_conn: Maximum connection count for any block type.
+            pconn_offsets: First pose-connection index for each block.
+            block_n_conn: Number of real connections for each block.
+            pconn_matrix: Pose-connection adjacency matrices, updated in place
+                with their all-pairs shortest paths.
+
+        Returns:
+            Connection-to-connection bond separations indexed by pose and
+            block pair.
+        """
         n_poses = block_n_conn.shape[0]
         max_n_blocks = block_n_conn.shape[1]
         max_n_conn = pbt_max_n_conn
         max_n_pconn = pconn_matrix.shape[1]
         assert pconn_matrix.shape[0] == n_poses
         assert pconn_matrix.shape[1] == pconn_matrix.shape[2]
+        assert pconn_offsets.shape == block_n_conn.shape
 
-        # the final destination tensor that we will have to carefully write to
-        # indexed pose-id x r1 x r2 x c1 x c2
-        # but, we will see later, has to be transposed at the r2/c1 dimensions
-        # so we can write to it in the correct order
-        inter_block_bondsep = torch.full(
-            (n_poses, max_n_blocks, max_n_blocks, max_n_conn, max_n_conn),
-            MAX_SIG_BOND_SEPARATION,
-            dtype=torch.int32,
-            device=pbt_device,
+        output_shape = (
+            n_poses,
+            max_n_blocks,
+            max_n_blocks,
+            max_n_conn,
+            max_n_conn,
         )
+        if max_n_pconn == 0:
+            return torch.full(
+                output_shape,
+                MAX_SIG_BOND_SEPARATION,
+                dtype=torch.int32,
+                device=pconn_matrix.device,
+            )
 
-        bconn_inds1 = (
-            torch.arange(max_n_conn, dtype=torch.int64, device=pbt_device)
-            .repeat(n_poses * max_n_blocks * max_n_blocks * max_n_conn)
-            .view(n_poses, max_n_blocks, max_n_blocks, max_n_conn, max_n_conn)
-        )
-        bconn_inds2 = torch.transpose(bconn_inds1, 3, 4)
-        # not all entries in the inter_block_bondsep tensor correspond to
-        # actual connections; this boolean tensor helps us identify the
-        # real entries
-        bconn_pair_real = torch.logical_and(
-            bconn_inds1 < block_n_conn[:, None, :, None, None],
-            bconn_inds2 < block_n_conn[:, :, None, None, None],
-        )
-
-        # in order to assign from a tensor ordered pose_id x pconn1 x pconn2
-        # we have to make these tensors (temporarily) indexed
-        # pose_id x r1 x c1 x r2 x c2
-        # later we will re-transpose these dimensions before returning
-        # the inter_block_bondsep tensor
-        bconn_pair_real = torch.transpose(bconn_pair_real, 2, 3)
-        inter_block_bondsep = torch.transpose(inter_block_bondsep, 2, 3)
-
-        pconn_inds1 = (
-            torch.arange(max_n_pconn, dtype=torch.int64, device=pbt_device)
-            .repeat(n_poses * max_n_pconn)
-            .view(n_poses, max_n_pconn, max_n_pconn)
-        )
-        pconn_inds2 = torch.transpose(pconn_inds1, 1, 2)
-        # same deal as with the bconn_pair_real tensor
-        pconn_pair_real = torch.logical_and(
-            pconn_inds1 < pose_n_pconn[:, None, None],
-            pconn_inds2 < pose_n_pconn[:, None, None],
-        )
-
-        # invoke the all-pairs-shortest-path algorithm on the connectivity
-        # matrices
         cls._shortest_paths_for_connectivity_graph(pconn_matrix)
 
-        # the big assignment!
-        inter_block_bondsep[bconn_pair_real] = pconn_matrix[pconn_pair_real]
+        bconn_ind = torch.arange(
+            max_n_conn, dtype=torch.int64, device=pconn_matrix.device
+        )
+        real_bconn = bconn_ind[None, None, :] < block_n_conn[:, :, None]
+        pconn_for_bconn = torch.where(
+            real_bconn,
+            pconn_offsets[:, :, None] + bconn_ind,
+            0,
+        ).flatten(1)
 
-        # now reorder so it's pose-ind x r1 x r2 x c1 x c2
-        return torch.transpose(inter_block_bondsep, 2, 3)
+        n_padded_bconn = pconn_for_bconn.shape[1]
+        pconn_rows = torch.gather(
+            pconn_matrix,
+            1,
+            pconn_for_bconn[:, :, None].expand(n_poses, n_padded_bconn, max_n_pconn),
+        )
+        inter_block_bondsep = torch.gather(
+            pconn_rows,
+            2,
+            pconn_for_bconn[:, None, :].expand(n_poses, n_padded_bconn, n_padded_bconn),
+        ).reshape(n_poses, max_n_blocks, max_n_conn, max_n_blocks, max_n_conn)
+        inter_block_bondsep = inter_block_bondsep.permute(0, 1, 3, 2, 4)
+
+        # Sentinel padded connections without constructing a dense 5-D mask.
+        inter_block_bondsep.masked_fill_(
+            ~real_bconn[:, :, None, :, None], MAX_SIG_BOND_SEPARATION
+        )
+        inter_block_bondsep.masked_fill_(
+            ~real_bconn[:, None, :, None, :], MAX_SIG_BOND_SEPARATION
+        )
+        return inter_block_bondsep.contiguous()
 
     @classmethod
     @validate_args

--- a/tmol/score/common/device_operations.cpu.impl.hh
+++ b/tmol/score/common/device_operations.cpu.impl.hh
@@ -22,13 +22,26 @@ struct DeviceOperations<tmol::Device::CPU> {
     }
   }
 
-  template <typename Int, typename Func>
+  template <typename launch_t, typename Int, typename Func>
   static void forall_stacks(ContextManager&, Int Nstacks, Int N, Func f) {
-    for (int stack = 0; stack < Nstacks; ++stack) {
-      for (Int i = 0; i < N; ++i) {
-        f(stack, i);
+    constexpr int64_t min_parallel_work = 32768;
+    int64_t const total_work = int64_t(Nstacks) * int64_t(N);
+    if (Nstacks <= 1 || total_work < min_parallel_work) {
+      for (Int stack = 0; stack < Nstacks; ++stack) {
+        for (Int i = 0; i < N; ++i) {
+          f(stack, i);
+        }
       }
+      return;
     }
+
+    at::parallel_for(0, Nstacks, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t stack = begin; stack < end; ++stack) {
+        for (Int i = 0; i < N; ++i) {
+          f(Int(stack), i);
+        }
+      }
+    });
   }
 
   template <typename Int, typename Func>

--- a/tmol/score/common/device_operations.cuda.impl.cuh
+++ b/tmol/score/common/device_operations.cuda.impl.cuh
@@ -40,11 +40,10 @@ struct DeviceOperations<tmol::Device::CUDA> {
     mgpu::transform<launch_t>(f, N, *context);
   }
 
-  template <typename Int, typename Func>
+  template <typename launch_t, typename Int, typename Func>
   static void forall_stacks(ContextManager& mgr, Int Nstacks, Int N, Func f) {
     std::shared_ptr<mgpu::standard_context_t> context = _get_context(mgr);
-    // mgpu::standard_context_t context;
-    mgpu::transform(
+    mgpu::transform<launch_t>(
         [=] MGPU_DEVICE(int index) {
           int stack = index / N;
           int i = index % N;

--- a/tmol/score/common/device_operations.hh
+++ b/tmol/score/common/device_operations.hh
@@ -16,7 +16,9 @@ struct DeviceOperations {
   template <typename launch_t, typename Func>
   static void forall(ContextManager& mgr, int N, Func f);
 
-  template <typename Int, typename Func>
+  /// Apply independent per-stack work, parallelizing stacks on CPU when the
+  /// workload is large enough to amortize thread-pool dispatch.
+  template <typename launch_t, typename Int, typename Func>
   static void forall_stacks(ContextManager& mgr, Int Nstacks, Int N, Func f);
 
   template <typename Int, typename Func>

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -298,16 +298,12 @@ struct detect_block_neighbors {
       Real reach) {
     LAUNCH_BOX_32;
 
-    auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int ind) {
-      int const n_poses = pose_stack_block_type.size(0);
-      int const max_n_blocks = pose_stack_block_type.size(1);
-
-      if (ind >= n_poses * max_n_blocks * max_n_blocks) return;
-
-      int const pose_ind = ind / (max_n_blocks * max_n_blocks);
-      int const block_pair_ind = ind % (max_n_blocks * max_n_blocks);
-      int const block_ind1 = block_pair_ind / max_n_blocks;
-      int const block_ind2 = block_pair_ind % max_n_blocks;
+    int const n_poses = pose_stack_block_type.size(0);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const block_pairs_per_pose = max_n_blocks * max_n_blocks;
+    auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int pose_ind, int pair) {
+      int const block_ind1 = pair / max_n_blocks;
+      int const block_ind2 = pair % max_n_blocks;
 
       if (block_ind1 > block_ind2) {
         return;
@@ -341,12 +337,8 @@ struct detect_block_neighbors {
         block_neighbors[pose_ind][block_ind1][block_ind2] = 1;
       }
     });
-    int n_block_pairs = pose_stack_block_type.size(0)
-                        * pose_stack_block_type.size(1)
-                        * pose_stack_block_type.size(1);
-
-    DeviceDispatch<D>::template forall<launch_t>(
-        mgr, n_block_pairs, detect_neighbors);
+    DeviceDispatch<D>::template forall_stacks<launch_t, int>(
+        mgr, n_poses, block_pairs_per_pose, detect_neighbors);
   }
 };
 

--- a/tmol/tests/pose/test_pose_stack_construction.py
+++ b/tmol/tests/pose/test_pose_stack_construction.py
@@ -403,7 +403,11 @@ def test_calculate_interblock_bondsep_from_connectivity_graph_heavy(torch_device
     block_n_conn = torch.tensor(
         [[2, 2, 3, 2, 3], [2, 3, 2, 3, 0]], dtype=torch.int32, device=torch_device
     )
-    pose_n_pconn = torch.tensor([12, 10], dtype=torch.int32, device=torch_device)
+    pconn_offsets = torch.tensor(
+        [[0, 2, 4, 7, 9], [0, 2, 5, 7, 10]],
+        dtype=torch.int64,
+        device=torch_device,
+    )
     pconn_matrix = torch.tensor(
         [
             [
@@ -440,7 +444,7 @@ def test_calculate_interblock_bondsep_from_connectivity_graph_heavy(torch_device
     )
 
     ibb = PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph_heavy(
-        pbt_max_n_conn, torch_device, block_n_conn, pose_n_pconn, pconn_matrix
+        pbt_max_n_conn, pconn_offsets, block_n_conn, pconn_matrix
     )
     inter_block_bondsep = ibb
 
@@ -526,6 +530,22 @@ def test_calculate_interblock_bondsep_from_connectivity_graph_heavy(torch_device
     )
 
     torch.testing.assert_close(inter_block_bondsep, inter_block_bondsep_gold)
+    assert inter_block_bondsep.is_contiguous()
+
+
+def test_calculate_interblock_bondsep_without_connections(torch_device):
+    block_n_conn = torch.zeros((2, 3), dtype=torch.int32, device=torch_device)
+    pconn_offsets = torch.zeros((2, 3), dtype=torch.int64, device=torch_device)
+    pconn_matrix = torch.empty((2, 0, 0), dtype=torch.int32, device=torch_device)
+
+    result = (
+        PoseStackBuilder._calculate_interblock_bondsep_from_connectivity_graph_heavy(
+            3, pconn_offsets, block_n_conn, pconn_matrix
+        )
+    )
+
+    assert result.shape == (2, 3, 3, 3, 3)
+    assert torch.all(result == MAX_SIG_BOND_SEPARATION)
 
 
 def test_incorporate_extra_connections_into_inter_res_conn_set(torch_device):

--- a/tmol/tests/score/common/device_operations/test.impl.hh
+++ b/tmol/tests/score/common/device_operations/test.impl.hh
@@ -42,7 +42,7 @@ auto DevOpsTests<D>::test_forall_stacks(TView<int32_t, 2, D> src)
   int n = src.size(1);
   auto dst_t = TPack<int32_t, 2, D>::empty({nstacks, n});
   auto dst = dst_t.view;
-  DO<D>::template forall_stacks<int>(
+  DO<D>::template forall_stacks<launch_t, int>(
       mgr, nstacks, n, [=] EIGEN_DEVICE_FUNC(int stack, int i) {
         dst[stack][i] = src[stack][i] * 2;
       });

--- a/tmol/tests/score/common/device_operations/test_device_operations.py
+++ b/tmol/tests/score/common/device_operations/test_device_operations.py
@@ -49,11 +49,12 @@ def test_forall_stacks(ext, torch_device):
 
 
 def test_forall_stacks_large(ext, torch_device):
-    # 20 stacks x 200 elements = 4000 total, spanning multiple CTAs.
+    # 128 stacks x 1024 elements exercises CPU stack parallelism and spans
+    # multiple CUDA CTAs.
     # src=ones, so dst[stack][i] = 1 * 2 = 2 everywhere.
-    src = torch.ones(20, 200, dtype=torch.int32, device=torch_device)
+    src = torch.ones(128, 1024, dtype=torch.int32, device=torch_device)
     result = ext.test_forall_stacks(src)
-    expected = torch.full((20, 200), 2, dtype=torch.int32)
+    expected = torch.full((128, 1024), 2, dtype=torch.int32)
     assert torch.equal(result.cpu(), expected)
 
 


### PR DESCRIPTION
## Summary

- parallelize `forall_stacks` across independent pose stacks on CPU once the measured workload threshold is large enough to amortize dispatch
- preserve each caller's explicit CUDA launch policy by threading `launch_t` through `forall_stacks`
- express block-neighbor detection directly as `(pose, pair)` work without redundant index decoding
- replace repeated 3-D to 5-D pose-connectivity index grids with broadcasted one-dimensional indices
- map all-pairs connection distances back to block connections with the offsets already computed upstream, avoiding the previous dense boolean indexing and `nonzero` temporaries
- preserve the established contiguous bond-separation layout, remove the unused `stretch2` dependency, and document the heavy connectivity mapping

The generic CPU `forall` remains serial because some scoring callbacks use non-atomic accumulation. Only the explicitly independent stack contract is parallelized.

## Performance

On a 48-thread CPU, combined beta scoring of repeated ubiquitin poses changed as follows:

| poses | master | this PR | change |
|---:|---:|---:|---:|
| 1 | 9.73 ms | 9.57 ms | 1.7% faster |
| 3 | 13.64 ms | 12.47 ms | 8.6% faster |
| 10 | 20.05 ms | 19.20 ms | 4.2% faster |
| 30 | 33.81 ms | 27.76 ms | 17.9% faster |
| 100 | 93.06 ms | 68.80 ms | 26.1% faster |

The final offset-gather mapping was compared in-process with the previous boolean-index implementation. For a 600-residue pose, the isolated CPU mapping fell from 10.45 to 1.11 ms (9.4x). On H200 it fell from 0.209 to 0.091 ms (2.3x), while incremental peak allocation fell from 67.7 to 28.1 MiB.

That mapping change improves complete canonical-form-to-pose construction on CPU at every tested size:

| residues | previous implementation | final implementation | change |
|---:|---:|---:|---:|
| 40 | 3.146 ms | 2.439 ms | 22.5% faster |
| 75 | 4.420 ms | 3.378 ms | 23.6% faster |
| 150 | 7.480 ms | 5.287 ms | 29.3% faster |
| 300 | 10.871 ms | 7.835 ms | 27.9% faster |
| 600 | 22.856 ms | 13.614 ms | 40.4% faster |

The same end-to-end A/B on H200 improved by 1.4%, 2.6%, 4.3%, 2.6%, and 3.9% at 40, 75, 150, 300, and 600 residues respectively.

With the original one-warp launch policy preserved, a 100-pose combined H200 forward score was 3.2368 ms versus 3.2363 ms on master (0.02% difference). A 20-iteration CUDA profile attributed nearly all remaining device time to the five substantive score kernels (LKBall, LJ/LK, hydrogen bonding, cart-bonded, and electrostatics); block-neighbor/launch overhead was below 1%. Nsight Compute showed those kernels to be compute/register-bound rather than DRAM-bound, so no speculative shared-kernel change is included.

## Verification

- pose/I/O/ligand CPU suite: 572 passed, 262 CUDA-skipped, 54 deselected
- focused CPU and H200 topology/ligand suite: 142 passed, 3 skipped
- no-connection, padded-connection, fragmented-ligand, and canonical-loading paths covered
- all 10 tutorial notebooks executed from the final source on CPU
- all 10 tutorial notebooks executed from the final source on H200 CUDA
- bond-separation values remain exact and the prior contiguous layout is asserted
- Black, Flake8, clang-format, and `git diff --check` clean