### PR TITLE
Accelerate CPU scoring, rotamer setup, and FastRelax

### DIFF
--- a/tmol/numeric/_dihedrals.py
+++ b/tmol/numeric/_dihedrals.py
@@ -1,12 +1,32 @@
+import numpy
 import torch
 
 from tmol.types import (
+    NDArray,
     validate_args,
     Tensor,
 )
 
 Coord64Array = Tensor[torch.double][:, 3]
 Angles = Tensor[float][:]
+
+
+def _numpy_coord_dihedrals(
+    a: NDArray[float][..., 3],
+    b: NDArray[float][..., 3],
+    c: NDArray[float][..., 3],
+    d: NDArray[float][..., 3],
+) -> NDArray[numpy.float32][...]:
+    """Return vectorized coordinate dihedrals for NumPy topology setup."""
+    ba = a - b
+    bc = c - b
+    cd = d - c
+    unit_bc = bc / numpy.linalg.norm(bc, axis=-1, keepdims=True)
+    v = ba - numpy.sum(ba * unit_bc, axis=-1, keepdims=True) * unit_bc
+    w = cd - numpy.sum(cd * unit_bc, axis=-1, keepdims=True) * unit_bc
+    x = numpy.sum(v * w, axis=-1)
+    y = numpy.sum(numpy.cross(unit_bc, v) * w, axis=-1)
+    return numpy.asarray(numpy.arctan2(y, x), dtype=numpy.float32)
 
 
 @validate_args
