### PR TITLE
Accelerate CUDA nucleic-acid scoring and interface guidance

### DIFF
--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -43,7 +43,13 @@ case "${NVCC_VER}" in
   *) DEFAULT_TORCH_CUDA_INDEX="https://download.pytorch.org/whl/cu128" ;;
 esac
 TORCH_CUDA_INDEX="${TMOL_CI_TORCH_CUDA_INDEX:-${DEFAULT_TORCH_CUDA_INDEX}}"
-retry uv pip install --upgrade torch --index-url "${TORCH_CUDA_INDEX}"
+NVCC_MAJOR=${NVCC_VER%%.*}
+TORCH_CUDA_MAJOR=$(python -c "import torch; print((torch.version.cuda or '').split('.')[0])" 2>/dev/null || true)
+if [[ "${TORCH_CUDA_MAJOR}" != "${NVCC_MAJOR}" ]]; then
+  retry uv pip install --upgrade torch --index-url "${TORCH_CUDA_INDEX}"
+else
+  echo "Reusing PyTorch $(python -c 'import torch; print(torch.__version__)') with CUDA $(python -c 'import torch; print(torch.version.cuda)')"
+fi
 # The extension must be configured with the same Torch/CUDA installation that
 # will load it at runtime.  PEP 517 build isolation otherwise resolves the
 # unbounded ``torch>=2.5`` build requirement independently; when a newer CUDA
@@ -52,7 +58,6 @@ retry uv pip install --upgrade torch --index-url "${TORCH_CUDA_INDEX}"
 retry uv pip install "scikit-build-core>=0.10" "pybind11>=2.12" ninja packaging
 assert_torch_cuda
 TORCH_CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])")
-NVCC_MAJOR=${NVCC_VER%%.*}
 if [[ "${TORCH_CUDA_MAJOR}" != "${NVCC_MAJOR}" ]]; then
   echo "PyTorch CUDA ${TORCH_CUDA_MAJOR} does not match nvcc ${NVCC_VER}" >&2
   exit 1

--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -89,9 +89,11 @@ for _A in "${_CUDA_ARCH_ARR[@]}"; do
   fi
 done
 export TORCH_CUDA_ARCH_LIST="${TORCH_ARCH_LIST# }"
+TORCH_CMAKE_DIR=$(python -c "from pathlib import Path; import torch; print(Path(torch.__file__).parent / 'share/cmake/Torch')")
 echo "=== Runner GPU sm_${RUN_GPU} | nvcc ${NVCC_VER} | CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS} ==="
 MAX_JOBS=12 pip install -v --no-deps --no-build-isolation \
   -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+  -Ccmake.define.Torch_DIR="${TORCH_CMAKE_DIR}" \
   -Ccmake.define.TMOL_BUILD_TESTS=ON \
   -Ccmake.define.TMOL_NVCC_THREADS=2 \
   -e .

--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -30,19 +30,38 @@ retry() {
   done
 }
 
-retry uv pip compile pyproject.toml --all-extras --output-file requirements.txt
-grep -vE "^(torch(|vision|audio)|numpy|nvidia-.*|triton|tensorrt|pynvml|pandas|scipy)==" \
-  requirements.txt > to_install.txt
-retry uv pip install -r to_install.txt
-TORCH_CUDA_INDEX="${TMOL_CI_TORCH_CUDA_INDEX:-https://download.pytorch.org/whl/cu128}"
-retry uv pip install torch --index-url "${TORCH_CUDA_INDEX}"
+BUILD_DEPS_TMP=$(mktemp -d)
+trap 'rm -rf "${BUILD_DEPS_TMP}"' EXIT
+retry uv pip compile --quiet pyproject.toml --all-extras \
+  --output-file "${BUILD_DEPS_TMP}/requirements.txt"
+grep -vE "^(torch(|vision|audio)|numpy|cuda-.*|nvidia-.*|triton|tensorrt|pynvml|pandas|scipy)==" \
+  "${BUILD_DEPS_TMP}/requirements.txt" > "${BUILD_DEPS_TMP}/to_install.txt"
+retry uv pip install -r "${BUILD_DEPS_TMP}/to_install.txt"
+NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
+case "${NVCC_VER}" in
+  13.*) DEFAULT_TORCH_CUDA_INDEX="https://download.pytorch.org/whl/cu130" ;;
+  *) DEFAULT_TORCH_CUDA_INDEX="https://download.pytorch.org/whl/cu128" ;;
+esac
+TORCH_CUDA_INDEX="${TMOL_CI_TORCH_CUDA_INDEX:-${DEFAULT_TORCH_CUDA_INDEX}}"
+retry uv pip install --upgrade torch --index-url "${TORCH_CUDA_INDEX}"
+# The extension must be configured with the same Torch/CUDA installation that
+# will load it at runtime.  PEP 517 build isolation otherwise resolves the
+# unbounded ``torch>=2.5`` build requirement independently; when a newer CUDA
+# major is current on PyPI this can silently produce (for example) a CUDA 13
+# extension in a CUDA 12.8 runtime environment.
+retry uv pip install "scikit-build-core>=0.10" "pybind11>=2.12" ninja packaging
 assert_torch_cuda
+TORCH_CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])")
+NVCC_MAJOR=${NVCC_VER%%.*}
+if [[ "${TORCH_CUDA_MAJOR}" != "${NVCC_MAJOR}" ]]; then
+  echo "PyTorch CUDA ${TORCH_CUDA_MAJOR} does not match nvcc ${NVCC_VER}" >&2
+  exit 1
+fi
 
 RUN_GPU=$(python -c "import torch; c=torch.cuda.get_device_capability(0); print(f'{c[0]}.{c[1]}')" 2>/dev/null || echo "n/a")
 # Test jobs only execute on this runner, so compiling every wheel architecture
 # wastes most of the job. Release wheels retain the all-supported-SM default.
 CUDA_ARCHS="${TMOL_CI_CUDA_ARCHITECTURES:-native}"
-NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
 if [[ "${CUDA_ARCHS}" == "native" ]]; then
   # Exercise CMake's native path in CI. JIT extensions still need PyTorch's
   # numeric spelling for the same runner GPU.
@@ -66,7 +85,7 @@ for _A in "${_CUDA_ARCH_ARR[@]}"; do
 done
 export TORCH_CUDA_ARCH_LIST="${TORCH_ARCH_LIST# }"
 echo "=== Runner GPU sm_${RUN_GPU} | nvcc ${NVCC_VER} | CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS} ==="
-MAX_JOBS=12 pip install -v --no-deps \
+MAX_JOBS=12 pip install -v --no-deps --no-build-isolation \
   -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
   -Ccmake.define.TMOL_BUILD_TESTS=ON \
   -Ccmake.define.TMOL_NVCC_THREADS=2 \

--- a/.github/ci/exec_gpu_apptainer.sh
+++ b/.github/ci/exec_gpu_apptainer.sh
@@ -37,6 +37,12 @@ fi
 if [[ -n "${TMOL_DOCS_BASE_URL:-}" ]]; then
   env_args+=(--env "TMOL_DOCS_BASE_URL=${TMOL_DOCS_BASE_URL}")
 fi
+if [[ -n "${TMOL_CI_CUDA_ARCHITECTURES:-}" ]]; then
+  env_args+=(--env "TMOL_CI_CUDA_ARCHITECTURES=${TMOL_CI_CUDA_ARCHITECTURES}")
+fi
+if [[ -n "${TMOL_CI_TORCH_CUDA_INDEX:-}" ]]; then
+  env_args+=(--env "TMOL_CI_TORCH_CUDA_INDEX=${TMOL_CI_TORCH_CUDA_INDEX}")
+fi
 
 apptainer exec --nv --fakeroot --containall \
   --bind "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \

