### PR TITLE
Prepare tmol 0.1.53 with portable CUDA wheels and Nsight profiling

### DIFF
--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -39,7 +39,9 @@ retry uv pip install torch --index-url "${TORCH_CUDA_INDEX}"
 assert_torch_cuda
 
 RUN_GPU=$(python -c "import torch; c=torch.cuda.get_device_capability(0); print(f'{c[0]}.{c[1]}')" 2>/dev/null || echo "n/a")
-CUDA_ARCHS="${TMOL_CI_CUDA_ARCHITECTURES:-80;86;89;90;100}"
+# Test jobs only execute on this runner, so compiling every wheel architecture
+# wastes most of the job. Release wheels retain the all-supported-SM default.
+CUDA_ARCHS="${TMOL_CI_CUDA_ARCHITECTURES:-native}"
 NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
 if [[ "${CUDA_ARCHS}" == "native" ]]; then
   CUDA_ARCHS="${RUN_GPU/./}"

--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -44,16 +44,19 @@ RUN_GPU=$(python -c "import torch; c=torch.cuda.get_device_capability(0); print(
 CUDA_ARCHS="${TMOL_CI_CUDA_ARCHITECTURES:-native}"
 NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
 if [[ "${CUDA_ARCHS}" == "native" ]]; then
-  CUDA_ARCHS="${RUN_GPU/./}"
+  # Exercise CMake's native path in CI. JIT extensions still need PyTorch's
+  # numeric spelling for the same runner GPU.
+  TORCH_CUDA_ARCHS="${RUN_GPU/./}"
 else
   case "${NVCC_VER}" in
     11.*|12.*) CUDA_ARCHS="80;86;89;90" ;;
   esac
+  TORCH_CUDA_ARCHS="${CUDA_ARCHS}"
 fi
 unset CMAKE_CUDA_ARCHITECTURES
 export CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}"
 TORCH_ARCH_LIST=""
-IFS=';' read -ra _CUDA_ARCH_ARR <<< "${CUDA_ARCHS}"
+IFS=';' read -ra _CUDA_ARCH_ARR <<< "${TORCH_CUDA_ARCHS}"
 for _A in "${_CUDA_ARCH_ARR[@]}"; do
   if [ "${#_A}" -eq 3 ]; then
     TORCH_ARCH_LIST+=" ${_A:0:2}.${_A:2:1}"