@@ -39,7 +59,7 @@ def coord_dihedrals(
 
     # angle between v and w in a plane is the torsion angle
     # v and w may not be normalized but that's fine since tan is y/x
-    x = torch.einsum("ij,ij->i", (v, w))
-    y = torch.einsum("ij,ij->i", (torch.linalg.cross(ubc, v), w))
+    x = torch.sum(v * w, dim=1)
+    y = torch.sum(torch.linalg.cross(ubc, v) * w, dim=1)
 
     return torch.atan2(y, x).type(torch.float)

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -32,10 +32,21 @@ def lbfgs_two_loop(grad, dirs, stps):
     S = stps.double()
     Y = dirs.double()
     g = -grad.double()
-    a = torch.einsum("ipk,pk->pi", S, g)  # a_i = s_i . g
-    b = torch.einsum("ipk,pk->pi", Y, g)  # b_i = y_i . g
-    SY = torch.einsum("ipk,jpk->pij", S, Y)  # SY_ij = s_i . y_j
-    YY = torch.einsum("ipk,jpk->pij", Y, Y)  # YY_ij = y_i . y_j
+    # FastRelax supplies float32 coordinates. Preserve the common einsum path
+    # for float64, where callers may compare independently minimized segments
+    # with a batched minimization at tight double-precision tolerances.
+    single_segment = grad.shape[0] == 1 and out_dtype == torch.float32
+    if single_segment:
+        S_one, Y_one, g_one = S[:, 0], Y[:, 0], g[0]
+        a = torch.mv(S_one, g_one).unsqueeze(0)  # a_i = s_i . g
+        b = torch.mv(Y_one, g_one).unsqueeze(0)  # b_i = y_i . g
+        SY = torch.mm(S_one, Y_one.T).unsqueeze(0)  # SY_ij = s_i . y_j
+        YY = torch.mm(Y_one, Y_one.T).unsqueeze(0)  # YY_ij = y_i . y_j
+    else:
+        a = torch.einsum("ipk,pk->pi", S, g)
+        b = torch.einsum("ipk,pk->pi", Y, g)
+        SY = torch.einsum("ipk,jpk->pij", S, Y)
+        YY = torch.einsum("ipk,jpk->pij", Y, Y)
     R = torch.triu(SY)  # upper-triangular incl. diagonal
     D = SY.diagonal(dim1=-2, dim2=-1)  # D_i = s_i . y_i
 
@@ -46,7 +57,10 @@ def lbfgs_two_loop(grad, dirs, stps):
     # u = R^-1 a
     u = torch.linalg.solve_triangular(R, a.unsqueeze(-1), upper=True).squeeze(-1)
     # v = (D + Y^T Y) u - b
-    v = torch.einsum("pij,pj->pi", YY, u) + D * u - b
+    if single_segment:
+        v = (torch.mv(YY[0], u[0]) + D[0] * u[0] - b[0]).unsqueeze(0)
+    else:
+        v = torch.einsum("pij,pj->pi", YY, u) + D * u - b
     # p1 = R^-T v
     p1 = torch.linalg.solve_triangular(
         R.transpose(-2, -1), v.unsqueeze(-1), upper=False
@@ -54,7 +68,13 @@ def lbfgs_two_loop(grad, dirs, stps):
     p2 = -u
 
     # result = g + S p1 + Y p2
-    result = g + torch.einsum("pi,ipk->pk", p1, S) + torch.einsum("pi,ipk->pk", p2, Y)
+    if single_segment:
+        result = (
+            g[0] + torch.mv(S[:, 0].T, p1[0]) + torch.mv(Y[:, 0].T, p2[0])
+        ).unsqueeze(0)
+    else:
+        result = g + torch.einsum("pi,ipk->pk", p1, S)
+        result += torch.einsum("pi,ipk->pk", p2, Y)
     result = result.to(out_dtype)
     return result.squeeze(0) if unbatched else result
 

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -1,5 +1,7 @@
-import torch
 from types import SimpleNamespace
+from typing import Any
+
+import torch
 from torch.optim import Optimizer
 
 
@@ -211,6 +213,50 @@ class LBFGS_Armijo(Optimizer):
 
     supports_segments = True
 
+    def add_param_group(self, param_group: dict[str, Any]) -> None:
+        """Add the optimizer's sole parameter group without compiler imports.
+
+        PyTorch's generic implementation is Dynamo-disabled and initializes
+        Dynamo, DTensor, and distributed operator registries on first use.
+        This optimizer supports exactly one group and one tensor, so that
+        general machinery adds substantial cold-start latency without adding
+        functionality.
+        """
+        if self.param_groups:
+            raise ValueError("LBFGS doesn't support per-parameter options")
+        if not isinstance(param_group, dict):
+            raise TypeError(f"param_group must be a dict, got {type(param_group)}")
+
+        params = param_group["params"]
+        params = [params] if isinstance(params, torch.Tensor) else list(params)
+        if len(params) != 1:
+            raise ValueError("LBFGS requires exactly one parameter tensor")
+        param = params[0]
+        if not isinstance(param, torch.Tensor):
+            raise TypeError(f"optimizer parameter must be a Tensor, got {type(param)}")
+        if not param.is_leaf and not param.retains_grad:
+            raise ValueError("can't optimize a non-leaf Tensor")
+
+        param_group = dict(param_group)
+        param_group["params"] = params
+        for name, default in self.defaults.items():
+            param_group.setdefault(name, default)
+        self.param_groups.append(param_group)
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        """Reset the single optimized tensor's gradient."""
+        for param in self._params:
+            if param.grad is None:
+                continue
+            if set_to_none:
+                param.grad = None
+            else:
+                if param.grad.grad_fn is not None:
+                    param.grad.detach_()
+                else:
+                    param.grad.requires_grad_(False)
+                param.grad.zero_()
+
     def __init__(
         self,
         params,
@@ -270,9 +316,34 @@ class LBFGS_Armijo(Optimizer):
         assert bool((segment_ids >= 0).all()), "segment_ids must be non-negative"
 
         n_segments = int(segment_ids.max().item()) + 1
+        if n_segments == 1:
+            self._segment_ids = segment_ids
+            self._n_segments = 1
+            self._segment_size = segment_ids.numel()
+            self._segments_are_dense = True
+            self._pad_index = None
+            return
+
         counts = torch.bincount(segment_ids, minlength=n_segments)
         assert bool((counts > 0).all()), "segment_ids must not skip a segment"
         segment_size = int(counts.max().item())
+
+        # Avoid sorting the overwhelmingly common dense layout: one pose, or
+        # equal-sized poses stored contiguously. Dense reductions only reshape
+        # the parameter vector and never consult ``_pad_index``.
+        segments_are_dense = False
+        if bool((counts == segment_size).all()):
+            expected = torch.arange(n_segments, device=segment_ids.device)
+            expected = expected.repeat_interleave(segment_size)
+            segments_are_dense = torch.equal(segment_ids, expected)
+
+        self._segment_ids = segment_ids
+        self._n_segments = n_segments
+        self._segment_size = segment_size
+        self._segments_are_dense = segments_are_dense
+        if segments_are_dense:
+            self._pad_index = None
+            return
 
         # rank of each element within its own segment
         order = torch.argsort(segment_ids, stable=True)
@@ -281,16 +352,7 @@ class LBFGS_Armijo(Optimizer):
         arange = torch.arange(segment_ids.numel(), device=order.device)
         rank[order] = arange - offsets[segment_ids[order]]
 
-        self._segment_ids = segment_ids
-        self._n_segments = n_segments
-        self._segment_size = segment_size
         self._pad_index = segment_ids * segment_size + rank
-        # The common Cartesian-minimization layout has equally sized segments
-        # stored consecutively. In that case padding is just a view/copy; keep
-        # the indexed path for heterogeneous or interleaved segment layouts.
-        self._segments_are_dense = bool(
-            (counts == segment_size).all() and torch.equal(self._pad_index, arange)
-        )
 
     def _seg_sum(self, values):
         """Sum a parameter-shaped vector within each segment."""
@@ -404,7 +466,7 @@ class LBFGS_Armijo(Optimizer):
         # The optimizer uses the per-segment tensor below for all line-search
         # and convergence decisions. Materializing a Python scalar here forces
         # a device synchronization and is only useful for verbose reporting.
-        loss = float(orig_loss) if self.verbose else None
+        loss = float(orig_loss.detach()) if self.verbose else None
         loss_vec = self._last_loss_vec
         state["func_evals"] += 1
 

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -248,17 +248,31 @@ class LBFGS_Armijo(Optimizer):
             raise TypeError(f"param_group must be a dict, got {type(param_group)}")
 
         params = param_group["params"]
-        params = [params] if isinstance(params, torch.Tensor) else list(params)
+        if isinstance(params, torch.Tensor):
+            params = [params]
+        elif isinstance(params, set):
+            raise TypeError("optimizer parameters must use an ordered collection")
+        else:
+            params = list(params)
         if len(params) != 1:
             raise ValueError("LBFGS requires exactly one parameter tensor")
         param = params[0]
+        param_name = None
+        if isinstance(param, tuple):
+            if len(param) != 2 or not isinstance(param[0], str):
+                raise TypeError(
+                    "named optimizer parameters must be (name, Tensor) pairs"
+                )
+            param_name, param = param
         if not isinstance(param, torch.Tensor):
             raise TypeError(f"optimizer parameter must be a Tensor, got {type(param)}")
         if not param.is_leaf and not param.retains_grad:
             raise ValueError("can't optimize a non-leaf Tensor")
 
         param_group = dict(param_group)
-        param_group["params"] = params
+        param_group["params"] = [param]
+        if param_name is not None:
+            param_group["param_names"] = [param_name]
         for name, default in self.defaults.items():
             param_group.setdefault(name, default)
         self.param_groups.append(param_group)

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -564,7 +564,6 @@ class LBFGS_Armijo(Optimizer):
             # cached across steps
             t=state.get("t"),
             prev_flat_grad=state.get("prev_flat_grad"),
-            prev_loss=state.get("prev_loss"),
             prev_loss_vec=state.get("prev_loss_vec"),
             # history
             old_dirs_mat=state["old_dirs_mat"],
@@ -805,7 +804,7 @@ class LBFGS_Armijo(Optimizer):
             func (callable): a function that evaluates energy
 
         Returns:
-            orig_loss: the energy (loss) following optimization
+            The initial loss, matching the ``Optimizer.step`` convention.
         """
         closure = self._wrap_closure(closure)
         self._closure_fn = closure
@@ -835,7 +834,6 @@ class LBFGS_Armijo(Optimizer):
                 ctx.prev_flat_grad = ctx.flat_grad.clone()
             else:
                 ctx.prev_flat_grad.copy_(ctx.flat_grad)
-            ctx.prev_loss = ctx.loss
             ctx.prev_loss_vec = ctx.loss_vec
 
             # Armijo updates will track step length during optimization
@@ -883,7 +881,6 @@ class LBFGS_Armijo(Optimizer):
         ctx.state["history_start"] = ctx.history_start
         ctx.state["history_count"] = ctx.history_count
         ctx.state["prev_flat_grad"] = ctx.prev_flat_grad
-        ctx.state["prev_loss"] = ctx.prev_loss
         ctx.state["prev_loss_vec"] = ctx.prev_loss_vec
         ctx.state["x_ref"] = ctx.x_ref
         ctx.state["needs_reset"] = ctx.needs_reset

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -41,7 +41,7 @@ def lbfgs_two_loop(grad, dirs, stps):
 
     # An absent slot has an all-zero row and column; a unit diagonal there keeps
     # R invertible and leaves the search direction unchanged.
-    R = R + torch.diag_embed((D == 0).to(R.dtype))
+    R.diagonal(dim1=-2, dim2=-1).masked_fill_(D == 0, 1)
 
     # u = R^-1 a
     u = torch.linalg.solve_triangular(R, a.unsqueeze(-1), upper=True).squeeze(-1)
@@ -245,17 +245,17 @@ class LBFGS_Armijo(Optimizer):
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         """Reset the single optimized tensor's gradient."""
-        for param in self._params:
-            if param.grad is None:
-                continue
-            if set_to_none:
-                param.grad = None
+        param = self._params[0]
+        if param.grad is None:
+            return
+        if set_to_none:
+            param.grad = None
+        else:
+            if param.grad.grad_fn is not None:
+                param.grad.detach_()
             else:
-                if param.grad.grad_fn is not None:
-                    param.grad.detach_()
-                else:
-                    param.grad.requires_grad_(False)
-                param.grad.zero_()
+                param.grad.requires_grad_(False)
+            param.grad.zero_()
 
     def __init__(
         self,
@@ -400,6 +400,12 @@ class LBFGS_Armijo(Optimizer):
         if self._segments_are_dense:
             return padded.reshape(-1)
         return padded.reshape(-1)[self._pad_index]
+
+    def _per_element(self, segment_values: torch.Tensor) -> torch.Tensor:
+        """Broadcast per-segment values to parameters without indexing one segment."""
+        if self._n_segments == 1:
+            return segment_values[0]
+        return segment_values[self._segment_ids]
 
     def _wrap_closure(self, closure):
         """Reduce a per-segment closure to a scalar, keeping the vector around.
@@ -578,12 +584,21 @@ class LBFGS_Armijo(Optimizer):
                     idx = ctx.history_start
                     ctx.history_start = (ctx.history_start + 1) % ctx.history_size
 
-                # advance the reference only for segments that took a good step
-                keep_elem = keep[self._segment_ids]
-                zero = torch.zeros((), dtype=y.dtype, device=y.device)
-                self._pad(torch.where(keep_elem, y, zero), out=ctx.old_dirs_mat[idx])
-                self._pad(torch.where(keep_elem, s, zero), out=ctx.old_stps_mat[idx])
-                ctx.x_ref = torch.where(keep_elem, x, ctx.x_ref)
+                # Advance the reference only for segments that took a good step.
+                if self._n_segments == 1:
+                    ctx.old_dirs_mat[idx, 0].copy_(y)
+                    ctx.old_stps_mat[idx, 0].copy_(s)
+                    ctx.x_ref.copy_(x)
+                else:
+                    keep_elem = self._per_element(keep)
+                    zero = torch.zeros((), dtype=y.dtype, device=y.device)
+                    self._pad(
+                        torch.where(keep_elem, y, zero), out=ctx.old_dirs_mat[idx]
+                    )
+                    self._pad(
+                        torch.where(keep_elem, s, zero), out=ctx.old_stps_mat[idx]
+                    )
+                    ctx.x_ref = torch.where(keep_elem, x, ctx.x_ref)
 
             # compute the approximate (L-BFGS) inverse Hessian
             if ctx.history_count == 0:
@@ -628,7 +643,7 @@ class LBFGS_Armijo(Optimizer):
         reset = ctx.needs_reset.nonzero(as_tuple=False).squeeze(-1)
         ctx.old_dirs_mat[:, reset, :] = 0.0
         ctx.old_stps_mat[:, reset, :] = 0.0
-        reset_elem = ctx.needs_reset[self._segment_ids]
+        reset_elem = self._per_element(ctx.needs_reset)
         ctx.d.copy_(torch.where(reset_elem, -ctx.flat_grad, ctx.d))
         ctx.x_ref = torch.where(reset_elem, ctx.x, ctx.x_ref)
         ctx.needs_reset = torch.zeros_like(ctx.needs_reset)
@@ -643,7 +658,7 @@ class LBFGS_Armijo(Optimizer):
         inactive = self._inactive(ctx)
         if not ctx.any_inactive:
             return
-        ctx.d.mul_((~inactive).to(ctx.d.dtype)[self._segment_ids])
+        ctx.d.mul_(self._per_element((~inactive).to(ctx.d.dtype)))
 
     def _directional_derivative(self, ctx, correct=True):
         """Compute and cache the directional derivative g . d per segment."""
@@ -654,7 +669,7 @@ class LBFGS_Armijo(Optimizer):
                 bad = (gtd_seg > -1e-5) & ~self._inactive(ctx)
                 if not bool(bad.any()):
                     break
-                bad_elem = bad[self._segment_ids]
+                bad_elem = self._per_element(bad)
                 if check == 1:
                     repaired = d * -torch.sign(flat_grad * d)
                 else:
@@ -685,7 +700,7 @@ class LBFGS_Armijo(Optimizer):
         )
         ctx.ls_evals = ls_evals
 
-        ctx.x.copy_(ctx.x_backup).add_(ctx.d * accepted[self._segment_ids])
+        ctx.x.copy_(ctx.x_backup).add_(ctx.d * self._per_element(accepted))
         if not trial_is_accepted:
             self._closure_fn()
         ctx.loss_vec = self._last_loss_vec
@@ -770,7 +785,7 @@ class LBFGS_Armijo(Optimizer):
             """Evaluate every segment at its own step size."""
             self.ls_func_evals += 1
             # Direct parameter update - eliminates _set_x_from_flat overhead
-            x.copy_(x_backup).add_(d * alpha_vec[self._segment_ids])
+            x.copy_(x_backup).add_(d * self._per_element(alpha_vec))
             closure()
             return self._last_loss_vec
 

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -128,8 +128,9 @@ def run_min(
     def closure() -> torch.Tensor:
         optimizer.zero_grad()
         E = sfxn_module()
-        E.sum().backward()
-        return E if segmented else E.sum()
+        total = E.sum()
+        total.backward()
+        return E if segmented else total
 
     if timing_device is not None:
         synchronize_device(timing_device)

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -47,6 +47,8 @@ class CartesianSfxnNetwork(torch.nn.Module):
         self.masked_coords = torch.nn.Parameter(
             self.full_coords.view(-1, self.full_coords.shape[-1])[self._coord_flat_idx]
         )
+        if self._all_coords_movable:
+            self.full_coords = self.masked_coords.view_as(self.full_coords)
 
         # pose each element of masked_coords belongs to, for per-pose minimization
         pose_for_atom = torch.div(
@@ -56,20 +58,15 @@ class CartesianSfxnNetwork(torch.nn.Module):
         )
         self.segment_ids = pose_for_atom.repeat_interleave(self.full_coords.shape[-1])
 
-        self.count = 0
-
-    def forward(self):
-        self.count += 1
-        if self._all_coords_movable:
-            self.full_coords = self.masked_coords.view_as(self.full_coords)
-        else:
+    def forward(self) -> torch.Tensor:
+        if not self._all_coords_movable:
             self.full_coords = self.full_coords.detach()
             self.full_coords.view(-1, self.full_coords.shape[-1])[
                 self._coord_flat_idx
             ] = self.masked_coords
         return self.whole_pose_scoring_module(self.full_coords)
 
-    def pose_stack_from_dofs(self):
+    def pose_stack_from_dofs(self) -> PoseStack:
         if self._all_coords_movable:
             full_coords = self.masked_coords.detach().view_as(self.full_coords).clone()
             return attrs.evolve(self.pose_stack, coords=full_coords)
@@ -154,11 +151,7 @@ class KinForestSfxnNetwork(torch.nn.Module):
         self.segment_ids = pose_for_dof[self._dof_flat_idx].to(torch.int64)
         assert bool((self.segment_ids >= 0).all()), "root node dofs cannot be minimized"
 
-        self.count = 0
-
-    def forward(self):
-        self.count += 1
-
+    def forward(self) -> torch.Tensor:
         # get rid of any gradients from the previous iteration
         self.full_dofs = self.full_dofs.detach()
         self.full_coords = self.full_coords.detach()
@@ -174,7 +167,7 @@ class KinForestSfxnNetwork(torch.nn.Module):
         # now evaluate the score
         return self.whole_pose_scoring_module(self.full_coords)
 
-    def pose_stack_from_dofs(self):
+    def pose_stack_from_dofs(self) -> PoseStack:
 
         full_dofs = self.full_dofs.clone()
         flat_coords = self.flat_coords.detach()

--- a/tmol/pack/compiled/compiled.cpu.cpp
+++ b/tmol/pack/compiled/compiled.cpu.cpp
@@ -89,8 +89,10 @@ auto AnnealerDispatch<D>::forward(
     std::vector<std::vector<Neighbor>> neighbors(n_res);
     for (int b = 0; b < n_res; ++b) {
       for (int b2 = 0; b2 < n_res; ++b2) {
-        if (b2 != b && chunk_offset_offsets[pose][b][b2] != -1) {
-          neighbors[b].push_back({b2, chunk_offset_offsets[pose][b2][b]});
+        if (b2 == b || chunk_offset_offsets[pose][b][b2] == -1) continue;
+        int64_t const reverse_offset = chunk_offset_offsets[pose][b2][b];
+        if (reverse_offset != -1) {
+          neighbors[b].push_back({b2, reverse_offset});
         }
       }
     }
@@ -194,7 +196,6 @@ auto AnnealerDispatch<D>::forward(
             // outer/row dimension.
             int64_t const k_ran_chunk_offset_offset =
                 neighbor.chunk_offset_offset;
-            if (k_ran_chunk_offset_offset == -1) continue;
             int64_t const krot_ranrot_chunk_offset = chunk_offsets
                 [k_ran_chunk_offset_offset + krot_chunk * ran_res_n_chunks
                  + ran_rot_chunk];

--- a/tmol/pack/compiled/compiled.cpu.cpp
+++ b/tmol/pack/compiled/compiled.cpu.cpp
@@ -75,17 +75,22 @@ auto AnnealerDispatch<D>::forward(
   float const high_temp = 100;
   float const low_temp = 0.3;  // matches Rosetta SimAnnealerBase::lowtemp
 
+  struct Neighbor {
+    int residue;
+    int64_t chunk_offset_offset;
+  };
+
   for (int pose = 0; pose < n_poses; ++pose) {
     int const n_res = pose_n_res[pose];
     int const pose_n_rotamers = n_rotamers_for_pose[pose];
     int const pose_rotamer_offset = rotamer_offset_for_pose[pose];
 
     // Build per-residue neighbor list for this pose
-    std::vector<std::vector<int>> neighbors(max_n_res);
+    std::vector<std::vector<Neighbor>> neighbors(max_n_res);
     for (int b = 0; b < n_res; ++b) {
       for (int b2 = 0; b2 < n_res; ++b2) {
         if (b2 != b && chunk_offset_offsets[pose][b][b2] != -1) {
-          neighbors[b].push_back(b2);
+          neighbors[b].push_back({b2, chunk_offset_offsets[pose][b2][b]});
         }
       }
     }
@@ -172,17 +177,14 @@ auto AnnealerDispatch<D>::forward(
               chunk_size, ran_res_n_rots - chunk_size * prev_rot_chunk);
           int const global_prev_rot = local_prev_rot + ran_res_offset;
 
-          double new_e = energy1b[global_ran_rot];
           double prev_e = energy1b[global_prev_rot];
-          double deltaE = new_e - prev_e;
+          double deltaE = energy1b[global_ran_rot] - prev_e;
 
-          for (int k : neighbors[ran_res]) {
+          for (Neighbor const& neighbor : neighbors[ran_res]) {
+            int const k = neighbor.residue;
             int const local_k_rot = current_rotamer_assignments[pose][traj][k];
-            int const k_n_rots = n_rotamers_for_res[pose][k];
             int const krot_chunk = local_k_rot / chunk_size;
             int const krot_in_chunk = local_k_rot - krot_chunk * chunk_size;
-            int const krot_chunk_size =
-                std::min(chunk_size, k_n_rots - chunk_size * krot_chunk);
 
             double k_new_e = 0;
             double k_prev_e = 0;
@@ -191,7 +193,7 @@ auto AnnealerDispatch<D>::forward(
             // (ran_res,k), so always index as [k][ran_res] with k as the
             // outer/row dimension.
             int64_t const k_ran_chunk_offset_offset =
-                chunk_offset_offsets[pose][k][ran_res];
+                neighbor.chunk_offset_offset;
             if (k_ran_chunk_offset_offset == -1) continue;
             int64_t const krot_ranrot_chunk_offset = chunk_offsets
                 [k_ran_chunk_offset_offset + krot_chunk * ran_res_n_chunks
@@ -211,7 +213,6 @@ auto AnnealerDispatch<D>::forward(
             }
 
             deltaE += k_new_e - k_prev_e;
-            new_e += k_new_e;
             prev_e += k_prev_e;
           }
 

--- a/tmol/pack/compiled/compiled.cpu.cpp
+++ b/tmol/pack/compiled/compiled.cpu.cpp
@@ -86,7 +86,7 @@ auto AnnealerDispatch<D>::forward(
     int const pose_rotamer_offset = rotamer_offset_for_pose[pose];
 
     // Build per-residue neighbor list for this pose
-    std::vector<std::vector<Neighbor>> neighbors(max_n_res);
+    std::vector<std::vector<Neighbor>> neighbors(n_res);
     for (int b = 0; b < n_res; ++b) {
       for (int b2 = 0; b2 < n_res; ++b2) {
         if (b2 != b && chunk_offset_offsets[pose][b][b2] != -1) {

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -308,10 +308,10 @@ MGPU_DEVICE float warp_wide_sim_annealing(
         }
       }
 
+      // Only the residue and local rotamer are consumed by the whole tile;
+      // global_new_rot and accept_rand remain lane-0-only below.
       ran_res = g.shfl(ran_res, 0);
       local_new_rot = g.shfl(local_new_rot, 0);
-      global_new_rot = g.shfl(global_new_rot, 0);
-      accept_rand = g.shfl(accept_rand, 0);
 
       int const local_prev_rot = current_rotamer_assignment[ran_res];
       int const global_prev_rot =

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -237,10 +237,13 @@ MGPU_DEVICE float warp_wide_sim_annealing(
   int const pose_rotamer_offset = ig.pose_rotamer_offset_[pose];
 
   float temperature = hi_temp;
-  float best_energy =
-      ig.template total_energy_for_assignment_parallel<ChunkSize>(
-          pose, g, current_rotamer_assignment);
-  float current_total_energy = best_energy;
+  float best_energy = 0.0f;
+  float current_total_energy = 0.0f;
+  if constexpr (TrackBestAssignment) {
+    best_energy = ig.template total_energy_for_assignment_parallel<ChunkSize>(
+        pose, g, current_rotamer_assignment);
+    current_total_energy = best_energy;
+  }
   int n_steps = 0;
 
   for (int i = 0; i < n_outer_iterations; ++i) {
@@ -395,12 +398,12 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       if (accept) {
         if (g.thread_rank() == 0) {
           current_rotamer_assignment[ran_res] = local_new_rot;
-          current_total_energy += total_delta_e;
         }
-        current_total_energy = g.shfl(current_total_energy, 0);
-        // Pure quench phases are monotonic and consume current directly, so
-        // they do not need an O(n_res) assignment copy after every acceptance.
         if constexpr (TrackBestAssignment) {
+          if (g.thread_rank() == 0) {
+            current_total_energy += total_delta_e;
+          }
+          current_total_energy = g.shfl(current_total_energy, 0);
           if (current_total_energy < best_energy) {
             best_energy = current_total_energy;
             for (int k = g.thread_rank(); k < n_res; k += 32) {
@@ -411,11 +414,13 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       }
 
       // Periodically recompute total energy to correct floating-point drift
-      if (++n_steps > 10000) {
-        n_steps = 0;
-        current_total_energy =
-            ig.template total_energy_for_assignment_parallel<ChunkSize>(
-                pose, g, current_rotamer_assignment);
+      if constexpr (TrackBestAssignment) {
+        if (++n_steps > 10000) {
+          n_steps = 0;
+          current_total_energy =
+              ig.template total_energy_for_assignment_parallel<ChunkSize>(
+                  pose, g, current_rotamer_assignment);
+        }
       }
 
     }  // end inner loop

--- a/tmol/pack/compiled/compiled.impl.hh
+++ b/tmol/pack/compiled/compiled.impl.hh
@@ -139,10 +139,11 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
             index,
             pose);
       } else {
-        respair_is_adjacent[pose][block1][block2] = 1;
+        DeviceDispatch<D>::store_idempotent(
+            respair_is_adjacent[pose][block1][block2], int32_t(1));
       }
     });
-    DeviceDispatch<D>::template forall<launch_t>(
+    DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_sparse_entries, note_adjacent_respairs);
 
     auto n_chunks_for_block_pair_tp =
@@ -221,14 +222,17 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
 
       // multiple threads will write exactly these values to these entries in
       // the chunk_pair_adjacency table
-      chunk_pair_adjacency
-          [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2] =
-              chunk1_size * chunk2_size;
-      chunk_pair_adjacency
-          [block_pair_chunk_offset_ji + chunk2 * n_chunks1 + chunk1] =
-              chunk1_size * chunk2_size;
+      int64_t const n_pairs = chunk1_size * chunk2_size;
+      DeviceDispatch<D>::store_idempotent(
+          chunk_pair_adjacency
+              [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2],
+          n_pairs);
+      DeviceDispatch<D>::store_idempotent(
+          chunk_pair_adjacency
+              [block_pair_chunk_offset_ji + chunk2 * n_chunks1 + chunk1],
+          n_pairs);
     });
-    DeviceDispatch<D>::template forall<launch_t>(
+    DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_sparse_entries, note_adjacent_chunk_pairs);
 
     auto chunk_pair_offsets_tp =
@@ -296,7 +300,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
                  + rot_ind_wi_chunk1] = energy;
           }
         });
-    DeviceDispatch<D>::template forall<launch_t>(
+    DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_sparse_entries, record_energies_in_energy1b_and_energy2b);
 
     // Mark the chunk_pair_offset_for_block_pair that are not adjacent w/ -1s
@@ -424,8 +428,8 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(
           find_min_energy_for_rotamer_and_block2);
     });
-    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-        mgr, n_rotamers * max_n_blocks, compute_best_energy_for_rotamers);
+    DeviceDispatch<D>::template foreach_grouped_workgroup<launch_t>(
+        mgr, n_rotamers, max_n_blocks, compute_best_energy_for_rotamers);
 
     if (bump_check) {
       // Now let's figure out the best energy for each block type
@@ -790,9 +794,10 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       return;
     }
     // Assert: molten_block1 < molten_block2
-    respair_is_adjacent[pose][molten_block1][molten_block2] = 1;
+    DeviceDispatch<D>::store_idempotent(
+        respair_is_adjacent[pose][molten_block1][molten_block2], int32_t(1));
   });
-  DeviceDispatch<D>::template forall<launch_t>(
+  DeviceDispatch<D>::template forall_independent<launch_t>(
       mgr, n_sparse_entries, note_adjacent_respairs);
 
   auto n_chunks_for_block_pair_tp = TPack<int64_t, 3, D>::zeros(
@@ -884,15 +889,17 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     // multiple threads will write exactly these values to these entries in the
     // chunk_pair_adjacency table
 
-    chunk_pair_adjacency
-        [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2] =
-            chunk1_size * chunk2_size;
-
-    chunk_pair_adjacency
-        [block_pair_chunk_offset_ji + chunk2 * n_chunks1 + chunk1] =
-            chunk1_size * chunk2_size;
+    int64_t const n_pairs = chunk1_size * chunk2_size;
+    DeviceDispatch<D>::store_idempotent(
+        chunk_pair_adjacency
+            [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2],
+        n_pairs);
+    DeviceDispatch<D>::store_idempotent(
+        chunk_pair_adjacency
+            [block_pair_chunk_offset_ji + chunk2 * n_chunks1 + chunk1],
+        n_pairs);
   });
-  DeviceDispatch<D>::template forall<launch_t>(
+  DeviceDispatch<D>::template forall_independent<launch_t>(
       mgr, n_sparse_entries, note_adjacent_chunk_pairs);
 
   auto chunk_pair_offsets_tp =

--- a/tmol/pack/compiled/simulated_annealing.hh
+++ b/tmol/pack/compiled/simulated_annealing.hh
@@ -67,12 +67,8 @@ inline
       continue;
     }
     int const irot_global = irot_local + oneb_offsets[i];
-    int const ires_n_rots = n_rotamers_for_res[i];
-    int const ires_n_chunks = (ires_n_rots - 1) / chunk_size + 1;
     int const irot_chunk = irot_local / chunk_size;
     int const irot_in_chunk = irot_local - chunk_size * irot_chunk;
-    int const irot_chunk_size =
-        min(chunk_size, ires_n_rots - chunk_size * irot_chunk);
 
     totalE += energy1b[irot_global];
     for (int j = i + 1; j < n_res; ++j) {
@@ -144,7 +140,6 @@ inline
 #endif
   int const n_res = n_rotamers_for_res.size(0);
 
-  int count_out = 0;
   float totalE = 0;
   for (int i = 0; i < n_res; ++i) {
     int const irot_local = rotamer_assignment[i];
@@ -154,12 +149,8 @@ inline
       continue;
     }
     int const irot_global = irot_local + oneb_offsets[i];
-    int const ires_n_rots = n_rotamers_for_res[i];
-    int const ires_n_chunks = (ires_n_rots - 1) / chunk_size + 1;
     int const irot_chunk = irot_local / chunk_size;
     int const irot_in_chunk = irot_local - chunk_size * irot_chunk;
-    int const irot_chunk_size =
-        min(chunk_size, ires_n_rots - chunk_size * irot_chunk);
 
     totalE += energy1b[irot_global];
     for (int j = i + 1; j < n_res; ++j) {

--- a/tmol/pack/rotamer/_build_rotamers.py
+++ b/tmol/pack/rotamer/_build_rotamers.py
@@ -1,5 +1,4 @@
 import numpy
-import numba
 import toolz
 import torch
 
@@ -28,6 +27,7 @@ from tmol.pack.rotamer import (
 )
 from tmol.pack import SetPackerTask
 from tmol.numeric import coord_dihedrals
+from tmol.numeric._dihedrals import _numpy_coord_dihedrals
 
 ConformerSample = tuple[
     Tensor[torch.int32][:],
@@ -102,12 +102,13 @@ def _build_chi_phi_c_corrections(
 
     n_types, max_n_chi = chi4_table.shape[:2]
     corrections = numpy.zeros((n_types, max_n_chi), dtype=numpy.float32)
+    correction_indices = []
+    ideal_chi_coords = []
+    ideal_phi_c = []
 
     for ti, rt in enumerate(pbt.active_block_types):
-        # ideal coords in restype atom order
-        ideal_coords = torch.tensor(
-            rt.ideal_coords[rt.at_to_icoor_ind], dtype=torch.float64
-        )
+        # Ideal coordinates in residue-type atom order.
+        ideal_coords = rt.ideal_coords[rt.at_to_icoor_ind]
         chi_names = sorted(k for k in rt.torsion_to_uaids if k.startswith("chi"))
         for ci in range(len(chi_names)):
             four_rto = chi4_table[ti, ci]
@@ -120,12 +121,17 @@ def _build_chi_phi_c_corrections(
             parent_kfo = int(parent_arr[ti, cda_kfo])
             if doftype_arr[ti, parent_kfo] == NodeType.jump:
                 continue
-            xyzs = ideal_coords[four_rto]
-            chi_ideal = float(
-                coord_dihedrals(xyzs[0:1], xyzs[1:2], xyzs[2:3], xyzs[3:4])[0]
-            )
-            phi_c_ideal = float(dofs_ideal[ti, cda_kfo, 3])
-            corrections[ti, ci] = chi_ideal - phi_c_ideal
+            correction_indices.append((ti, ci))
+            ideal_chi_coords.append(ideal_coords[four_rto])
+            ideal_phi_c.append(dofs_ideal[ti, cda_kfo, 3])
+
+    if correction_indices:
+        xyzs = numpy.stack(ideal_chi_coords)
+        chi_ideal = _numpy_coord_dihedrals(
+            xyzs[:, 0], xyzs[:, 1], xyzs[:, 2], xyzs[:, 3]
+        )
+        correction_indices = numpy.asarray(correction_indices).T
+        corrections[tuple(correction_indices)] = chi_ideal - numpy.asarray(ideal_phi_c)
 
     object.__setattr__(pbt, "_chi_phi_c_corrections", corrections)
     return corrections
@@ -333,47 +339,76 @@ def annotate_everything(
     object.__setattr__(pbt, cache_name, previously_annotated | sampler_names)
 
 
-@numba.jit(nopython=True)
 def update_nodes(
-    nodes_orig, genStartsStack, n_nodes_offset_for_rot, n_atoms_offset_for_rot
-):
-    """Merge the 1-residue-kinforest nodes data so that all the rotamers can be
-    built in a single generational-segmented-scan call. This has the structure
-    of load-balanced search operation.
+    nodes_orig: NDArray[numpy.int32][:],
+    genStartsStack: NDArray[numpy.int32][:, :, 2],
+    n_nodes_offset_for_rot: NDArray[numpy.int64][:],
+    n_atoms_offset_for_rot: NDArray[numpy.int64][:],
+) -> NDArray[numpy.int32][:]:
+    """Merge residue-local nodes into one generational scan layout.
+
+    Args:
+        nodes_orig: Concatenated residue-local node indices.
+        genStartsStack: Per-conformer generation and scan boundaries.
+        n_nodes_offset_for_rot: Start of each conformer's local node array.
+        n_atoms_offset_for_rot: Start of each conformer in the merged forest.
+
+    Returns:
+        Merged node indices ordered by generation, then conformer.
     """
 
-    n_gens = genStartsStack.shape[1]
-    n_nodes = nodes_orig.shape[0]
-    n_rotamers = n_atoms_offset_for_rot.shape[0]
-    nodes = numpy.zeros(n_nodes, dtype=numpy.int32)
-    count = 0
-    for i in range(n_gens - 1):
-        for j in range(n_rotamers):
-            for k in range(genStartsStack[j, i, 0], genStartsStack[j, i + 1, 0]):
-                nodes[count] = nodes_orig[n_nodes_offset_for_rot[j] + k]
-                if nodes[count] != 0:
-                    nodes[count] += n_atoms_offset_for_rot[j]
-                count += 1
+    n_rotamers = genStartsStack.shape[0]
+    rotamer_indices = numpy.arange(n_rotamers)
+    nodes = numpy.empty(nodes_orig.shape[0], dtype=numpy.int32)
+    output_offset = 0
+    for generation in range(genStartsStack.shape[1] - 1):
+        starts = genStartsStack[:, generation, 0]
+        lengths = numpy.maximum(genStartsStack[:, generation + 1, 0] - starts, 0)
+        count = int(lengths.sum())
+        if count == 0:
+            continue
+        rotamer = numpy.repeat(rotamer_indices, lengths)
+        within_rotamer = numpy.arange(count) - numpy.repeat(
+            numpy.cumsum(lengths) - lengths, lengths
+        )
+        source = n_nodes_offset_for_rot[rotamer] + starts[rotamer] + within_rotamer
+        values = nodes_orig[source].copy()
+        non_root = values != 0
+        values[non_root] += n_atoms_offset_for_rot[rotamer[non_root]]
+        nodes[output_offset : output_offset + count] = values
+        output_offset += count
+    assert output_offset == nodes.shape[0]
     return nodes
 
 
-@numba.jit(nopython=True)
 def update_scan_starts(
-    n_scans, atomStartsOffsets, scanStartsStack, genStartsStack, ngenStack
-):
-    n_gens = genStartsStack.shape[1]
+    n_scans: int,
+    atomStartsOffsets: NDArray[numpy.int64][:, :],
+    scanStartsStack: NDArray[numpy.int32][:, :],
+    genStartsStack: NDArray[numpy.int32][:, :, 2],
+    ngenStack: NDArray[numpy.int32][:, :],
+) -> NDArray[numpy.int32][:]:
+    """Merge residue-local scan starts into generation-major order."""
     n_rotamers = genStartsStack.shape[0]
-    scanStarts = numpy.zeros((n_scans,), dtype=numpy.int32)
-    count = 0
-    for i in range(n_gens - 1):
-        for j in range(n_rotamers):
-            for k in range(ngenStack[i, j]):
-                scanStarts[count] = (
-                    atomStartsOffsets[i, j]
-                    + scanStartsStack[j, genStartsStack[j, i, 1] + k]
-                )
-                count += 1
-    return scanStarts
+    rotamer_indices = numpy.arange(n_rotamers)
+    scan_starts = numpy.empty(n_scans, dtype=numpy.int32)
+    output_offset = 0
+    for generation in range(genStartsStack.shape[1] - 1):
+        lengths = ngenStack[generation]
+        count = int(lengths.sum())
+        if count == 0:
+            continue
+        rotamer = numpy.repeat(rotamer_indices, lengths)
+        within_rotamer = numpy.arange(count) - numpy.repeat(
+            numpy.cumsum(lengths) - lengths, lengths
+        )
+        source = genStartsStack[rotamer, generation, 1] + within_rotamer
+        scan_starts[output_offset : output_offset + count] = (
+            atomStartsOffsets[generation, rotamer] + scanStartsStack[rotamer, source]
+        )
+        output_offset += count
+    assert output_offset == n_scans
+    return scan_starts
 
 
 @validate_args
@@ -405,8 +440,6 @@ def construct_scans_for_conformers(
     ngenStack[ngenStack < 0] = 0
     ngenStackCumsum = numpy.cumsum(ngenStack.reshape(-1), axis=0)
 
-    # jitted function that operates on the CPU; need to figure
-    # out how to replace this with a GPU-compatible version
     scanStarts = update_scan_starts(
         ngenStackCumsum[-1],
         atomStartsOffsets,
@@ -431,55 +464,50 @@ def construct_scans_for_conformers(
     return nodes, scanStarts, gen_starts
 
 
-@numba.jit(nopython=True)
 def load_from_rotamers(
     arr: NDArray[numpy.int32][:, :],
     n_atoms_total: int,
     n_atoms_for_rot: NDArray[numpy.int32][:],
-):
+) -> NDArray[numpy.int32][:]:
+    """Compact real per-conformer entries behind one virtual root."""
     compact_arr = numpy.zeros((n_atoms_total + 1,), dtype=numpy.int32)
-    count = 1
-    for i in range(n_atoms_for_rot.shape[0]):
-        for j in range(n_atoms_for_rot[i]):
-            compact_arr[count] = arr[i][j]
-            count += 1
+    atom_is_real = numpy.arange(arr.shape[1]) < n_atoms_for_rot[:, None]
+    compact_arr[1:] = arr[atom_is_real]
     return compact_arr
 
 
-@numba.jit(nopython=True)
 def load_from_rotamers_w_offsets(
     arr: NDArray[numpy.int32][:, :],
     n_atoms_total: int,
     n_atoms_for_rot: NDArray[numpy.int32][:],
-    n_atoms_offset_for_rot: NDArray[numpy.int32][:],
-):
+    n_atoms_offset_for_rot: NDArray[numpy.int64][:],
+) -> NDArray[numpy.int32][:]:
+    """Compact real entries and translate their conformer-local indices."""
     compact_arr = numpy.zeros((n_atoms_total + 1,), dtype=numpy.int32)
-    count = 1
-    for i in range(n_atoms_for_rot.shape[0]):
-        for j in range(n_atoms_for_rot[i]):
-            compact_arr[count] = arr[i][j] + n_atoms_offset_for_rot[i]
-            count += 1
+    atom_is_real = numpy.arange(arr.shape[1]) < n_atoms_for_rot[:, None]
+    offsets = numpy.repeat(
+        n_atoms_offset_for_rot[: n_atoms_for_rot.shape[0]], n_atoms_for_rot
+    )
+    compact_arr[1:] = arr[atom_is_real] + offsets
     return compact_arr
 
 
-@numba.jit(nopython=True)
 def load_rotamer_parents(
     parents: NDArray[numpy.int32][:, :],
     n_atoms_total: int,
     n_atoms_for_rot: NDArray[numpy.int32][:],
-    n_atoms_offset_for_rot: NDArray[numpy.int32][:],
-):
+    n_atoms_offset_for_rot: NDArray[numpy.int64][:],
+) -> NDArray[numpy.int32][:]:
+    """Compact parent indices while joining conformers at a virtual root."""
     compact_arr = numpy.zeros((n_atoms_total + 1,), dtype=numpy.int32)
-    count = 1
-    for i in range(n_atoms_for_rot.shape[0]):
-        for j in range(n_atoms_for_rot[i]):
-            # offset by 1 for the root node of each rotamer
-            # because the parent array has -1 for root nodes'
-            # parents and we want to make it 0
-            compact_arr[count] = parents[i][j] + (
-                n_atoms_offset_for_rot[i] if j != 0 else 1
-            )
-            count += 1
+    atom_is_real = numpy.arange(parents.shape[1]) < n_atoms_for_rot[:, None]
+    offsets = numpy.repeat(
+        n_atoms_offset_for_rot[: n_atoms_for_rot.shape[0]], n_atoms_for_rot
+    )
+    # Root parents are -1 and should map to the shared root at index zero.
+    rotamer_starts = numpy.cumsum(n_atoms_for_rot) - n_atoms_for_rot
+    offsets[rotamer_starts] = 1
+    compact_arr[1:] = parents[atom_is_real] + offsets
     return compact_arr
 
 

--- a/tmol/pack/rotamer/_build_rotamers.py
+++ b/tmol/pack/rotamer/_build_rotamers.py
@@ -506,6 +506,7 @@ def load_rotamer_parents(
     )
     # Root parents are -1 and should map to the shared root at index zero.
     rotamer_starts = numpy.cumsum(n_atoms_for_rot) - n_atoms_for_rot
+    rotamer_starts = rotamer_starts[n_atoms_for_rot > 0]
     offsets[rotamer_starts] = 1
     compact_arr[1:] = parents[atom_is_real] + offsets
     return compact_arr

--- a/tmol/pack/rotamer/_mainchain_fingerprint.py
+++ b/tmol/pack/rotamer/_mainchain_fingerprint.py
@@ -9,7 +9,7 @@ from tmol.types import (
     Tensor,
     validate_args,
 )
-from tmol.numeric import coord_dihedrals
+from tmol.numeric._dihedrals import _numpy_coord_dihedrals
 from tmol.database import PatchedChemicalDatabase
 from tmol.chemical import RefinedResidueType
 from tmol.pose import PackedBlockTypes
@@ -224,19 +224,14 @@ def create_non_sidechain_fingerprint(  # noqa: C901
 
                 mc_anc_icoor_ind = rt.at_to_icoor_ind[mc_anc]
 
-                def t64(coord):
-                    return torch.tensor(coord, dtype=torch.float64).unsqueeze(0)
-
-                at1_coord = t64(rt.ideal_coords[mc1_icoor_ind])
-                at2_coord = t64(rt.ideal_coords[mc_anc_icoor_ind])
-                at3_coord = t64(rt.ideal_coords[mc2_icoor_ind])
-                at4_coord = t64(rt.ideal_coords[rt.at_to_icoor_ind[nsc_at]])
-
-                # now we have four coordinates, measure the dihedral
+                # Measure the improper dihedral around the main-chain atom.
                 dihe = numpy.degrees(
-                    coord_dihedrals(at4_coord, at2_coord, at1_coord, at3_coord).numpy()[
-                        0
-                    ]
+                    _numpy_coord_dihedrals(
+                        rt.ideal_coords[rt.at_to_icoor_ind[nsc_at]],
+                        rt.ideal_coords[mc_anc_icoor_ind],
+                        rt.ideal_coords[mc1_icoor_ind],
+                        rt.ideal_coords[mc2_icoor_ind],
+                    )
                 )
                 # some atoms are going to be placed in the plane
                 # defined by the three "main chain" atoms. If the

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -120,7 +120,7 @@ class _ParallelScoreTerms(torch.autograd.Function):
         autocast_dtype: torch.dtype,
         autocast_cache_enabled: bool,
     ) -> torch.Tensor:
-        term_coords = coords.detach().requires_grad_(True)
+        term_coords = coords
         futures = [
             executor.submit(
                 _score_call_in_thread,

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -93,6 +93,8 @@ def _score_grad_in_thread(
     create_graph: bool,
 ) -> torch.Tensor | None:
     """Differentiate one independent CPU score-term graph."""
+    if not scores.requires_grad:
+        return None
     with torch.set_grad_enabled(create_graph):
         (term_grad,) = torch.autograd.grad(
             scores,

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -662,6 +662,11 @@ class WholePoseScoringModule:
     ):
         self.weights = torch.nn.Parameter(weights.unsqueeze(1), requires_grad=False)
         self.term_modules = tuple(term_modules)
+        self._has_trainable_term_parameters = any(
+            parameter.requires_grad
+            for term in self.term_modules
+            for parameter in term.parameters()
+        )
         cpu_workers = min(
             _MAX_CPU_SCORE_TERM_WORKERS,
             torch.get_num_threads(),
@@ -701,6 +706,8 @@ class WholePoseScoringModule:
     def unweighted_scores(self, coords):
         needs_grad = torch.is_grad_enabled() and coords.requires_grad
         cpu_workers = self._cpu_term_workers
+        if torch.is_grad_enabled() and self._has_trainable_term_parameters:
+            cpu_workers = 0
         if (
             cpu_workers >= 2
             and not needs_grad

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -58,6 +58,20 @@ def _cpu_score_term_executor(n_workers: int) -> ThreadPoolExecutor:
         return executor
 
 
+def _cpu_score_term_worker_counts(
+    n_terms: int, device: torch.device
+) -> tuple[int, int]:
+    """Return conservative default and large-forward CPU worker counts."""
+    if device.type != "cpu":
+        return 0, 0
+    n_threads = torch.get_num_threads()
+    workers = min(_MAX_CPU_SCORE_TERM_WORKERS, n_threads, n_terms)
+    forward_workers = workers
+    if n_threads >= _CPU_WIDE_FORWARD_SCORE_MIN_THREADS:
+        forward_workers = min(_MAX_CPU_FORWARD_SCORE_TERM_WORKERS, n_threads, n_terms)
+    return workers, forward_workers
+
+
 def _reset_cpu_score_term_executors_after_fork() -> None:
     """Discard parent-process thread pools in a forked child."""
     global _CPU_SCORE_TERM_EXECUTORS, _CPU_SCORE_TERM_EXECUTOR_LOCK
@@ -667,21 +681,8 @@ class WholePoseScoringModule:
             for term in self.term_modules
             for parameter in term.parameters()
         )
-        cpu_workers = min(
-            _MAX_CPU_SCORE_TERM_WORKERS,
-            torch.get_num_threads(),
-            len(self.term_modules),
-        )
-        self._cpu_term_workers = cpu_workers if weights.device.type == "cpu" else 0
-        cpu_forward_workers = cpu_workers
-        if torch.get_num_threads() >= _CPU_WIDE_FORWARD_SCORE_MIN_THREADS:
-            cpu_forward_workers = min(
-                _MAX_CPU_FORWARD_SCORE_TERM_WORKERS,
-                torch.get_num_threads(),
-                len(self.term_modules),
-            )
-        self._cpu_forward_workers = (
-            cpu_forward_workers if weights.device.type == "cpu" else 0
+        self._cpu_term_workers, self._cpu_forward_workers = (
+            _cpu_score_term_worker_counts(len(self.term_modules), weights.device)
         )
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
@@ -840,12 +841,51 @@ class BlockPairScoringModule:
         self.weights = torch.nn.Parameter(
             weights.unsqueeze(1).unsqueeze(1).unsqueeze(1), requires_grad=False
         )
-        self.term_modules = term_modules
+        self.term_modules = tuple(term_modules)
+        self._active_term_modules = tuple(
+            term
+            for term in self.term_modules
+            if not isinstance(term, ZeroTermPoseScoringModule)
+        )
+        self._has_trainable_term_parameters = any(
+            parameter.requires_grad
+            for term in self.term_modules
+            for parameter in term.parameters()
+        )
+        self._cpu_term_workers, self._cpu_forward_workers = (
+            _cpu_score_term_worker_counts(len(self.term_modules), weights.device)
+        )
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         if sum_terms and apply_weights:
+            cpu_workers = self._cpu_term_workers
+            if coords.shape[0] >= _CPU_WIDE_FORWARD_SCORE_MIN_POSES:
+                cpu_workers = self._cpu_forward_workers
+            differentiable = torch.is_grad_enabled() and (
+                coords.requires_grad or self._has_trainable_term_parameters
+            )
+            active_results = None
+            if (
+                cpu_workers >= 2
+                and not differentiable
+                and len(self._active_term_modules) >= 2
+            ):
+                executor = _cpu_score_term_executor(cpu_workers)
+                context = (
+                    torch.is_grad_enabled(),
+                    torch.is_inference_mode_enabled(),
+                    torch.is_autocast_enabled("cpu"),
+                    torch.get_autocast_dtype("cpu"),
+                    torch.is_autocast_cache_enabled(),
+                )
+                futures = [
+                    executor.submit(_score_call_in_thread, term, coords, *context)
+                    for term in self._active_term_modules
+                ]
+                active_results = iter(future.result() for future in futures)
+
             active_scores = []
             active_weights = []
             weight_offset = 0
@@ -853,7 +893,9 @@ class BlockPairScoringModule:
                 if isinstance(term, ZeroTermPoseScoringModule):
                     weight_offset += term.shape[0]
                     continue
-                scores = term(coords)
+                scores = (
+                    term(coords) if active_results is None else next(active_results)
+                )
                 next_offset = weight_offset + scores.shape[0]
                 active_scores.append(scores)
                 active_weights.append(self.weights[weight_offset:next_offset])
@@ -888,12 +930,9 @@ class RotamerScoringModule:
             weights.view(-1, 1, 1, 1), requires_grad=False
         )
         self.term_modules = tuple(term_modules)
-        cpu_workers = min(
-            _MAX_CPU_SCORE_TERM_WORKERS,
-            torch.get_num_threads(),
-            len(self.term_modules),
+        self._cpu_term_workers, _ = _cpu_score_term_worker_counts(
+            len(self.term_modules), weights.device
         )
-        self._cpu_term_workers = cpu_workers if weights.device.type == "cpu" else 0
 
     def __call__(self, coords: torch.Tensor) -> torch.Tensor:
         if not torch.is_grad_enabled() and coords.requires_grad:

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1,5 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
 import logging
-from typing import Dict, Sequence
+import os
+import threading
+from typing import Callable, Dict, Sequence, TypeVar
 import warnings
 
 import torch
@@ -26,8 +29,211 @@ logger = logging.getLogger(__name__)
 SFXN_FORMAT_VERSION: str = "1.0"
 
 # Exact CUDA tensor equality synchronizes with the host. Only pay that cost
-# when one duplicate sparse index layout would retain at least 16 MiB.
-_ROTAMER_LAYOUT_DEDUP_MIN_BYTES = 16 * 1024 * 1024
+# when one duplicate sparse index layout would retain at least 16 MiB. CPU
+# equality has no synchronization penalty, so all matching layouts are tested.
+_CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES = 16 * 1024 * 1024
+_CPU_ROTAMER_SORTED_LAYOUT_MIN_NNZ = 4096
+_MAX_CPU_SCORE_TERM_WORKERS = 4
+_CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS = 8192
+_CPU_SCORE_TERM_EXECUTORS: dict[int, ThreadPoolExecutor] = {}
+_CPU_SCORE_TERM_EXECUTOR_LOCK = threading.Lock()
+_ScoreCallResult = TypeVar("_ScoreCallResult")
+
+
+def _cpu_score_term_executor(n_workers: int) -> ThreadPoolExecutor:
+    """Return a process-local executor shared by rendered CPU scorers."""
+    with _CPU_SCORE_TERM_EXECUTOR_LOCK:
+        executor = _CPU_SCORE_TERM_EXECUTORS.get(n_workers)
+        if executor is None:
+            executor = ThreadPoolExecutor(
+                max_workers=n_workers, thread_name_prefix="tmol-score"
+            )
+            _CPU_SCORE_TERM_EXECUTORS[n_workers] = executor
+        return executor
+
+
+def _reset_cpu_score_term_executors_after_fork() -> None:
+    """Discard parent-process thread pools in a forked child."""
+    global _CPU_SCORE_TERM_EXECUTORS, _CPU_SCORE_TERM_EXECUTOR_LOCK
+    _CPU_SCORE_TERM_EXECUTORS = {}
+    _CPU_SCORE_TERM_EXECUTOR_LOCK = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_cpu_score_term_executors_after_fork)
+
+
+def _score_call_in_thread(
+    score_call: Callable[[torch.Tensor], _ScoreCallResult],
+    coords: torch.Tensor,
+    grad_enabled: bool,
+    inference_mode_enabled: bool,
+    autocast_enabled: bool,
+    autocast_dtype: torch.dtype,
+    autocast_cache_enabled: bool,
+) -> _ScoreCallResult:
+    """Evaluate one CPU score term with the caller's thread-local modes."""
+    with (
+        torch.inference_mode(inference_mode_enabled),
+        torch.set_grad_enabled(grad_enabled),
+        torch.autocast(
+            "cpu",
+            enabled=autocast_enabled,
+            dtype=autocast_dtype,
+            cache_enabled=autocast_cache_enabled,
+        ),
+    ):
+        return score_call(coords)
+
+
+def _score_grad_in_thread(
+    scores: torch.Tensor,
+    coords: torch.Tensor,
+    grad_scores: torch.Tensor,
+    create_graph: bool,
+) -> torch.Tensor | None:
+    """Differentiate one independent CPU score-term graph."""
+    with torch.set_grad_enabled(create_graph):
+        (term_grad,) = torch.autograd.grad(
+            scores,
+            coords,
+            grad_scores,
+            retain_graph=True,
+            create_graph=create_graph,
+            allow_unused=True,
+        )
+    return term_grad
+
+
+class _ParallelScoreTerms(torch.autograd.Function):
+    """Run CPU term forwards concurrently with deterministic accumulation."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        coords: torch.Tensor,
+        executor: ThreadPoolExecutor,
+        term_modules: Sequence[torch.nn.Module],
+        autocast_enabled: bool,
+        autocast_dtype: torch.dtype,
+        autocast_cache_enabled: bool,
+    ) -> torch.Tensor:
+        term_coords = coords.detach().requires_grad_(True)
+        futures = [
+            executor.submit(
+                _score_call_in_thread,
+                term,
+                term_coords,
+                True,
+                False,
+                autocast_enabled,
+                autocast_dtype,
+                autocast_cache_enabled,
+            )
+            for term in term_modules
+        ]
+        term_scores = tuple(future.result() for future in futures)
+        ctx.term_coords = term_coords
+        ctx.term_scores = term_scores
+        ctx.term_sizes = tuple(scores.shape[0] for scores in term_scores)
+        ctx.executor = executor
+        ctx.parallel_backward = (
+            coords.numel() >= _CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS
+        )
+        return torch.cat(term_scores, dim=0).detach()
+
+    @staticmethod
+    def backward(ctx, grad_scores: torch.Tensor):
+        # Serial scoring creates the term autograd nodes in score-type order;
+        # PyTorch visits those nodes in reverse order. Preserve that reduction
+        # order so concurrent forward scheduling cannot perturb minimization.
+        create_graph = torch.is_grad_enabled()
+        term_grad_inputs = []
+        offset = sum(ctx.term_sizes)
+        for term_scores, term_size in zip(
+            reversed(ctx.term_scores), reversed(ctx.term_sizes)
+        ):
+            offset -= term_size
+            term_grad_inputs.append(
+                (
+                    term_scores,
+                    ctx.term_coords,
+                    grad_scores[offset : offset + term_size],
+                    create_graph,
+                )
+            )
+
+        if ctx.parallel_backward:
+            term_grad_futures = [
+                ctx.executor.submit(
+                    _score_grad_in_thread,
+                    *grad_input,
+                )
+                for grad_input in term_grad_inputs
+            ]
+            term_grads = [future.result() for future in term_grad_futures]
+        else:
+            term_grads = [
+                _score_grad_in_thread(*grad_input) for grad_input in term_grad_inputs
+            ]
+
+        grad_coords = None
+        for term_grad in term_grads:
+            if term_grad is not None:
+                grad_coords = (
+                    term_grad if grad_coords is None else grad_coords + term_grad
+                )
+        return grad_coords, None, None, None, None, None
+
+
+def _linearize_rotamer_indices(indices: torch.Tensor, n_rots: int) -> torch.Tensor:
+    """Encode ``[pose, rotamer_i, rotamer_j]`` indices as sortable integers."""
+    indices_64 = indices.to(torch.int64)
+    return (indices_64[0] * n_rots + indices_64[1]) * n_rots + indices_64[2]
+
+
+def _try_coalesce_cpu_rotamer_layouts(
+    indices: Sequence[torch.Tensor],
+    values: Sequence[torch.Tensor],
+    n_poses: int,
+    n_rots: int,
+) -> torch.Tensor | None:
+    """Merge sparse CPU layouts when the largest layout contains their union.
+
+    Sorting one complete layout and mapping the smaller layouts into it avoids
+    concatenating and sorting every repeated index. ``None`` requests the
+    general sparse-coalesce path when that containment invariant does not hold.
+    """
+    if len(indices) < 2:
+        return None
+
+    largest = max(range(len(indices)), key=lambda i: indices[i].shape[1])
+    if indices[largest].shape[1] < _CPU_ROTAMER_SORTED_LAYOUT_MIN_NNZ:
+        return None
+
+    keys = [_linearize_rotamer_indices(layout, n_rots) for layout in indices]
+    sorted_keys, order = torch.sort(keys[largest])
+    if sorted_keys.numel() > 1 and bool(torch.any(sorted_keys[1:] == sorted_keys[:-1])):
+        return None
+
+    combined_values = values[largest][order].clone()
+    for layout_index, layout_keys in enumerate(keys):
+        if layout_index == largest or layout_keys.numel() == 0:
+            continue
+        positions = torch.searchsorted(sorted_keys, layout_keys)
+        if bool(torch.any(positions == sorted_keys.numel())) or not torch.equal(
+            sorted_keys[positions], layout_keys
+        ):
+            return None
+        combined_values.index_add_(0, positions, values[layout_index])
+
+    return torch.sparse_coo_tensor(
+        indices[largest][:, order],
+        combined_values,
+        size=(n_poses, n_rots, n_rots),
+        is_coalesced=True,
+        check_invariants=False,
+    )
 
 
 class ScoreFunction:
@@ -447,7 +653,13 @@ class WholePoseScoringModule:
         term_modules: Sequence[torch.nn.Module],
     ):
         self.weights = torch.nn.Parameter(weights.unsqueeze(1), requires_grad=False)
-        self.term_modules = term_modules
+        self.term_modules = tuple(term_modules)
+        cpu_workers = min(
+            _MAX_CPU_SCORE_TERM_WORKERS,
+            torch.get_num_threads(),
+            len(self.term_modules),
+        )
+        self._cpu_term_workers = cpu_workers if weights.device.type == "cpu" else 0
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
         if sum_terms and apply_weights:
@@ -469,7 +681,33 @@ class WholePoseScoringModule:
         return summed
 
     def unweighted_scores(self, coords):
-        return torch.cat([term(coords) for term in self.term_modules], dim=0)
+        if self._cpu_term_workers < 2:
+            return torch.cat([term(coords) for term in self.term_modules], dim=0)
+
+        executor = _cpu_score_term_executor(self._cpu_term_workers)
+        autocast_context = (
+            torch.is_autocast_enabled("cpu"),
+            torch.get_autocast_dtype("cpu"),
+            torch.is_autocast_cache_enabled(),
+        )
+        if torch.is_grad_enabled() and coords.requires_grad:
+            return _ParallelScoreTerms.apply(
+                coords,
+                executor,
+                self.term_modules,
+                *autocast_context,
+            )
+
+        context = (
+            torch.is_grad_enabled(),
+            torch.is_inference_mode_enabled(),
+            *autocast_context,
+        )
+        futures = [
+            executor.submit(_score_call_in_thread, term, coords, *context)
+            for term in self.term_modules
+        ]
+        return torch.cat([future.result() for future in futures], dim=0)
 
     def enable_cuda_graphs(self, example_coords, mode="both"):
         """Capture the default weighted score for a fixed coordinate shape.
@@ -616,7 +854,13 @@ class RotamerScoringModule:
         self.weights = torch.nn.Parameter(
             weights.view(-1, 1, 1, 1), requires_grad=False
         )
-        self.term_modules = term_modules
+        self.term_modules = tuple(term_modules)
+        cpu_workers = min(
+            _MAX_CPU_SCORE_TERM_WORKERS,
+            torch.get_num_threads(),
+            len(self.term_modules),
+        )
+        self._cpu_term_workers = cpu_workers if weights.device.type == "cpu" else 0
 
     def __call__(self, coords: torch.Tensor) -> torch.Tensor:
         if not torch.is_grad_enabled() and coords.requires_grad:
@@ -632,8 +876,33 @@ class RotamerScoringModule:
         n_rots: int | None = None
         weights_offset = 0
 
-        for term in self.term_modules:
-            scores, indices = term.forward(coords)  # [n_subterms, nnz], [3, nnz]
+        parallel = self._cpu_term_workers >= 2 and not (
+            torch.is_grad_enabled() and coords.requires_grad
+        )
+        if parallel:
+            executor = _cpu_score_term_executor(self._cpu_term_workers)
+            context = (
+                torch.is_grad_enabled(),
+                torch.is_inference_mode_enabled(),
+                torch.is_autocast_enabled("cpu"),
+                torch.get_autocast_dtype("cpu"),
+                torch.is_autocast_cache_enabled(),
+            )
+            futures = [
+                executor.submit(
+                    _score_call_in_thread,
+                    term.forward,
+                    coords,
+                    *context,
+                )
+                for term in self.term_modules
+            ]
+            term_results = [future.result() for future in futures]
+        else:
+            term_results = [term.forward(coords) for term in self.term_modules]
+
+        for term, (scores, indices) in zip(self.term_modules, term_results):
+            # [n_subterms, nnz], [3, nnz]
             n_subterms = scores.shape[0]
 
             # Apply per-subterm weights and sum to [nnz] — no sparse tensor yet.
@@ -644,8 +913,9 @@ class RotamerScoringModule:
             # values now so the sparse coalesce does not sort another copy of
             # the same, potentially multi-gigabyte, index layout.
             deduplicate_layout = (
-                indices.numel() * indices.element_size()
-                >= _ROTAMER_LAYOUT_DEDUP_MIN_BYTES
+                indices.device.type == "cpu"
+                or indices.numel() * indices.element_size()
+                >= _CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES
             )
             candidate_layouts = (
                 layouts_by_nnz.get(indices.shape[1], ()) if deduplicate_layout else ()
@@ -674,7 +944,17 @@ class RotamerScoringModule:
                 torch.zeros((3, 0), dtype=torch.int32, device=coords.device),
                 torch.zeros(0, dtype=torch.float32, device=coords.device),
                 size=(0, 0, 0),
+                is_coalesced=True,
+                check_invariants=False,
             )
+        assert n_rots is not None
+
+        if coords.device.type == "cpu":
+            coalesced = _try_coalesce_cpu_rotamer_layouts(
+                all_indices, all_values, n_poses, n_rots
+            )
+            if coalesced is not None:
+                return coalesced
 
         combined_values = torch.cat(all_values)
         combined_indices = torch.cat(all_indices, dim=1)
@@ -682,4 +962,6 @@ class RotamerScoringModule:
             combined_indices,
             combined_values,
             size=(n_poses, n_rots, n_rots),
+            is_coalesced=False,
+            check_invariants=False,
         )

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -34,6 +34,12 @@ SFXN_FORMAT_VERSION: str = "1.0"
 _CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES = 16 * 1024 * 1024
 _CPU_ROTAMER_SORTED_LAYOUT_MIN_NNZ = 4096
 _MAX_CPU_SCORE_TERM_WORKERS = 4
+# Large multi-pose, forward-only scoring benefits from exposing more
+# independent terms. Differentiable scoring stays at four workers because its
+# concurrent backward graphs otherwise compete for the same intra-op threads.
+_MAX_CPU_FORWARD_SCORE_TERM_WORKERS = 8
+_CPU_WIDE_FORWARD_SCORE_MIN_POSES = 20
+_CPU_WIDE_FORWARD_SCORE_MIN_THREADS = 32
 _CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS = 8192
 _CPU_SCORE_TERM_EXECUTORS: dict[int, ThreadPoolExecutor] = {}
 _CPU_SCORE_TERM_EXECUTOR_LOCK = threading.Lock()
@@ -662,6 +668,16 @@ class WholePoseScoringModule:
             len(self.term_modules),
         )
         self._cpu_term_workers = cpu_workers if weights.device.type == "cpu" else 0
+        cpu_forward_workers = cpu_workers
+        if torch.get_num_threads() >= _CPU_WIDE_FORWARD_SCORE_MIN_THREADS:
+            cpu_forward_workers = min(
+                _MAX_CPU_FORWARD_SCORE_TERM_WORKERS,
+                torch.get_num_threads(),
+                len(self.term_modules),
+            )
+        self._cpu_forward_workers = (
+            cpu_forward_workers if weights.device.type == "cpu" else 0
+        )
 
     def __call__(self, coords, sum_terms=True, apply_weights=True):
         if sum_terms and apply_weights:
@@ -683,16 +699,24 @@ class WholePoseScoringModule:
         return summed
 
     def unweighted_scores(self, coords):
-        if self._cpu_term_workers < 2:
+        needs_grad = torch.is_grad_enabled() and coords.requires_grad
+        cpu_workers = self._cpu_term_workers
+        if (
+            cpu_workers >= 2
+            and not needs_grad
+            and coords.shape[0] >= _CPU_WIDE_FORWARD_SCORE_MIN_POSES
+        ):
+            cpu_workers = self._cpu_forward_workers
+        if cpu_workers < 2:
             return torch.cat([term(coords) for term in self.term_modules], dim=0)
 
-        executor = _cpu_score_term_executor(self._cpu_term_workers)
+        executor = _cpu_score_term_executor(cpu_workers)
         autocast_context = (
             torch.is_autocast_enabled("cpu"),
             torch.get_autocast_dtype("cpu"),
             torch.is_autocast_cache_enabled(),
         )
-        if torch.is_grad_enabled() and coords.requires_grad:
+        if needs_grad:
             return _ParallelScoreTerms.apply(
                 coords,
                 executor,

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -856,35 +856,45 @@ class BlockPairScoringModule:
             _cpu_score_term_worker_counts(len(self.term_modules), weights.device)
         )
 
+    def _cpu_workers_for_coords(self, coords: torch.Tensor) -> int:
+        """Return the worker count selected for this pose batch."""
+        if coords.shape[0] >= _CPU_WIDE_FORWARD_SCORE_MIN_POSES:
+            return self._cpu_forward_workers
+        return self._cpu_term_workers
+
+    def _parallel_forward_scores(
+        self, coords: torch.Tensor
+    ) -> tuple[torch.Tensor, ...] | None:
+        """Evaluate active CPU terms concurrently for a forward-only call."""
+        cpu_workers = self._cpu_workers_for_coords(coords)
+        differentiable = torch.is_grad_enabled() and (
+            coords.requires_grad or self._has_trainable_term_parameters
+        )
+        if cpu_workers < 2 or differentiable or len(self._active_term_modules) < 2:
+            return None
+
+        executor = _cpu_score_term_executor(cpu_workers)
+        context = (
+            torch.is_grad_enabled(),
+            torch.is_inference_mode_enabled(),
+            torch.is_autocast_enabled("cpu"),
+            torch.get_autocast_dtype("cpu"),
+            torch.is_autocast_cache_enabled(),
+        )
+        futures = [
+            executor.submit(_score_call_in_thread, term, coords, *context)
+            for term in self._active_term_modules
+        ]
+        return tuple(future.result() for future in futures)
+
     def __call__(self, coords, sum_terms=True, apply_weights=True):
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         if sum_terms and apply_weights:
-            cpu_workers = self._cpu_term_workers
-            if coords.shape[0] >= _CPU_WIDE_FORWARD_SCORE_MIN_POSES:
-                cpu_workers = self._cpu_forward_workers
-            differentiable = torch.is_grad_enabled() and (
-                coords.requires_grad or self._has_trainable_term_parameters
+            parallel_scores = self._parallel_forward_scores(coords)
+            active_results = (
+                iter(parallel_scores) if parallel_scores is not None else None
             )
-            active_results = None
-            if (
-                cpu_workers >= 2
-                and not differentiable
-                and len(self._active_term_modules) >= 2
-            ):
-                executor = _cpu_score_term_executor(cpu_workers)
-                context = (
-                    torch.is_grad_enabled(),
-                    torch.is_inference_mode_enabled(),
-                    torch.is_autocast_enabled("cpu"),
-                    torch.get_autocast_dtype("cpu"),
-                    torch.is_autocast_cache_enabled(),
-                )
-                futures = [
-                    executor.submit(_score_call_in_thread, term, coords, *context)
-                    for term in self._active_term_modules
-                ]
-                active_results = iter(future.result() for future in futures)
 
             active_scores = []
             active_weights = []
@@ -910,8 +920,23 @@ class BlockPairScoringModule:
 
         return summed
 
-    def unweighted_scores(self, coords):
-        return torch.cat([term(coords) for term in self.term_modules], dim=0)
+    def unweighted_scores(self, coords: torch.Tensor) -> torch.Tensor:
+        parallel_scores = self._parallel_forward_scores(coords)
+        if parallel_scores is None:
+            return torch.cat([term(coords) for term in self.term_modules], dim=0)
+
+        active_results = iter(parallel_scores)
+        return torch.cat(
+            [
+                (
+                    term(coords)
+                    if isinstance(term, ZeroTermPoseScoringModule)
+                    else next(active_results)
+                )
+                for term in self.term_modules
+            ],
+            dim=0,
+        )
 
 
 class RotamerScoringModule:

--- a/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
+++ b/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
@@ -366,8 +366,8 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     }
   });
 
-  DeviceDispatch<Dev>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, rama_omega_func);
+  DeviceDispatch<Dev>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, rama_omega_func);
 
   return {V_t, dV_dxyz_t};
 };