--- a/.github/ci/gpu_env.sh
+++ b/.github/ci/gpu_env.sh
@@ -49,7 +49,8 @@ print(
 if torch.version.cuda is None:
     sys.exit(
         "PyTorch has no CUDA support (CPU-only wheel). "
-        "Install from https://download.pytorch.org/whl/cu128"
+        "Install a wheel matching the build CUDA toolkit from "
+        "https://download.pytorch.org/whl/"
     )
 if not torch.cuda.is_available():
     sys.exit(

--- a/.github/ci/setup_ci_venv.sh
+++ b/.github/ci/setup_ci_venv.sh
@@ -26,7 +26,10 @@ if [ -z "$PYTHON_BIN" ]; then
 fi
 
 if [ ! -d .venv ]; then
-  "$PYTHON_BIN" -m venv .venv
+  # The GPU image already provides a CUDA-matched NVIDIA PyTorch build. Make it
+  # visible to the venv so clean CI jobs do not redownload several GB of CUDA
+  # wheels; build_package.sh still replaces it when the CUDA majors differ.
+  "$PYTHON_BIN" -m venv --system-site-packages .venv
 fi
 source .venv/bin/activate
 pip install pip --upgrade

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,8 @@ set(_C_SOURCES
   tmol/score/lk_ball/potentials/compiled.ops.cpp
   tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
   tmol/score/lk_ball/potentials/gen_pose_waters.cpu.cpp
+  # score/na_torsion (CUDA implementation registered separately below)
+  tmol/score/na_torsion/potentials/compiled.ops.cpp
 )
 
 if(TMOL_HAS_CUDA)
@@ -431,6 +433,7 @@ if(TMOL_HAS_CUDA)
     tmol/score/ljlk/potentials/ljlk_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/gen_pose_waters.cuda.cu
+    tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
   )
 endif()
 

--- a/dev/benchmark_fast_relax.py
+++ b/dev/benchmark_fast_relax.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Time end-to-end Cartesian FastRelax on a chosen benchmark system."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import torch
+
+from benchmark_score_matrix import SYSTEMS, load_system, synchronize
+from tmol.kinematics import CartesianMoveMap, FoldForest
+from tmol.pack import PackerPalette
+from tmol.pose import PoseStackBuilder
+from tmol.relax import fast_relax
+from tmol.score import beta2016_score_function
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=("cpu", "cuda"), required=True)
+    parser.add_argument("--system", choices=sorted(SYSTEMS), default="protein-76")
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=20260902)
+    parser.add_argument("--cuda-graph", action="store_true")
+    parser.add_argument("--no-opt-h", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if min(args.batch, args.trials, args.repeats) < 1:
+        raise SystemExit("batch, trials, and repeats must be positive")
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA requested but torch.cuda.is_available() is false")
+
+    base, database = load_system(SYSTEMS[args.system], device, not args.no_opt_h)
+    initial = PoseStackBuilder.from_poses([base] * args.batch, device)
+    fold_forest = FoldForest.reasonable_fold_forest(initial)
+    move_map = CartesianMoveMap()
+    sfxn = beta2016_score_function(device, param_db=database)
+    initial_scorer = sfxn.render_whole_pose_scoring_module(initial)
+    initial_score = initial_scorer(initial.coords).detach()
+
+    if args.cuda_graph and device.type != "cuda":
+        raise SystemExit("--cuda-graph requires --device cuda")
+
+    for trial in range(args.trials):
+        torch.manual_seed(args.seed + trial)
+        pose = initial.clone()
+        synchronize(device)
+        start = time.perf_counter()
+        relaxed = fast_relax(
+            pose,
+            sfxn,
+            PackerPalette(),
+            move_map,
+            fold_forest,
+            num_repeats=args.repeats,
+            cuda_graph=args.cuda_graph,
+            verbose=args.verbose,
+        )
+        synchronize(device)
+        seconds = time.perf_counter() - start
+        scorer = sfxn.render_whole_pose_scoring_module(relaxed)
+        final_score = scorer(relaxed.coords).detach()
+        print(
+            json.dumps(
+                {
+                    "batch": args.batch,
+                    "device": str(device),
+                    "final_score": final_score.cpu().tolist(),
+                    "initial_score": initial_score.cpu().tolist(),
+                    "repeats": args.repeats,
+                    "seconds": seconds,
+                    "system": args.system,
+                    "trial": trial,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/benchmark_fast_relax.py
+++ b/dev/benchmark_fast_relax.py
@@ -24,8 +24,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--batch", type=int, default=1)
     parser.add_argument("--trials", type=int, default=3)
     parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--cpu-threads", type=int, default=1)
     parser.add_argument("--seed", type=int, default=20260902)
-    parser.add_argument("--cuda-graph", action="store_true")
+    graph_group = parser.add_mutually_exclusive_group()
+    graph_group.add_argument(
+        "--cuda-graph",
+        dest="cuda_graph",
+        action="store_true",
+        default=None,
+        help="force CUDA graph replay (default: automatic by chemistry)",
+    )
+    graph_group.add_argument(
+        "--no-cuda-graph",
+        dest="cuda_graph",
+        action="store_false",
+        help="force eager scoring",
+    )
     parser.add_argument("--no-opt-h", action="store_true")
     parser.add_argument("--verbose", action="store_true")
     return parser.parse_args()
@@ -33,8 +47,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    if min(args.batch, args.trials, args.repeats) < 1:
-        raise SystemExit("batch, trials, and repeats must be positive")
+    if min(args.batch, args.trials, args.repeats, args.cpu_threads) < 1:
+        raise SystemExit("batch, trials, repeats, and cpu-threads must be positive")
+    torch.set_num_threads(args.cpu_threads)
     device = torch.device(args.device)
     if device.type == "cuda" and not torch.cuda.is_available():
         raise SystemExit("CUDA requested but torch.cuda.is_available() is false")
@@ -47,7 +62,7 @@ def main() -> None:
     initial_scorer = sfxn.render_whole_pose_scoring_module(initial)
     initial_score = initial_scorer(initial.coords).detach()
 
-    if args.cuda_graph and device.type != "cuda":
+    if args.cuda_graph is True and device.type != "cuda":
         raise SystemExit("--cuda-graph requires --device cuda")
 
     for trial in range(args.trials):

--- a/dev/benchmark_score_matrix.py
+++ b/dev/benchmark_score_matrix.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Benchmark tmol scoring on representative biomolecular systems.
+
+This runner keeps structure preparation, score-function rendering, and steady-
+state scoring as separate measurements.  It is intentionally independent of
+pytest-benchmark so the same command can run under Nsight Systems/Compute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+from tmol.database import ParameterDatabase
+from tmol.io import pose_stack_from_biotite, pose_stack_from_pdb
+from tmol.pose import PoseStack, PoseStackBuilder
+from tmol.score import beta2016_score_function
+from tmol.tests.data import data_path
+
+
+@dataclass(frozen=True)
+class SystemSpec:
+    kind: str
+    path: str
+    ligand_params: str | None = None
+
+
+@dataclass(frozen=True)
+class Timing:
+    system: str
+    kind: str
+    device: str
+    cuda_graph: str
+    batch: int
+    residues: int
+    padded_atoms: int
+    prepare_s: float
+    batch_s: float
+    render_s: float
+    graph_setup_s: float
+    forward_ms: float
+    forward_backward_ms: float
+    peak_memory_mb: float | None
+
+
+SYSTEMS = {
+    "protein-76": SystemSpec("protein", "pdb/1ubq.pdb"),
+    "protein-300": SystemSpec("protein", "pdb/bysize_300_res_6f8b.pdb"),
+    "protein-600": SystemSpec("protein", "pdb/bysize_600_res_5m4a.pdb"),
+    "dna-24": SystemSpec("dna", "pdb/1bna.pdb"),
+    "rna-42": SystemSpec("rna", "pdb/3zp8.pdb"),
+    "protein-dna": SystemSpec("protein-dna", "pdb/1ysa.pdb"),
+    "ligand-hsp90": SystemSpec(
+        "protein-ligand",
+        "protein_ligand_test/hsp90.tmol.nomin.cif",
+        "protein_ligand_test/hsp90.xtal-lig.mmff94.tmol",
+    ),
+    "ligand-hivrt": SystemSpec(
+        "protein-ligand",
+        "protein_ligand_test/hivrt.tmol.nomin.cif",
+        "protein_ligand_test/hivrt.xtal-lig.mmff94.tmol",
+    ),
+}
+
+
+def synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def elapsed(device: torch.device, operation: Callable[[], object]) -> float:
+    synchronize(device)
+    start = time.perf_counter()
+    operation()
+    synchronize(device)
+    return time.perf_counter() - start
+
+
+def load_system(
+    spec: SystemSpec, device: torch.device, optimize_hydrogens: bool
+) -> tuple[PoseStack, ParameterDatabase]:
+    path = data_path(spec.path)
+    if spec.ligand_params is None:
+        return (
+            pose_stack_from_pdb(path.read_text(), device),
+            ParameterDatabase.get_default(),
+        )
+
+    import biotite.structure as struc
+    import biotite.structure.io
+
+    structure = biotite.structure.io.load_structure(
+        str(path), model=1, include_bonds=True
+    )
+    if isinstance(structure, struc.AtomArrayStack):
+        structure = structure[0]
+    pose, context = pose_stack_from_biotite(
+        structure,
+        device,
+        prepare_ligands=True,
+        ligand_params_files=[str(data_path(spec.ligand_params))],
+        no_optH=not optimize_hydrogens,
+        sample_proton_chi=False,
+        param_db=ParameterDatabase.get_default(),
+        return_context=True,
+    )
+    return pose, context.parameter_database
+
+
+def median_seconds(
+    operation: Callable[[], object], device: torch.device, warmup: int, rounds: int
+) -> float:
+    for _ in range(warmup):
+        operation()
+    synchronize(device)
+    return statistics.median(elapsed(device, operation) for _ in range(rounds))
+
+
+def benchmark_system(
+    name: str,
+    spec: SystemSpec,
+    device: torch.device,
+    batch: int,
+    optimize_hydrogens: bool,
+    warmup: int,
+    rounds: int,
+    cuda_graph: str,
+) -> Timing:
+    holder: dict[str, object] = {}
+
+    def prepare() -> None:
+        holder["pose"], holder["database"] = load_system(
+            spec, device, optimize_hydrogens
+        )
+
+    prepare_s = elapsed(device, prepare)
+    pose = holder["pose"]
+    database = holder["database"]
+    assert isinstance(pose, PoseStack)
+    assert isinstance(database, ParameterDatabase)
+
+    batched_holder: dict[str, PoseStack] = {}
+
+    def make_batch() -> None:
+        batched_holder["pose"] = PoseStackBuilder.from_poses([pose] * batch, device)
+
+    batch_s = elapsed(device, make_batch)
+    batched = batched_holder["pose"]
+    sfxn = beta2016_score_function(device, param_db=database)
+    scorer_holder: dict[str, object] = {}
+    render_s = elapsed(
+        device,
+        lambda: scorer_holder.update(
+            scorer=sfxn.render_whole_pose_scoring_module(batched)
+        ),
+    )
+    scorer = scorer_holder["scorer"]
+    graph_setup_s = 0.0
+    if cuda_graph != "none":
+        graph_setup_s = elapsed(
+            device,
+            lambda: scorer.enable_cuda_graphs(batched.coords, mode=cuda_graph),
+        )
+
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(device)
+
+    coords = batched.coords.detach()
+
+    def forward() -> None:
+        with torch.no_grad():
+            scorer(coords).sum()
+
+    forward_s = median_seconds(forward, device, warmup, rounds)
+
+    def forward_backward() -> None:
+        grad_coords = coords.detach().requires_grad_(True)
+        scorer(grad_coords).sum().backward()
+
+    full_s = median_seconds(forward_backward, device, warmup, rounds)
+    peak_memory_mb = (
+        torch.cuda.max_memory_allocated(device) / (1024 * 1024)
+        if device.type == "cuda"
+        else None
+    )
+    residues = int((batched.block_type_ind[0] >= 0).sum())
+
+    return Timing(
+        system=name,
+        kind=spec.kind,
+        device=str(device),
+        cuda_graph=cuda_graph,
+        batch=batch,
+        residues=residues,
+        padded_atoms=batched.coords.shape[1],
+        prepare_s=prepare_s,
+        batch_s=batch_s,
+        render_s=render_s,
+        graph_setup_s=graph_setup_s,
+        forward_ms=forward_s * 1000,
+        forward_backward_ms=full_s * 1000,
+        peak_memory_mb=peak_memory_mb,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=("cpu", "cuda"), required=True)
+    parser.add_argument(
+        "--systems", nargs="+", choices=sorted(SYSTEMS), default=list(SYSTEMS)
+    )
+    parser.add_argument("--batches", nargs="+", type=int, default=(1, 8))
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--cpu-threads", type=int, default=1)
+    parser.add_argument(
+        "--cuda-graph",
+        choices=("none", "forward", "forward_backward", "both"),
+        default="none",
+    )
+    parser.add_argument(
+        "--no-opt-h",
+        action="store_true",
+        help="skip hydrogen optimization during ligand pose preparation",
+    )
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.cpu_threads < 1 or args.warmup < 0 or args.rounds < 1:
+        raise SystemExit("cpu-threads and rounds must be positive; warmup may be zero")
+    if any(batch < 1 for batch in args.batches):
+        raise SystemExit("batch sizes must be positive")
+
+    torch.set_num_threads(args.cpu_threads)
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA requested but torch.cuda.is_available() is false")
+    if device.type != "cuda" and args.cuda_graph != "none":
+        raise SystemExit("--cuda-graph requires --device cuda")
+
+    rows = []
+    for name in args.systems:
+        for batch in args.batches:
+            row = benchmark_system(
+                name,
+                SYSTEMS[name],
+                device,
+                batch,
+                not args.no_opt_h,
+                args.warmup,
+                args.rounds,
+                args.cuda_graph,
+            )
+            rows.append(asdict(row))
+            print(json.dumps(rows[-1], sort_keys=True), flush=True)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -140,3 +140,11 @@ The default minimizer is Cartesian and reads
 protocol but is not used by that minimizer. To minimize kinematic degrees of
 freedom, pass a configured `MoveMap`, a `FoldForest`, and a compatible
 kinematic `min_fn`.
+
+On CUDA, `fast_relax()` automatically uses graph replay for poses containing
+DNA or RNA, where repeated kernel-launch overhead is significant. Protein-only
+and protein–ligand poses remain eager. Pass `cuda_graph=True` or
+`cuda_graph=False` to override that choice; custom minimizers manage their own
+execution mode and cannot be combined with `cuda_graph=True`. Graph capture has
+a one-time startup cost, so explicitly disable it for a single latency-sensitive
+nucleic-acid relaxation that will not be repeated in the same process.

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -187,13 +187,16 @@ def calculate_block_pair_ddg(
         )
         pose_stack = run_cart_min(pose_stack, sfxn, coord_mask)
 
-    scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    other_mask = mask2 if mask2 is not None else ~mask
+    sets_are_disjoint = mask2 is None or not bool((mask & other_mask).any())
+    scorer = sfxn.render_block_pair_scoring_module(
+        pose_stack, interaction_only=sets_are_disjoint
+    )
     defer_weights = single_block_indices is not None
     block_pair_scores = scorer(
         pose_stack.coords, sum_terms=False, apply_weights=not defer_weights
     )
 
-    other_mask = mask2 if mask2 is not None else ~mask
     if single_block_indices is None:
         ddg_scores = _sum_cross_block_scores(
             block_pair_scores, mask, other_mask, memory_efficient=memory_efficient
@@ -203,7 +206,7 @@ def calculate_block_pair_ddg(
             block_pair_scores,
             single_block_indices,
             other_mask,
-            sets_are_disjoint=mask2 is None,
+            sets_are_disjoint=sets_are_disjoint,
         )
         term_weights = scorer.weights[:, 0, 0, 0].unsqueeze(1)
         ddg_scores = ddg_scores * term_weights

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -199,6 +199,7 @@ def run_cart_min(
     optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
     optimizer_kwargs: dict[str, object] | None = None,
     verbose: bool = False,
+    cuda_graph: bool = False,
 ) -> PoseStack:
     """Run minimization on a PoseStack in Cartesian coordinate space.
 
@@ -211,13 +212,19 @@ def run_cart_min(
         optimizer_cls: Closure-based PyTorch optimizer class.
         optimizer_kwargs: Optional optimizer constructor arguments.
         verbose: Print synchronized setup and minimization timings.
+        cuda_graph: Capture the fixed-shape CUDA scoring forward/backward path.
 
     Returns:
         A new pose stack containing the minimized coordinates.
     """
     from tmol.optimization import CartesianSfxnNetwork
 
-    cart_network = CartesianSfxnNetwork(sfxn, pose_stack, coord_mask)
+    cart_network = CartesianSfxnNetwork(
+        sfxn,
+        pose_stack,
+        coord_mask,
+        cuda_graph="forward_backward" if cuda_graph else False,
+    )
 
     return run_min(
         cart_network,

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -28,6 +28,11 @@ class CartesianSfxnNetwork(torch.nn.Module):
             pose_stack, cuda_graph=cuda_graph
         )
         self.whole_pose_scoring_module = wpsm
+        self._score_function = score_function
+        self._score_function_versions = (
+            score_function._terms_version,
+            score_function._options_version,
+        )
 
         self.pose_stack = pose_stack
         # clone: forward() writes into full_coords in place, which would
@@ -63,6 +68,57 @@ class CartesianSfxnNetwork(torch.nn.Module):
             rounding_mode="floor",
         )
         self.segment_ids = pose_for_atom.repeat_interleave(self.full_coords.shape[-1])
+
+    def _reusable_for(
+        self,
+        score_function: ScoreFunction,
+        pose_stack: PoseStack,
+        coord_mask=None,
+    ) -> bool:
+        """Return whether this network can score another pose without rendering."""
+        if coord_mask is None:
+            coord_mask = pose_stack.real_atoms
+        return (
+            score_function is self._score_function
+            and self._score_function_versions
+            == (
+                self._score_function._terms_version,
+                self._score_function._options_version,
+            )
+            and pose_stack.packed_block_types is self.pose_stack.packed_block_types
+            and pose_stack.constraint_set is self.pose_stack.constraint_set
+            and pose_stack.coords.shape == self.pose_stack.coords.shape
+            and torch.equal(coord_mask, self.coord_mask)
+            and torch.equal(pose_stack.block_type_ind, self.pose_stack.block_type_ind)
+            and torch.equal(
+                pose_stack.block_coord_offset, self.pose_stack.block_coord_offset
+            )
+            and pose_stack.inter_residue_connections
+            is self.pose_stack.inter_residue_connections
+            and pose_stack.inter_block_bondsep is self.pose_stack.inter_block_bondsep
+        )
+
+    def _reset(
+        self, score_function: ScoreFunction, pose_stack: PoseStack, coord_mask=None
+    ) -> bool:
+        """Reset for a compatible pose topology; report whether it was reused."""
+        if not self._reusable_for(score_function, pose_stack, coord_mask):
+            return False
+
+        self.pose_stack = pose_stack
+        with torch.no_grad():
+            self.whole_pose_scoring_module.weights.copy_(
+                score_function.weights_tensor().unsqueeze(1)
+            )
+            if self._all_coords_movable:
+                self.masked_coords.copy_(pose_stack.coords.reshape(-1, 3))
+            else:
+                self.full_coords.copy_(pose_stack.coords)
+                self.masked_coords.copy_(
+                    pose_stack.coords.reshape(-1, 3)[self._coord_flat_idx]
+                )
+        self.masked_coords.grad = None
+        return True
 
     def forward(self) -> torch.Tensor:
         if not self._all_coords_movable:

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -16,11 +16,17 @@ class CartesianSfxnNetwork(torch.nn.Module):
     """Differentiable score network over selected Cartesian coordinates."""
 
     def __init__(
-        self, score_function: ScoreFunction, pose_stack: PoseStack, coord_mask=None
+        self,
+        score_function: ScoreFunction,
+        pose_stack: PoseStack,
+        coord_mask=None,
+        cuda_graph: bool | str = False,
     ):
         super(CartesianSfxnNetwork, self).__init__()
 
-        wpsm = score_function.render_whole_pose_scoring_module(pose_stack)
+        wpsm = score_function.render_whole_pose_scoring_module(
+            pose_stack, cuda_graph=cuda_graph
+        )
         self.whole_pose_scoring_module = wpsm
 
         self.pose_stack = pose_stack

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -1,6 +1,7 @@
 import time
 import warnings
 from collections.abc import Callable, Sequence
+from functools import partial
 from typing import Protocol
 
 import attr
@@ -142,6 +143,7 @@ def _default_cart_min_fn(
     fold_forest: FoldForest,
     move_map: MoveMap | CartesianMoveMap,
     verbose: bool,
+    cuda_graph: bool = False,
 ) -> PoseStack:
     """Run Cartesian LBFGS using a Cartesian move map's coordinate mask."""
     coord_mask = move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
@@ -150,6 +152,7 @@ def _default_cart_min_fn(
         sfxn,
         coord_mask=coord_mask,
         verbose=verbose,
+        cuda_graph=cuda_graph,
         optimizer_kwargs={"verbose": verbose},
     )
 
@@ -166,6 +169,7 @@ def fast_relax(  # noqa: C901
     ramp_constraints: bool | None = None,  # default True
     schedule: Sequence[RelaxScheduleEntry] | None = None,
     min_fn: RelaxMinimizer | None = None,
+    cuda_graph: bool = False,
     verbose: bool = False,
 ) -> PoseStack:
     """Relax poses through repeated side-chain packing and minimization.
@@ -190,13 +194,16 @@ def fast_relax(  # noqa: C901
             ``DEFAULT_RELAX_SCHEDULE``.
         min_fn: Minimizer called with the pose, score function, fold forest,
             move map, and verbosity. Defaults to Cartesian minimization.
+        cuda_graph: Capture the default Cartesian minimizer's repeated CUDA
+            scoring path. This can substantially reduce launch overhead for
+            nucleic-acid systems. It cannot be combined with a custom ``min_fn``.
         verbose: Print timing information for each step.
 
     Returns:
         Best-scoring relaxed poses across all repeats.
     """
-    if min_fn is None:
-        min_fn = _default_cart_min_fn
+    if min_fn is not None and cuda_graph:
+        raise ValueError("cuda_graph cannot be combined with a custom min_fn")
     if schedule is None:
         schedule = DEFAULT_RELAX_SCHEDULE
 
@@ -249,6 +256,9 @@ def fast_relax(  # noqa: C901
     wpsm = sfxn.render_whole_pose_scoring_module(pose_stack)
     best_score = wpsm(pose_stack.coords)
     best_ps = pose_stack.clone()
+
+    if min_fn is None:
+        min_fn = partial(_default_cart_min_fn, cuda_graph=cuda_graph)
 
     ps = pose_stack
     for _ in range(num_repeats):

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -1,7 +1,6 @@
 import time
 import warnings
 from collections.abc import Callable, Sequence
-from functools import partial
 from typing import Protocol
 
 import attr
@@ -26,7 +25,12 @@ from tmol.pack.rotamer import (
     FixedAAChiSampler,
     IncludeCurrentSampler,
 )
-from tmol.optimization import run_cart_min, run_kin_min
+from tmol.optimization import (
+    CartesianSfxnNetwork,
+    run_cart_min,
+    run_kin_min,
+    run_min,
+)
 from tmol.types import Tensor
 from tmol.utility._device import synchronize_device
 
@@ -157,6 +161,59 @@ def _default_cart_min_fn(
     )
 
 
+class _DefaultCartesianMinimizer:
+    """Cartesian minimizer that reuses rendering for unchanged pose topology."""
+
+    def __init__(self, cuda_graph: bool):
+        self.cuda_graph = cuda_graph
+        self.network: CartesianSfxnNetwork | None = None
+
+    def __call__(
+        self,
+        pose_stack: PoseStack,
+        sfxn: ScoreFunction,
+        *,
+        fold_forest: FoldForest,
+        move_map: MoveMap | CartesianMoveMap,
+        verbose: bool,
+    ) -> PoseStack:
+        del fold_forest
+        coord_mask = (
+            move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
+        )
+        if self.network is None or not self.network._reset(
+            sfxn, pose_stack, coord_mask
+        ):
+            self.network = CartesianSfxnNetwork(
+                sfxn,
+                pose_stack,
+                coord_mask,
+                cuda_graph="forward_backward" if self.cuda_graph else False,
+            )
+        return run_min(
+            self.network,
+            verbose=verbose,
+            optimizer_kwargs={"verbose": verbose},
+        )
+
+
+def _resolve_cuda_graph_mode(pose_stack: PoseStack, cuda_graph: bool | None) -> bool:
+    """Choose graph replay automatically where launch overhead dominates."""
+    if cuda_graph is not None:
+        return cuda_graph
+    if pose_stack.device.type != "cuda":
+        return False
+
+    used_block_types = torch.unique(pose_stack.block_type_ind).tolist()
+    active_block_types = pose_stack.packed_block_types.active_block_types
+    return any(
+        block_type_ind >= 0
+        and active_block_types[block_type_ind].properties.polymer.backbone_type
+        in ("dna", "rna")
+        for block_type_ind in used_block_types
+    )
+
+
 def fast_relax(  # noqa: C901
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
@@ -169,7 +226,7 @@ def fast_relax(  # noqa: C901
     ramp_constraints: bool | None = None,  # default True
     schedule: Sequence[RelaxScheduleEntry] | None = None,
     min_fn: RelaxMinimizer | None = None,
-    cuda_graph: bool = False,
+    cuda_graph: bool | None = None,
     verbose: bool = False,
 ) -> PoseStack:
     """Relax poses through repeated side-chain packing and minimization.
@@ -195,14 +252,15 @@ def fast_relax(  # noqa: C901
         min_fn: Minimizer called with the pose, score function, fold forest,
             move map, and verbosity. Defaults to Cartesian minimization.
         cuda_graph: Capture the default Cartesian minimizer's repeated CUDA
-            scoring path. This can substantially reduce launch overhead for
-            nucleic-acid systems. It cannot be combined with a custom ``min_fn``.
+            scoring path. By default, enable it automatically for CUDA poses
+            containing DNA or RNA, where launch overhead dominates. Pass ``False``
+            to disable it. It cannot be combined with a custom ``min_fn``.
         verbose: Print timing information for each step.
 
     Returns:
         Best-scoring relaxed poses across all repeats.
     """
-    if min_fn is not None and cuda_graph:
+    if min_fn is not None and cuda_graph is True:
         raise ValueError("cuda_graph cannot be combined with a custom min_fn")
     if schedule is None:
         schedule = DEFAULT_RELAX_SCHEDULE
@@ -258,7 +316,9 @@ def fast_relax(  # noqa: C901
     best_ps = pose_stack.clone()
 
     if min_fn is None:
-        min_fn = partial(_default_cart_min_fn, cuda_graph=cuda_graph)
+        min_fn = _DefaultCartesianMinimizer(
+            _resolve_cuda_graph_mode(pose_stack, cuda_graph)
+        )
 
     ps = pose_stack
     for _ in range(num_repeats):

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -112,9 +112,31 @@ class EnergyTerm:
     def get_rotamer_score_term_function(self):
         raise NotImplementedError()
 
+    def get_rotamer_score_term_attributes(
+        self, pose_stack: PoseStack, rotamer_set: RotamerSet
+    ):
+        """Return immutable parameters for a rendered rotamer scorer.
+
+        Most terms use the same topology data for pose and rotamer scoring.
+        Terms whose candidate topology can be resolved once at render time may
+        override this hook instead of repeating that work on every score call.
+        """
+        return self.get_score_term_attributes(pose_stack)
+
     def pose_score_term_is_invariant_zero(self, pose_stack: PoseStack):
         """Whether this term is identically zero for this fixed pose topology."""
         return False
+
+    def block_pair_score_term_is_invariant_zero_off_diagonal(
+        self, pose_stack: PoseStack
+    ):
+        """Whether this term contributes only to self-block matrix entries.
+
+        One-body terms are diagonal by definition. Terms with a higher body
+        count may override this when their block-pair attribution is still
+        strictly diagonal.
+        """
+        return self.n_bodies() == 1
 
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
         if self.pose_score_term_is_invariant_zero(pose_stack):
@@ -133,8 +155,13 @@ class EnergyTerm:
             f,
         )
 
-    def render_block_pair_scoring_module(self, pose_stack: PoseStack):
-        if self.pose_score_term_is_invariant_zero(pose_stack):
+    def render_block_pair_scoring_module(
+        self, pose_stack: PoseStack, *, interaction_only: bool = False
+    ):
+        if self.pose_score_term_is_invariant_zero(pose_stack) or (
+            interaction_only
+            and self.block_pair_score_term_is_invariant_zero_off_diagonal(pose_stack)
+        ):
             return ZeroTermPoseScoringModule(
                 self.class_name(),
                 len(self.score_types()),
@@ -161,6 +188,6 @@ class EnergyTerm:
         return TermRotamerScoringModule(
             self.class_name(),
             rotamer_set,
-            self.get_score_term_attributes(pose_stack),
+            self.get_rotamer_score_term_attributes(pose_stack, rotamer_set),
             f,
         )

--- a/tmol/score/_fragment_interactions.py
+++ b/tmol/score/_fragment_interactions.py
@@ -253,7 +253,7 @@ def calculate_fragment_interactions(
     if bool(partner_mask.flatten()[mapping_data.record_linear_indices].any()):
         raise ValueError("partner_mask must not include ligand fragment blocks")
 
-    scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    scorer = sfxn.render_block_pair_scoring_module(pose_stack, interaction_only=True)
     block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
     result = _sum_fragment_partner_scores(
         block_pair_scores,

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -472,7 +472,9 @@ class ScoreFunction:
             scoring_module.enable_cuda_graphs(pose_stack.coords, mode=mode)
         return scoring_module
 
-    def render_block_pair_scoring_module(self, pose_stack: PoseStack):
+    def render_block_pair_scoring_module(
+        self, pose_stack: PoseStack, *, interaction_only: bool = False
+    ):
         """Create an object designed to evaluate the score of a set of Poses
         repeatedly as the Poses change their conformation, e.g., as in
         minimization. This object will derive from torch.nn.Module and
@@ -480,10 +482,18 @@ class ScoreFunction:
         terms that themselves are derived from torch.nn.Module. This
         object's __call__ will return a tensor of weighted energies of
         shape (n_poses, max_n_blocks, max_n_blocks).
+
+        Set ``interaction_only=True`` when only strictly off-diagonal block
+        pairs will be consumed. Terms whose block-pair scores are known to be
+        diagonal-only are then omitted. Diagonal entries in the returned
+        matrix are incomplete in this mode.
         """
         self.pre_work_initialization(pose_stack)
         term_modules = [
-            t.render_block_pair_scoring_module(pose_stack) for t in self.all_terms()
+            t.render_block_pair_scoring_module(
+                pose_stack, interaction_only=interaction_only
+            )
+            for t in self.all_terms()
         ]
         return BlockPairScoringModule(self.weights_tensor(), term_modules)
 
@@ -919,6 +929,41 @@ class BlockPairScoringModule:
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
 
         return summed
+
+    def score_interactions(
+        self,
+        coords: torch.Tensor,
+        block_pair_indices: torch.Tensor,
+        *,
+        sum_terms: bool = True,
+        apply_weights: bool = True,
+    ) -> torch.Tensor:
+        """Sum selected block-pair entries with one indexed reduction.
+
+        Args:
+            coords: Pose coordinates accepted by this rendered scorer.
+            block_pair_indices: Shared block pairs shaped ``[n_pairs, 2]``.
+                Each row contains ``(block_i, block_j)`` and is applied to
+                every pose in the coordinate batch.
+            sum_terms: Sum the score-type dimension when true.
+            apply_weights: Apply the score function's weights when true.
+
+        Returns:
+            Scores shaped ``[n_poses]`` when ``sum_terms`` is true, otherwise
+            ``[n_score_types, n_poses]``.
+        """
+        if block_pair_indices.ndim != 2 or block_pair_indices.shape[1] != 2:
+            raise ValueError("block_pair_indices must have shape [n_pairs, 2]")
+        if block_pair_indices.device != coords.device:
+            raise ValueError(
+                "block_pair_indices must be on the same device as coordinates"
+            )
+        if block_pair_indices.dtype not in (torch.int32, torch.int64):
+            raise TypeError("block_pair_indices must have an integer dtype")
+        block_i, block_j = block_pair_indices.to(torch.int64).unbind(dim=1)
+        scores = self(coords, sum_terms=sum_terms, apply_weights=apply_weights)
+        pair_dimension = 1 if sum_terms else 2
+        return scores[..., block_i, block_j].sum(dim=pair_dimension)
 
     def unweighted_scores(self, coords: torch.Tensor) -> torch.Tensor:
         parallel_scores = self._parallel_forward_scores(coords)

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -33,24 +33,25 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 def connectivity_weight(Real bonded_path_length) -> Real {
   if (bonded_path_length > 4) {
-    return 1.0;
+    return Real(1);
   } else if (bonded_path_length == 4) {
-    return 0.2;
+    return Real(0.2);
   } else {
-    return 0.0;
+    return Real(0);
   }
 }
 
 // sigmoidal distance-dependant dielectric
-def eps(Real dist, float D, float D0, float S) -> Real {
+def eps(Real dist, Real D, Real D0, Real S) -> Real {
   return (
       D
-      - 0.5 * (D - D0) * (2 + 2 * dist * S + dist * dist * S * S)
+      - Real(0.5) * (D - D0)
+            * (Real(2) + Real(2) * dist * S + dist * dist * S * S)
             * std::exp(-dist * S));
 }
 
-def deps_ddist(Real dist, float D, float D0, float S) -> Real {
-  return (0.5 * (D - D0) * dist * dist * S * S * S * std::exp(-dist * S));
+def deps_ddist(Real dist, Real D, Real D0, Real S) -> Real {
+  return Real(0.5) * (D - D0) * dist * dist * S * S * S * std::exp(-dist * S);
 }
 
 def elec_delec_ddist(
@@ -59,9 +60,9 @@ def elec_delec_ddist(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> tuple<Real, Real> {
-  Real low_poly_start = params.min_dis - 0.25;
-  Real low_poly_end = params.min_dis + 0.25;
-  Real hi_poly_start = params.max_dis - 1.0;
+  Real low_poly_start = params.min_dis - Real(0.25);
+  Real low_poly_end = params.min_dis + Real(0.25);
+  Real hi_poly_start = params.max_dis - Real(1);
   Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);
@@ -120,9 +121,9 @@ def elec(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> Real {
-  Real low_poly_start = params.min_dis - 0.25;
-  Real low_poly_end = params.min_dis + 0.25;
-  Real hi_poly_start = params.max_dis - 1.0;
+  Real low_poly_start = params.min_dis - Real(0.25);
+  Real low_poly_end = params.min_dis + Real(0.25);
+  Real hi_poly_start = params.max_dis - Real(1);
   Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -63,7 +63,7 @@ struct lk_fraction {
   static def square(Real v) -> Real { return v * v; }
 
   static def V(WatersMat WI, Real3 J, Real lj_radius_j) -> Real {
-    Real d2_low = square(1.4 + lj_radius_j) - ramp_width_A2;
+    Real d2_low = square(Real(1.4) + lj_radius_j) - ramp_width_A2;
     if (d2_low < 0.0) d2_low = 0.0;
 
     Real wted_d2_delta = 0;
@@ -91,7 +91,7 @@ struct lk_fraction {
   }
 
   static def V_dV(WatersMat WI, Real3 J, Real lj_radius_j) -> V_dV_t {
-    Real d2_low = square(1.4 + lj_radius_j) - ramp_width_A2;
+    Real d2_low = square(Real(1.4) + lj_radius_j) - ramp_width_A2;
     if (d2_low < 0.0) d2_low = 0.0;
 
     Real wted_d2_delta = 0.0;
@@ -125,7 +125,7 @@ struct lk_fraction {
     } else if (wted_d2_delta < ramp_width_A2) {
       frac = square(1 - square(wted_d2_delta / ramp_width_A2));
       if (wted_d2_delta > 0) {
-        dfrac_dwted_d2 = -4.0 * wted_d2_delta
+        dfrac_dwted_d2 = Real(-4) * wted_d2_delta
                          * (square(ramp_width_A2) - square(wted_d2_delta))
                          / square(square(ramp_width_A2));
       }
@@ -183,7 +183,7 @@ struct lk_bridge_fraction {
       -> Real {
     // The bridge score has compact support in the base-atom separation. Test
     // that inexpensive condition before evaluating any water-pair exponentials.
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real overlap_target_len2 = Real(8) / Real(3) * square(lkb_water_dist);
     Real overlap_len2 = (I - J).squaredNorm();
     Real base_delta = fabs(overlap_len2 - overlap_target_len2);
     if (base_delta > angle_overlap_A2) return Real(0);
@@ -217,19 +217,19 @@ struct lk_bridge_fraction {
       Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
       -> V_dV_t {
     // Reject geometrically impossible bridges before the water-overlap loop.
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real overlap_target_len2 = Real(8) / Real(3) * square(lkb_water_dist);
     Real3 delta_ij = I - J;
     Real overlap_len2 = delta_ij.squaredNorm();
     Real base_delta = overlap_len2 - overlap_target_len2;
     if (std::abs(base_delta) > angle_overlap_A2) {
       return V_dV_t{Real(0), dV_t::Zero()};
     }
-    Real3 d_wted_d2_delta_d_I = 2.0 * delta_ij;
-    Real3 d_wted_d2_delta_d_J = -2.0 * delta_ij;
+    Real3 d_wted_d2_delta_d_I = Real(2) * delta_ij;
+    Real3 d_wted_d2_delta_d_J = Real(-2) * delta_ij;
     Real anglefrac = square(1 - square(base_delta / angle_overlap_A2));
     Real d_anglefrac_d_base_delta =
         std::abs(base_delta) > 0.0
-            ? -4.0 * base_delta
+            ? Real(-4) * base_delta
                   * (square(angle_overlap_A2) - square(base_delta))
                   / square(square(angle_overlap_A2))
             : Real(0);
@@ -268,7 +268,7 @@ struct lk_bridge_fraction {
       wted_d2_delta = -std::log(wted_d2_delta);
       overlapfrac = square(1 - square(wted_d2_delta / overlap_width_A2));
       d_overlapfrac_d_wted_d2 =
-          -4.0 * wted_d2_delta
+          Real(-4) * wted_d2_delta
           * (square(overlap_width_A2) - square(wted_d2_delta))
           / square(square(overlap_width_A2));
     }
@@ -578,8 +578,8 @@ struct lk_ball_score {
     Real const iso_scale = weights[w_lk_ball_iso]
                            + weights[w_lk_ball] * frac_desolv.V
                            + weights[w_lk_bridge] * frac_bridge.V;
-    Real const bridge_scale =
-        weights[w_lk_bridge] * lk_iso.V + weights[w_lk_bridge_uncpl] * 0.5;
+    Real const bridge_scale = weights[w_lk_bridge] * lk_iso.V
+                              + weights[w_lk_bridge_uncpl] * Real(0.5);
     Real3 const d_iso_dI = lk_iso.dV_ddist * dist.dV_dA;
 
     return lk_ball_weighted_dVt<Real, MAX_WATER>{
@@ -1285,7 +1285,7 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
         MAX_N_WATER * occluder_atom_tile_ind + wi);
   }
 
-  auto dV = lk_ball_score<Real, 4>::weighted_dV(
+  auto dV = lk_ball_score<Real, MAX_N_WATER>::weighted_dV(
       polar_xyz,
       occluder_xyz,
       wmat_polar,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -979,10 +979,31 @@ class LKBallPoseScoreDispatch {
           store_calculated_energies);
     });
 
-    // Since we have the sphere overlap results from the forward pass,
-    // there's only a single kernel launch here
+    // Large, spatially sparse pose stacks can contain far more candidate
+    // block pairs than neighboring pairs.  A CTA for every candidate then
+    // spends most of the launch scheduling budget only checking a zero in the
+    // neighbor matrix.  Keep a sufficiently large resident grid and let each
+    // warp stride over candidates instead.  Unlike compacting the matrix with
+    // a prefix scan, this has no device-to-host synchronization and is safe to
+    // capture in a CUDA graph.
+#ifdef __NVCC__
+    int const n_candidate_pairs = n_poses * max_n_upper_triangle_inds;
+    constexpr int max_persistent_workgroups = 1 << 14;
+    int const n_workgroups = n_candidate_pairs < max_persistent_workgroups
+                                 ? n_candidate_pairs
+                                 : max_persistent_workgroups;
+    auto eval_derivs_strided = ([=] TMOL_DEVICE_FUNC(int cta) {
+      for (int workgroup = cta; workgroup < n_candidate_pairs;
+           workgroup += n_workgroups) {
+        eval_derivs(workgroup);
+      }
+    });
+    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+        mgr, n_workgroups, eval_derivs_strided);
+#else
     DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
         mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
+#endif
 
     return {dV_d_pose_coords_t, dV_d_water_coords_t};
   }

--- a/tmol/score/na_torsion/_na_torsion_energy_term.py
+++ b/tmol/score/na_torsion/_na_torsion_energy_term.py
@@ -133,6 +133,11 @@ class NaTorsionEnergyTerm(EnergyTerm):
     def pose_score_term_is_invariant_zero(self, pose_stack):
         return not self._pose_has_na(pose_stack)
 
+    def block_pair_score_term_is_invariant_zero_off_diagonal(self, pose_stack):
+        # The torsions may read atoms from a bonded neighbour, but their energy
+        # is attributed to the nucleotide's diagonal block-pair entry.
+        return True
+
     def get_score_term_attributes(self, pose_stack):
         p = self.params
         has_na = self._pose_has_na(pose_stack)
@@ -173,6 +178,25 @@ class NaTorsionEnergyTerm(EnergyTerm):
             p.pucker_temperature,
             p.bin_blend_sdev,
         ]
+
+    def get_rotamer_score_term_attributes(self, pose_stack, rotamer_set):
+        """Resolve candidate torsion atom indices once when rendering."""
+        pbt = pose_stack.packed_block_types
+        indices = _rotamer_indices(
+            rotamer_set.block_type_ind_for_rot,
+            rotamer_set.pose_for_rot,
+            rotamer_set.block_ind_for_rot,
+            rotamer_set.coord_offset_for_rot,
+            rotamer_set.rot_offset_for_block,
+            rotamer_set.first_rot_block_type,
+            pose_stack.inter_residue_connections,
+            pbt.atom_downstream_of_conn,
+            pbt.na_torsion_base,
+            pbt.na_torsion_uaids,
+            pbt.na_torsion_ring,
+            pbt.na_torsion_down,
+        )
+        return [*self.get_score_term_attributes(pose_stack), *indices]
 
 
 def _resolve_uaids(
@@ -290,6 +314,37 @@ def eval_na_torsion_for_pose(
             (n_poses, max_n_blocks), dtype=rot_coords.dtype, device=rot_coords.device
         )
         return _finish((zero, zero), output_block_pair_energies)
+
+    if rot_coords.is_cuda and not output_block_pair_energies:
+        from .potentials import na_torsion_pose_score
+
+        return na_torsion_pose_score(
+            rot_coords,
+            pose_base,
+            pose_is_na,
+            pose_torsion_indices,
+            pose_torsion_ok,
+            pose_ring_indices,
+            pose_ring_ok,
+            pose_prev,
+            backbone_means,
+            backbone_sdev,
+            sugar_means,
+            chi_means,
+            sdev_sugar,
+            sdev_chi,
+            well_pucker,
+            well_alpha_gamma,
+            well_bibii_pucker,
+            well_alphanext_bibii,
+            well_chi_syn,
+            is_north,
+            weight_bb,
+            weight_chi,
+            weight_sugar,
+            pucker_temperature,
+            bin_blend_sdev,
+        )
 
     e_bb, e_chi, e_sugar, e_well = _pose_subterms(
         rot_coords,
@@ -678,6 +733,68 @@ def _resolve_rotamer_uaids(
     return rot_coord_offset.to(torch.int64)[rot] + local, ok
 
 
+def _rotamer_indices(
+    block_type_ind_for_rot,
+    pose_ind_for_rot,
+    block_ind_for_rot,
+    rot_coord_offset,
+    first_rot_for_block,
+    first_rot_block_type,
+    inter_residue_connections,
+    atom_downstream_of_conn,
+    bt_base,
+    bt_uaids,
+    bt_ring,
+    bt_down,
+):
+    """Resolve immutable candidate atom indices for rotamer/search scoring."""
+    bt = block_type_ind_for_rot.to(torch.int64)
+    bt_safe = bt.clamp_min(0)
+    base = torch.where(bt >= 0, bt_base.to(torch.int64)[bt_safe], -1)
+    pose = pose_ind_for_rot.to(torch.int64)
+    block = block_ind_for_rot.to(torch.int64)
+
+    torsion_indices, atom_ok = _resolve_rotamer_uaids(
+        bt_uaids[bt_safe],
+        pose,
+        block,
+        rot_coord_offset,
+        first_rot_for_block,
+        first_rot_block_type,
+        inter_residue_connections,
+        atom_downstream_of_conn,
+    )
+    is_na = base >= 0
+    torsion_ok = atom_ok.all(-1) & is_na.unsqueeze(-1)
+
+    ring_local = bt_ring.to(torch.int64)[bt_safe]
+    ring_ok = (ring_local >= 0) & is_na.unsqueeze(-1)
+    ring_indices = rot_coord_offset.to(torch.int64).unsqueeze(-1) + ring_local
+
+    # A candidate's beta term reads the BI/BII state of the preceding
+    # nucleotide from that block's first (background) rotamer.
+    down = bt_down.to(torch.int64)[bt_safe]
+    prev_block = inter_residue_connections.to(torch.int64)[
+        pose, block, down.clamp_min(0), 0
+    ]
+    has_prev = (down >= 0) & (prev_block >= 0)
+    prev = torch.where(
+        has_prev,
+        first_rot_for_block.to(torch.int64)[pose, prev_block.clamp_min(0)],
+        torch.full_like(prev_block, -1),
+    )
+    return (
+        base,
+        is_na,
+        torsion_indices,
+        atom_ok,
+        torsion_ok,
+        ring_indices,
+        ring_ok,
+        prev,
+    )
+
+
 def eval_na_torsion_for_rotamers(
     # common args
     rot_coords,
@@ -726,6 +843,14 @@ def eval_na_torsion_for_rotamers(
     weight_bb,
     weight_chi,
     weight_sugar,
+    rotamer_base,
+    rotamer_is_na,
+    rotamer_torsion_indices,
+    rotamer_atom_ok,
+    rotamer_torsion_ok,
+    rotamer_ring_indices,
+    rotamer_ring_ok,
+    rotamer_prev,
     output_block_pair_energies: bool,
 ):
     device = rot_coords.device
@@ -736,79 +861,77 @@ def eval_na_torsion_for_rotamers(
     if not has_na:
         score = torch.zeros((2, n_rots), dtype=dtype, device=device)
     else:
-        bt = block_type_ind_for_rot.to(torch.int64)
-        base = torch.where(bt >= 0, bt_base.to(torch.int64)[bt.clamp_min(0)], -1)
-        pose = pose_ind_for_rot.to(torch.int64)
-        block = block_ind_for_rot.to(torch.int64)
-        bt_safe = bt.clamp_min(0)
+        base = rotamer_base
+        is_na = rotamer_is_na
+        if rot_coords.is_cuda and not rot_coords.requires_grad:
+            from .potentials import na_torsion_pose_score
 
-        index, ok = _resolve_rotamer_uaids(
-            bt_uaids[bt_safe],
-            pose,
-            block,
-            rot_coord_offset,
-            first_rot_for_block,
-            first_rot_block_type,
-            inter_residue_connections,
-            atom_downstream_of_conn,
-        )
-        is_na = base >= 0
-        tor_ok = ok.all(-1) & is_na.unsqueeze(-1)
+            score = na_torsion_pose_score(
+                rot_coords,
+                base.unsqueeze(1),
+                is_na.unsqueeze(1),
+                rotamer_torsion_indices.unsqueeze(1),
+                rotamer_torsion_ok.unsqueeze(1),
+                rotamer_ring_indices.unsqueeze(1),
+                rotamer_ring_ok.unsqueeze(1),
+                rotamer_prev.unsqueeze(1),
+                backbone_means,
+                backbone_sdev,
+                sugar_means,
+                chi_means,
+                sdev_sugar,
+                sdev_chi,
+                well_pucker,
+                well_alpha_gamma,
+                well_bibii_pucker,
+                well_alphanext_bibii,
+                well_chi_syn,
+                is_north,
+                weight_bb,
+                weight_chi,
+                weight_sugar,
+                pucker_temperature,
+                bin_blend_sdev,
+            )[0]
+        else:
 
-        def gather_coords(index, ok):
-            xyz = rot_coords[index.clamp_min(0).reshape(-1)].reshape(*index.shape, 3)
-            return torch.where(ok.unsqueeze(-1), xyz, torch.zeros_like(xyz))
+            def gather_coords(index, ok):
+                xyz = rot_coords[index.clamp_min(0).reshape(-1)].reshape(
+                    *index.shape, 3
+                )
+                return torch.where(ok.unsqueeze(-1), xyz, torch.zeros_like(xyz))
 
-        xyz = gather_coords(index, ok)
-
-        ring_local = bt_ring.to(torch.int64)[bt_safe]
-        ring_ok = (ring_local >= 0) & is_na.unsqueeze(-1)
-        ring_xyz = gather_coords(
-            rot_coord_offset.to(torch.int64).unsqueeze(-1) + ring_local, ring_ok
-        )
-
-        # the preceding nucleotide is never itself a rotamer being built, so
-        # beta reads the BI/BII state off that block's background rotamer
-        down = bt_down.to(torch.int64)[bt_safe]
-        prev_block = inter_residue_connections.to(torch.int64)[
-            pose, block, down.clamp_min(0), 0
-        ]
-        has_prev = (down >= 0) & (prev_block >= 0)
-        prev = torch.where(
-            has_prev,
-            first_rot_for_block.to(torch.int64)[pose, prev_block.clamp_min(0)],
-            torch.full_like(prev_block, -1),
-        )
-
-        e_bb, e_chi, e_sugar, e_well = _subterm_energies(
-            xyz,
-            tor_ok,
-            ring_xyz,
-            base,
-            prev,
-            backbone_means,
-            backbone_sdev,
-            sugar_means,
-            chi_means,
-            sdev_sugar,
-            sdev_chi,
-            well_pucker,
-            well_alpha_gamma,
-            well_bibii_pucker,
-            well_alphanext_bibii,
-            well_chi_syn,
-            is_north,
-            pucker_temperature,
-            bin_blend_sdev,
-        )
-        poly = polymer_index(base)
-        harmonic = (
-            weight_bb[poly] * e_bb
-            + weight_chi[poly] * e_chi
-            + weight_sugar[poly] * e_sugar
-        )
-        score = torch.stack([harmonic, e_well])
-        score = torch.where(is_na.unsqueeze(0), score, torch.zeros_like(score))
+            xyz = gather_coords(rotamer_torsion_indices, rotamer_atom_ok)
+            ring_xyz = gather_coords(rotamer_ring_indices, rotamer_ring_ok)
+            e_bb, e_chi, e_sugar, e_well = _subterm_energies(
+                xyz,
+                rotamer_torsion_ok,
+                ring_xyz,
+                base,
+                rotamer_prev,
+                backbone_means,
+                backbone_sdev,
+                sugar_means,
+                chi_means,
+                sdev_sugar,
+                sdev_chi,
+                well_pucker,
+                well_alpha_gamma,
+                well_bibii_pucker,
+                well_alphanext_bibii,
+                well_chi_syn,
+                is_north,
+                pucker_temperature,
+                bin_blend_sdev,
+            )
+            poly = polymer_index(base)
+            harmonic = (
+                weight_bb[poly] * e_bb
+                + weight_chi[poly] * e_chi
+                + weight_sugar[poly] * e_sugar
+            )
+            score = torch.stack([harmonic, e_well])
+            score = torch.where(is_na.unsqueeze(0), score, torch.zeros_like(score))
 
     if output_block_pair_energies:
         # a one-body term: each energy sits on the diagonal of the rotamer pair

--- a/tmol/score/na_torsion/potentials/__init__.py
+++ b/tmol/score/na_torsion/potentials/__init__.py
@@ -1,0 +1,3 @@
+"""Compiled nucleic-acid torsion potentials."""
+
+from ._compiled import na_torsion_pose_score  # noqa: F401

--- a/tmol/score/na_torsion/potentials/_compiled.py
+++ b/tmol/score/na_torsion/potentials/_compiled.py
@@ -1,0 +1,10 @@
+from tmol._load_ext import load_ops
+
+_ops = load_ops(
+    __name__,
+    __file__,
+    ["compiled.ops.cpp", "na_torsion_pose_score.cuda.cu"],
+    "tmol_na_torsion",
+)
+
+na_torsion_pose_score = _ops.na_torsion_pose_score

--- a/tmol/score/na_torsion/potentials/compiled.ops.cpp
+++ b/tmol/score/na_torsion/potentials/compiled.ops.cpp
@@ -1,0 +1,174 @@
+#include <torch/library.h>
+
+#ifdef WITH_CUDA
+#include <torch/torch.h>
+
+#include "na_torsion_pose_score.hh"
+#endif
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+#ifdef WITH_CUDA
+using torch::Tensor;
+using torch::autograd::AutogradContext;
+using torch::autograd::Function;
+using torch::autograd::tensor_list;
+
+class NaTorsionPoseScoreOp
+    : public torch::autograd::Function<NaTorsionPoseScoreOp> {
+ public:
+  static std::vector<Tensor> forward(
+      AutogradContext* ctx,
+      Tensor coords,
+      Tensor base,
+      Tensor is_na,
+      Tensor torsion_indices,
+      Tensor torsion_ok,
+      Tensor ring_indices,
+      Tensor ring_ok,
+      Tensor prev,
+      Tensor backbone_means,
+      Tensor backbone_sdev,
+      Tensor sugar_means,
+      Tensor chi_means,
+      Tensor sdev_sugar,
+      Tensor sdev_chi,
+      Tensor well_pucker,
+      Tensor well_alpha_gamma,
+      Tensor well_bibii_pucker,
+      Tensor well_alphanext_bibii,
+      Tensor well_chi_syn,
+      Tensor is_north,
+      Tensor weight_bb,
+      Tensor weight_chi,
+      Tensor weight_sugar,
+      double pucker_temperature,
+      double bin_blend_sdev) {
+    auto result = na_torsion_pose_score_cuda(
+        coords,
+        base,
+        is_na,
+        torsion_indices,
+        torsion_ok,
+        ring_indices,
+        ring_ok,
+        prev,
+        backbone_means,
+        backbone_sdev,
+        sugar_means,
+        chi_means,
+        sdev_sugar,
+        sdev_chi,
+        well_pucker,
+        well_alpha_gamma,
+        well_bibii_pucker,
+        well_alphanext_bibii,
+        well_chi_syn,
+        is_north,
+        weight_bb,
+        weight_chi,
+        weight_sugar,
+        pucker_temperature,
+        bin_blend_sdev,
+        coords.requires_grad());
+    auto score = std::get<0>(result);
+    auto derivatives = std::get<1>(result);
+    ctx->save_for_backward({derivatives});
+    ctx->mark_non_differentiable({derivatives});
+    return {score, derivatives};
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    auto saved = ctx->get_saved_variables();
+    auto grad_coords =
+        na_torsion_pose_score_backward_cuda(saved[0], grad_outputs[0]);
+    return {
+        grad_coords, Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(),
+    };
+  }
+};
+
+std::tuple<Tensor, Tensor> na_torsion_pose_score(
+    Tensor coords,
+    Tensor base,
+    Tensor is_na,
+    Tensor torsion_indices,
+    Tensor torsion_ok,
+    Tensor ring_indices,
+    Tensor ring_ok,
+    Tensor prev,
+    Tensor backbone_means,
+    Tensor backbone_sdev,
+    Tensor sugar_means,
+    Tensor chi_means,
+    Tensor sdev_sugar,
+    Tensor sdev_chi,
+    Tensor well_pucker,
+    Tensor well_alpha_gamma,
+    Tensor well_bibii_pucker,
+    Tensor well_alphanext_bibii,
+    Tensor well_chi_syn,
+    Tensor is_north,
+    Tensor weight_bb,
+    Tensor weight_chi,
+    Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev) {
+  auto result = NaTorsionPoseScoreOp::apply(
+      coords,
+      base,
+      is_na,
+      torsion_indices,
+      torsion_ok,
+      ring_indices,
+      ring_ok,
+      prev,
+      backbone_means,
+      backbone_sdev,
+      sugar_means,
+      chi_means,
+      sdev_sugar,
+      sdev_chi,
+      well_pucker,
+      well_alpha_gamma,
+      well_bibii_pucker,
+      well_alphanext_bibii,
+      well_chi_syn,
+      is_north,
+      weight_bb,
+      weight_chi,
+      weight_sugar,
+      pucker_temperature,
+      bin_blend_sdev);
+  return {result[0], result[1]};
+}
+#endif
+
+TORCH_LIBRARY(tmol_na_torsion, m) {
+#ifdef WITH_CUDA
+  m.def("na_torsion_pose_score", &na_torsion_pose_score);
+#else
+  m.def(
+      "na_torsion_pose_score("
+      "Tensor coords, Tensor base, Tensor is_na, Tensor torsion_indices, "
+      "Tensor torsion_ok, Tensor ring_indices, Tensor ring_ok, Tensor prev, "
+      "Tensor backbone_means, Tensor backbone_sdev, Tensor sugar_means, "
+      "Tensor chi_means, Tensor sdev_sugar, Tensor sdev_chi, "
+      "Tensor well_pucker, Tensor well_alpha_gamma, "
+      "Tensor well_bibii_pucker, Tensor well_alphanext_bibii, "
+      "Tensor well_chi_syn, Tensor is_north, Tensor weight_bb, "
+      "Tensor weight_chi, Tensor weight_sugar, float pucker_temperature, "
+      "float bin_blend_sdev) -> (Tensor, Tensor)");
+#endif
+}
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
+++ b/tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
@@ -1,0 +1,1129 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+
+#include <cmath>
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+constexpr int N_TORSION = 10;
+constexpr int N_PUCKER = 10;
+constexpr int ALPHA = 0;
+constexpr int BETA = 1;
+constexpr int GAMMA = 2;
+constexpr int DELTA = 3;
+constexpr int EPSILON = 4;
+constexpr int ZETA = 5;
+constexpr int CHI = 9;
+
+template <typename Real>
+struct Vec3 {
+  Real x, y, z;
+};
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator+(Vec3<Real> a, Vec3<Real> b) {
+  return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator-(Vec3<Real> a, Vec3<Real> b) {
+  return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator*(Vec3<Real> a, Real s) {
+  return {a.x * s, a.y * s, a.z * s};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real>& operator+=(Vec3<Real>& a, Vec3<Real> b) {
+  a.x += b.x;
+  a.y += b.y;
+  a.z += b.z;
+  return a;
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real>& operator-=(Vec3<Real>& a, Vec3<Real> b) {
+  a.x -= b.x;
+  a.y -= b.y;
+  a.z -= b.z;
+  return a;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real dot(Vec3<Real> a, Vec3<Real> b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real norm(Vec3<Real> value) {
+  return sqrt(dot(value, value));
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> cross(Vec3<Real> a, Vec3<Real> b) {
+  return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> unit(Vec3<Real> value) {
+  Real magnitude = norm(value);
+  Real inv = Real(1) / (magnitude > Real(1e-9) ? magnitude : Real(1e-9));
+  return value * inv;
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> reverse_unit(
+    Vec3<Real> value, Vec3<Real> normalized, Vec3<Real> d_normalized) {
+  Real magnitude = norm(value);
+  if (magnitude <= Real(1e-9)) return d_normalized * Real(1e9);
+  return (d_normalized - normalized * dot(normalized, d_normalized))
+         * (Real(1) / magnitude);
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> load_coord(
+    Real const* coords, int64_t atom) {
+  Real const* xyz = coords + atom * 3;
+  return {xyz[0], xyz[1], xyz[2]};
+}
+
+template <typename Real>
+__device__ __forceinline__ Real mod360(Real angle) {
+  angle = fmod(angle, Real(360));
+  return angle < Real(0) ? angle + Real(360) : angle;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real wrap_degrees(Real angle) {
+  return mod360(angle + Real(180)) - Real(180);
+}
+
+template <typename Real>
+__device__ __forceinline__ Real sigmoid(Real value) {
+  return Real(1) / (Real(1) + exp(-value));
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+dihedral_degrees(Vec3<Real> p0, Vec3<Real> p1, Vec3<Real> p2, Vec3<Real> p3) {
+  Vec3<Real> b0 = p0 - p1;
+  Vec3<Real> b1 = unit(p2 - p1);
+  Vec3<Real> b2 = p3 - p2;
+  Vec3<Real> v = b0 - b1 * dot(b0, b1);
+  Vec3<Real> w = b2 - b1 * dot(b2, b1);
+  Real y = dot(cross(b1, v), w);
+  Real x = dot(v, w);
+  return mod360(atan2(y, x) * Real(180.0 / 3.14159265358979323846));
+}
+
+template <typename Real>
+__device__ __forceinline__ Real torsion_angle(
+    Real const* coords,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int flat_block,
+    int torsion) {
+  if (!torsion_ok[flat_block * N_TORSION + torsion]) return Real(0);
+  int offset = (flat_block * N_TORSION + torsion) * 4;
+  return dihedral_degrees(
+      load_coord(coords, torsion_indices[offset]),
+      load_coord(coords, torsion_indices[offset + 1]),
+      load_coord(coords, torsion_indices[offset + 2]),
+      load_coord(coords, torsion_indices[offset + 3]));
+}
+
+template <typename Real>
+__device__ __forceinline__ void pucker_weights(
+    Real const* coords,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int flat_block,
+    Real temperature,
+    Real* pucker) {
+  Vec3<Real> ring[5];
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    ring[atom] = ring_ok[offset] ? load_coord(coords, ring_indices[offset])
+                                 : Vec3<Real>{Real(0), Real(0), Real(0)};
+  }
+
+  Real plane[5];
+  Real exxo[5];
+  Real min_plane = Real(1e20);
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Vec3<Real> a0 = ring[rotation];
+    Vec3<Real> a1 = ring[(rotation + 1) % 5];
+    Vec3<Real> a2 = ring[(rotation + 2) % 5];
+    Vec3<Real> a3 = ring[(rotation + 3) % 5];
+    Vec3<Real> a4 = ring[(rotation + 4) % 5];
+    Vec3<Real> normal = unit(cross(a1 - a0, a2 - a1));
+    plane[rotation] = abs(dot(normal, unit(a3 - a2)));
+    exxo[rotation] = dot(normal, unit(a4 - (a3 + a0) * Real(0.5)));
+    min_plane = plane[rotation] < min_plane ? plane[rotation] : min_plane;
+  }
+
+  Real rotation_weight[5];
+  Real weight_sum = Real(0);
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    rotation_weight[rotation] =
+        exp(-(plane[rotation] - min_plane) / temperature);
+    weight_sum += rotation_weight[rotation];
+  }
+
+  constexpr int slot[10] = {9, 0, 6, 2, 8, 4, 5, 1, 7, 3};
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Real weight = rotation_weight[rotation] / weight_sum;
+    Real endo = sigmoid(Real(-2) * exxo[rotation] / temperature);
+    pucker[slot[rotation]] = weight * endo;
+    pucker[slot[rotation + 5]] = weight * (Real(1) - endo);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ void triple_bin_weights(
+    Real angle, Real const* means, Real sdev, Real* weights) {
+  Real total = Real(0);
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    weights[bin] = exp(-dev * dev / (Real(2) * sdev * sdev));
+    total += weights[bin];
+  }
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) weights[bin] /= total;
+}
+
+template <typename Real>
+__device__ __forceinline__ void triple_bin_weights_deriv(
+    Real angle,
+    Real const* means,
+    Real sdev,
+    Real* weights,
+    Real* derivatives) {
+  triple_bin_weights(angle, means, sdev, weights);
+  Real mean_log_deriv = Real(0);
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    derivatives[bin] = -dev / (sdev * sdev);
+    mean_log_deriv += weights[bin] * derivatives[bin];
+  }
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    derivatives[bin] = weights[bin] * (derivatives[bin] - mean_log_deriv);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+blended_devsq(Real angle, Real const* means, Real const* weights, int n_bins) {
+  Real value = Real(0);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    value += weights[bin] * dev * dev;
+  }
+  return value;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real blended_devsq_deriv(
+    Real angle,
+    Real const* means,
+    Real const* weights,
+    Real const* weight_derivatives,
+    int n_bins) {
+  Real derivative = Real(0);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    derivative +=
+        weight_derivatives[bin] * dev * dev + Real(2) * weights[bin] * dev;
+  }
+  return derivative;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+bi_bii_weight_deriv(Real epsilon, Real zeta, Real weight) {
+  constexpr Real rad = Real(3.14159265358979323846 / 180.0);
+  Real delta = wrap_degrees(epsilon - zeta) * rad;
+  return weight * (Real(1) - weight) * Real(-40) * cos(delta) * rad;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real syn_weight_deriv(Real chi, Real& weight) {
+  Real wrapped = mod360(chi);
+  Real lower = sigmoid((wrapped - Real(20)) / Real(5));
+  Real upper = sigmoid((Real(100) - wrapped) / Real(5));
+  weight = lower * upper;
+  return lower * (Real(1) - lower) * upper / Real(5)
+         - lower * upper * (Real(1) - upper) / Real(5);
+}
+
+template <typename Real>
+struct DihedralDeriv {
+  Vec3<Real> atom[4];
+};
+
+template <typename Real>
+__device__ __forceinline__ DihedralDeriv<Real> dihedral_deriv(
+    Vec3<Real> i, Vec3<Real> j, Vec3<Real> k, Vec3<Real> l) {
+  Vec3<Real> f = i - j;
+  Vec3<Real> g = j - k;
+  Vec3<Real> h = l - k;
+  Vec3<Real> a = cross(f, g);
+  Vec3<Real> b = cross(h, g);
+  Real a2 = dot(a, a);
+  Real b2 = dot(b, b);
+  Real gnorm = norm(g);
+  Real fg = dot(f, g);
+  Real hg = dot(h, g);
+  DihedralDeriv<Real> result;
+  result.atom[0] = a * (-gnorm / a2);
+  result.atom[1] =
+      a * (gnorm / a2 + fg / (a2 * gnorm)) - b * (hg / (b2 * gnorm));
+  result.atom[2] =
+      b * (-gnorm / b2 + hg / (b2 * gnorm)) - a * (fg / (a2 * gnorm));
+  result.atom[3] = b * (gnorm / b2);
+  return result;
+}
+
+template <typename Real>
+__device__ __forceinline__ void add_torsion_gradient(
+    Real const* coords,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int flat_block,
+    int torsion,
+    Real harmonic_deriv,
+    Real well_deriv,
+    int n_atoms,
+    Real* derivatives) {
+  if (!torsion_ok[flat_block * N_TORSION + torsion]) return;
+  int offset = (flat_block * N_TORSION + torsion) * 4;
+  int64_t atom[4];
+  Vec3<Real> xyz[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    atom[i] = torsion_indices[offset + i];
+    xyz[i] = load_coord(coords, atom[i]);
+  }
+  auto d_angle = dihedral_deriv(xyz[0], xyz[1], xyz[2], xyz[3]);
+  constexpr Real degrees_per_radian = Real(180.0 / 3.14159265358979323846);
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    int64_t coord = atom[i] * 3;
+    Vec3<Real> d = d_angle.atom[i] * degrees_per_radian;
+    atomicAdd(derivatives + coord, harmonic_deriv * d.x);
+    atomicAdd(derivatives + coord + 1, harmonic_deriv * d.y);
+    atomicAdd(derivatives + coord + 2, harmonic_deriv * d.z);
+    atomicAdd(derivatives + n_atoms * 3 + coord, well_deriv * d.x);
+    atomicAdd(derivatives + n_atoms * 3 + coord + 1, well_deriv * d.y);
+    atomicAdd(derivatives + n_atoms * 3 + coord + 2, well_deriv * d.z);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ void add_pucker_gradient(
+    Real const* coords,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int flat_block,
+    Real temperature,
+    Real const* pucker,
+    Real const d_energy_dpucker[2][N_PUCKER],
+    int n_atoms,
+    Real* derivatives) {
+  constexpr int slot[N_PUCKER] = {9, 0, 6, 2, 8, 4, 5, 1, 7, 3};
+  Vec3<Real> ring[5];
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    ring[atom] = ring_ok[offset] ? load_coord(coords, ring_indices[offset])
+                                 : Vec3<Real>{Real(0), Real(0), Real(0)};
+  }
+
+  Real mean_coeff[2] = {Real(0), Real(0)};
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Real endo = pucker[slot[rotation]];
+    Real exo = pucker[slot[rotation + 5]];
+    Real weight = endo + exo;
+    Real p_endo = endo / weight;
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real coeff =
+          p_endo * d_energy_dpucker[score][slot[rotation]]
+          + (Real(1) - p_endo) * d_energy_dpucker[score][slot[rotation + 5]];
+      mean_coeff[score] += weight * coeff;
+    }
+  }
+
+  Vec3<Real> ring_gradient[2][5];
+#pragma unroll
+  for (int score = 0; score < 2; ++score) {
+#pragma unroll
+    for (int atom = 0; atom < 5; ++atom) {
+      ring_gradient[score][atom] = {Real(0), Real(0), Real(0)};
+    }
+  }
+
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    int i0 = rotation;
+    int i1 = (rotation + 1) % 5;
+    int i2 = (rotation + 2) % 5;
+    int i3 = (rotation + 3) % 5;
+    int i4 = (rotation + 4) % 5;
+    Vec3<Real> u = ring[i1] - ring[i0];
+    Vec3<Real> v = ring[i2] - ring[i1];
+    Vec3<Real> c = cross(u, v);
+    Vec3<Real> n = unit(c);
+    Vec3<Real> edge = ring[i3] - ring[i2];
+    Vec3<Real> m = unit(edge);
+    Real q = dot(n, m);
+    Vec3<Real> apex = ring[i4] - (ring[i3] + ring[i0]) * Real(0.5);
+    Vec3<Real> h = unit(apex);
+    Real exxo = dot(n, h);
+    Real endo = pucker[slot[rotation]];
+    Real exo = pucker[slot[rotation + 5]];
+    Real weight = endo + exo;
+    Real p_endo = endo / weight;
+
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real endo_coeff = d_energy_dpucker[score][slot[rotation]];
+      Real exo_coeff = d_energy_dpucker[score][slot[rotation + 5]];
+      Real coeff = p_endo * endo_coeff + (Real(1) - p_endo) * exo_coeff;
+      Real d_plane = -weight * (coeff - mean_coeff[score]) / temperature;
+      Real d_exxo = weight * (endo_coeff - exo_coeff) * p_endo
+                    * (Real(1) - p_endo) * Real(-2) / temperature;
+      Real abs_deriv =
+          q > Real(0) ? Real(1) : (q < Real(0) ? Real(-1) : Real(0));
+      Real d_q = d_plane * abs_deriv;
+
+      Vec3<Real> d_n = m * d_q + h * d_exxo;
+      Vec3<Real> d_m = n * d_q;
+      Vec3<Real> d_h = n * d_exxo;
+      Vec3<Real> d_c = reverse_unit(c, n, d_n);
+      Vec3<Real> d_u = cross(v, d_c);
+      Vec3<Real> d_v = cross(d_c, u);
+      Vec3<Real> d_edge = reverse_unit(edge, m, d_m);
+      Vec3<Real> d_apex = reverse_unit(apex, h, d_h);
+
+      ring_gradient[score][i0] -= d_u + d_apex * Real(0.5);
+      ring_gradient[score][i1] += d_u - d_v;
+      ring_gradient[score][i2] += d_v - d_edge;
+      ring_gradient[score][i3] += d_edge - d_apex * Real(0.5);
+      ring_gradient[score][i4] += d_apex;
+    }
+  }
+
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    if (!ring_ok[offset]) continue;
+    int64_t coord = ring_indices[offset] * 3;
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real* out = derivatives + score * n_atoms * 3 + coord;
+      atomicAdd(out, ring_gradient[score][atom].x);
+      atomicAdd(out + 1, ring_gradient[score][atom].y);
+      atomicAdd(out + 2, ring_gradient[score][atom].z);
+    }
+  }
+}
+
+template <typename Real>
+__global__ void na_torsion_forward_kernel(
+    Real const* coords,
+    int64_t const* base,
+    bool const* is_na,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int64_t const* prev,
+    Real const* backbone_means,
+    Real const* backbone_sdev,
+    Real const* sugar_means,
+    Real const* chi_means,
+    Real const* sdev_sugar,
+    Real const* sdev_chi,
+    Real const* well_pucker,
+    Real const* well_alpha_gamma,
+    Real const* well_bibii_pucker,
+    Real const* well_alphanext_bibii,
+    Real const* well_chi_syn,
+    bool const* is_north,
+    Real const* weight_bb,
+    Real const* weight_chi,
+    Real const* weight_sugar,
+    Real pucker_temperature,
+    Real bin_blend_sdev,
+    int n_poses,
+    int max_n_blocks,
+    Real* output) {
+  int flat_block = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_blocks = n_poses * max_n_blocks;
+  if (flat_block >= n_blocks || !is_na[flat_block]) return;
+
+  int pose = flat_block / max_n_blocks;
+  int base_ind = int(base[flat_block]);
+  int polymer = base_ind >> 2;
+  Real torsion[N_TORSION];
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    torsion[tor] =
+        torsion_angle(coords, torsion_indices, torsion_ok, flat_block, tor);
+  }
+  Real pucker[N_PUCKER];
+  pucker_weights(
+      coords, ring_indices, ring_ok, flat_block, pucker_temperature, pucker);
+
+  Real const* means = backbone_means + polymer * 6 * 3;
+  Real const* sdev_bb = backbone_sdev + polymer * 6;
+  Real zero = Real(0);
+  Real e_bb = zero;
+  Real alpha_w[3], gamma_w[3];
+  triple_bin_weights(
+      torsion[ALPHA], means + ALPHA * 3, bin_blend_sdev, alpha_w);
+  triple_bin_weights(
+      torsion[GAMMA], means + GAMMA * 3, bin_blend_sdev, gamma_w);
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    e_bb += blended_devsq(torsion[ALPHA], means + ALPHA * 3, alpha_w, 3)
+            / (sdev_bb[ALPHA] * sdev_bb[ALPHA]);
+  }
+  if (torsion_ok[flat_block * N_TORSION + GAMMA]) {
+    e_bb += blended_devsq(torsion[GAMMA], means + GAMMA * 3, gamma_w, 3)
+            / (sdev_bb[GAMMA] * sdev_bb[GAMMA]);
+  }
+
+  bool both = torsion_ok[flat_block * N_TORSION + EPSILON]
+              && torsion_ok[flat_block * N_TORSION + ZETA];
+  Real w_bi = sigmoid(
+      Real(-40)
+      * sin(
+          wrap_degrees(torsion[EPSILON] - torsion[ZETA])
+          * Real(3.14159265358979323846 / 180.0)));
+  Real bibii_w[2] = {w_bi, Real(1) - w_bi};
+  if (both) {
+    for (int tor = EPSILON; tor <= ZETA; ++tor) {
+      e_bb += blended_devsq(torsion[tor], means + tor * 3, bibii_w, 2)
+              / (sdev_bb[tor] * sdev_bb[tor]);
+    }
+  }
+
+  int prev_block = int(prev[flat_block]);
+  bool prev_ok = prev_block >= 0 && torsion_ok[prev_block * N_TORSION + EPSILON]
+                 && torsion_ok[prev_block * N_TORSION + ZETA];
+  Real w_beta = Real(1);
+  if (prev_ok) {
+    Real prev_epsilon =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, EPSILON);
+    Real prev_zeta =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, ZETA);
+    w_beta = sigmoid(
+        Real(-40)
+        * sin(
+            wrap_degrees(prev_epsilon - prev_zeta)
+            * Real(3.14159265358979323846 / 180.0)));
+  }
+  Real beta_w[2] = {w_beta, Real(1) - w_beta};
+  if (torsion_ok[flat_block * N_TORSION + BETA]) {
+    e_bb += blended_devsq(torsion[BETA], means + BETA * 3, beta_w, 2)
+            / (sdev_bb[BETA] * sdev_bb[BETA]);
+  }
+
+  Real chi = torsion[CHI];
+  Real chi_mod = mod360(chi);
+  Real w_syn = sigmoid((chi_mod - Real(20)) / Real(5))
+               * sigmoid((Real(100) - chi_mod) / Real(5));
+  Real e_chi = zero;
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real dev_syn = wrap_degrees(chi - Real(50));
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(chi - chi_means[base_ind * N_PUCKER + puck]);
+      e_chi += pucker[puck]
+               * ((Real(1) - w_syn) * dev * dev + w_syn * dev_syn * dev_syn);
+    }
+    e_chi /= sdev_chi[polymer] * sdev_chi[polymer];
+  }
+
+  constexpr int sugar_torsion[4] = {DELTA, 6, 7, 8};
+  Real e_sugar = zero;
+#pragma unroll
+  for (int slot = 0; slot < 4; ++slot) {
+    int tor = sugar_torsion[slot];
+    if (!torsion_ok[flat_block * N_TORSION + tor]) continue;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(
+          torsion[tor] - sugar_means[(polymer * N_PUCKER + puck) * 4 + slot]);
+      e_sugar += pucker[puck] * dev * dev;
+    }
+  }
+  e_sugar /= sdev_sugar[polymer] * sdev_sugar[polymer];
+
+  Real e_well = zero;
+#pragma unroll
+  for (int puck = 0; puck < N_PUCKER; ++puck) {
+    e_well += pucker[puck] * well_pucker[polymer * N_PUCKER + puck];
+  }
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]
+      && torsion_ok[flat_block * N_TORSION + GAMMA]) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int g = 0; g < 3; ++g) {
+        e_well += alpha_w[a] * well_alpha_gamma[(polymer * 3 + a) * 3 + g]
+                  * gamma_w[g];
+      }
+    }
+  }
+  if (both) {
+    Real north = zero;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) north += pucker[puck];
+    }
+    Real ns[2] = {north, Real(1) - north};
+#pragma unroll
+    for (int bi = 0; bi < 2; ++bi) {
+#pragma unroll
+      for (int state = 0; state < 2; ++state) {
+        e_well += bibii_w[bi]
+                  * well_bibii_pucker[(polymer * 2 + bi) * 2 + state]
+                  * ns[state];
+      }
+    }
+  }
+  if (prev_ok && torsion_ok[flat_block * N_TORSION + ALPHA]) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int bi = 0; bi < 2; ++bi) {
+        e_well += alpha_w[a] * well_alphanext_bibii[(polymer * 3 + a) * 2 + bi]
+                  * beta_w[bi];
+      }
+    }
+  }
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+#pragma unroll
+    for (int syn = 0; syn < 2; ++syn) {
+      Real syn_w = syn == 0 ? Real(1) - w_syn : w_syn;
+#pragma unroll
+      for (int puck = 0; puck < N_PUCKER; ++puck) {
+        e_well += syn_w * well_chi_syn[(syn * N_PUCKER + puck) * 8 + base_ind]
+                  * pucker[puck];
+      }
+    }
+  }
+
+  Real harmonic = weight_bb[polymer] * e_bb + weight_chi[polymer] * e_chi
+                  + weight_sugar[polymer] * e_sugar;
+  atomicAdd(output + pose, harmonic);
+  atomicAdd(output + n_poses + pose, e_well);
+}
+
+template <typename Real>
+// The gradient path accumulates the two energies while their shared torsion,
+// pucker, and bin intermediates are live, avoiding a separate forward kernel.
+__global__ void na_torsion_derivative_kernel(
+    Real const* coords,
+    int64_t const* base,
+    bool const* is_na,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int64_t const* prev,
+    Real const* backbone_means,
+    Real const* backbone_sdev,
+    Real const* sugar_means,
+    Real const* chi_means,
+    Real const* sdev_sugar,
+    Real const* sdev_chi,
+    Real const* well_pucker,
+    Real const* well_alpha_gamma,
+    Real const* well_bibii_pucker,
+    Real const* well_alphanext_bibii,
+    Real const* well_chi_syn,
+    bool const* is_north,
+    Real const* weight_bb,
+    Real const* weight_chi,
+    Real const* weight_sugar,
+    Real pucker_temperature,
+    Real bin_blend_sdev,
+    int n_poses,
+    int max_n_blocks,
+    int n_atoms,
+    Real* derivatives,
+    Real* output) {
+  int flat_block = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_blocks = n_poses * max_n_blocks;
+  if (flat_block >= n_blocks || !is_na[flat_block]) return;
+
+  int pose = flat_block / max_n_blocks;
+  int base_ind = int(base[flat_block]);
+  int polymer = base_ind >> 2;
+  Real torsion[N_TORSION];
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    torsion[tor] =
+        torsion_angle(coords, torsion_indices, torsion_ok, flat_block, tor);
+  }
+  Real pucker[N_PUCKER];
+  pucker_weights(
+      coords, ring_indices, ring_ok, flat_block, pucker_temperature, pucker);
+
+  Real d_angle[2][N_TORSION] = {};
+  Real d_pucker[2][N_PUCKER] = {};
+  Real d_prev[2][2] = {};
+  Real energy[2] = {};
+  Real const* means = backbone_means + polymer * 6 * 3;
+  Real const* sdev_bb = backbone_sdev + polymer * 6;
+  Real bb_weight = weight_bb[polymer];
+  Real chi_weight = weight_chi[polymer];
+  Real sugar_weight = weight_sugar[polymer];
+
+  Real alpha_w[3], alpha_dw[3], gamma_w[3], gamma_dw[3];
+  triple_bin_weights_deriv(
+      torsion[ALPHA], means + ALPHA * 3, bin_blend_sdev, alpha_w, alpha_dw);
+  triple_bin_weights_deriv(
+      torsion[GAMMA], means + GAMMA * 3, bin_blend_sdev, gamma_w, gamma_dw);
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    Real inv_var = Real(1) / (sdev_bb[ALPHA] * sdev_bb[ALPHA]);
+    energy[0] += bb_weight
+                 * blended_devsq(torsion[ALPHA], means + ALPHA * 3, alpha_w, 3)
+                 * inv_var;
+    d_angle[0][ALPHA] +=
+        bb_weight
+        * blended_devsq_deriv(
+            torsion[ALPHA], means + ALPHA * 3, alpha_w, alpha_dw, 3)
+        * inv_var;
+  }
+  if (torsion_ok[flat_block * N_TORSION + GAMMA]) {
+    Real inv_var = Real(1) / (sdev_bb[GAMMA] * sdev_bb[GAMMA]);
+    energy[0] += bb_weight
+                 * blended_devsq(torsion[GAMMA], means + GAMMA * 3, gamma_w, 3)
+                 * inv_var;
+    d_angle[0][GAMMA] +=
+        bb_weight
+        * blended_devsq_deriv(
+            torsion[GAMMA], means + GAMMA * 3, gamma_w, gamma_dw, 3)
+        * inv_var;
+  }
+
+  bool both = torsion_ok[flat_block * N_TORSION + EPSILON]
+              && torsion_ok[flat_block * N_TORSION + ZETA];
+  Real w_bi = sigmoid(
+      Real(-40)
+      * sin(
+          wrap_degrees(torsion[EPSILON] - torsion[ZETA])
+          * Real(3.14159265358979323846 / 180.0)));
+  Real dw_bi = bi_bii_weight_deriv(torsion[EPSILON], torsion[ZETA], w_bi);
+  if (both) {
+    Real weight_derivative = Real(0);
+    for (int tor = EPSILON; tor <= ZETA; ++tor) {
+      Real dev_bi = wrap_degrees(torsion[tor] - means[tor * 3]);
+      Real dev_bii = wrap_degrees(torsion[tor] - means[tor * 3 + 1]);
+      Real inv_var = Real(1) / (sdev_bb[tor] * sdev_bb[tor]);
+      energy[0] +=
+          bb_weight
+          * (w_bi * dev_bi * dev_bi + (Real(1) - w_bi) * dev_bii * dev_bii)
+          * inv_var;
+      d_angle[0][tor] += bb_weight * Real(2)
+                         * (w_bi * dev_bi + (Real(1) - w_bi) * dev_bii)
+                         * inv_var;
+      weight_derivative += (dev_bi * dev_bi - dev_bii * dev_bii) * inv_var;
+    }
+    d_angle[0][EPSILON] += bb_weight * weight_derivative * dw_bi;
+    d_angle[0][ZETA] -= bb_weight * weight_derivative * dw_bi;
+  }
+
+  int prev_block = int(prev[flat_block]);
+  bool prev_ok = prev_block >= 0 && torsion_ok[prev_block * N_TORSION + EPSILON]
+                 && torsion_ok[prev_block * N_TORSION + ZETA];
+  Real prev_w_bi = Real(1);
+  Real prev_dw_bi = Real(0);
+  if (prev_ok) {
+    Real prev_epsilon =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, EPSILON);
+    Real prev_zeta =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, ZETA);
+    prev_w_bi = sigmoid(
+        Real(-40)
+        * sin(
+            wrap_degrees(prev_epsilon - prev_zeta)
+            * Real(3.14159265358979323846 / 180.0)));
+    prev_dw_bi = bi_bii_weight_deriv(prev_epsilon, prev_zeta, prev_w_bi);
+  }
+  if (torsion_ok[flat_block * N_TORSION + BETA]) {
+    Real dev_bi = wrap_degrees(torsion[BETA] - means[BETA * 3]);
+    Real dev_bii = wrap_degrees(torsion[BETA] - means[BETA * 3 + 1]);
+    Real inv_var = Real(1) / (sdev_bb[BETA] * sdev_bb[BETA]);
+    energy[0] += bb_weight
+                 * (prev_w_bi * dev_bi * dev_bi
+                    + (Real(1) - prev_w_bi) * dev_bii * dev_bii)
+                 * inv_var;
+    d_angle[0][BETA] += bb_weight * Real(2)
+                        * (prev_w_bi * dev_bi + (Real(1) - prev_w_bi) * dev_bii)
+                        * inv_var;
+    if (prev_ok) {
+      Real through_weight = bb_weight * (dev_bi * dev_bi - dev_bii * dev_bii)
+                            * inv_var * prev_dw_bi;
+      d_prev[0][0] += through_weight;
+      d_prev[0][1] -= through_weight;
+    }
+  }
+
+  Real w_syn;
+  Real dw_syn = syn_weight_deriv(torsion[CHI], w_syn);
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real dev_syn = wrap_degrees(torsion[CHI] - Real(50));
+    Real inv_var = Real(1) / (sdev_chi[polymer] * sdev_chi[polymer]);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev =
+          wrap_degrees(torsion[CHI] - chi_means[base_ind * N_PUCKER + puck]);
+      Real coeff =
+          ((Real(1) - w_syn) * dev * dev + w_syn * dev_syn * dev_syn) * inv_var;
+      energy[0] += chi_weight * pucker[puck] * coeff;
+      d_pucker[0][puck] += chi_weight * coeff;
+      d_angle[0][CHI] +=
+          chi_weight * pucker[puck]
+          * (Real(2) * ((Real(1) - w_syn) * dev + w_syn * dev_syn)
+             + dw_syn * (dev_syn * dev_syn - dev * dev))
+          * inv_var;
+    }
+  }
+
+  constexpr int sugar_torsion[4] = {DELTA, 6, 7, 8};
+  Real sugar_inv_var = Real(1) / (sdev_sugar[polymer] * sdev_sugar[polymer]);
+#pragma unroll
+  for (int slot = 0; slot < 4; ++slot) {
+    int tor = sugar_torsion[slot];
+    if (!torsion_ok[flat_block * N_TORSION + tor]) continue;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(
+          torsion[tor] - sugar_means[(polymer * N_PUCKER + puck) * 4 + slot]);
+      energy[0] += sugar_weight * pucker[puck] * dev * dev * sugar_inv_var;
+      d_pucker[0][puck] += sugar_weight * dev * dev * sugar_inv_var;
+      d_angle[0][tor] +=
+          sugar_weight * pucker[puck] * Real(2) * dev * sugar_inv_var;
+    }
+  }
+
+#pragma unroll
+  for (int puck = 0; puck < N_PUCKER; ++puck) {
+    Real well = well_pucker[polymer * N_PUCKER + puck];
+    energy[1] += pucker[puck] * well;
+    d_pucker[1][puck] += well;
+  }
+
+  bool alpha_gamma_ok = torsion_ok[flat_block * N_TORSION + ALPHA]
+                        && torsion_ok[flat_block * N_TORSION + GAMMA];
+  if (alpha_gamma_ok) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int g = 0; g < 3; ++g) {
+        Real table = well_alpha_gamma[(polymer * 3 + a) * 3 + g];
+        energy[1] += alpha_w[a] * table * gamma_w[g];
+        d_angle[1][ALPHA] += alpha_dw[a] * table * gamma_w[g];
+        d_angle[1][GAMMA] += alpha_w[a] * table * gamma_dw[g];
+      }
+    }
+  }
+
+  if (both) {
+    Real north = Real(0);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) north += pucker[puck];
+    }
+    Real ns[2] = {north, Real(1) - north};
+    Real state_value[2] = {Real(0), Real(0)};
+    Real weight_derivative = Real(0);
+#pragma unroll
+    for (int state = 0; state < 2; ++state) {
+      Real bi = well_bibii_pucker[(polymer * 2) * 2 + state];
+      Real bii = well_bibii_pucker[(polymer * 2 + 1) * 2 + state];
+      state_value[state] = w_bi * bi + (Real(1) - w_bi) * bii;
+      energy[1] += ns[state] * state_value[state];
+      weight_derivative += ns[state] * (bi - bii);
+    }
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) {
+        d_pucker[1][puck] += state_value[0] - state_value[1];
+      }
+    }
+    d_angle[1][EPSILON] += weight_derivative * dw_bi;
+    d_angle[1][ZETA] -= weight_derivative * dw_bi;
+  }
+
+  if (prev_ok && torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    Real prev_weight_derivative = Real(0);
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+      Real bi = well_alphanext_bibii[(polymer * 3 + a) * 2];
+      Real bii = well_alphanext_bibii[(polymer * 3 + a) * 2 + 1];
+      Real state_value = prev_w_bi * bi + (Real(1) - prev_w_bi) * bii;
+      energy[1] += alpha_w[a] * state_value;
+      d_angle[1][ALPHA] += alpha_dw[a] * state_value;
+      prev_weight_derivative += alpha_w[a] * (bi - bii);
+    }
+    Real through_weight = prev_weight_derivative * prev_dw_bi;
+    d_prev[1][0] += through_weight;
+    d_prev[1][1] -= through_weight;
+  }
+
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real chi_weight_derivative = Real(0);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real anti = well_chi_syn[puck * 8 + base_ind];
+      Real syn = well_chi_syn[(N_PUCKER + puck) * 8 + base_ind];
+      Real state_value = (Real(1) - w_syn) * anti + w_syn * syn;
+      energy[1] += pucker[puck] * state_value;
+      d_pucker[1][puck] += state_value;
+      chi_weight_derivative += pucker[puck] * (syn - anti);
+    }
+    d_angle[1][CHI] += dw_syn * chi_weight_derivative;
+  }
+
+  atomicAdd(output + pose, energy[0]);
+  atomicAdd(output + n_poses + pose, energy[1]);
+
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        flat_block,
+        tor,
+        d_angle[0][tor],
+        d_angle[1][tor],
+        n_atoms,
+        derivatives);
+  }
+  if (prev_ok) {
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        prev_block,
+        EPSILON,
+        d_prev[0][0],
+        d_prev[1][0],
+        n_atoms,
+        derivatives);
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        prev_block,
+        ZETA,
+        d_prev[0][1],
+        d_prev[1][1],
+        n_atoms,
+        derivatives);
+  }
+  add_pucker_gradient(
+      coords,
+      ring_indices,
+      ring_ok,
+      flat_block,
+      pucker_temperature,
+      pucker,
+      d_pucker,
+      n_atoms,
+      derivatives);
+}
+
+std::tuple<at::Tensor, at::Tensor> na_torsion_pose_score_cuda(
+    at::Tensor coords,
+    at::Tensor base,
+    at::Tensor is_na,
+    at::Tensor torsion_indices,
+    at::Tensor torsion_ok,
+    at::Tensor ring_indices,
+    at::Tensor ring_ok,
+    at::Tensor prev,
+    at::Tensor backbone_means,
+    at::Tensor backbone_sdev,
+    at::Tensor sugar_means,
+    at::Tensor chi_means,
+    at::Tensor sdev_sugar,
+    at::Tensor sdev_chi,
+    at::Tensor well_pucker,
+    at::Tensor well_alpha_gamma,
+    at::Tensor well_bibii_pucker,
+    at::Tensor well_alphanext_bibii,
+    at::Tensor well_chi_syn,
+    at::Tensor is_north,
+    at::Tensor weight_bb,
+    at::Tensor weight_chi,
+    at::Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev,
+    bool compute_derivs) {
+  TORCH_CHECK(coords.is_cuda(), "na_torsion_pose_score requires CUDA tensors");
+  TORCH_CHECK(coords.is_contiguous(), "coords must be contiguous");
+  int n_poses = int(base.size(0));
+  int max_n_blocks = int(base.size(1));
+  auto output = at::zeros({2, n_poses}, coords.options());
+  auto derivatives = compute_derivs
+                         ? at::zeros({2, coords.size(0), 3}, coords.options())
+                         : at::empty({0}, coords.options());
+  c10::cuda::CUDAGuard guard(coords.device());
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int threads = 128;
+  int blocks = (n_poses * max_n_blocks + threads - 1) / threads;
+  AT_DISPATCH_FLOATING_TYPES(
+      coords.scalar_type(), "na_torsion_pose_score_cuda", [&] {
+        if (!compute_derivs) {
+          na_torsion_forward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+              coords.const_data_ptr<scalar_t>(),
+              base.const_data_ptr<int64_t>(),
+              is_na.const_data_ptr<bool>(),
+              torsion_indices.const_data_ptr<int64_t>(),
+              torsion_ok.const_data_ptr<bool>(),
+              ring_indices.const_data_ptr<int64_t>(),
+              ring_ok.const_data_ptr<bool>(),
+              prev.const_data_ptr<int64_t>(),
+              backbone_means.const_data_ptr<scalar_t>(),
+              backbone_sdev.const_data_ptr<scalar_t>(),
+              sugar_means.const_data_ptr<scalar_t>(),
+              chi_means.const_data_ptr<scalar_t>(),
+              sdev_sugar.const_data_ptr<scalar_t>(),
+              sdev_chi.const_data_ptr<scalar_t>(),
+              well_pucker.const_data_ptr<scalar_t>(),
+              well_alpha_gamma.const_data_ptr<scalar_t>(),
+              well_bibii_pucker.const_data_ptr<scalar_t>(),
+              well_alphanext_bibii.const_data_ptr<scalar_t>(),
+              well_chi_syn.const_data_ptr<scalar_t>(),
+              is_north.const_data_ptr<bool>(),
+              weight_bb.const_data_ptr<scalar_t>(),
+              weight_chi.const_data_ptr<scalar_t>(),
+              weight_sugar.const_data_ptr<scalar_t>(),
+              scalar_t(pucker_temperature),
+              scalar_t(bin_blend_sdev),
+              n_poses,
+              max_n_blocks,
+              output.mutable_data_ptr<scalar_t>());
+        } else {
+          na_torsion_derivative_kernel<scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  coords.const_data_ptr<scalar_t>(),
+                  base.const_data_ptr<int64_t>(),
+                  is_na.const_data_ptr<bool>(),
+                  torsion_indices.const_data_ptr<int64_t>(),
+                  torsion_ok.const_data_ptr<bool>(),
+                  ring_indices.const_data_ptr<int64_t>(),
+                  ring_ok.const_data_ptr<bool>(),
+                  prev.const_data_ptr<int64_t>(),
+                  backbone_means.const_data_ptr<scalar_t>(),
+                  backbone_sdev.const_data_ptr<scalar_t>(),
+                  sugar_means.const_data_ptr<scalar_t>(),
+                  chi_means.const_data_ptr<scalar_t>(),
+                  sdev_sugar.const_data_ptr<scalar_t>(),
+                  sdev_chi.const_data_ptr<scalar_t>(),
+                  well_pucker.const_data_ptr<scalar_t>(),
+                  well_alpha_gamma.const_data_ptr<scalar_t>(),
+                  well_bibii_pucker.const_data_ptr<scalar_t>(),
+                  well_alphanext_bibii.const_data_ptr<scalar_t>(),
+                  well_chi_syn.const_data_ptr<scalar_t>(),
+                  is_north.const_data_ptr<bool>(),
+                  weight_bb.const_data_ptr<scalar_t>(),
+                  weight_chi.const_data_ptr<scalar_t>(),
+                  weight_sugar.const_data_ptr<scalar_t>(),
+                  scalar_t(pucker_temperature),
+                  scalar_t(bin_blend_sdev),
+                  n_poses,
+                  max_n_blocks,
+                  int(coords.size(0)),
+                  derivatives.mutable_data_ptr<scalar_t>(),
+                  output.mutable_data_ptr<scalar_t>());
+        }
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {output, derivatives};
+}
+
+template <typename Real>
+__global__ void na_torsion_backward_kernel(
+    Real const* derivatives,
+    Real const* grad_output,
+    int64_t grad_stride_score,
+    int64_t grad_stride_pose,
+    int n_poses,
+    int n_atoms,
+    Real* grad_coords) {
+  int index = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_values = n_atoms * 3;
+  if (index >= n_values) return;
+  int atom = index / 3;
+  int atoms_per_pose = n_atoms / n_poses;
+  int pose = atom / atoms_per_pose;
+  Real grad_harmonic = grad_output[pose * grad_stride_pose];
+  Real grad_well = grad_output[grad_stride_score + pose * grad_stride_pose];
+  grad_coords[index] = grad_harmonic * derivatives[index]
+                       + grad_well * derivatives[n_values + index];
+}
+
+at::Tensor na_torsion_pose_score_backward_cuda(
+    at::Tensor derivatives, at::Tensor grad_output) {
+  TORCH_CHECK(derivatives.is_cuda(), "NA torsion derivatives must be CUDA");
+  TORCH_CHECK(
+      grad_output.is_cuda(), "NA torsion output gradients must be CUDA");
+  TORCH_CHECK(
+      derivatives.dim() == 3 && derivatives.size(0) == 2,
+      "expected derivatives shaped [2, n_atoms, 3]");
+  TORCH_CHECK(
+      grad_output.dim() == 2 && grad_output.size(0) == 2,
+      "expected output gradients shaped [2, n_poses]");
+  int n_poses = int(grad_output.size(1));
+  int n_atoms = int(derivatives.size(1));
+  TORCH_CHECK(n_atoms % n_poses == 0, "atoms must divide evenly among poses");
+  auto grad_coords = at::empty({n_atoms, 3}, derivatives.options());
+  c10::cuda::CUDAGuard guard(derivatives.device());
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int threads = 256;
+  int blocks = (n_atoms * 3 + threads - 1) / threads;
+  AT_DISPATCH_FLOATING_TYPES(
+      derivatives.scalar_type(), "na_torsion_pose_score_backward_cuda", [&] {
+        na_torsion_backward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+            derivatives.const_data_ptr<scalar_t>(),
+            grad_output.const_data_ptr<scalar_t>(),
+            grad_output.stride(0),
+            grad_output.stride(1),
+            n_poses,
+            n_atoms,
+            grad_coords.mutable_data_ptr<scalar_t>());
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return grad_coords;
+}
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/na_torsion/potentials/na_torsion_pose_score.hh
+++ b/tmol/score/na_torsion/potentials/na_torsion_pose_score.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+std::tuple<at::Tensor, at::Tensor> na_torsion_pose_score_cuda(
+    at::Tensor coords,
+    at::Tensor base,
+    at::Tensor is_na,
+    at::Tensor torsion_indices,
+    at::Tensor torsion_ok,
+    at::Tensor ring_indices,
+    at::Tensor ring_ok,
+    at::Tensor prev,
+    at::Tensor backbone_means,
+    at::Tensor backbone_sdev,
+    at::Tensor sugar_means,
+    at::Tensor chi_means,
+    at::Tensor sdev_sugar,
+    at::Tensor sdev_chi,
+    at::Tensor well_pucker,
+    at::Tensor well_alpha_gamma,
+    at::Tensor well_bibii_pucker,
+    at::Tensor well_alphanext_bibii,
+    at::Tensor well_chi_syn,
+    at::Tensor is_north,
+    at::Tensor weight_bb,
+    at::Tensor weight_chi,
+    at::Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev,
+    bool compute_derivs);
+
+at::Tensor na_torsion_pose_score_backward_cuda(
+    at::Tensor derivatives, at::Tensor grad_output);
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/tests/ligand/test_protein_ligand_ddg.py
+++ b/tmol/tests/ligand/test_protein_ligand_ddg.py
@@ -26,6 +26,7 @@ import torch
 
 PLI_DATA_DIR = data_path("protein_ligand_test")
 LIGAND_RES_NAME = "LG1"
+ROSETTA_DDG_ATOL = 0.11
 
 # Weighted block-pair ddG (beta2016, minimize=False, pack=False, no_optH=True)
 # captured on CPU from fixture CIF + fixture .tmol params.
@@ -58,6 +59,20 @@ _GOLDEN_DDG: dict[str, float] = {
     "tk": -29.913303,
     "vegfr2": 48.350834,
 }
+
+
+def _rosetta_ddg(target: str) -> float:
+    """Read Rosetta's weighted interface score from the checked-in scorefile."""
+    suffix = (
+        "_complex_nometals.sc" if target in {"ace", "ada", "pde5"} else "_complex.sc"
+    )
+    score_lines = [
+        line.split()
+        for line in (PLI_DATA_DIR / f"{target}{suffix}").read_text().splitlines()
+        if line.startswith("SCORE:")
+    ]
+    score_fields = dict(zip(score_lines[0][1:], score_lines[1][1:]))
+    return float(score_fields["dG_total"])
 
 
 def _load_complex_cif(target: str):
@@ -126,7 +141,10 @@ def _weighted_ddg_from_fixtures(target: str, torch_device: torch.device) -> floa
 
 @pytest.mark.parametrize("target", sorted(_GOLDEN_DDG))
 def test_protein_ligand_cif_to_ddg_golden(target: str, torch_device) -> None:
-    """CIF complex + golden .tmol params reproduces pinned weighted ddG."""
+    """CIF complex reproduces pinned tmol and checked-in Rosetta ddG."""
     actual = _weighted_ddg_from_fixtures(target, torch_device)
     expected = _GOLDEN_DDG[target]
     numpy.testing.assert_allclose(actual, expected, rtol=1e-3, atol=1e-3)
+    numpy.testing.assert_allclose(
+        actual, _rosetta_ddg(target), rtol=0, atol=ROSETTA_DDG_ATOL
+    )

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -127,7 +127,9 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
 
     class ScoreFunction:
         @staticmethod
-        def render_block_pair_scoring_module(_pose):
+        def render_block_pair_scoring_module(_pose, *, interaction_only=False):
+            assert interaction_only
+
             class Scorer:
                 def __init__(self):
                     self.weights = weights
@@ -153,6 +155,32 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
         score_utils.calculate_block_pair_ddg(
             Pose(), block_indices.float(), sfxn=ScoreFunction(), minimize=False
         )
+
+
+def test_calculate_ddg_retains_diagonal_terms_for_overlapping_masks(torch_device):
+    class Pose:
+        device = torch_device
+        n_poses = 1
+        block_type_ind = torch.zeros(1, 2, dtype=torch.int32, device=torch_device)
+        coords = torch.empty(1, 0, 3, device=torch_device)
+
+    scores = torch.zeros((1, 1, 2, 2), device=torch_device)
+    scores[0, 0, 0, 0] = 3
+    rendered_modes = []
+
+    class ScoreFunction:
+        @staticmethod
+        def render_block_pair_scoring_module(_pose, *, interaction_only=False):
+            rendered_modes.append(interaction_only)
+            return lambda _coords, sum_terms, apply_weights=True: scores
+
+    mask = torch.tensor([[True, False]], device=torch_device)
+    result = score_utils.calculate_block_pair_ddg(
+        Pose(), mask, mask, sfxn=ScoreFunction(), minimize=False
+    )
+
+    torch.testing.assert_close(result, torch.tensor([3.0], device=torch_device))
+    assert rendered_modes == [False]
 
 
 def test_interacting_coord_mask_matches_per_pose_reference(

--- a/tmol/tests/optimization/test_minimizers.py
+++ b/tmol/tests/optimization/test_minimizers.py
@@ -58,7 +58,11 @@ def test_run_cart_min_smoke(
     wpsm = sfxn.render_whole_pose_scoring_module(pose_stack)
 
     start_score = wpsm(pose_stack.coords)
-    minimized_pose_stack = run_cart_min(pose_stack, sfxn)
+    minimized_pose_stack = run_cart_min(
+        pose_stack,
+        sfxn,
+        cuda_graph=torch_device.type == "cuda",
+    )
     end_score = wpsm(minimized_pose_stack.coords)
 
     assert torch.all(end_score < start_score)

--- a/tmol/tests/optimization/test_scorefunction_minimization.py
+++ b/tmol/tests/optimization/test_scorefunction_minimization.py
@@ -1,5 +1,6 @@
-import torch
+import attr
 import pytest
+import torch
 
 from tmol.io import pose_stack_from_pdb
 from tmol.pose import PoseStackBuilder
@@ -47,6 +48,43 @@ def test_cart_minimize_w_pose_and_sfxn_smoke(ubq_pdb, default_database, torch_de
         cart_sfxn_network.full_coords
     ).sum()
     assert E1 < E0
+
+
+def test_cart_network_reset_reuses_topology_and_updates_weights(
+    ubq_pdb, default_database, torch_device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+    network = CartesianSfxnNetwork(
+        sfxn,
+        pose_stack,
+        cuda_graph=("forward_backward" if torch_device.type == "cuda" else False),
+    )
+
+    # A cloned pose has independent connectivity storage; FastRelax packing
+    # preserves these tensors within a ramp, so only that case is reusable.
+    assert not network._reusable_for(sfxn, pose_stack.clone())
+
+    updated_pose = attr.evolve(pose_stack, coords=pose_stack.coords + 0.01)
+    assert network._reusable_for(sfxn, updated_pose)
+
+    sfxn.set_weight(ScoreType.fa_ljatr, 0.5)
+    assert network._reset(sfxn, updated_pose)
+    actual = network()
+    expected_network = CartesianSfxnNetwork(sfxn, updated_pose)
+    expected = expected_network()
+
+    torch.testing.assert_close(network.full_coords, updated_pose.coords)
+    torch.testing.assert_close(
+        network.whole_pose_scoring_module.weights[:, 0], sfxn.weights_tensor()
+    )
+    torch.testing.assert_close(actual, expected)
+
+    # Adding or removing a term changes the rendered module layout and must
+    # force the caller to build a fresh network.
+    sfxn.set_weight(ScoreType.fa_ljatr, 0.0)
+    assert not network._reset(sfxn, updated_pose)
 
 
 def test_kin_minimize_w_pose_and_sfxn_smoke(ubq_pdb, default_database, torch_device):

--- a/tmol/tests/relax/test_fast_relax.py
+++ b/tmol/tests/relax/test_fast_relax.py
@@ -2,7 +2,7 @@ import torch
 import numpy
 import pytest
 
-from tmol.relax import _default_cart_min_fn, fast_relax
+from tmol.relax import fast_relax
 import time
 
 from tmol.pose import (
@@ -111,8 +111,7 @@ def test_fast_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_
 def test_cart_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_poses):
     """Cartesian fast-relax on ubiquitin using CartesianSfxnNetwork.
 
-    Mirrors test_fast_relax_ubq but swaps the kinematic min_fn for the
-    Cartesian one via _default_cart_min_fn + CartesianMoveMap.
+    Exercise the default Cartesian minimizer with CUDA graph capture.
     """
     if torch_device == torch.device("cpu"):
         pytest.skip("CUDA only test")
@@ -146,7 +145,7 @@ def test_cart_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_
         cart_mm,
         fold_forest,
         task_operations=[task_op],
-        min_fn=_default_cart_min_fn,
+        cuda_graph=True,
         num_repeats=1,
         verbose=verbose,
     )

--- a/tmol/tests/relax/test_fast_relax.py
+++ b/tmol/tests/relax/test_fast_relax.py
@@ -1,9 +1,11 @@
-import torch
+import time
+
 import numpy
 import pytest
+import torch
 
 from tmol.relax import fast_relax
-import time
+from tmol.relax._fast_relax import _resolve_cuda_graph_mode
 
 from tmol.pose import (
     PoseStack,
@@ -53,6 +55,25 @@ def get_relax_sfxn(default_database, torch_device):
     sfxn.set_weight(ScoreType.disulfide, 1.0)
 
     return sfxn
+
+
+@pytest.mark.parametrize(
+    "pdb_fixture, expected",
+    [
+        ("ubq_pdb", False),
+        ("dna_pdb", True),
+        ("rna_pdb", True),
+        ("protein_dna_pdb", True),
+    ],
+)
+def test_fast_relax_automatic_graph_mode(request, pdb_fixture, expected, torch_device):
+    pose_stack = pose_stack_from_pdb(request.getfixturevalue(pdb_fixture), torch_device)
+
+    assert _resolve_cuda_graph_mode(pose_stack, None) == (
+        expected and torch_device.type == "cuda"
+    )
+    assert _resolve_cuda_graph_mode(pose_stack, True)
+    assert not _resolve_cuda_graph_mode(pose_stack, False)
 
 
 @pytest.mark.parametrize("n_poses", [1])

--- a/tmol/tests/score/na_torsion/test_na_torsion_benchmark.py
+++ b/tmol/tests/score/na_torsion/test_na_torsion_benchmark.py
@@ -35,20 +35,22 @@ def _sfxn(variant, default_database, device):
 
 
 @pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10, 30, 100]))
-@pytest.mark.parametrize("benchmark_pass", ["forward", "full"])
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb"])
+@pytest.mark.parametrize("benchmark_pass", ["forward", "backward", "full"])
 @pytest.mark.parametrize("variant", ["na_torsion", "beta2016_no_na", "beta2016"])
 @pytest.mark.benchmark(group="na_torsion_score")
 def test_na_torsion_benchmark(
     benchmark,
+    fixture,
     benchmark_pass,
     variant,
     n_poses,
-    dna_pdb,
+    request,
     default_database,
     torch_device,
 ):
     n_poses = int(n_poses)
-    pose_stack1 = pose_stack_from_pdb(dna_pdb, torch_device)
+    pose_stack1 = pose_stack_from_pdb(request.getfixturevalue(fixture), torch_device)
     pose_stack_n = PoseStackBuilder.from_poses([pose_stack1] * n_poses, torch_device)
 
     sfxn = _sfxn(variant, default_database, torch_device)
@@ -62,6 +64,15 @@ def test_na_torsion_benchmark(
             scores.cpu()
             return scores
 
+    elif benchmark_pass == "backward":
+        coords = pose_stack_n.coords.detach().requires_grad_(True)
+        scores = torch.sum(scorer(coords))
+
+        @benchmark
+        def score_pass():
+            (grad,) = torch.autograd.grad(scores, coords, retain_graph=True)
+            return grad.cpu()
+
     elif benchmark_pass == "full":
         pose_stack_n.coords.requires_grad_(True)
 
@@ -73,5 +84,54 @@ def test_na_torsion_benchmark(
 
     else:
         raise NotImplementedError
+
+    score_pass
+
+
+@pytest.mark.parametrize("implementation", ["native", "eager"])
+@pytest.mark.parametrize("n_poses", zero_padded_counts([1, 3, 10]))
+@pytest.mark.benchmark(group="na_torsion_rotamer_score")
+def test_na_torsion_rotamer_benchmark(
+    benchmark,
+    implementation,
+    n_poses,
+    protein_dna_pdb,
+    default_database,
+    torch_device,
+):
+    """Benchmark the one-body NA term used while searching rotamers."""
+    if torch_device.type != "cuda":
+        pytest.skip("native NA torsion rotamer scoring is CUDA-only")
+
+    from tmol.pack import PackerPalette, PackerTask, SetPackerTask
+    from tmol.pack.rotamer import IncludeCurrentSampler, build_rotamers
+
+    n_poses = int(n_poses)
+    pose = pose_stack_from_pdb(protein_dna_pdb, torch_device)
+    pose = PoseStackBuilder.from_poses([pose] * n_poses, torch_device)
+    task = PackerTask(pose, PackerPalette())
+    task.restrict_to_repacking()
+    task.add_conformer_sampler(IncludeCurrentSampler())
+    pose, rotamers = build_rotamers(
+        pose,
+        SetPackerTask.from_packer_task(task),
+        pose.packed_block_types.chem_db,
+    )
+
+    sfxn = ScoreFunction(default_database, torch_device)
+    for score_type in NaTorsionEnergyTerm.score_types():
+        sfxn.set_weight(score_type, 1.0)
+    scorer = sfxn.render_rotamer_scoring_module(pose, rotamers).term_modules[0]
+    coords = rotamers.coords.detach()
+    if implementation == "eager":
+        # The production fast-path decision uses requires_grad. Under no_grad,
+        # this selects the reference expression without building an autograd graph.
+        coords.requires_grad_(True)
+
+    @benchmark
+    def score_pass():
+        with torch.no_grad():
+            scores, _ = scorer(coords)
+        return scores.cpu()
 
     score_pass

--- a/tmol/tests/score/na_torsion/test_na_torsion_energy_term.py
+++ b/tmol/tests/score/na_torsion/test_na_torsion_energy_term.py
@@ -10,6 +10,8 @@ from tmol.score.na_torsion import (
     polymer_index,
     wrap_degrees,
 )
+from tmol.score.na_torsion._na_torsion_energy_term import _pose_subterms
+from tmol.score.common import ZeroTermPoseScoringModule
 
 
 def _term_and_pose(pdb, torch_device):
@@ -25,6 +27,20 @@ def _term_and_pose(pdb, torch_device):
 def test_smoke(default_database, torch_device):
     term = NaTorsionEnergyTerm(param_db=default_database, device=torch_device)
     assert term.device == torch_device
+
+
+def test_interaction_only_omits_diagonal_na_torsions(dna_pdb, torch_device):
+    term, pose_stack = _term_and_pose(dna_pdb, torch_device)
+
+    scorer = term.render_block_pair_scoring_module(pose_stack, interaction_only=True)
+
+    assert isinstance(scorer, ZeroTermPoseScoringModule)
+    assert scorer(pose_stack.coords).shape == (
+        2,
+        pose_stack.n_poses,
+        pose_stack.max_n_blocks,
+        pose_stack.max_n_blocks,
+    )
 
 
 @pytest.mark.parametrize(
@@ -101,6 +117,151 @@ def _subterms(term, ps):
     )
 
 
+def _native_pose_scores(term, ps, coords):
+    from tmol.score.na_torsion.potentials import na_torsion_pose_score
+
+    p = term.params
+    return na_torsion_pose_score(
+        coords.flatten(0, -2),
+        *ps.na_torsion_pose_params,
+        p.backbone_means,
+        p.backbone_sdev,
+        p.sugar_means,
+        p.chi_means,
+        p.sdev_sugar,
+        p.sdev_chi,
+        p.well_pucker,
+        p.well_alpha_gamma,
+        p.well_bibii_pucker,
+        p.well_alphanext_bibii,
+        p.well_chi_syn,
+        p.is_north,
+        p.weight_bb,
+        p.weight_chi,
+        p.weight_sugar,
+        p.pucker_temperature,
+        p.bin_blend_sdev,
+    )[0]
+
+
+def _reference_pose_scores(term, ps, coords):
+    p = term.params
+    bb, chi, sugar, well = _pose_subterms(
+        coords.flatten(0, -2),
+        *ps.na_torsion_pose_params,
+        p.backbone_means,
+        p.backbone_sdev,
+        p.sugar_means,
+        p.chi_means,
+        p.sdev_sugar,
+        p.sdev_chi,
+        p.well_pucker,
+        p.well_alpha_gamma,
+        p.well_bibii_pucker,
+        p.well_alphanext_bibii,
+        p.well_chi_syn,
+        p.is_north,
+        p.pucker_temperature,
+        p.bin_blend_sdev,
+    )
+    poly = polymer_index(ps.na_torsion_pose_params[0])
+    harmonic = p.weight_bb[poly] * bb + p.weight_chi[poly] * chi
+    harmonic = harmonic + p.weight_sugar[poly] * sugar
+    mask = ps.na_torsion_pose_params[1]
+    zero = torch.zeros_like(harmonic)
+    return torch.stack(
+        [
+            torch.where(mask, harmonic, zero).sum(dim=1),
+            torch.where(mask, well, zero).sum(dim=1),
+        ]
+    )
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+@pytest.mark.parametrize("n_poses", [1, 3])
+def test_native_cuda_pose_scores_match_reference(
+    n_poses, fixture, request, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("native NA torsion scoring is CUDA-only")
+
+    from tmol.pose import PoseStackBuilder
+
+    term, ps1 = _term_and_pose(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * n_poses, torch_device)
+    term.setup_packed_block_types(ps.packed_block_types)
+    term.setup_poses(ps)
+
+    expected = _reference_pose_scores(term, ps, ps.coords)
+    actual = _native_pose_scores(term, ps, ps.coords)
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-3)
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+@pytest.mark.parametrize("n_poses", [1, 3])
+def test_native_cuda_pose_gradients_match_reference(
+    n_poses, fixture, request, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("native NA torsion scoring is CUDA-only")
+
+    from tmol.pose import PoseStackBuilder
+
+    term, ps1 = _term_and_pose(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * n_poses, torch_device)
+    term.setup_packed_block_types(ps.packed_block_types)
+    term.setup_poses(ps)
+    reference_coords = ps.coords.detach().clone().requires_grad_(True)
+    native_coords = ps.coords.detach().clone().requires_grad_(True)
+    reference = _reference_pose_scores(term, ps, reference_coords)
+    native = _native_pose_scores(term, ps, native_coords)
+    output_weights = torch.linspace(
+        -1.2,
+        0.7,
+        2 * n_poses,
+        dtype=ps.coords.dtype,
+        device=torch_device,
+    ).reshape(2, n_poses)
+    (reference_grad,) = torch.autograd.grad(
+        torch.sum(reference * output_weights), reference_coords
+    )
+    (native_grad,) = torch.autograd.grad(
+        torch.sum(native * output_weights), native_coords
+    )
+
+    torch.testing.assert_close(native, reference, rtol=2e-5, atol=2e-3)
+    torch.testing.assert_close(native_grad, reference_grad, rtol=5e-4, atol=5e-2)
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+def test_native_cuda_pose_scoring_is_graph_capture_safe(
+    fixture, request, default_database, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA graph capture requires CUDA")
+
+    from tmol.pose import PoseStackBuilder
+    from tmol.score import ScoreFunction
+
+    ps1 = pose_stack_from_pdb(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * 3, torch_device)
+    sfxn = ScoreFunction(default_database, torch_device)
+    for score_type in NaTorsionEnergyTerm.score_types():
+        sfxn.set_weight(score_type, 1.0)
+
+    eager = sfxn.render_whole_pose_scoring_module(ps)
+    graphed = sfxn.render_whole_pose_scoring_module(ps, cuda_graph="both")
+    eager_coords = ps.coords.detach().clone().requires_grad_(True)
+    graph_coords = ps.coords.detach().clone().requires_grad_(True)
+    eager_score = eager(eager_coords)
+    graph_score = graphed(graph_coords)
+    (eager_grad,) = torch.autograd.grad(eager_score.sum(), eager_coords)
+    (graph_grad,) = torch.autograd.grad(graph_score.sum(), graph_coords)
+
+    torch.testing.assert_close(graph_score, eager_score)
+    torch.testing.assert_close(graph_grad, eager_grad)
+
+
 @pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb"])
 def test_subterms_sum_to_the_totals(fixture, request, torch_device):
     term, ps = _term_and_pose(request.getfixturevalue(fixture), torch_device)
@@ -144,11 +305,19 @@ def test_rotamer_energies_match_the_pose_energies(protein_dna_pdb, torch_device)
         ps, SetPackerTask.from_packer_task(task), ps.packed_block_types.chem_db
     )
 
-    per_rot = (
-        sfxn.render_rotamer_scoring_module(ps, rotamer_set)(rotamer_set.coords)
-        .coalesce()
-        .to_dense()
-    )
+    rotamer_scorer = sfxn.render_rotamer_scoring_module(ps, rotamer_set)
+    per_rot_sparse = rotamer_scorer(rotamer_set.coords).coalesce()
+    if torch_device.type == "cuda":
+        # Requiring coordinate gradients selects the eager reference path;
+        # ordinary search/packing inference uses the native CUDA row kernel.
+        eager = rotamer_scorer(
+            rotamer_set.coords.detach().clone().requires_grad_(True)
+        ).coalesce()
+        torch.testing.assert_close(per_rot_sparse.indices(), eager.indices())
+        torch.testing.assert_close(
+            per_rot_sparse.values(), eager.values(), rtol=2e-5, atol=2e-3
+        )
+    per_rot = per_rot_sparse.to_dense()
     per_block = sfxn.render_block_pair_scoring_module(ps)(ps.coords)
 
     pose = rotamer_set.pose_for_rot.to(torch.int64)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -576,6 +576,52 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
         assert torch.equal(parallel_score, serial_score)
 
 
+def test_interaction_only_block_pair_scoring_skips_diagonal_terms(
+    ubq_pdb, default_database, torch_device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    sfxn = beta2016_score_function(torch_device, default_database)
+    full_scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    interaction_scorer = sfxn.render_block_pair_scoring_module(
+        pose_stack, interaction_only=True
+    )
+
+    full = full_scorer(pose_stack.coords, sum_terms=False)
+    interaction = interaction_scorer(pose_stack.coords, sum_terms=False)
+    off_diagonal = ~torch.eye(
+        pose_stack.max_n_blocks, dtype=torch.bool, device=torch_device
+    )
+    torch.testing.assert_close(interaction[..., off_diagonal], full[..., off_diagonal])
+    block_pairs = torch.nonzero(off_diagonal, as_tuple=False)
+    torch.testing.assert_close(
+        interaction_scorer.score_interactions(
+            pose_stack.coords, block_pairs, sum_terms=False
+        ),
+        full[..., off_diagonal].sum(dim=2),
+    )
+    assert len(interaction_scorer._active_term_modules) < len(
+        full_scorer._active_term_modules
+    )
+
+
+def test_score_interactions_validates_block_pairs(ubq_pdb, torch_device):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=2)
+    scorer = beta2016_score_function(torch_device).render_block_pair_scoring_module(
+        pose_stack, interaction_only=True
+    )
+
+    with pytest.raises(ValueError, match="shape"):
+        scorer.score_interactions(
+            pose_stack.coords,
+            torch.zeros((2,), dtype=torch.int64, device=torch_device),
+        )
+    with pytest.raises(TypeError, match="integer"):
+        scorer.score_interactions(
+            pose_stack.coords,
+            torch.zeros((1, 2), dtype=torch.float32, device=torch_device),
+        )
+
+
 def test_block_pair_gradients_respect_sparse_upstream_weights(
     ubq_pdb, default_database, torch_device
 ):

--- a/tmol/tests/utility/test_cpp_extension.py
+++ b/tmol/tests/utility/test_cpp_extension.py
@@ -1,0 +1,39 @@
+from tmol.utility import _cpp_extension
+
+
+def test_required_cxx_standard():
+    assert _cpp_extension._required_cxx_standard("2", "12") == 17
+    assert _cpp_extension._required_cxx_standard("2", "13") == 20
+    assert _cpp_extension._required_cxx_standard("3", "0") == 20
+
+
+def test_active_torch_cxx_standard_flags_match():
+    expected = _cpp_extension._required_cxx_standard(
+        *_cpp_extension.get_torch_version()
+    )
+
+    assert f"--std=c++{expected}" in _cpp_extension._required_flags
+    assert f"-std=c++{expected}" in _cpp_extension._required_cuda_flags
+
+
+def test_select_cuda_architecture_prefers_active_device():
+    select = _cpp_extension._select_cuda_architecture
+    assert select(None, (9, 0)) == "9.0"
+    assert select("   ", (9, 0)) == "9.0"
+    assert select("8.0;9.0;12.0+PTX", (12, 0)) == "12.0"
+    assert select("7.5;8.0;8.6;9.0", (8, 9)) == "8.9"
+    assert select("8.6 9.0", (9, 0)) == "9.0"
+    assert select("8.6", (9, 0)) == "8.6"
+
+
+def test_custom_extension_flags_preserve_release_optimization():
+    kwargs = _cpp_extension._augment_kwargs(
+        "test_extension",
+        ["test.cpp"],
+        extra_cflags=["-DCUSTOM_CXX"],
+        extra_cuda_cflags=["-DCUSTOM_CUDA"],
+        with_cuda=False,
+    )
+
+    assert kwargs["extra_cflags"][:2] == ["-O3", "-DCUSTOM_CXX"]
+    assert kwargs["extra_cuda_cflags"][:2] == ["-O3", "-DCUSTOM_CUDA"]

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -45,8 +45,6 @@ _cccl_include = _get_cccl_include()
 if _cccl_include:
     _default_include_paths.append(_cccl_include)
 
-_required_flags = ["--std=c++17", "-DWITH_NVTX", "-w"]
-
 if os.environ.get("DEBUG"):
     _default_flags = ["-O3", "-DDEBUG"]
     # _default_flags = ["-g", "-Og", "-DDEBUG"]
@@ -65,8 +63,18 @@ def get_torch_version():
 
 torch_major, torch_minor = get_torch_version()
 
+
+def _required_cxx_standard(torch_major, torch_minor):
+    """Return the language standard required by this PyTorch release."""
+    version = int(torch_major), int(torch_minor)
+    return 20 if version >= (2, 13) else 17
+
+
+_cxx_standard = _required_cxx_standard(torch_major, torch_minor)
+_required_flags = [f"--std=c++{_cxx_standard}", "-DWITH_NVTX", "-w"]
+
 _required_cuda_flags = [
-    "-std=c++17",
+    f"-std=c++{_cxx_standard}",
     "--expt-extended-lambda",
     "-DWITH_NVTX",
     "-w",
@@ -74,6 +82,23 @@ _required_cuda_flags = [
     f"-DTORCH_VERSION_MAJOR={torch_major}",
     f"-DTORCH_VERSION_MINOR={torch_minor}",
 ]
+
+
+def _select_cuda_architecture(arch_list, device_capability):
+    """Choose the active device from a possibly multi-architecture setting."""
+    current = ".".join(str(part) for part in device_capability)
+    if not arch_list:
+        return current
+    requested = arch_list.replace(" ", ";").split(";")
+    requested = [arch.removesuffix("+PTX") for arch in requested if arch]
+    if not requested:
+        return current
+    # A multi-architecture value commonly comes from a wheel/container build
+    # environment and can lag newly installed hardware. A local JIT build is
+    # for the active device, so do not silently compile its first (often
+    # oldest) entry when the device is absent. Preserve a single explicit
+    # architecture as the user's deliberate cross-compilation request.
+    return current if len(requested) > 1 else requested[0]
 
 
 # Add an additional --gpu-architecture flag to the nvcc command:
@@ -86,12 +111,9 @@ if torch.cuda.is_available():
 
     arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
     # If not given, determine what's needed for the GPU that can be found
-    if not arch_list:
-        _major, _minor = torch.cuda.get_device_capability(0)
-    else:
-        # Take the first architecture listed.
-        # Deal with lists that are ' ' or ';' separated
-        _major, _minor = arch_list.replace(" ", ";").split(";")[0].split(".")
+    _major, _minor = _select_cuda_architecture(
+        arch_list, torch.cuda.get_device_capability()
+    ).split(".")
     _required_cuda_flags.append(f"--gpu-architecture=sm_{_major}{_minor}")
 
     # we need to add the search path for nvtx3
@@ -128,10 +150,11 @@ _default_cuda_flags = ["-O3"]
 # commands to the terminal
 def _augment_kwargs(name, sources, **kwargs):
     kwargs["extra_cflags"] = (
-        list(kwargs.get("extra_cflags", _default_flags)) + _required_flags
+        _default_flags + list(kwargs.get("extra_cflags", [])) + _required_flags
     )
     kwargs["extra_cuda_cflags"] = (
-        list(kwargs.get("extra_cuda_cflags", _default_cuda_flags))
+        _default_cuda_flags
+        + list(kwargs.get("extra_cuda_cflags", []))
         + _required_cuda_flags
     )
     kwargs["extra_include_paths"] = (


### PR DESCRIPTION
## Summary

- add a fused native CUDA path for nucleic-acid whole-pose and rotamer torsion scoring, replacing the previous large Python/autograd launch graph
- expose an interaction-focused block-pair scorer that omits provably diagonal-only terms and reduces selected pairs through one small public API
- reduce LKBall backward launch overhead without changing its score or gradient contract
- expose fixed-shape CUDA graph replay through Cartesian minimization and `fast_relax()`; CUDA poses containing DNA or RNA select it automatically, with one boolean override
- reuse rendered Cartesian scorers across FastRelax weight ramps when topology and score-term layout are unchanged
- harden CUDA extension/CI builds against build-isolation Torch/CUDA mismatches and explicit architecture requirements
- add reproducible benchmark runners for proteins, DNA, RNA, protein–DNA, and protein–ligand systems

The RFD4 guidance-side scoring path is intentionally small:

```python
scorer = sfxn.render_block_pair_scoring_module(pose_stack, interaction_only=True)
energy = scorer.score_interactions(pose_stack.coords, block_pair_indices)
```

For relaxation, the public campaign interface remains one call:

```python
relaxed = fast_relax(pose_stack, sfxn, palette, move_map, fold_forest)
```

`cuda_graph=True` or `False` overrides automatic selection. Both interfaces operate on TMol packed topology and parameter databases; they contain no protein/ligand/PTM/metal residue allowlists. Chemistry added to TMol therefore reaches the Atom37/Biotite adapter and RFD4 guidance without a new RFD4 conversion path.

## Why graph replay is automatic only for nucleic-acid poses

Kernel work was optimized before choosing the graph policy. The native nucleic-acid rotamer path reduces one representative mixed protein–DNA profile from 1,540 CUDA operations / 2.345 ms to 15 operations / 0.191 ms, and steady-state rotamer scoring improves from 4.28–4.30 ms to 0.117–0.137 ms (31–37x across batches 1, 3, and 10).

After that rewrite, fixed-shape forward+backward scoring was remeasured on CUDA (median of 20 synchronized trials):

| system | batch | eager | graph replay | speedup |
| --- | ---: | ---: | ---: | ---: |
| DNA24 | 1 | 6.406 ms | 0.644 ms | 9.95x |
| DNA24 | 8 | 4.250 ms | 0.875 ms | 4.86x |
| RNA42 | 1 | 4.074 ms | 0.706 ms | 5.77x |
| RNA42 | 8 | 6.435 ms | 1.258 ms | 5.11x |
| protein–DNA154 | 1 | 4.071 ms | 0.896 ms | 4.54x |
| protein–DNA154 | 8 | 4.101 ms | 3.084 ms | 1.33x |

Capture takes about 18–23 ms after normal initialization and is amortized by repeated minimizer/guidance evaluations. Pure protein and protein–ligand scoring measured only 1–7% replay improvement, while their end-to-end relaxation is packing-dominated, so eager execution avoids capture/storage costs by default. Mixed poses containing DNA or RNA use replay because they retain a material gradient-workload benefit. Exact historical eager trajectories remain available with `cuda_graph=False`.

## Interaction-guidance performance

`interaction_only=True` skips every score term whose block-pair contribution is invariantly zero off diagonal. Off-diagonal values and coordinate gradients match the full block-pair scorer; diagonal entries are explicitly documented as incomplete in this mode.

CUDA forward / forward+backward timings for the same selected interface calculation:

| system / batch | full block-pair | interaction-only | speedup |
| --- | ---: | ---: | ---: |
| DNA24 / 1 | 6.562 / 29.848 ms | 1.762 / 5.399 ms | 3.73x / 5.53x |
| DNA24 / 10 | 6.688 / 29.181 ms | 1.812 / 5.370 ms | 3.69x / 5.44x |
| RNA42 / 1 | 6.835 / 30.699 ms | 2.195 / 10.999 ms | 3.11x / 2.79x |
| RNA42 / 10 | 6.889 / 30.421 ms | 2.154 / 10.869 ms | 3.20x / 2.80x |
| protein–DNA154 / 1 | 5.078 / 30.054 ms | 2.061 / 10.868 ms | 2.46x / 2.77x |
| protein–DNA154 / 10 | 6.937 / 31.632 ms | 2.870 / 10.553 ms | 2.42x / 3.00x |

The final `score_interactions()` implementation deliberately preserves the scorer's fast operation ordering and adds only one indexed reduction. A per-term reduction variant was 4–6% slower and was removed. Disjoint fragment/DDG helpers select the optimized rendering automatically; overlapping selections retain complete diagonal semantics.

## LKBall and build results

The accepted LKBall scheduling change reduces a representative batch-100 protein–DNA forward+backward measurement from 13.60 ms to 11.94 ms and its backward portion from 8.14 ms to 6.46 ms. Scores differ by at most 3.66e-4 and coordinate gradients by 8.34e-7 in the A/B check. A more aggressive bridge fusion increased register spills and runtime, so it was not retained.

CUDA build hardening prevents two failure modes found in the original CI run:

1. PEP 517 isolation selecting a different Torch/CUDA toolchain from the runtime environment.
2. Native code built only for `sm_89` being executed on `sm_90`, producing no-kernel-image failures.

The build now reuses a matching container Torch installation when possible, validates CUDA-major compatibility, and forwards explicit architecture/index overrides into Apptainer.

## Validation

- full CPU suite: 1,625 passed, 1,071 skipped, 5 expected failures, 1 XPASS
- hosted full CUDA suite: 1,004 passed, 20 skipped, 0 failures (1,024 tests)
- LKBall CUDA suite: 27 passed
- RFD4 co-designed full, partial, and beam-search guidance/metric suite: 60 passed, 6 GPU-skipped
- checked-in protein–ligand Rosetta interface references: Pearson `r=0.9999981`, RMSE `0.0490` REU, maximum absolute difference `0.0962` REU
- checked-in DUD ligand references: Pearson `r=0.9999999995`, RMSE `2.86e-4` REU across 75 weighted term values
- lint, formatting, C++ formatting, Bash syntax, Python compilation, and diff checks pass locally

Hosted CPU, CUDA, documentation, and wheel smoke checks are running on this head.