--- a/.github/scripts/test_colab_release_config.py
+++ b/.github/scripts/test_colab_release_config.py
@@ -35,6 +35,12 @@ def test_colab_selects_the_published_wheel_for_each_supported_python():
     assert module.RELEASE_WHEEL_CUDA == "12.8"
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     assert module.TMOL_RELEASE == project["project"]["version"]
+    assert (
+        project["tool"]["scikit-build"]["cmake"]["define"]["CMAKE_CUDA_ARCHITECTURES"][
+            "default"
+        ]
+        == "native"
+    )
     assert module.RELEASE_WHEEL_PYTHONS == {(3, 12), (3, 13)}
     assert module._wheel_url((3, 12)).endswith(
         "/v0.1.53/" "tmol-0.1.53+cu128torch2.11-cp312-cp312-manylinux_2_28_x86_64.whl"

--- a/.github/scripts/test_colab_release_config.py
+++ b/.github/scripts/test_colab_release_config.py
@@ -71,7 +71,7 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
     build_template = _workflow(".github/workflows/_build_wheel.yml")
     cuda_archs = build_template[True]["workflow_call"]["inputs"]["cuda-archs"]
     assert "75;80;86;89;90" in cuda_archs["description"]
-    assert "80;86;89;90;100" in cuda_archs["description"]
+    assert "every sm_75+ target reported by nvcc" in cuda_archs["description"]
 
     publish = _workflow(".github/workflows/publish.yml")
     publish_rows = publish["jobs"]["build_wheels"]["strategy"]["matrix"]["include"]

--- a/.github/scripts/test_colab_release_config.py
+++ b/.github/scripts/test_colab_release_config.py
@@ -30,17 +30,17 @@ def test_colab_selects_the_published_wheel_for_each_supported_python():
     source = (ROOT / "docs/tutorial/colab_setup.py").read_text(encoding="utf-8")
 
     assert module.TUTORIAL_REF == "master"
-    assert module.TMOL_RELEASE == "0.1.52"
+    assert module.TMOL_RELEASE == "0.1.53"
     assert module.RELEASE_WHEEL_TORCH_MINOR == "2.11"
     assert module.RELEASE_WHEEL_CUDA == "12.8"
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     assert module.TMOL_RELEASE == project["project"]["version"]
     assert module.RELEASE_WHEEL_PYTHONS == {(3, 12), (3, 13)}
     assert module._wheel_url((3, 12)).endswith(
-        "/v0.1.52/" "tmol-0.1.52+cu128torch2.11-cp312-cp312-manylinux_2_28_x86_64.whl"
+        "/v0.1.53/" "tmol-0.1.53+cu128torch2.11-cp312-cp312-manylinux_2_28_x86_64.whl"
     )
     assert module._wheel_url((3, 13)).endswith(
-        "/v0.1.52/" "tmol-0.1.52+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
+        "/v0.1.53/" "tmol-0.1.53+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
     )
     with pytest.raises(ValueError, match="Unsupported Colab Python version"):
         module._wheel_url((3, 14))

--- a/.github/workflows/_build_macos_wheel.yml
+++ b/.github/workflows/_build_macos_wheel.yml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install \
             "torch==${{ inputs.torch-package-version }}" \
-            'cmake>=3.18,<4' 'scikit-build-core>=0.10' ninja \
+            'cmake>=3.24,<4' 'scikit-build-core>=0.10' ninja \
             'packaging>=24.2' 'pybind11>=2.12' delocate
 
       - name: Set ABI-qualified wheel version

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -339,7 +339,7 @@ jobs:
             unset PYTHONPATH
             export PYTHONNOUSERSITE=1
             ${TARGET_VENV}/bin/pip install \
-              'cmake>=3.18,<4' 'scikit-build-core>=0.10' ninja 'packaging>=24.2' 'pybind11>=2.12' auditwheel
+              'cmake>=3.24,<4' 'scikit-build-core>=0.10' ninja 'packaging>=24.2' 'pybind11>=2.12' auditwheel
           "
 
       - name: Set ABI-qualified wheel version

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -62,7 +62,8 @@ on:
         description: >
           Override CMAKE_CUDA_ARCHITECTURES (semicolon-separated SM list). When
           empty, this workflow defaults to "75;80;86;89;90" (CUDA<13) or
-          "80;86;89;90;100" (CUDA>=13). Set e.g. "75;80;89" to make the
+          every sm_75+ target reported by nvcc (CUDA>=13). Set e.g.
+          "75;80;89" to make the
           Colab/T4 wheel's supported architectures explicit.
 
 jobs:
@@ -349,8 +350,10 @@ jobs:
 
       - name: Build wheel
         run: |
+          # Balance the two layers of CUDA parallelism for 4-core hosted
+          # runners: two Ninja jobs, each with two nvcc worker threads.
           docker exec \
-            -e MAX_JOBS=1 \
+            -e MAX_JOBS=2 \
             -e CUDA_ARCHS_OVERRIDE="${{ inputs.cuda-archs }}" \
             -e CUDA_HOME="${CUDA_HOME}" \
             -e CUDAToolkit_ROOT="${CUDA_HOME}" \
@@ -380,7 +383,7 @@ jobs:
               if [ -n "${CUDA_ARCHS_OVERRIDE}" ]; then
                 CUDA_ARCHS="${CUDA_ARCHS_OVERRIDE}"
               elif [ "$CUDA_MAJOR" -ge 13 ]; then
-                CUDA_ARCHS="80;86;89;90;100"
+                CUDA_ARCHS="all"
               else
                 CUDA_ARCHS="75;80;86;89;90"
               fi
@@ -392,7 +395,7 @@ jobs:
                 -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
                 "${CUDA_COMPILER_DEFINE[@]}" \
                 -Ccmake.define.pybind11_DIR="${PYBIND11_CMAKE_DIR}" \
-                -Ccmake.define.TMOL_NVCC_THREADS=1
+                -Ccmake.define.TMOL_NVCC_THREADS=2
             else
               '"${TARGET_VENV}"'/bin/pip wheel . --no-build-isolation --no-deps -w dist \
                 -Ccmake.define.TMOL_ENABLE_CUDA=OFF \

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -350,8 +350,8 @@ jobs:
 
       - name: Build wheel
         run: |
-          # Balance the two layers of CUDA parallelism for 4-core hosted
-          # runners: two Ninja jobs, each with two nvcc worker threads.
+          # Two independent nvcc jobs use the 4-core hosted runners efficiently
+          # without the memory spike from nesting nvcc worker parallelism.
           docker exec \
             -e MAX_JOBS=2 \
             -e CUDA_ARCHS_OVERRIDE="${{ inputs.cuda-archs }}" \
@@ -395,11 +395,66 @@ jobs:
                 -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
                 "${CUDA_COMPILER_DEFINE[@]}" \
                 -Ccmake.define.pybind11_DIR="${PYBIND11_CMAKE_DIR}" \
-                -Ccmake.define.TMOL_NVCC_THREADS=2
+                -Ccmake.define.TMOL_NVCC_THREADS=1
             else
               '"${TARGET_VENV}"'/bin/pip wheel . --no-build-isolation --no-deps -w dist \
                 -Ccmake.define.TMOL_ENABLE_CUDA=OFF \
                 -Ccmake.define.pybind11_DIR="${PYBIND11_CMAKE_DIR}"
+            fi
+          '
+
+      - name: Validate CUDA architecture contract
+        if: inputs.enable-cuda
+        run: |
+          docker exec \
+            -e CUDA_ARCHS_OVERRIDE="${{ inputs.cuda-archs }}" \
+            -e CUDA_HOME="${CUDA_HOME}" \
+            "$BUILDER" bash -euo pipefail -c '
+            cache=$(find build -name CMakeCache.txt -print -quit)
+            test -n "${cache}"
+            actual=$(sed -n "s/^CMAKE_CUDA_ARCHITECTURES:STRING=//p" "${cache}")
+            test -n "${actual}"
+            echo "Built CMAKE_CUDA_ARCHITECTURES=${actual}"
+
+            cuda_major=$("${CUDA_HOME}/bin/nvcc" --version \
+              | sed -n "s/.*release \([0-9][0-9]*\)\..*/\1/p" \
+              | head -1)
+            validate_all=false
+            if [ "${CUDA_ARCHS_OVERRIDE}" = all ] || {
+              [ -z "${CUDA_ARCHS_OVERRIDE}" ] && [ "${cuda_major}" -ge 13 ]
+            }; then
+              validate_all=true
+            fi
+            if [ "${validate_all}" = true ]; then
+              mapfile -t supported < <(
+                "${CUDA_HOME}/bin/nvcc" --list-gpu-code \
+                  | sed -n "s/^sm_\([0-9][0-9]*\)$/\1/p" \
+                  | awk "\$1 >= 75" \
+                  | sort -nu
+              )
+              test "${#supported[@]}" -gt 0
+              expected=""
+              last=$((${#supported[@]} - 1))
+              for index in "${!supported[@]}"; do
+                arch=${supported[$index]}
+                if [ "${index}" -lt "${last}" ]; then
+                  arch="${arch}-real"
+                fi
+                expected="${expected:+${expected};}${arch}"
+              done
+              test "${actual}" = "${expected}" || {
+                echo "Expected CUDA architectures ${expected}, got ${actual}" >&2
+                exit 1
+              }
+
+              ninja_file=$(dirname "${cache}")/build.ninja
+              test -f "${ninja_file}"
+              for arch in "${supported[@]}"; do
+                grep -Fq "arch=compute_${arch}" "${ninja_file}" || {
+                  echo "Generated build omits compute_${arch}" >&2
+                  exit 1
+                }
+              done
             fi
           '
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -361,7 +361,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "cmake>=3.18,<4" "scikit-build-core>=0.10" ninja "packaging>=24.2" "pybind11>=2.12" build
+          pip install "cmake>=3.24,<4" "scikit-build-core>=0.10" ninja "packaging>=24.2" "pybind11>=2.12" build
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build sdist

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -5,10 +5,12 @@ on:
   pull_request:
     branches: [master]
     paths:
+      - CMakeLists.txt
       - .github/workflows/_build_macos_wheel.yml
       - .github/workflows/_build_wheel.yml
       - .github/workflows/publish.yml
       - .github/workflows/wheel-smoke.yml
+      - pyproject.toml
       - scripts/validate_release_manifest.py
       - scripts/set_release_wheel_version.py
       - tmol_build_backend.py
@@ -439,6 +441,26 @@ jobs:
       use-manylinux-build: true
       target-arch: ${{ matrix.arch }}
 
+  # CMake and release-build changes must compile the same CUDA 13 architecture
+  # set used by tagged releases. CPU-only pull-request wheels cannot catch
+  # dropped device images or unsupported nvcc flags.
+  build-linux-cuda:
+    name: "smoke py3.12 CUDA 13 x86_64"
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/_build_wheel.yml
+    with:
+      runs-on: ubuntu-22.04
+      container-image: nvidia/cuda:13.0.2-devel-ubuntu24.04
+      torch-version: "2.13"
+      torch-package-version: "2.13.0"
+      python-version: "3.12"
+      label: "smoke py3.12 CUDA 13 x86_64"
+      pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
+      enable-cuda: true
+      cuda-archs: all
+      use-manylinux-build: true
+      target-arch: x86_64
+
   test-linux-cpu:
     name: "install cp312 cputorch2.13 ${{ matrix.arch }}"
     needs: build-linux-cpu
@@ -496,6 +518,56 @@ jobs:
           _ensure_loaded()
           print("tmol", tmol.__version__)
           print("torch", torch.__version__)
+          PY
+
+  test-linux-cuda:
+    name: "install cp312 cu130torch2.13 x86_64"
+    needs: build-linux-cuda
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-cp312-cu130torch2.13-x86_64
+          path: wheels
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install wheel with its PyTorch ABI
+        run: |
+          set -euo pipefail
+          set -- wheels/*.whl
+          test "$#" -eq 1
+          case "$(basename "$1")" in
+            tmol-*+cu130torch2.13-cp312-cp312-manylinux_2_28_x86_64.whl) ;;
+            *)
+              echo "Unexpected Linux CUDA wheel: $1"
+              exit 1
+              ;;
+          esac
+          python -m pip install --upgrade pip
+          python -m pip install 'torch==2.13.0' \
+            --index-url https://download.pytorch.org/whl/cu130
+          python -m pip install "$1"
+
+      - name: Load native extensions
+        working-directory: /tmp
+        run: |
+          python - <<'PY'
+          from importlib.metadata import version
+
+          import torch
+          import tmol
+          from tmol._cpp_lib import _ensure_loaded
+
+          assert torch.__version__.startswith("2.13.")
+          assert torch.version.cuda.startswith("13.0")
+          assert version("tmol").endswith("+cu130torch2.13")
+          _ensure_loaded()
+          print("tmol", tmol.__version__)
+          print("torch", torch.__version__, "cuda", torch.version.cuda)
           PY
 
   build-macos-cpu:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .torch_extensions
 .torch_ext_cpu
+.bench/
 
 # Conda environment
 .conda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.31)
+cmake_minimum_required(VERSION 3.24...3.31)
 
 option(TMOL_ENABLE_CUDA "Build CUDA extensions (disable for CPU-only)" ON)
 
@@ -56,30 +56,21 @@ if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
       "tmol: nvcc --list-gpu-code did not report any supported sm_75+ targets "
       "(exit ${_TMOL_NVCC_GPU_CODE_RESULT}): ${_TMOL_NVCC_GPU_CODE_ERROR}")
   endif()
-  # Ship native SASS for every target and a single forward-compatible PTX
+  # Ship SASS for every release target and a single forward-compatible PTX
   # image at the newest target. Unsuffixed numeric CMake architectures would
   # otherwise embed redundant PTX for every generation.
-  set(_TMOL_NVCC_DEFAULT_ARCHS "")
+  set(_TMOL_NVCC_RELEASE_ARCHS "")
   list(LENGTH _TMOL_NVCC_SUPPORTED_ARCHS _TMOL_NVCC_ARCH_COUNT)
   math(EXPR _TMOL_NVCC_LAST_ARCH_INDEX "${_TMOL_NVCC_ARCH_COUNT} - 1")
   foreach(_ARCH_INDEX RANGE ${_TMOL_NVCC_LAST_ARCH_INDEX})
     list(GET _TMOL_NVCC_SUPPORTED_ARCHS ${_ARCH_INDEX} _SM_ARCH)
     if(_ARCH_INDEX EQUAL _TMOL_NVCC_LAST_ARCH_INDEX)
-      list(APPEND _TMOL_NVCC_DEFAULT_ARCHS "${_SM_ARCH}")
+      list(APPEND _TMOL_NVCC_RELEASE_ARCHS "${_SM_ARCH}")
     else()
-      list(APPEND _TMOL_NVCC_DEFAULT_ARCHS "${_SM_ARCH}-real")
+      list(APPEND _TMOL_NVCC_RELEASE_ARCHS "${_SM_ARCH}-real")
     endif()
   endforeach()
 
-  if(DEFINED CMAKE_CUDA_ARCHITECTURES AND
-      (CMAKE_CUDA_ARCHITECTURES STREQUAL "native" OR
-       CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major" OR
-       CMAKE_CUDA_ARCHITECTURES STREQUAL "all"))
-    # Resolve symbolic values ourselves. This works with the project's CMake
-    # 3.18 floor and prevents CMake from guessing a target newer than its nvcc.
-    unset(CMAKE_CUDA_ARCHITECTURES)
-    unset(CMAKE_CUDA_ARCHITECTURES CACHE)
-  endif()
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     if(DEFINED ENV{CMAKE_CUDA_ARCHITECTURES})
       set(CMAKE_CUDA_ARCHITECTURES "$ENV{CMAKE_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures")
@@ -99,45 +90,51 @@ if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
       endforeach()
       set(CMAKE_CUDA_ARCHITECTURES ${_CLEAN_ARCHS} CACHE STRING "CUDA architectures")
     else()
-      set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_NVCC_DEFAULT_ARCHS}" CACHE STRING "CUDA architectures")
+      set(CMAKE_CUDA_ARCHITECTURES "native" CACHE STRING "CUDA architectures")
     endif()
   endif()
-  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native" OR
-      CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major" OR
+  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major" OR
       CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
-    # An environment override may have reintroduced a symbolic value after the
-    # cache entry above was cleared.
-    set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_NVCC_DEFAULT_ARCHS}" CACHE STRING "CUDA architectures" FORCE)
+    # CMake's symbolic all values are compiler-policy dependent. Resolve them
+    # to nvcc's exact sm_75+ list so release wheels cannot silently omit an
+    # architecture discovered above.
+    set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_NVCC_RELEASE_ARCHS}" CACHE STRING "CUDA architectures" FORCE)
   endif()
 
-  # Filter requested arches by exact compiler support. Architectures are not a
-  # simple compatibility interval, so a maximum-value clamp is incorrect.
-  set(_TMOL_FILTERED_ARCHS "")
-  set(_TMOL_REJECTED_ARCHS "")
-  foreach(_A ${CMAKE_CUDA_ARCHITECTURES})
-    string(REPLACE "-real" "" _A_NUM "${_A}")
-    string(REPLACE "-virtual" "" _A_NUM "${_A_NUM}")
-    if(_A_NUM IN_LIST _TMOL_NVCC_SUPPORTED_ARCHS)
-      list(APPEND _TMOL_FILTERED_ARCHS "${_A}")
-    else()
-      list(APPEND _TMOL_REJECTED_ARCHS "${_A}")
+  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    # CMake 3.24+ queries the GPU(s) visible at configure time and emits only
+    # their native device code. This is the fast default for local builds.
+    set(_TMOL_CUDA_ARCHITECTURES "native")
+  else()
+    # Filter requested numeric arches by exact compiler support. Architectures
+    # are not a simple compatibility interval, so a maximum clamp is wrong.
+    set(_TMOL_FILTERED_ARCHS "")
+    set(_TMOL_REJECTED_ARCHS "")
+    foreach(_A ${CMAKE_CUDA_ARCHITECTURES})
+      string(REPLACE "-real" "" _A_NUM "${_A}")
+      string(REPLACE "-virtual" "" _A_NUM "${_A_NUM}")
+      if(_A_NUM IN_LIST _TMOL_NVCC_SUPPORTED_ARCHS)
+        list(APPEND _TMOL_FILTERED_ARCHS "${_A}")
+      else()
+        list(APPEND _TMOL_REJECTED_ARCHS "${_A}")
+      endif()
+    endforeach()
+    if(NOT _TMOL_FILTERED_ARCHS)
+      message(FATAL_ERROR
+        "tmol: none of the requested CUDA architectures "
+        "(${CMAKE_CUDA_ARCHITECTURES}) are supported by ${CMAKE_CUDA_COMPILER}; "
+        "supported sm_75+ targets: ${_TMOL_NVCC_SUPPORTED_ARCHS}")
     endif()
-  endforeach()
-  if(NOT _TMOL_FILTERED_ARCHS)
-    message(FATAL_ERROR
-      "tmol: none of the requested CUDA architectures "
-      "(${CMAKE_CUDA_ARCHITECTURES}) are supported by ${CMAKE_CUDA_COMPILER}; "
-      "supported sm_75+ targets: ${_TMOL_NVCC_SUPPORTED_ARCHS}")
+    if(_TMOL_REJECTED_ARCHS)
+      message(WARNING
+        "tmol: ignoring CUDA architectures not supported by this nvcc: "
+        "${_TMOL_REJECTED_ARCHS}")
+    endif()
+    set(_TMOL_CUDA_ARCHITECTURES "${_TMOL_FILTERED_ARCHS}")
   endif()
-  if(_TMOL_REJECTED_ARCHS)
-    message(WARNING
-      "tmol: ignoring CUDA architectures not supported by this nvcc: "
-      "${_TMOL_REJECTED_ARCHS}")
-  endif()
-  # Preserve the resolved list independently: project() may normalize the
-  # special value that originally arrived through the cache and overwrite
-  # CMAKE_CUDA_ARCHITECTURES while enabling CUDA.
-  set(_TMOL_CUDA_ARCHITECTURES "${_TMOL_FILTERED_ARCHS}")
+  # Preserve the selected value independently: project() may overwrite the
+  # cache while enabling CUDA. `all` is numeric here; `native` intentionally
+  # remains symbolic so nvcc resolves the GPU visible at compile time.
   set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures" FORCE)
   set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}")
   message(STATUS "tmol: nvcc supports sm_75+ targets ${_TMOL_NVCC_SUPPORTED_ARCHS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
        CMAKE_CUDA_ARCHITECTURES STREQUAL "all"))
     # Resolve symbolic values ourselves. This works with the project's CMake
     # 3.18 floor and prevents CMake from guessing a target newer than its nvcc.
+    unset(CMAKE_CUDA_ARCHITECTURES)
     unset(CMAKE_CUDA_ARCHITECTURES CACHE)
   endif()
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
@@ -133,11 +134,18 @@ if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
       "tmol: ignoring CUDA architectures not supported by this nvcc: "
       "${_TMOL_REJECTED_ARCHS}")
   endif()
-  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_FILTERED_ARCHS}" CACHE STRING "CUDA architectures" FORCE)
+  # Preserve the resolved list independently: project() may normalize the
+  # special value that originally arrived through the cache and overwrite
+  # CMAKE_CUDA_ARCHITECTURES while enabling CUDA.
+  set(_TMOL_CUDA_ARCHITECTURES "${_TMOL_FILTERED_ARCHS}")
+  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures" FORCE)
+  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}")
   message(STATUS "tmol: nvcc supports sm_75+ targets ${_TMOL_NVCC_SUPPORTED_ARCHS}")
   message(STATUS "tmol: using CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
 
   project(tmol LANGUAGES CXX CUDA)
+  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures" FORCE)
+  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}")
   set(TMOL_HAS_CUDA TRUE)
   message(STATUS "tmol: CUDA enabled, CMAKE_CUDA_ARCHITECTURES = ${CMAKE_CUDA_ARCHITECTURES}")
 else()
@@ -189,10 +197,6 @@ endif()
 message(STATUS "tmol: PyTorch ${TORCH_VERSION_MAJOR}.${TORCH_VERSION_MINOR}, using C++${_TMOL_CXX_STANDARD}")
 
 if(TMOL_HAS_CUDA)
-  # Save CMAKE_CUDA_ARCHITECTURES before find_package(Torch) — Caffe2 sets it to OFF.
-  get_property(_TMOL_CUDA_ARCHITECTURES CACHE CMAKE_CUDA_ARCHITECTURES PROPERTY VALUE)
-  message(STATUS "tmol: _TMOL_CUDA_ARCHITECTURES (from cache) = ${_TMOL_CUDA_ARCHITECTURES}")
-
   # Set TORCH_CUDA_ARCH_LIST env var BEFORE find_package(Torch) so that
   # Caffe2's cuda.cmake uses our architectures instead of defaulting to
   # all archs nvcc supports (which includes sm_52 that lacks double atomicAdd).
@@ -228,6 +232,7 @@ if(TMOL_HAS_CUDA)
   # Caffe2's TorchConfig.cmake can set CMAKE_CUDA_ARCHITECTURES=OFF or inherit
   # PyTorch's full -gencode list (including arches this nvcc cannot compile).
   set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures" FORCE)
+  set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_CUDA_ARCHITECTURES}")
   message(STATUS "tmol: Restored CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
 
   # Caffe2's TorchConfig.cmake unconditionally appends the -gencode flags that
@@ -237,18 +242,9 @@ if(TMOL_HAS_CUDA)
   string(REGEX REPLACE " +" " " CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
   string(STRIP "${CMAKE_CUDA_FLAGS}" CMAKE_CUDA_FLAGS)
 
-  set(_TMOL_GENCODE_FLAGS "")
-  foreach(_A ${_TMOL_CUDA_ARCHITECTURES})
-    string(REPLACE "-real" "" _A_CLEAN "${_A}")
-    if("${_A}" STREQUAL "${_A_CLEAN}")
-      set(_TMOL_GENCODE_FLAGS "${_TMOL_GENCODE_FLAGS} -gencode arch=compute_${_A_CLEAN},code=sm_${_A_CLEAN} -gencode arch=compute_${_A_CLEAN},code=compute_${_A_CLEAN}")
-    else()
-      set(_TMOL_GENCODE_FLAGS "${_TMOL_GENCODE_FLAGS} -gencode arch=compute_${_A_CLEAN},code=sm_${_A_CLEAN}")
-    endif()
-  endforeach()
-  string(STRIP "${_TMOL_GENCODE_FLAGS}" _TMOL_GENCODE_FLAGS)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${_TMOL_GENCODE_FLAGS}")
-  message(STATUS "tmol: CMAKE_CUDA_FLAGS after fixing gencode = ${CMAKE_CUDA_FLAGS}")
+  # CMake emits the requested architecture flags for each CUDA target. Do not
+  # append another copy here: doing so compiles every device image twice.
+  message(STATUS "tmol: CMAKE_CUDA_FLAGS after removing Torch gencode = ${CMAKE_CUDA_FLAGS}")
 endif()
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,25 +7,77 @@ option(TMOL_ENABLE_CUDA "Build CUDA extensions (disable for CPU-only)" ON)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 include(CheckLanguage)
+if(TMOL_ENABLE_CUDA AND NOT CMAKE_CUDA_COMPILER)
+  # check_language() does not reliably discover toolkit installs under
+  # /usr/local/cuda when CMake is launched outside an activated CUDA env.
+  find_program(
+    _TMOL_NVCC_EXECUTABLE
+    NAMES nvcc
+    HINTS "$ENV{CUDA_HOME}" "$ENV{CUDA_PATH}" /usr/local/cuda
+    PATH_SUFFIXES bin
+  )
+  if(_TMOL_NVCC_EXECUTABLE)
+    set(CMAKE_CUDA_COMPILER "${_TMOL_NVCC_EXECUTABLE}" CACHE FILEPATH "CUDA compiler")
+  endif()
+endif()
 check_language(CUDA)
 
 if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
   # ── CUDA architecture selection — MUST be set before project() so that
   # enable_language(CUDA) uses our architectures, not the nvcc defaults.
   # CMAKE_CUDA_ARCHITECTURES can be set via:
-  #   -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90"  (from scikit-build-core -C flags)
+  #   -DCMAKE_CUDA_ARCHITECTURES="80;90;103"  (from scikit-build-core -C flags)
   #   TORCH_CUDA_ARCH_LIST env var (PyTorch format: "7.0 8.0 9.0+PTX")
   #   or falls back to a sensible default.
   #
-  # CMake 4.x may leave CMAKE_CUDA_ARCHITECTURES at "native" (build-node GPU).
-  # On Blackwell that becomes sm_120 while Apptainer nvcc is often CUDA 12.x
-  # and fails with "Unsupported gpu architecture 'compute_120'".
-  if(DEFINED CMAKE_CUDA_ARCHITECTURES)
-    if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native"
-        OR CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major"
-        OR CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
-      unset(CMAKE_CUDA_ARCHITECTURES CACHE)
+  # Ask nvcc instead of maintaining a version-to-architecture table. CUDA 13.1,
+  # for example, can emit sm_103 and sm_121 even though a numeric "max arch"
+  # test would neither validate the former nor discover the latter. Keep the
+  # project floor at Turing (sm_75), matching tmol's supported Colab wheels.
+  execute_process(
+    COMMAND ${CMAKE_CUDA_COMPILER} --list-gpu-code
+    OUTPUT_VARIABLE _TMOL_NVCC_GPU_CODE
+    ERROR_VARIABLE _TMOL_NVCC_GPU_CODE_ERROR
+    RESULT_VARIABLE _TMOL_NVCC_GPU_CODE_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCHALL "sm_[0-9]+" _TMOL_NVCC_SM_NAMES "${_TMOL_NVCC_GPU_CODE}")
+  set(_TMOL_NVCC_SUPPORTED_ARCHS "")
+  foreach(_SM_NAME ${_TMOL_NVCC_SM_NAMES})
+    string(REPLACE "sm_" "" _SM_ARCH "${_SM_NAME}")
+    if(_SM_ARCH GREATER_EQUAL 75)
+      list(APPEND _TMOL_NVCC_SUPPORTED_ARCHS "${_SM_ARCH}")
     endif()
+  endforeach()
+  list(REMOVE_DUPLICATES _TMOL_NVCC_SUPPORTED_ARCHS)
+  list(SORT _TMOL_NVCC_SUPPORTED_ARCHS COMPARE NATURAL ORDER ASCENDING)
+  if(NOT _TMOL_NVCC_SUPPORTED_ARCHS)
+    message(FATAL_ERROR
+      "tmol: nvcc --list-gpu-code did not report any supported sm_75+ targets "
+      "(exit ${_TMOL_NVCC_GPU_CODE_RESULT}): ${_TMOL_NVCC_GPU_CODE_ERROR}")
+  endif()
+  # Ship native SASS for every target and a single forward-compatible PTX
+  # image at the newest target. Unsuffixed numeric CMake architectures would
+  # otherwise embed redundant PTX for every generation.
+  set(_TMOL_NVCC_DEFAULT_ARCHS "")
+  list(LENGTH _TMOL_NVCC_SUPPORTED_ARCHS _TMOL_NVCC_ARCH_COUNT)
+  math(EXPR _TMOL_NVCC_LAST_ARCH_INDEX "${_TMOL_NVCC_ARCH_COUNT} - 1")
+  foreach(_ARCH_INDEX RANGE ${_TMOL_NVCC_LAST_ARCH_INDEX})
+    list(GET _TMOL_NVCC_SUPPORTED_ARCHS ${_ARCH_INDEX} _SM_ARCH)
+    if(_ARCH_INDEX EQUAL _TMOL_NVCC_LAST_ARCH_INDEX)
+      list(APPEND _TMOL_NVCC_DEFAULT_ARCHS "${_SM_ARCH}")
+    else()
+      list(APPEND _TMOL_NVCC_DEFAULT_ARCHS "${_SM_ARCH}-real")
+    endif()
+  endforeach()
+
+  if(DEFINED CMAKE_CUDA_ARCHITECTURES AND
+      (CMAKE_CUDA_ARCHITECTURES STREQUAL "native" OR
+       CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major" OR
+       CMAKE_CUDA_ARCHITECTURES STREQUAL "all"))
+    # Resolve symbolic values ourselves. This works with the project's CMake
+    # 3.18 floor and prevents CMake from guessing a target newer than its nvcc.
+    unset(CMAKE_CUDA_ARCHITECTURES CACHE)
   endif()
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     if(DEFINED ENV{CMAKE_CUDA_ARCHITECTURES})
@@ -46,39 +98,44 @@ if(CMAKE_CUDA_COMPILER AND TMOL_ENABLE_CUDA)
       endforeach()
       set(CMAKE_CUDA_ARCHITECTURES ${_CLEAN_ARCHS} CACHE STRING "CUDA architectures")
     else()
-      set(CMAKE_CUDA_ARCHITECTURES "80;86;89;90" CACHE STRING "CUDA architectures")
+      set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_NVCC_DEFAULT_ARCHS}" CACHE STRING "CUDA architectures")
     endif()
+  endif()
+  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native" OR
+      CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major" OR
+      CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
+    # An environment override may have reintroduced a symbolic value after the
+    # cache entry above was cleared.
+    set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_NVCC_DEFAULT_ARCHS}" CACHE STRING "CUDA architectures" FORCE)
   endif()
 
-  # Clamp requested arches to what this nvcc can actually compile.
-  execute_process(
-    COMMAND ${CMAKE_CUDA_COMPILER} --version
-    OUTPUT_VARIABLE _TMOL_NVCC_VERSION_OUTPUT
-    ERROR_VARIABLE _TMOL_NVCC_VERSION_OUTPUT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  set(_TMOL_NVCC_MAX_ARCH 90)
-  if(_TMOL_NVCC_VERSION_OUTPUT MATCHES "release ([0-9]+)\\.([0-9]+)")
-    set(_TMOL_NVCC_MAJOR "${CMAKE_MATCH_1}")
-    set(_TMOL_NVCC_MINOR "${CMAKE_MATCH_2}")
-    if(_TMOL_NVCC_MAJOR GREATER_EQUAL 13)
-      set(_TMOL_NVCC_MAX_ARCH 120)
-    elseif(_TMOL_NVCC_MAJOR EQUAL 12 AND _TMOL_NVCC_MINOR GREATER_EQUAL 8)
-      set(_TMOL_NVCC_MAX_ARCH 100)
-    endif()
-  endif()
+  # Filter requested arches by exact compiler support. Architectures are not a
+  # simple compatibility interval, so a maximum-value clamp is incorrect.
   set(_TMOL_FILTERED_ARCHS "")
+  set(_TMOL_REJECTED_ARCHS "")
   foreach(_A ${CMAKE_CUDA_ARCHITECTURES})
     string(REPLACE "-real" "" _A_NUM "${_A}")
-    if(_A_NUM MATCHES "^[0-9]+$" AND _A_NUM LESS_EQUAL _TMOL_NVCC_MAX_ARCH)
+    string(REPLACE "-virtual" "" _A_NUM "${_A_NUM}")
+    if(_A_NUM IN_LIST _TMOL_NVCC_SUPPORTED_ARCHS)
       list(APPEND _TMOL_FILTERED_ARCHS "${_A}")
+    else()
+      list(APPEND _TMOL_REJECTED_ARCHS "${_A}")
     endif()
   endforeach()
   if(NOT _TMOL_FILTERED_ARCHS)
-    set(_TMOL_FILTERED_ARCHS "80;86;89;90")
+    message(FATAL_ERROR
+      "tmol: none of the requested CUDA architectures "
+      "(${CMAKE_CUDA_ARCHITECTURES}) are supported by ${CMAKE_CUDA_COMPILER}; "
+      "supported sm_75+ targets: ${_TMOL_NVCC_SUPPORTED_ARCHS}")
+  endif()
+  if(_TMOL_REJECTED_ARCHS)
+    message(WARNING
+      "tmol: ignoring CUDA architectures not supported by this nvcc: "
+      "${_TMOL_REJECTED_ARCHS}")
   endif()
   set(CMAKE_CUDA_ARCHITECTURES "${_TMOL_FILTERED_ARCHS}" CACHE STRING "CUDA architectures" FORCE)
-  message(STATUS "tmol: nvcc max arch ${_TMOL_NVCC_MAX_ARCH}, using CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
+  message(STATUS "tmol: nvcc supports sm_75+ targets ${_TMOL_NVCC_SUPPORTED_ARCHS}")
+  message(STATUS "tmol: using CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
 
   project(tmol LANGUAGES CXX CUDA)
   set(TMOL_HAS_CUDA TRUE)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,8 +33,11 @@ pip install -e .
 # Build with test extensions
 pip install -e . -Ccmake.define.TMOL_BUILD_TESTS=ON
 
-# Target specific GPU architectures (default: every sm_75+ target supported by nvcc)
+# Target specific GPU architectures (default: "80;86;89;90")
 pip install -e . -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="80;90"
+
+# Build every sm_75+ target supported by nvcc (used for CUDA 13 release wheels)
+pip install -e . -Ccmake.define.CMAKE_CUDA_ARCHITECTURES=all
 
 # Control parallelism
 MAX_JOBS=4 pip install -e . -Ccmake.define.TMOL_NVCC_THREADS=2
@@ -44,7 +47,7 @@ CMake build options:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CMAKE_CUDA_ARCHITECTURES` | `all` | GPU compute capabilities to compile for. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
+| `CMAKE_CUDA_ARCHITECTURES` | `80;86;89;90` | GPU compute capabilities to compile for. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
 | `TMOL_BUILD_TESTS` | `OFF` | Build test-only C++/CUDA extensions |
 | `TMOL_NVCC_THREADS` | `4` | Threads per nvcc invocation |
 | `TMOL_ENABLE_CUDA` | `ON` | Set to `OFF` for CPU-only build (no `nvcc` needed) |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ git clone https://github.com/uw-ipd/tmol.git && cd tmol
 pip install -e ".[dev]"   # builds C++/CUDA extensions via CMake
 ```
 
-Requirements: Python 3.11+, PyTorch 2.8+, C++17 compiler, CMake 3.18+. CUDA toolkit (`nvcc`) is optional — without it, only CPU extensions are built. Pre-built wheels are published for Python `cp311`-`cp314`.
+Requirements: Python 3.11+, PyTorch 2.8+, C++17 compiler, CMake 3.24+. CUDA toolkit (`nvcc`) is optional — without it, only CPU extensions are built. Pre-built wheels are published for Python `cp311`-`cp314`.
 
 ## Building Extensions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ pip install -e .
 # Build with test extensions
 pip install -e . -Ccmake.define.TMOL_BUILD_TESTS=ON
 
-# Target specific GPU architectures (default: "80;86;89;90")
+# Target specific GPU architectures (default: every sm_75+ target supported by nvcc)
 pip install -e . -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="80;90"
 
 # Control parallelism
@@ -44,7 +44,7 @@ CMake build options:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CMAKE_CUDA_ARCHITECTURES` | `80;86;89;90` | GPU compute capabilities to compile for |
+| `CMAKE_CUDA_ARCHITECTURES` | `all` | GPU compute capabilities to compile for. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
 | `TMOL_BUILD_TESTS` | `OFF` | Build test-only C++/CUDA extensions |
 | `TMOL_NVCC_THREADS` | `4` | Threads per nvcc invocation |
 | `TMOL_ENABLE_CUDA` | `ON` | Set to `OFF` for CPU-only build (no `nvcc` needed) |

--- a/dev/README.md
+++ b/dev/README.md
@@ -45,19 +45,10 @@ stdout. See `.buildkite/bin/benchmark` for invocation details.
 
 # Profiling benchmarks:
 
-Benchmarks can be under under the nvprof profiler to capture perf traces
-for analysis. This runs the benchmark *without* profiling for timing
-information then executes a run under the nvprof profiler for
-tracing. As the profile introduces non-trivial overhead, the profiler will
-execute a single "warmup" pass under profiling followed by a "run" pass,
-each under a nvtx range. 
-
-Use the nvprof `-o <outfile>` option to capture a trace for
-visual inspection.
+`dev/bin/profile_benchmark` captures a timeline with Nsight Systems by default,
+or hardware counters with Nsight Compute when passed `--tool ncu`. Use
+`--output <prefix>` to choose the report path. Arguments after `--` are sent to
+the profiler; other arguments are pytest selectors.
 
 Example:
-  `dev/bin/profile_benchmark tmol/tests/score -k cuda-full-lk_ball -- -o profile.nvvp`
-
-Then view via nvidia visual profiler:
-
-  `/usr/local/cuda/bin/nvvp profile.nvvp`
+  `dev/bin/profile_benchmark --output profile/lk-ball tmol/tests/score -k cuda-full-lk_ball`

--- a/dev/bin/profile_benchmark.ipy
+++ b/dev/bin/profile_benchmark.ipy
@@ -1,25 +1,100 @@
-#!/bin/sh
-''''exec ipython "$0" -- ${1+"$@"} # '''
-# vi: filetype=python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+"""Profile a pytest benchmark with Nsight Systems or Nsight Compute.
 
-import tempfile
+Arguments before ``--`` are pytest arguments. Arguments after ``--`` are
+passed directly to the selected profiler.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import shutil
+import socket
 import subprocess
 import sys
-import shlex
-import shutil
-import argparse
 
-parser = argparse.ArgumentParser(prog='profile_benchmark.ipy')
-parser.add_argument('args', nargs=argparse.REMAINDER, metavar="<benchmark args> -- <nvprof_args>")
-options = parser.parse_args()
 
-try:
-    splitargs = options.args.index("--")
-except ValueError:
-    splitargs = len(options.args)
+def parse_args() -> tuple[argparse.Namespace, list[str], list[str]]:
+    argv = sys.argv[1:]
+    try:
+        separator = argv.index("--")
+    except ValueError:
+        separator = len(argv)
 
-benchmark_args = " ".join(map(shlex.quote, options.args[:splitargs]))
-nvprof_args = " ".join(map(shlex.quote, options.args[splitargs + 1:]))
+    parser = argparse.ArgumentParser(
+        description="Profile tmol pytest benchmarks with NVIDIA Nsight."
+    )
+    parser.add_argument(
+        "--tool",
+        choices=("nsys", "ncu"),
+        default=os.environ.get("TMOL_PROFILE_TOOL", "nsys"),
+    )
+    parser.add_argument(
+        "--output",
+        help="output prefix (default: dev/profile/<host>/<UTC timestamp>)",
+    )
+    parser.add_argument(
+        "--python",
+        default=os.environ.get("TMOL_PROFILE_PYTHON", sys.executable),
+        help="Python interpreter containing tmol and pytest (default: current interpreter)",
+    )
+    options, pytest_args = parser.parse_known_args(argv[:separator])
+    return options, pytest_args, argv[separator + 1 :]
 
-!nvprof --profile-from-start off {nvprof_args} -- pytest --benchmark-enable --benchmark-cuda-profile {benchmark_args}
+
+def default_output() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path("dev") / "profile" / socket.gethostname() / stamp
+
+
+def main() -> int:
+    options, pytest_args, profiler_args = parse_args()
+    profiler = shutil.which(options.tool)
+    if profiler is None:
+        raise SystemExit(f"{options.tool} is not on PATH; install NVIDIA Nsight tools")
+
+    output = Path(options.output) if options.output else default_output()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    pytest_command = [
+        options.python,
+        "-m",
+        "pytest",
+        "--benchmark-enable",
+        "--benchmark-only",
+        "--benchmark-min-rounds=1",
+        "--benchmark-max-time=.01",
+        *pytest_args,
+    ]
+    if options.tool == "nsys":
+        command = [
+            profiler,
+            "profile",
+            "--trace=cuda,nvtx,osrt",
+            "--sample=none",
+            "--force-overwrite=true",
+            "--output",
+            str(output),
+            *profiler_args,
+            *pytest_command,
+        ]
+    else:
+        command = [
+            profiler,
+            "--target-processes=all",
+            "--set=full",
+            "--force-overwrite",
+            "--export",
+            str(output),
+            *profiler_args,
+            *pytest_command,
+        ]
+
+    print("Profiling command:", " ".join(command), flush=True)
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The documentation is built with Sphinx, MyST Markdown, nbsphinx, and autodoc.
 
 ```bash
 pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.5"
-pip install scikit-build-core pybind11 ninja packaging "cmake>=3.18,<4"
+pip install scikit-build-core pybind11 ninja packaging "cmake>=3.24,<4"
 TMOL_DISABLE_WHEEL_FETCH=1 \
   pip install --no-build-isolation -e ".[docs]" \
   -Ccmake.define.TMOL_ENABLE_CUDA=OFF

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -21,7 +21,7 @@ Two documentation forms serve different purposes:
 
 ```bash
 pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.5"
-pip install scikit-build-core pybind11 ninja packaging "cmake>=3.18,<4"
+pip install scikit-build-core pybind11 ninja packaging "cmake>=3.24,<4"
 TMOL_DISABLE_WHEEL_FETCH=1 \
   pip install --no-build-isolation -e ".[docs]" \
   -Ccmake.define.TMOL_ENABLE_CUDA=OFF

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,11 +127,11 @@ python -c "import sys, torch; print(f'Python {sys.version_info.major}.{sys.versi
 ## Google Colab
 
 Colab GPU runtimes currently use PyTorch 2.11.0 with CUDA 12.8 and may provide
-Python 3.12 or 3.13. TMol v0.1.52 provides separate Python-ABI wheels compiled
+Python 3.12 or 3.13. TMol v0.1.53 provides separate Python-ABI wheels compiled
 for T4 (`sm_75`), A100 (`sm_80`), and L4 (`sm_89`) GPUs. For Python 3.13:
 
 ```bash
-pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.52/tmol-0.1.52+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.53/tmol-0.1.53+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
 ```
 
 The tutorial bootstrap selects the wheel matching the runtime's Python ABI and

--- a/docs/tutorial/colab_setup.py
+++ b/docs/tutorial/colab_setup.py
@@ -10,7 +10,7 @@ from urllib.request import urlretrieve
 
 TUTORIAL_REF = "master"
 RAW_BASE = f"https://raw.githubusercontent.com/uw-ipd/tmol/{TUTORIAL_REF}"
-TMOL_RELEASE = "0.1.52"
+TMOL_RELEASE = "0.1.53"
 RELEASE_WHEEL_TORCH_MINOR = "2.11"
 RELEASE_WHEEL_CUDA = "12.8"
 RELEASE_WHEEL_PYTHONS = frozenset({(3, 12), (3, 13)})

--- a/docs/user_guide/benchmarking.md
+++ b/docs/user_guide/benchmarking.md
@@ -53,12 +53,25 @@ Ancillary benchmark plots live near the tests as `plot_*.py` scripts.
 
 ## Profiling
 
-`dev/bin/profile_benchmark` wraps the legacy `nvprof` command and the TMol
-pytest CUDA-profile hook:
+`dev/bin/profile_benchmark` runs a short pytest benchmark under Nsight Systems
+by default:
 
 ```bash
-dev/bin/profile_benchmark tmol/tests/score -k cuda-full-lk_ball -- -o profile.nvvp
+dev/bin/profile_benchmark --output profile/ljlk \
+  tmol/tests/score -k cuda-full-ljlk
 ```
 
-Use it only in a CUDA environment that still provides `nvprof`; current NVIDIA
-toolkits may require a separate Nsight-based profiling workflow instead.
+Use Nsight Compute when kernel-level counters are needed; arguments after `--`
+are forwarded to the profiler:
+
+```bash
+dev/bin/profile_benchmark --tool ncu --output profile/ljlk-kernels \
+  tmol/tests/score -k cuda-forward-ljlk-100 -- \
+  --kernel-name regex:ljlk --launch-count 20
+```
+
+The output prefix defaults to `dev/profile/<host>/<UTC timestamp>`. Keep pytest
+selectors narrow: profiling every parametrized benchmark produces a very large
+trace and makes hardware-counter collection unnecessarily slow. If the wrapper
+is not launched from the development environment, pass its interpreter with
+`--python /path/to/venv/bin/python` or set `TMOL_PROFILE_PYTHON`.

--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -53,7 +53,7 @@ Important CMake variables:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `CMAKE_CUDA_ARCHITECTURES` | `all` | GPU architectures to compile. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
+| `CMAKE_CUDA_ARCHITECTURES` | `80;86;89;90` | GPU architectures to compile. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
 | `TMOL_BUILD_TESTS` | `OFF` | Build test-only extensions. |
 | `TMOL_NVCC_THREADS` | `4` | Threads per `nvcc` invocation. |
 | `TMOL_ENABLE_CUDA` | `ON` | Turn off for CPU-only builds. |

--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -22,7 +22,7 @@ Requirements:
 - Python 3.11 or newer.
 - PyTorch 2.5 or newer.
 - A C++17 compiler.
-- CMake 3.18 or newer.
+- CMake 3.24 or newer.
 - CUDA toolkit with `nvcc` for CUDA builds.
 
 Without CUDA, use a CPU-only build:
@@ -53,7 +53,7 @@ Important CMake variables:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `CMAKE_CUDA_ARCHITECTURES` | `80;86;89;90` | GPU architectures to compile. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
+| `CMAKE_CUDA_ARCHITECTURES` | `native` | `native` compiles only for GPUs visible at configure time. `all`, used for release wheels, emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
 | `TMOL_BUILD_TESTS` | `OFF` | Build test-only extensions. |
 | `TMOL_NVCC_THREADS` | `4` | Threads per `nvcc` invocation. |
 | `TMOL_ENABLE_CUDA` | `ON` | Turn off for CPU-only builds. |

--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -53,7 +53,7 @@ Important CMake variables:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `CMAKE_CUDA_ARCHITECTURES` | `80;86;89;90` | GPU architectures to compile. |
+| `CMAKE_CUDA_ARCHITECTURES` | `all` | GPU architectures to compile. `all` emits SASS for every sm_75+ target reported by `nvcc --list-gpu-code`, plus PTX for the newest target. |
 | `TMOL_BUILD_TESTS` | `OFF` | Build test-only extensions. |
 | `TMOL_NVCC_THREADS` | `4` | Threads per `nvcc` invocation. |
 | `TMOL_ENABLE_CUDA` | `ON` | Turn off for CPU-only builds. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,14 +141,14 @@ backend-path = ["."]
 minimum-version = "0.10"
 build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
-cmake.version = ">=3.18,<4"
+cmake.version = ">=3.24,<4"
 wheel.packages = ["tmol"]
 wheel.install-dir = "."
 sdist.cmake = false
 editable.mode = "inplace"
 
 [tool.scikit-build.cmake.define]
-CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "80;86;89;90"}
+CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "native"}
 TMOL_BUILD_TESTS = {env = "TMOL_BUILD_TESTS", default = "OFF"}
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.52"
+version = "0.1.53"
 
 dependencies = [
     # Core ML framework

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ sdist.cmake = false
 editable.mode = "inplace"
 
 [tool.scikit-build.cmake.define]
-CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "all"}
+CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "80;86;89;90"}
 TMOL_BUILD_TESTS = {env = "TMOL_BUILD_TESTS", default = "OFF"}
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ sdist.cmake = false
 editable.mode = "inplace"
 
 [tool.scikit-build.cmake.define]
-CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "80;86;89;90"}
+CMAKE_CUDA_ARCHITECTURES = {env = "CMAKE_CUDA_ARCHITECTURES", default = "all"}
 TMOL_BUILD_TESTS = {env = "TMOL_BUILD_TESTS", default = "OFF"}
 
 [tool.cibuildwheel]


### PR DESCRIPTION
## Summary

- prepare the package, Colab bootstrap, and installation docs for tmol 0.1.53
- default local/editable CUDA builds to CMake `native`, compiling only for GPUs visible at build time
- resolve release `all` from `nvcc --list-gpu-code` and retain every supported sm_75+ target in CUDA 13 release wheels
- preserve the release list across CMake and Torch configuration without duplicate `-gencode` work
- replace the obsolete nvprof wrapper with Nsight Systems/Compute
- build and install a CUDA 13 release-style wheel on packaging PRs and validate its architecture contract
- use two Ninja jobs with one nvcc worker each on four-core wheel builders
- exclude local `.bench/` profiling caches from source distributions

## Validation

- local CUDA 13.0 release configuration resolves `75;80;86;87;88;89;90;100;103;110;120;121`; the cache retains the exact list after `project()` and Torch discovery, and every generated CUDA rule contains each target once
- allocated H200 native configuration emits `-arch=native`; a representative LJ/LK CUDA compile produced only `sm_90`
- representative full-architecture LJ/LK and electrostatics compilation: 764.6s (`-j1`, nvcc threads=1) -> 453.1s (`-j2`, nvcc threads=1), 40.7% faster on four pinned CPU cores
- nested `-j2`/nvcc-threads=2 reached 244.8s locally but OOMed the hosted wheel runner; the retained layout limits compilation to two concurrent CUDA frontends (~7.25 GiB observed compiler peak)
- pre-commit passed; Colab/release configuration tests passed (4/4); shell syntax passed
- local 0.1.53 sdist built successfully and contains no `.bench/` files
- exact-head CI must pass CPU, GPU, docs, CPU wheels, and the real CUDA 13 release-wheel build/install before merge