@@ -653,8 +653,8 @@ auto BackboneTorsionPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
     }
   });
 
-  DeviceDispatch<Dev>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, rama_omega_func);
+  DeviceDispatch<Dev>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, rama_omega_func);
 
   return dV_dxyz_t;
 };

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -1533,8 +1533,13 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     });
     DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
   });
-  DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-      mgr, dispatch_indices.size(1), eval_subgraphs_for_interaction);
+  if (compute_derivs) {
+    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_subgraphs_for_interaction);
+  } else {
+    DeviceDispatch<D>::template foreach_independent_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_subgraphs_for_interaction);
+  }
 
   return {
       V_t,

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -13,7 +13,7 @@ class _CoordinateIndependentScore(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        return None, None
+        return None, grad_output
 
 
 def _coordinate_independent_score(

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -4,16 +4,33 @@ import torch
 from tmol.score.common import convert_float64
 
 
-class _ZeroCoordinates(torch.autograd.Function):
-    """Attach a no-op coordinate gradient without launching a device kernel."""
+class _CoordinateIndependentScore(torch.autograd.Function):
+    """Attach a no-op coordinate edge without launching a device kernel."""
 
     @staticmethod
-    def forward(ctx, coords, zero, shape):
-        return zero.expand(shape)
+    def forward(ctx, coords, score):
+        return score
 
     @staticmethod
     def backward(ctx, grad_output):
-        return None, None, None
+        return None, None
+
+
+def _coordinate_independent_score(
+    coords: torch.Tensor, score: torch.Tensor
+) -> torch.Tensor:
+    """Preserve backward compatibility for a coordinate-independent score.
+
+    Args:
+        coords: Coordinates accepted by the score term.
+        score: A score with no mathematical dependence on ``coords``.
+
+    Returns:
+        ``score`` with a no-op autograd edge only when ``coords`` requires one.
+    """
+    if torch.is_grad_enabled() and coords.requires_grad:
+        return _CoordinateIndependentScore.apply(coords, score)
+    return score
 
 
 class ZeroTermPoseScoringModule(torch.nn.Module):
@@ -45,9 +62,7 @@ class ZeroTermPoseScoringModule(torch.nn.Module):
         # backward() even when that term has no coordinate dependence. Attach
         # a custom no-op edge so that convention remains valid without a
         # reduction kernel or a persistent leaf gradient.
-        if torch.is_grad_enabled() and coords.requires_grad:
-            return _ZeroCoordinates.apply(coords, zero, self.shape)
-        return zero.expand(self.shape)
+        return _coordinate_independent_score(coords, zero.expand(self.shape))
 
 
 class TermScoringModule(torch.nn.Module):

--- a/tmol/score/common/device_operations.cpu.impl.hh
+++ b/tmol/score/common/device_operations.cpu.impl.hh
@@ -22,26 +22,49 @@ struct DeviceOperations<tmol::Device::CPU> {
     }
   }
 
-  template <typename launch_t, typename Int, typename Func>
-  static void forall_stacks(ContextManager&, Int Nstacks, Int N, Func f) {
+  template <typename launch_t, typename Func>
+  static void forall_independent(ContextManager&, int N, Func f) {
     constexpr int64_t min_parallel_work = 32768;
-    int64_t const total_work = int64_t(Nstacks) * int64_t(N);
-    if (Nstacks <= 1 || total_work < min_parallel_work) {
-      for (Int stack = 0; stack < Nstacks; ++stack) {
-        for (Int i = 0; i < N; ++i) {
-          f(stack, i);
-        }
+    if (N < min_parallel_work) {
+      for (int i = 0; i < N; ++i) {
+        f(i);
       }
       return;
     }
 
-    at::parallel_for(0, Nstacks, 1, [=](int64_t begin, int64_t end) {
-      for (int64_t stack = begin; stack < end; ++stack) {
-        for (Int i = 0; i < N; ++i) {
-          f(Int(stack), i);
+    at::parallel_for(0, N, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        f(int(i));
+      }
+    });
+  }
+
+  template <typename launch_t, typename Func>
+  static void forall_grouped(
+      ContextManager& mgr, int n_groups, int items_per_group, Func f) {
+    if (n_groups <= 1) {
+      forall<launch_t>(mgr, n_groups * items_per_group, f);
+      return;
+    }
+
+    at::parallel_for(0, n_groups, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t group = begin; group < end; ++group) {
+        int const first_item = group * items_per_group;
+        for (int item = 0; item < items_per_group; ++item) {
+          f(first_item + item);
         }
       }
     });
+  }
+
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int32_t& target, int32_t value) {
+    __atomic_store_n(&target, value, __ATOMIC_RELAXED);
+  }
+
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int64_t& target, int64_t value) {
+    __atomic_store_n(&target, value, __ATOMIC_RELAXED);
   }
 
   template <typename Int, typename Func>
@@ -64,21 +87,45 @@ struct DeviceOperations<tmol::Device::CPU> {
   }
 
   template <typename launch_t, typename Func>
-  static void foreach_pose_workgroup(
-      ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f) {
-    if (n_poses <= 1) {
-      foreach_workgroup<launch_t>(mgr, n_poses * workgroups_per_pose, f);
+  static void foreach_independent_workgroup(
+      ContextManager&, int n_workgroups, Func f) {
+    constexpr int64_t min_parallel_workgroups = 256;
+    if (n_workgroups < min_parallel_workgroups) {
+      for (int i = 0; i < n_workgroups; ++i) {
+        f(i);
+      }
       return;
     }
 
-    at::parallel_for(0, n_poses, 1, [=](int64_t begin, int64_t end) {
-      for (int64_t pose = begin; pose < end; ++pose) {
-        int const first_workgroup = pose * workgroups_per_pose;
-        for (int i = 0; i < workgroups_per_pose; ++i) {
+    at::parallel_for(0, n_workgroups, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        f(int(i));
+      }
+    });
+  }
+
+  template <typename launch_t, typename Func>
+  static void foreach_grouped_workgroup(
+      ContextManager& mgr, int n_groups, int workgroups_per_group, Func f) {
+    if (n_groups <= 1) {
+      foreach_workgroup<launch_t>(mgr, n_groups * workgroups_per_group, f);
+      return;
+    }
+
+    at::parallel_for(0, n_groups, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t group = begin; group < end; ++group) {
+        int const first_workgroup = group * workgroups_per_group;
+        for (int i = 0; i < workgroups_per_group; ++i) {
           f(first_workgroup + i);
         }
       }
     });
+  }
+
+  template <typename launch_t, typename Func>
+  static void foreach_pose_workgroup(
+      ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f) {
+    foreach_grouped_workgroup<launch_t>(mgr, n_poses, workgroups_per_pose, f);
   }
 
   template <mgpu::scan_type_t scan_type, typename T, typename OP>

--- a/tmol/score/common/device_operations.cuda.impl.cuh
+++ b/tmol/score/common/device_operations.cuda.impl.cuh
@@ -40,17 +40,31 @@ struct DeviceOperations<tmol::Device::CUDA> {
     mgpu::transform<launch_t>(f, N, *context);
   }
 
-  template <typename launch_t, typename Int, typename Func>
-  static void forall_stacks(ContextManager& mgr, Int Nstacks, Int N, Func f) {
-    std::shared_ptr<mgpu::standard_context_t> context = _get_context(mgr);
-    mgpu::transform<launch_t>(
-        [=] MGPU_DEVICE(int index) {
-          int stack = index / N;
-          int i = index % N;
-          f(stack, i);
-        },
-        N * Nstacks,
-        *context);
+  template <typename launch_t, typename Func>
+  static void forall_independent(ContextManager& mgr, int N, Func f) {
+    forall<launch_t>(mgr, N, f);
+  }
+
+  template <typename launch_t, typename Func>
+  static void forall_grouped(
+      ContextManager& mgr, int n_groups, int items_per_group, Func f) {
+    forall<launch_t>(mgr, n_groups * items_per_group, f);
+  }
+
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int32_t& target, int32_t value) {
+#ifdef __CUDA_ARCH__
+    atomicExch(&target, value);
+#endif
+  }
+
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int64_t& target, int64_t value) {
+#ifdef __CUDA_ARCH__
+    atomicExch(
+        reinterpret_cast<unsigned long long*>(&target),
+        static_cast<unsigned long long>(value));
+#endif
   }
 
   template <typename Int, typename Func>
@@ -79,9 +93,21 @@ struct DeviceOperations<tmol::Device::CUDA> {
   }
 
   template <typename launch_t, typename Func>
+  static void foreach_independent_workgroup(
+      ContextManager& mgr, int n_workgroups, Func f) {
+    foreach_workgroup<launch_t>(mgr, n_workgroups, f);
+  }
+
+  template <typename launch_t, typename Func>
+  static void foreach_grouped_workgroup(
+      ContextManager& mgr, int n_groups, int workgroups_per_group, Func f) {
+    foreach_workgroup<launch_t>(mgr, n_groups * workgroups_per_group, f);
+  }
+
+  template <typename launch_t, typename Func>
   static void foreach_pose_workgroup(
       ContextManager& mgr, int n_poses, int workgroups_per_pose, Func f) {
-    foreach_workgroup<launch_t>(mgr, n_poses * workgroups_per_pose, f);
+    foreach_grouped_workgroup<launch_t>(mgr, n_poses, workgroups_per_pose, f);
   }
 
   template <mgpu::scan_type_t scan_type, typename T, typename OP>

--- a/tmol/score/common/device_operations.hh
+++ b/tmol/score/common/device_operations.hh
@@ -16,10 +16,22 @@ struct DeviceOperations {
   template <typename launch_t, typename Func>
   static void forall(ContextManager& mgr, int N, Func f);
 
-  /// Apply independent per-stack work, parallelizing stacks on CPU when the
-  /// workload is large enough to amortize thread-pool dispatch.
-  template <typename launch_t, typename Int, typename Func>
-  static void forall_stacks(ContextManager& mgr, Int Nstacks, Int N, Func f);
+  /// Apply independent element work, parallelizing elements on CPU.
+  /// Callbacks may execute concurrently and must write to disjoint outputs.
+  template <typename launch_t, typename Func>
+  static void forall_independent(ContextManager& mgr, int N, Func f);
+
+  /// Apply flattened element work, keeping each CPU group's elements serial.
+  /// Groups must write to disjoint outputs. CUDA retains one thread per item.
+  template <typename launch_t, typename Func>
+  static void forall_grouped(
+      ContextManager& mgr, int n_groups, int items_per_group, Func f);
+
+  /// Store a value that concurrent callbacks may write identically.
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int32_t& target, int32_t value);
+  static EIGEN_DEVICE_FUNC void store_idempotent(
+      int64_t& target, int64_t value);
 
   template <typename Int, typename Func>
   static void foreach_combination_triple(
@@ -27,6 +39,17 @@ struct DeviceOperations {
 
   template <typename launch_t, typename Func>
   static void foreach_workgroup(ContextManager& mgr, int n_workgroups, Func f);
+
+  /// Run workgroups concurrently on CPU when their outputs are disjoint.
+  template <typename launch_t, typename Func>
+  static void foreach_independent_workgroup(
+      ContextManager& mgr, int n_workgroups, Func f);
+
+  /// Run workgroup callbacks in independent groups. CPU groups run in
+  /// parallel while workgroups within a group retain their serial order.
+  template <typename launch_t, typename Func>
+  static void foreach_grouped_workgroup(
+      ContextManager& mgr, int n_groups, int workgroups_per_group, Func f);
 
   /// Run pose-grouped workgroups, parallelizing independent poses on CPU.
   /// The callback receives a flattened pose-major workgroup index; workgroups

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -101,7 +101,7 @@ struct compute_rot_spheres {
           thread0_write_out_result);
     });
 
-    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+    DeviceDispatch<D>::template foreach_independent_workgroup<launch_t>(
         mgr, rot_coord_offset.size(0), compute_spheres);
   }
 };
@@ -279,7 +279,7 @@ struct detect_rot_neighbors {
     std::uint64_t n_rot_pairs = std::uint64_t(n_rots_for_block.size(0))
                                 * max_n_rots_per_pose * max_n_rots_per_pose;
 
-    DeviceDispatch<D>::template forall<launch_t>(
+    DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_rot_pairs, detect_neighbors);
   }
 };
@@ -301,7 +301,9 @@ struct detect_block_neighbors {
     int const n_poses = pose_stack_block_type.size(0);
     int const max_n_blocks = pose_stack_block_type.size(1);
     int const block_pairs_per_pose = max_n_blocks * max_n_blocks;
-    auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int pose_ind, int pair) {
+    auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int index) {
+      int const pose_ind = index / block_pairs_per_pose;
+      int const pair = index % block_pairs_per_pose;
       int const block_ind1 = pair / max_n_blocks;
       int const block_ind2 = pair % max_n_blocks;
 
@@ -337,8 +339,8 @@ struct detect_block_neighbors {
         block_neighbors[pose_ind][block_ind1][block_ind2] = 1;
       }
     });
-    DeviceDispatch<D>::template forall_stacks<launch_t, int>(
-        mgr, n_poses, block_pairs_per_pose, detect_neighbors);
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_poses * block_pairs_per_pose, detect_neighbors);
   }
 };
 
@@ -386,7 +388,8 @@ struct rot_neighbor_indices {
       }
     });
 
-    DeviceDispatch<D>::template forall<launch_t>(mgr, n_cells, fill_indices);
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, fill_indices);
 
     return rot_neighbor_indices;
   }
@@ -434,7 +437,8 @@ struct block_neighbor_indices {
       }
     });
 
-    DeviceDispatch<D>::template forall<launch_t>(mgr, n_cells, fill_indices);
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, fill_indices);
 
     return block_neighbor_indices;
   }
@@ -496,7 +500,7 @@ struct compute_block_spheres_from_rot_spheres {
       block_spheres[pose][block][3] = rmax;
     });
 
-    DeviceDispatch<D>::template forall<launch_t>(
+    DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_poses * max_n_blocks, compute);
   }
 };
@@ -542,7 +546,8 @@ struct rot_neighbor_indices_from_block_neighbors {
         }
       }
     });
-    DeviceDispatch<D>::template forall<launch_t>(mgr, n_cells, compute_counts);
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, compute_counts);
 
     // Step 2: prefix scan → per-block-pair offsets and total
     auto pair_offsets_t = TPack<Int, 3, D>::zeros_like(block_neighbors);
@@ -595,7 +600,8 @@ struct rot_neighbor_indices_from_block_neighbors {
         }
       }
     });
-    DeviceDispatch<D>::template forall<launch_t>(mgr, n_cells, fill);
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, fill);
 
     return indices_t;
   }

--- a/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
+++ b/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
@@ -217,8 +217,8 @@ auto DisulfidePoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     }
   });
 
-  DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, eval_energies);
+  DeviceDispatch<D>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, eval_energies);
 
   return {V_t, dV_dx_t};
 }
@@ -374,8 +374,8 @@ auto DisulfidePoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     }
   });
 
-  DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, eval_derivs);
+  DeviceDispatch<D>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, eval_derivs);
 
   return dV_dcoords_t;
 }

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -440,8 +440,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     }
   });
 
-  DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, func);
+  DeviceDispatch<D>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, func);
 
   return {V_t, dV_dx_t};
 }
@@ -799,8 +799,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     }
   });
 
-  DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, func);
+  DeviceDispatch<D>::template forall_grouped<launch_t>(
+      mgr, n_poses, max_n_blocks, func);
 
   return dV_dx_t;
 }  // namespace potentials

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -1432,8 +1432,13 @@ auto ElecRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // mgpu::standard_context_t context(wrapped_stream.stream());
 
   // 2
-  DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-      mgr, dispatch_indices.size(1), eval_energies_by_block);
+  if (compute_derivs) {
+    DeviceDispatch<D>::template foreach_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies_by_block);
+  } else {
+    DeviceDispatch<D>::template foreach_independent_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies_by_block);
+  }
 
   return {output_t, dV_dcoords_t, dispatch_indices_t};
 }  // namespace potentials

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -1263,8 +1263,13 @@ auto GenBondedRotamerScoreDispatch<DeviceOps, D, Real, Int>::forward(
     });
     DeviceOps<D>::template for_each_in_workgroup<nt>(reduce_and_write);
   });
-  DeviceOps<D>::template foreach_workgroup<launch_t>(
-      mgr, n_output_intxns_total, eval_torsions_for_interaction);
+  if (compute_derivs) {
+    DeviceOps<D>::template foreach_workgroup<launch_t>(
+        mgr, n_output_intxns_total, eval_torsions_for_interaction);
+  } else {
+    DeviceOps<D>::template foreach_independent_workgroup<launch_t>(
+        mgr, n_output_intxns_total, eval_torsions_for_interaction);
+  }
 
   return {
       V_t,

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -1405,8 +1405,13 @@ auto HBondRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   // at::cuda::getDefaultCUDAStream(); mgpu::standard_context_t
   // context(wrapped_stream.stream());
 
-  DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
-      mgr, dispatch_indices.size(1), eval_energies);
+  if (compute_derivs) {
+    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies);
+  } else {
+    DeviceDispatch<Dev>::template foreach_independent_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies);
+  }
 
   // DeviceDispatch<Dev>::synchronize_device();
   return {output_t, dV_dcoords_t, dispatch_indices_t};

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -1812,8 +1812,13 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // within striking distance
 
   assert(output_block_pair_energies);
-  DeviceOperations<D>::template foreach_workgroup<launch_t>(
-      mgr, dispatch_indices.size(1), eval_energies_by_block);
+  if (require_gradient) {
+    DeviceOperations<D>::template foreach_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies_by_block);
+  } else {
+    DeviceOperations<D>::template foreach_independent_workgroup<launch_t>(
+        mgr, dispatch_indices.size(1), eval_energies_by_block);
+  }
 
   return {output_t, dV_dcoords_t, dispatch_indices_t};
 }  // LJLKRotamerScoreDispatch::forward

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -1358,7 +1358,7 @@ class LKBallRotamerScoreDispatch {
     // context(wrapped_stream.stream());
 
     // 3 Only the forward pass in this calculation
-    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+    DeviceDispatch<Dev>::template foreach_independent_workgroup<launch_t>(
         mgr, dispatch_indices.size(1), eval_energies_by_block);
 
     return {output_t, dispatch_indices_t};

--- a/tmol/score/ref/_ref_energy_term.py
+++ b/tmol/score/ref/_ref_energy_term.py
@@ -3,6 +3,7 @@ import torch
 from .._energy_term import EnergyTerm
 
 from tmol.database import ParameterDatabase
+from tmol.score.common._scoring_module import _coordinate_independent_score
 
 from tmol.chemical import RefinedResidueType
 from tmol.pose import (
@@ -137,9 +138,7 @@ def eval_ref_energy_for_pose(
         # computed once while rendering the scoring module, not on every call.
         score = pose_ref.view_as(pose_ref)
 
-    score.requires_grad = True  # a bit of a hack to make the benchmark test not error out because there are no grads
-
-    return score, None
+    return _coordinate_independent_score(_rot_coords, score), None
 
 
 def eval_ref_energy_for_rotamers(
@@ -187,5 +186,4 @@ def eval_ref_energy_for_rotamers(
         output_scores.index_add_(0, pose_ind_for_rot64, rotamer_scores)
         indices = torch.zeros((0,), dtype=torch.int32, device=device)
     output_scores = output_scores.unsqueeze(0)
-    output_scores.requires_grad = True  # a bit of a hack to make the benchmark test not error out because there are no grads
-    return output_scores, indices
+    return _coordinate_independent_score(rot_coords, output_scores), indices

--- a/tmol/score/ref/_ref_energy_term.py
+++ b/tmol/score/ref/_ref_energy_term.py
@@ -136,7 +136,7 @@ def eval_ref_energy_for_pose(
     else:
         # Reference energies are coordinate-independent. Their per-pose sum is
         # computed once while rendering the scoring module, not on every call.
-        score = pose_ref.view_as(pose_ref)
+        score = pose_ref
 
     return _coordinate_independent_score(_rot_coords, score), None
 

--- a/tmol/tests/numeric/test_dihedrals.py
+++ b/tmol/tests/numeric/test_dihedrals.py
@@ -3,6 +3,7 @@ import numpy
 import torch
 
 from tmol.numeric import coord_dihedrals
+from tmol.numeric._dihedrals import _numpy_coord_dihedrals
 from tmol.utility import parse_angle
 
 
@@ -38,3 +39,14 @@ def test_coord_dihedrals():
     )
 
     numpy.testing.assert_allclose(calc_dihedrals.numpy(), dihedrals, atol=1e-5)
+
+
+def test_numpy_coord_dihedrals_matches_torch():
+    generator = numpy.random.default_rng(7)
+    coords = generator.normal(size=(1000, 4, 3))
+    tensor_coords = torch.as_tensor(coords, dtype=torch.float64)
+
+    expected = coord_dihedrals(*(tensor_coords[:, i] for i in range(4))).numpy()
+    actual = _numpy_coord_dihedrals(*(coords[:, i] for i in range(4)))
+
+    numpy.testing.assert_array_equal(actual, expected)

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -34,6 +34,15 @@ def test_lbfgs_requires_one_parameter_tensor():
         LBFGS_Armijo([x, y])
 
 
+def test_lbfgs_accepts_one_named_parameter():
+    x = torch.nn.Parameter(torch.zeros(1))
+
+    optimizer = LBFGS_Armijo([("x", x)])
+
+    assert optimizer.param_groups[0]["params"][0] is x
+    assert optimizer.param_groups[0]["param_names"] == ["x"]
+
+
 def test_lbfgs_zero_grad_supports_both_reset_modes():
     x = torch.nn.Parameter(torch.ones(2))
     optimizer = LBFGS_Armijo([x])

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -26,6 +26,27 @@ class SimpleLJScore:
         return self
 
 
+def test_lbfgs_requires_one_parameter_tensor():
+    x = torch.nn.Parameter(torch.zeros(1))
+    y = torch.nn.Parameter(torch.zeros(1))
+
+    with pytest.raises(ValueError, match="exactly one parameter tensor"):
+        LBFGS_Armijo([x, y])
+
+
+def test_lbfgs_zero_grad_supports_both_reset_modes():
+    x = torch.nn.Parameter(torch.ones(2))
+    optimizer = LBFGS_Armijo([x])
+
+    x.sum().backward()
+    optimizer.zero_grad(set_to_none=False)
+    torch.testing.assert_close(x.grad, torch.zeros_like(x))
+
+    x.sum().backward()
+    optimizer.zero_grad()
+    assert x.grad is None
+
+
 def test_lbfgs_armijo():
     dtype = torch.float
     device = torch.device("cpu")

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -48,6 +48,18 @@ def test_contiguous_unequal_segments_use_padding(torch_device):
     )
 
 
+def test_equal_interleaved_segments_use_indexed_padding(torch_device):
+    x = torch.nn.Parameter(torch.zeros(6, device=torch_device))
+    segment_ids = torch.tensor([0, 1, 0, 1, 0, 1], device=torch_device)
+    optimizer = LBFGS_Armijo([x], segment_ids=segment_ids)
+    values = torch.arange(6, dtype=x.dtype, device=torch_device)
+
+    assert not optimizer._segments_are_dense
+    torch.testing.assert_close(
+        optimizer._seg_sum(values), torch.tensor([6.0, 9.0], device=torch_device)
+    )
+
+
 def test_batched_two_loop_matches_one_problem_at_a_time(torch_device):
     grad, dirs, stps = _history(7, 4, 13, torch.float64, torch_device)
     batched = lbfgs_two_loop(grad, dirs, stps)

--- a/tmol/tests/pack/rotamer/test_build_rotamers.py
+++ b/tmol/tests/pack/rotamer/test_build_rotamers.py
@@ -16,6 +16,7 @@ from tmol.pack.rotamer import (
     merge_conformer_samples,
     calculate_rotamer_coords,
     get_rotamer_origin_data,
+    load_rotamer_parents,
     create_dof_inds_to_copy_from_orig_to_rotamers_for_sampler,
     FixedAAChiSampler,
 )
@@ -62,6 +63,16 @@ def test_chi_atom_table_orders_double_digit_chis_numerically():
             dtype=numpy.int32,
         ),
     )
+
+
+def test_load_rotamer_parents_accepts_empty_conformer():
+    parents = numpy.zeros((1, 1), dtype=numpy.int32)
+    n_atoms = numpy.zeros(1, dtype=numpy.int32)
+    offsets = numpy.zeros(1, dtype=numpy.int64)
+
+    compact = load_rotamer_parents(parents, 0, n_atoms, offsets)
+
+    numpy.testing.assert_array_equal(compact, numpy.zeros(1, dtype=numpy.int32))
 
 
 def test_annotate_restypes(

--- a/tmol/tests/score/common/device_operations/test.hh
+++ b/tmol/tests/score/common/device_operations/test.hh
@@ -15,8 +15,12 @@ struct DevOpsTests {
   // dst[i] = src[i] + i
   static auto test_forall(TView<int32_t, 1, D> src) -> TPack<int32_t, 1, D>;
 
-  // dst[stack][i] = src[stack][i] * 2
-  static auto test_forall_stacks(TView<int32_t, 2, D> src)
+  // dst[i] = src[i] + i, with disjoint parallel work on CPU
+  static auto test_forall_independent(TView<int32_t, 1, D> src)
+      -> TPack<int32_t, 1, D>;
+
+  // dst[group][i] = src[group][i] + flattened element index
+  static auto test_forall_grouped(TView<int32_t, 2, D> src)
       -> TPack<int32_t, 2, D>;
 
   // dst[i][j][k] = src[i][j][k] + 1
@@ -25,6 +29,10 @@ struct DevOpsTests {
 
   // dst[wg] = src[wg] + wg
   static auto test_foreach_workgroup(TView<int32_t, 1, D> src)
+      -> TPack<int32_t, 1, D>;
+
+  // dst[wg] = src[wg] + wg, with disjoint parallel work on CPU
+  static auto test_foreach_independent_workgroup(TView<int32_t, 1, D> src)
       -> TPack<int32_t, 1, D>;
 
   // dst[pose][wg] = src[pose][wg] + flattened workgroup index

--- a/tmol/tests/score/common/device_operations/test.impl.hh
+++ b/tmol/tests/score/common/device_operations/test.impl.hh
@@ -35,16 +35,30 @@ auto DevOpsTests<D>::test_forall(TView<int32_t, 1, D> src)
 }
 
 template <tmol::Device D>
-auto DevOpsTests<D>::test_forall_stacks(TView<int32_t, 2, D> src)
+auto DevOpsTests<D>::test_forall_independent(TView<int32_t, 1, D> src)
+    -> TPack<int32_t, 1, D> {
+  ContextManager mgr;
+  int n = src.size(0);
+  auto dst_t = TPack<int32_t, 1, D>::empty({n});
+  auto dst = dst_t.view;
+  DO<D>::template forall_independent<launch_t>(
+      mgr, n, [=] EIGEN_DEVICE_FUNC(int i) { dst[i] = src[i] + i; });
+  return dst_t;
+}
+
+template <tmol::Device D>
+auto DevOpsTests<D>::test_forall_grouped(TView<int32_t, 2, D> src)
     -> TPack<int32_t, 2, D> {
   ContextManager mgr;
-  int nstacks = src.size(0);
-  int n = src.size(1);
-  auto dst_t = TPack<int32_t, 2, D>::empty({nstacks, n});
+  int const n_groups = src.size(0);
+  int const items_per_group = src.size(1);
+  auto dst_t = TPack<int32_t, 2, D>::empty({n_groups, items_per_group});
   auto dst = dst_t.view;
-  DO<D>::template forall_stacks<launch_t, int>(
-      mgr, nstacks, n, [=] EIGEN_DEVICE_FUNC(int stack, int i) {
-        dst[stack][i] = src[stack][i] * 2;
+  DO<D>::template forall_grouped<launch_t>(
+      mgr, n_groups, items_per_group, [=] EIGEN_DEVICE_FUNC(int index) {
+        int const group = index / items_per_group;
+        int const item = index % items_per_group;
+        dst[group][item] = src[group][item] + index;
       });
   return dst_t;
 }
@@ -73,6 +87,18 @@ auto DevOpsTests<D>::test_foreach_workgroup(TView<int32_t, 1, D> src)
   auto dst_t = TPack<int32_t, 1, D>::empty({n});
   auto dst = dst_t.view;
   DO<D>::template foreach_workgroup<launch_t>(
+      mgr, n, [=] EIGEN_DEVICE_FUNC(int wg) { dst[wg] = src[wg] + wg; });
+  return dst_t;
+}
+
+template <tmol::Device D>
+auto DevOpsTests<D>::test_foreach_independent_workgroup(
+    TView<int32_t, 1, D> src) -> TPack<int32_t, 1, D> {
+  ContextManager mgr;
+  int n = src.size(0);
+  auto dst_t = TPack<int32_t, 1, D>::empty({n});
+  auto dst = dst_t.view;
+  DO<D>::template foreach_independent_workgroup<launch_t>(
       mgr, n, [=] EIGEN_DEVICE_FUNC(int wg) { dst[wg] = src[wg] + wg; });
   return dst_t;
 }

--- a/tmol/tests/score/common/device_operations/test.pybind.cpp
+++ b/tmol/tests/score/common/device_operations/test.pybind.cpp
@@ -9,12 +9,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   using CPU = DevOpsTests<Device::CPU>;
 
   m.def("test_forall", &CPU::test_forall, "src"_a);
-  m.def("test_forall_stacks", &CPU::test_forall_stacks, "src"_a);
+  m.def("test_forall_independent", &CPU::test_forall_independent, "src"_a);
+  m.def("test_forall_grouped", &CPU::test_forall_grouped, "src"_a);
   m.def(
       "test_foreach_combination_triple",
       &CPU::test_foreach_combination_triple,
       "src"_a);
   m.def("test_foreach_workgroup", &CPU::test_foreach_workgroup, "src"_a);
+  m.def(
+      "test_foreach_independent_workgroup",
+      &CPU::test_foreach_independent_workgroup,
+      "src"_a);
   m.def(
       "test_foreach_pose_workgroup",
       &CPU::test_foreach_pose_workgroup,
@@ -52,12 +57,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // All functions take TView arguments; pybind resolves CPU vs CUDA overloads
   // by inspecting the device of the input tensors.
   m.def("test_forall", &CUDA::test_forall, "src"_a);
-  m.def("test_forall_stacks", &CUDA::test_forall_stacks, "src"_a);
+  m.def("test_forall_independent", &CUDA::test_forall_independent, "src"_a);
+  m.def("test_forall_grouped", &CUDA::test_forall_grouped, "src"_a);
   m.def(
       "test_foreach_combination_triple",
       &CUDA::test_foreach_combination_triple,
       "src"_a);
   m.def("test_foreach_workgroup", &CUDA::test_foreach_workgroup, "src"_a);
+  m.def(
+      "test_foreach_independent_workgroup",
+      &CUDA::test_foreach_independent_workgroup,
+      "src"_a);
   m.def(
       "test_foreach_pose_workgroup",
       &CUDA::test_foreach_pose_workgroup,

--- a/tmol/tests/score/common/device_operations/test_device_operations.py
+++ b/tmol/tests/score/common/device_operations/test_device_operations.py
@@ -36,25 +36,22 @@ def test_forall_large(ext, torch_device):
     assert torch.equal(result.cpu(), expected)
 
 
-# ---------------------------------------------------------------------------
-# forall_stacks: dst[stack][i] = src[stack][i] * 2
-# ---------------------------------------------------------------------------
+def test_forall_independent(ext, torch_device):
+    src = torch.zeros(1000, dtype=torch.int32, device=torch_device)
+    result = ext.test_forall_independent(src)
+    assert torch.equal(result.cpu(), torch.arange(1000, dtype=torch.int32))
 
 
-def test_forall_stacks(ext, torch_device):
-    src = torch.arange(12, dtype=torch.int32, device=torch_device).reshape(3, 4)
-    result = ext.test_forall_stacks(src)
-    expected = torch.arange(12, dtype=torch.int32).reshape(3, 4) * 2
-    assert torch.equal(result.cpu(), expected)
+def test_forall_independent_large(ext, torch_device):
+    src = torch.zeros(100_000, dtype=torch.int32, device=torch_device)
+    result = ext.test_forall_independent(src)
+    assert torch.equal(result.cpu(), torch.arange(100_000, dtype=torch.int32))
 
 
-def test_forall_stacks_large(ext, torch_device):
-    # 128 stacks x 1024 elements exercises CPU stack parallelism and spans
-    # multiple CUDA CTAs.
-    # src=ones, so dst[stack][i] = 1 * 2 = 2 everywhere.
-    src = torch.ones(128, 1024, dtype=torch.int32, device=torch_device)
-    result = ext.test_forall_stacks(src)
-    expected = torch.full((128, 1024), 2, dtype=torch.int32)
+def test_forall_grouped(ext, torch_device):
+    src = torch.zeros((8, 17), dtype=torch.int32, device=torch_device)
+    result = ext.test_forall_grouped(src)
+    expected = torch.arange(src.numel(), dtype=torch.int32).reshape_as(src.cpu())
     assert torch.equal(result.cpu(), expected)
 
 
@@ -99,6 +96,12 @@ def test_foreach_workgroup_large(ext, torch_device):
     result = ext.test_foreach_workgroup(src)
     expected = torch.arange(N, dtype=torch.int32)
     assert torch.equal(result.cpu(), expected)
+
+
+def test_foreach_independent_workgroup(ext, torch_device):
+    src = torch.zeros(1000, dtype=torch.int32, device=torch_device)
+    result = ext.test_foreach_independent_workgroup(src)
+    assert torch.equal(result.cpu(), torch.arange(1000, dtype=torch.int32))
 
 
 def test_foreach_pose_workgroup(ext, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -283,6 +283,27 @@ def test_large_cpu_forward_uses_wider_term_pool(monkeypatch):
     assert worker_counts == [8, 4]
 
 
+def test_cpu_whole_pose_preserves_trainable_term_gradients(monkeypatch):
+    class TrainableTerm(torch.nn.Module):
+        def __init__(self, scale):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(scale))
+
+        def forward(self, coords):
+            return (self.scale * coords.square().sum()).reshape(1, 1)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 2)
+    terms = [TrainableTerm(2.0), TrainableTerm(3.0)]
+    scorer = WholePoseScoringModule(torch.ones(2), terms)
+    coords = torch.arange(3.0, requires_grad=True)
+
+    scorer(coords).backward()
+
+    torch.testing.assert_close(coords.grad, 10 * coords.detach())
+    for term in terms:
+        torch.testing.assert_close(term.scale.grad, coords.detach().square().sum())
+
+
 def test_cpu_parallel_whole_pose_gradient_matches_serial_order(
     ubq_pdb, default_database, torch_device, monkeypatch
 ):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -258,6 +258,31 @@ def test_cpu_whole_pose_terms_run_concurrently_and_preserve_modes(monkeypatch):
     )
 
 
+def test_large_cpu_forward_uses_wider_term_pool(monkeypatch):
+    class SumTerm(torch.nn.Module):
+        def forward(self, coords):
+            return coords.sum().reshape(1, 1)
+
+    worker_counts = []
+    executor_for_workers = score_function_module._cpu_score_term_executor
+
+    def recording_executor(n_workers):
+        worker_counts.append(n_workers)
+        return executor_for_workers(n_workers)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 32)
+    monkeypatch.setattr(
+        score_function_module, "_cpu_score_term_executor", recording_executor
+    )
+    scorer = WholePoseScoringModule(torch.ones(8), [SumTerm() for _ in range(8)])
+    coords = torch.ones((20, 1, 3))
+
+    scorer(coords)
+    scorer(coords.requires_grad_()).sum().backward()
+
+    assert worker_counts == [8, 4]
+
+
 def test_cpu_parallel_whole_pose_gradient_matches_serial_order(
     ubq_pdb, default_database, torch_device, monkeypatch
 ):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -538,6 +538,7 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
     # check individual terms
     full_score = full_scorer(pose_stack.coords, sum_terms=False)
     block_score = block_scorer(pose_stack.coords, sum_terms=False)
+    assert not block_score.requires_grad
     torch.testing.assert_close(
         full_score, torch.sum(block_score, dim=(2, 3)), atol=1e-3, rtol=1e-3
     )
@@ -549,10 +550,14 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
         full_score, torch.sum(block_score, dim=(1, 2)), atol=1e-3, rtol=1e-3
     )
     if torch_device.type == "cpu":
-        parallel_score = block_scorer(pose_stack.coords)
+        with torch.no_grad():
+            parallel_score = block_scorer(pose_stack.coords)
+
         block_scorer._cpu_term_workers = 0
         block_scorer._cpu_forward_workers = 0
-        serial_score = block_scorer(pose_stack.coords)
+        with torch.no_grad():
+            serial_score = block_scorer(pose_stack.coords)
+
         assert torch.equal(parallel_score, serial_score)
 
 
@@ -631,6 +636,14 @@ def test_cpu_block_pair_terms_parallelize_only_forward(monkeypatch):
         scores = scorer(torch.ones((1, 1, 3)))
 
     torch.testing.assert_close(scores, torch.full((1, 2, 2), 9.0))
+    assert all(term.thread_ids[0] != threading.get_ident() for term in terms)
+
+    for term in terms:
+        term.thread_ids.clear()
+    with torch.no_grad():
+        unweighted = scorer(torch.ones((1, 1, 3)), sum_terms=False, apply_weights=False)
+
+    torch.testing.assert_close(unweighted[:, 0, 0, 0], torch.tensor([3.0, 0.0, 6.0]))
     assert all(term.thread_ids[0] != threading.get_ident() for term in terms)
 
     coords = torch.ones((1, 1, 3), requires_grad=True)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -1,6 +1,7 @@
 import torch
 import numpy
 import os
+import threading
 import pytest
 
 from tmol.score import _score_function as score_function_module
@@ -188,11 +189,100 @@ def test_no_grad_scoring_detaches_coordinates():
     assert not term.input_requires_grad
 
 
+def test_cpu_whole_pose_terms_run_concurrently_and_preserve_modes(monkeypatch):
+    monkeypatch.setattr(
+        score_function_module,
+        "_CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS",
+        0,
+    )
+
+    class RecordingTerm(torch.nn.Module):
+        def __init__(self, scale):
+            super().__init__()
+            self.scale = scale
+            self.calls = []
+
+        def forward(self, coords):
+            self.calls.append(
+                (
+                    threading.get_ident(),
+                    torch.is_grad_enabled(),
+                    torch.is_inference_mode_enabled(),
+                )
+            )
+            return (self.scale * coords.square().sum()).reshape(1, 1)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
+    terms = [RecordingTerm(scale) for scale in (1.0, 2.0, 3.0, 4.0)]
+    scorer = WholePoseScoringModule(torch.ones(4), terms)
+    coords = torch.arange(3.0, requires_grad=True)
+
+    score = scorer(coords)
+    score.backward(retain_graph=True)
+
+    torch.testing.assert_close(score, torch.tensor([50.0]))
+    torch.testing.assert_close(coords.grad, 20 * coords.detach())
+    coords.grad = None
+    score.backward()
+    torch.testing.assert_close(coords.grad, 20 * coords.detach())
+    assert all(
+        call[0] != threading.get_ident() for term in terms for call in term.calls
+    )
+    assert all(call[1:] == (True, False) for term in terms for call in term.calls)
+
+    for term in terms:
+        term.calls.clear()
+    with torch.inference_mode():
+        scorer(coords)
+    assert all(call[1:] == (False, True) for term in terms for call in term.calls)
+
+    for term in terms:
+        term.calls.clear()
+    scorer._cpu_term_workers = 0
+    scorer(coords)
+    assert all(
+        call[0] == threading.get_ident() for term in terms for call in term.calls
+    )
+
+
+def test_cpu_parallel_whole_pose_gradient_matches_serial_order(
+    ubq_pdb, default_database, torch_device, monkeypatch
+):
+    if torch_device.type != "cpu":
+        pytest.skip("CPU term-parallel scoring test")
+
+    monkeypatch.setattr(
+        score_function_module,
+        "_CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS",
+        0,
+    )
+
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    scorer = beta2016_score_function(
+        torch_device, default_database
+    ).render_whole_pose_scoring_module(pose)
+
+    def score_and_gradient():
+        coords = pose.coords.detach().clone().requires_grad_(True)
+        score = scorer(coords)
+        (gradient,) = torch.autograd.grad(score.sum(), coords)
+        return score, gradient
+
+    parallel_score, parallel_gradient = score_and_gradient()
+    scorer._cpu_term_workers = 0
+    serial_score, serial_gradient = score_and_gradient()
+
+    assert torch.equal(parallel_score, serial_score)
+    assert torch.equal(parallel_gradient, serial_gradient)
+
+
 def test_rotamer_scorer_combines_identical_sparse_layouts(
     torch_device: torch.device,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(score_function_module, "_ROTAMER_LAYOUT_DEDUP_MIN_BYTES", 0)
+    monkeypatch.setattr(
+        score_function_module, "_CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES", 0
+    )
 
     class SparseTerm(torch.nn.Module):
         def __init__(self, scores: torch.Tensor, indices: torch.Tensor) -> None:
@@ -234,6 +324,65 @@ def test_rotamer_scorer_combines_identical_sparse_layouts(
     )
     dense_scores.sum().backward()
     torch.testing.assert_close(coords.grad, torch.tensor(61.0, device=torch_device))
+
+
+def test_cpu_rotamer_scorer_coalesces_subset_layouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(score_function_module, "_CPU_ROTAMER_SORTED_LAYOUT_MIN_NNZ", 0)
+
+    class SparseTerm(torch.nn.Module):
+        def __init__(self, scores: torch.Tensor, indices: torch.Tensor) -> None:
+            super().__init__()
+            self.scores = scores
+            self.indices = indices
+            self.n_poses = 1
+            self.n_rots = 3
+
+        def forward(self, coords: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return self.scores * coords, self.indices
+
+    complete = torch.tensor([[0, 0, 0], [2, 0, 1], [2, 0, 1]], dtype=torch.int32)
+    subset = complete[:, [0, 2]]
+    scorer = RotamerScoringModule(
+        torch.tensor([1.0, 2.0]),
+        [
+            SparseTerm(torch.tensor([[1.0, 2.0, 3.0]]), complete),
+            SparseTerm(torch.tensor([[4.0, 5.0]]), subset),
+        ],
+    )
+    coords = torch.ones((), requires_grad=True)
+
+    scores = scorer(coords)
+
+    assert scores.is_coalesced()
+    torch.testing.assert_close(
+        scores.to_dense(),
+        torch.tensor([[[2.0, 0.0, 0.0], [0.0, 13.0, 0.0], [0.0, 0.0, 9.0]]]),
+    )
+    scores.values().sum().backward()
+    torch.testing.assert_close(coords.grad, torch.tensor(24.0))
+
+
+def test_cpu_rotamer_terms_run_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    barrier = threading.Barrier(2, timeout=2)
+
+    class SparseTerm(torch.nn.Module):
+        n_poses = 1
+        n_rots = 1
+
+        def forward(self, coords: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            barrier.wait()
+            scores = coords.reshape(1, 1)
+            indices = torch.zeros((3, 1), dtype=torch.int32)
+            return scores, indices
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 2)
+    scorer = RotamerScoringModule(torch.ones(2), [SparseTerm(), SparseTerm()])
+
+    scores = scorer(torch.ones(()))
+
+    torch.testing.assert_close(scores.to_dense(), torch.tensor([[[2.0]]]))
 
 
 def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -289,6 +289,39 @@ def test_cpu_parallel_whole_pose_gradient_matches_serial_order(
     assert torch.equal(parallel_gradient, serial_gradient)
 
 
+@pytest.mark.parametrize(
+    "backward_threshold", [0, 10_000], ids=["parallel", "single-call"]
+)
+def test_cpu_parallel_whole_pose_supports_second_coordinate_derivatives(
+    monkeypatch: pytest.MonkeyPatch, backward_threshold: int
+) -> None:
+    class QuadraticTerm(torch.nn.Module):
+        def __init__(self, scale: float) -> None:
+            super().__init__()
+            self.scale = scale
+
+        def forward(self, coords: torch.Tensor) -> torch.Tensor:
+            return (self.scale * coords.square().sum()).reshape(1, 1)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
+    monkeypatch.setattr(
+        score_function_module,
+        "_CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS",
+        backward_threshold,
+    )
+    scorer = WholePoseScoringModule(
+        torch.ones(4), [QuadraticTerm(scale) for scale in (1.0, 2.0, 3.0, 4.0)]
+    )
+    coords = torch.arange(3.0, requires_grad=True)
+
+    score = scorer(coords).sum()
+    (gradient,) = torch.autograd.grad(score, coords, create_graph=True)
+    (second_derivative,) = torch.autograd.grad(gradient.sum(), coords)
+
+    torch.testing.assert_close(gradient, 20 * coords.detach())
+    torch.testing.assert_close(second_derivative, torch.full_like(coords, 20))
+
+
 def test_rotamer_scorer_combines_identical_sparse_layouts(
     torch_device: torch.device,
     monkeypatch: pytest.MonkeyPatch,

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -212,15 +212,28 @@ def test_cpu_whole_pose_terms_run_concurrently_and_preserve_modes(monkeypatch):
             )
             return (self.scale * coords.square().sum()).reshape(1, 1)
 
+    class ConstantTerm(RecordingTerm):
+        def forward(self, coords):
+            self.calls.append(
+                (
+                    threading.get_ident(),
+                    torch.is_grad_enabled(),
+                    torch.is_inference_mode_enabled(),
+                )
+            )
+            return torch.ones((1, 1), dtype=coords.dtype, device=coords.device)
+
     monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
-    terms = [RecordingTerm(scale) for scale in (1.0, 2.0, 3.0, 4.0)]
-    scorer = WholePoseScoringModule(torch.ones(4), terms)
+    terms = [RecordingTerm(scale) for scale in (1.0, 2.0, 3.0, 4.0)] + [
+        ConstantTerm(0.0)
+    ]
+    scorer = WholePoseScoringModule(torch.ones(5), terms)
     coords = torch.arange(3.0, requires_grad=True)
 
     score = scorer(coords)
     score.backward(retain_graph=True)
 
-    torch.testing.assert_close(score, torch.tensor([50.0]))
+    torch.testing.assert_close(score, torch.tensor([51.0]))
     torch.testing.assert_close(coords.grad, 20 * coords.detach())
     coords.grad = None
     score.backward()

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -548,6 +548,12 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
     torch.testing.assert_close(
         full_score, torch.sum(block_score, dim=(1, 2)), atol=1e-3, rtol=1e-3
     )
+    if torch_device.type == "cpu":
+        parallel_score = block_scorer(pose_stack.coords)
+        block_scorer._cpu_term_workers = 0
+        block_scorer._cpu_forward_workers = 0
+        serial_score = block_scorer(pose_stack.coords)
+        assert torch.equal(parallel_score, serial_score)
 
 
 def test_block_pair_gradients_respect_sparse_upstream_weights(
@@ -592,6 +598,49 @@ def test_block_pair_scoring_supports_only_invariant_zero_terms(torch_device):
     assert scores.shape == (3, 4, 4)
     assert torch.count_nonzero(scores) == 0
     scores.sum().backward()
+
+
+def test_cpu_block_pair_terms_parallelize_only_forward(monkeypatch):
+    barrier = threading.Barrier(2, timeout=2)
+
+    class RecordingTerm(torch.nn.Module):
+        def __init__(self, scale):
+            super().__init__()
+            self.scale = scale
+            self.parallel = True
+            self.thread_ids = []
+
+        def forward(self, coords):
+            self.thread_ids.append(threading.get_ident())
+            if self.parallel:
+                barrier.wait()
+            return (self.scale * coords.sum()).expand(1, 1, 2, 2)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 2)
+    terms = [RecordingTerm(1.0), RecordingTerm(2.0)]
+    scorer = BlockPairScoringModule(
+        torch.tensor([1.0, 7.0, 1.0]),
+        [
+            terms[0],
+            ZeroTermPoseScoringModule("zero", 1, 1, torch.device("cpu"), 2),
+            terms[1],
+        ],
+    )
+
+    with torch.no_grad():
+        scores = scorer(torch.ones((1, 1, 3)))
+
+    torch.testing.assert_close(scores, torch.full((1, 2, 2), 9.0))
+    assert all(term.thread_ids[0] != threading.get_ident() for term in terms)
+
+    coords = torch.ones((1, 1, 3), requires_grad=True)
+    for term in terms:
+        term.parallel = False
+        term.thread_ids.clear()
+    scorer(coords).sum().backward()
+
+    torch.testing.assert_close(coords.grad, torch.full_like(coords, 12.0))
+    assert all(term.thread_ids == [threading.get_ident()] for term in terms)
 
 
 def test_virtual_residue_scoring(ubq_pdb, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -16,6 +16,7 @@ from tmol.score._score_function import (
     WholePoseScoringModule,
 )
 from tmol.score.common import ZeroTermPoseScoringModule
+from tmol.score.common._scoring_module import _coordinate_independent_score
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
     DEFAULT_ATOM_OCCUPANCY,
@@ -187,6 +188,20 @@ def test_no_grad_scoring_detaches_coordinates():
     with torch.no_grad():
         scorer(coords)
     assert not term.input_requires_grad
+
+
+def test_coordinate_independent_score_preserves_its_own_gradient():
+    coords = torch.ones(3, requires_grad=True)
+    score = torch.ones(2, requires_grad=True)
+
+    coords_grad, score_grad = torch.autograd.grad(
+        _coordinate_independent_score(coords, score).sum(),
+        (coords, score),
+        allow_unused=True,
+    )
+
+    assert coords_grad is None
+    torch.testing.assert_close(score_grad, torch.ones_like(score))
 
 
 def test_cpu_whole_pose_terms_run_concurrently_and_preserve_modes(monkeypatch):


### PR DESCRIPTION
## Summary

This PR removes the largest profiled CPU bottlenecks in scoring and FastRelax while retaining the existing CUDA launch topology.

- parallelizes explicitly independent CPU element/workgroup kernels while keeping potentially colliding work grouped and serial
- evaluates independent whole-pose and forward-only block-pair score terms concurrently, including the per-term tensors consumed by mutation ddG, wider scheduling for large CPU pose batches, and bounded independent backward graphs with deterministic gradient accumulation order
- speeds rotamer construction by replacing repeated cold Numba compilation with vectorized NumPy setup and by caching/coalescing repeated sparse layouts
- parallelizes CPU interaction-graph construction and forward-only rotamer score kernels
- reduces LBFGS cold initialization, single-pose broadcasting, dense segmented-reduction overhead, and float32 single-segment search-direction overhead
- replaces small einsum-based dihedral reductions with direct reductions
- precomputes and filters CPU annealer neighbor offsets in per-pose storage and elides unused CUDA quench bookkeeping
- preserves higher coordinate derivatives through the parallel CPU scorer for force-derived losses
- removes the reference term's forced autograd leaf while retaining its no-op coordinate edge for genuinely differentiable calls without suppressing gradients through the score itself

CUDA remains on its existing kernel launch path. CUDA graphs, multi-stream term launches, batched serial autograd-engine reductions, size-only CPU backward throttling, alternate CartBonded occupancy settings, float32 LBFGS solves, and broader CPU rotamer metadata caches were profiled and rejected because they regressed results, determinism, or measured workloads; none are included here.

## Performance

Measured against v0.1.53 master with the same benchmark harness.

| CPU ubiquitin pose batch | Forward, master | Forward, PR | Full, master | Full, PR |
|---:|---:|---:|---:|---:|
| 1 | 9.58 ms | 3.85 ms | 15.65 ms | 8.08 ms |
| 10 | 17.19 ms | 7.20 ms | 29.48 ms | 15.51 ms |
| 100 | 74.96 ms | 23.98 ms | 113.85 ms | 54.19 ms |

One-pose CPU FastRelax fell from 53.75 s to 7.26-7.42 s across final isolated repeats, a 7.2-7.4x speedup. The final minimizer-only delta is modest but consistent at the median: 7.374 s versus 7.440 s at the previous pushed head, with the exact same final score (`-274.087097`).

On H200, combined score forward/backward remains neutral to 6% faster across batches 1-100. Five alternating one-pose Cartesian FastRelax repeats at the final head had medians of 3.117 s versus 3.158 s at the previous head (1.3% faster); the isolated 128-step single-segment L-BFGS direction calculation fell from 0.326 ms to 0.203 ms (38% faster). The larger branch-versus-master comparison remains 2.96-4.08 s versus 6.54 s, depending on the stochastic packing/minimizer trajectory.

Additional isolated results:

- complete `build_rotamers`: 22.92 ms to 13.66 ms, 40% faster
- jump-parent chi correction: 5.86 ms to 1.46 ms, 4.0x faster
- repeated annotation pass: 6.33 ms to 0.013 ms after caching
- 64-pose nearby-atom mask: 30.33 ms to 0.48-0.73 ms, 42-63x faster
- CPU interaction-graph construction: approximately 3.2x faster
- CPU simulated annealing: 70.1-72.8 ms to 44.5-45.4 ms across five fresh-process medians, approximately 36-38% faster
- H200 simulated annealing: 125.6-125.8 ms to 124.3-124.8 ms across three alternating medians, approximately 1% faster
- default CPU block-pair scoring: 10.42 to 5.11 ms at batch 1, 14.70 to 8.07 ms at batch 8, and 22.53 to 11.80 ms at batch 32 (1.8-2.0x faster); separate DNA and protein topologies improved 1.8-3.2x
- public single-site `calculate_block_pair_ddg`: 1.43-1.71x faster at batch 1 and 1.50-1.55x at batch 8 for ubiquitin; DNA and mixed/protein systems improved 1.3-2.5x at batch 1 and 1.5-2.1x at batch 8, with scores bitwise equal to the serial route
- forward-only CPU batches of 20-100 poses: a further 10-22% faster across protein, DNA, and mixed/ligand test topologies by widening term concurrency only on hosts with at least 32 intra-op threads

## Correctness and validation

- full CPU suite at the final compiled head: 1,549 passed, 963 skipped, 5 xfailed, 1 xpassed; the final CPU annealer cleanup additionally passes the focused pack suite and seeded equivalence checks below
- final-head CPU pack suite: 87 passed, 74 skipped; scores and assignments remain byte-identical across 50 explicitly seeded runs
- final-head block-pair/reference/score/ddG suite: 70 passed, 60 skipped; real block-pair outputs and public mutation-ddG results are bitwise equal to the serial path
- final-head H200 block-pair/reference/score/ddG suite: 127 passed, 3 skipped
- H200 focused optimizer/scoring suite at the preceding head: 87 passed, 3 skipped, 1 xfailed
- final-head H200 pack suite: 27 passed; scores and assignments match the baseline byte-for-byte across 20 seeds
- H200 full suite at the preceding head: 2,474 passed, 19 skipped, 5 xfailed, 2 xpassed
- parallel whole-pose scoring is checked against serial execution with bitwise-equal scores and coordinate gradients
- repeated backward, second coordinate derivatives, inference mode, no-grad behavior, sparse-layout coalescing, and both dense/interleaved LBFGS segments have focused tests
- Black, Flake8, clang-format, and git diff checks pass

The branch is rebased onto v0.1.53 master.
