### PR TITLE
Accelerate CUDA scoring and harden build/release reliability

### DIFF
--- a/.github/ci/build_package.sh
+++ b/.github/ci/build_package.sh
@@ -30,19 +30,44 @@ retry() {
   done
 }
 
-retry uv pip compile pyproject.toml --all-extras --output-file requirements.txt
-grep -vE "^(torch(|vision|audio)|numpy|nvidia-.*|triton|tensorrt|pynvml|pandas|scipy)==" \
-  requirements.txt > to_install.txt
-retry uv pip install -r to_install.txt
-TORCH_CUDA_INDEX="${TMOL_CI_TORCH_CUDA_INDEX:-https://download.pytorch.org/whl/cu128}"
-retry uv pip install torch --index-url "${TORCH_CUDA_INDEX}"
+BUILD_DEPS_TMP=$(mktemp -d)
+trap 'rm -rf "${BUILD_DEPS_TMP}"' EXIT
+retry uv pip compile --quiet pyproject.toml --all-extras \
+  --output-file "${BUILD_DEPS_TMP}/requirements.txt"
+grep -vE "^(torch(|vision|audio)|numpy|cuda-.*|nvidia-.*|triton|tensorrt|pynvml|pandas|scipy)==" \
+  "${BUILD_DEPS_TMP}/requirements.txt" > "${BUILD_DEPS_TMP}/to_install.txt"
+retry uv pip install -r "${BUILD_DEPS_TMP}/to_install.txt"
+NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
+case "${NVCC_VER}" in
+  13.*) DEFAULT_TORCH_CUDA_INDEX="https://download.pytorch.org/whl/cu130" ;;
+  *) DEFAULT_TORCH_CUDA_INDEX="https://download.pytorch.org/whl/cu128" ;;
+esac
+TORCH_CUDA_INDEX="${TMOL_CI_TORCH_CUDA_INDEX:-${DEFAULT_TORCH_CUDA_INDEX}}"
+NVCC_MAJOR=${NVCC_VER%%.*}
+TORCH_CUDA_MAJOR=$(python -c "import torch; print((torch.version.cuda or '').split('.')[0])" 2>/dev/null || true)
+if [[ "${TORCH_CUDA_MAJOR}" != "${NVCC_MAJOR}" ]]; then
+  retry uv pip install --upgrade torch --index-url "${TORCH_CUDA_INDEX}"
+else
+  echo "Reusing PyTorch $(python -c 'import torch; print(torch.__version__)') with CUDA $(python -c 'import torch; print(torch.version.cuda)')"
+fi
+# The extension must be configured with the same Torch/CUDA installation that
+# will load it at runtime.  PEP 517 build isolation otherwise resolves the
+# unbounded ``torch>=2.5`` build requirement independently; when a newer CUDA
+# major is current on PyPI this can silently produce (for example) a CUDA 13
+# extension in a CUDA 12.8 runtime environment.
+retry uv pip install 'cmake>=3.24,<4' 'scikit-build-core>=0.10' ninja \
+  'packaging>=24.2' 'pybind11>=2.12'
 assert_torch_cuda
+TORCH_CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])")
+if [[ "${TORCH_CUDA_MAJOR}" != "${NVCC_MAJOR}" ]]; then
+  echo "PyTorch CUDA ${TORCH_CUDA_MAJOR} does not match nvcc ${NVCC_VER}" >&2
+  exit 1
+fi
 
 RUN_GPU=$(python -c "import torch; c=torch.cuda.get_device_capability(0); print(f'{c[0]}.{c[1]}')" 2>/dev/null || echo "n/a")
 # Test jobs only execute on this runner, so compiling every wheel architecture
 # wastes most of the job. Release wheels retain the all-supported-SM default.
 CUDA_ARCHS="${TMOL_CI_CUDA_ARCHITECTURES:-native}"
-NVCC_VER=$(nvcc --version 2>&1 | sed -n 's/.*release \([0-9.]*\).*/\1/p' | head -1)
 if [[ "${CUDA_ARCHS}" == "native" ]]; then
   # Exercise CMake's native path in CI. JIT extensions still need PyTorch's
   # numeric spelling for the same runner GPU.
@@ -65,9 +90,13 @@ for _A in "${_CUDA_ARCH_ARR[@]}"; do
   fi
 done
 export TORCH_CUDA_ARCH_LIST="${TORCH_ARCH_LIST# }"
+TORCH_CMAKE_DIR=$(python -c "from pathlib import Path; import torch; print(Path(torch.__file__).parent / 'share/cmake/Torch')")
 echo "=== Runner GPU sm_${RUN_GPU} | nvcc ${NVCC_VER} | CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS} ==="
-MAX_JOBS=12 pip install -v --no-deps \
+# Compile against the same PyTorch installation used by the test process.
+# Build isolation may resolve a newer PyTorch with an incompatible C++ ABI.
+MAX_JOBS=12 pip install -v --no-build-isolation --no-deps \
   -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+  -Ccmake.define.Torch_DIR="${TORCH_CMAKE_DIR}" \
   -Ccmake.define.TMOL_BUILD_TESTS=ON \
   -Ccmake.define.TMOL_NVCC_THREADS=2 \
   -e .

--- a/.github/ci/exec_gpu_apptainer.sh
+++ b/.github/ci/exec_gpu_apptainer.sh
@@ -37,6 +37,12 @@ fi
 if [[ -n "${TMOL_DOCS_BASE_URL:-}" ]]; then
   env_args+=(--env "TMOL_DOCS_BASE_URL=${TMOL_DOCS_BASE_URL}")
 fi
+if [[ -n "${TMOL_CI_CUDA_ARCHITECTURES:-}" ]]; then
+  env_args+=(--env "TMOL_CI_CUDA_ARCHITECTURES=${TMOL_CI_CUDA_ARCHITECTURES}")
+fi
+if [[ -n "${TMOL_CI_TORCH_CUDA_INDEX:-}" ]]; then
+  env_args+=(--env "TMOL_CI_TORCH_CUDA_INDEX=${TMOL_CI_TORCH_CUDA_INDEX}")
+fi
 
 apptainer exec --nv --fakeroot --containall \
   --bind "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \

--- a/.github/ci/gpu_env.sh
+++ b/.github/ci/gpu_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# GPU container env tweaks shared by CUDA test and benchmark lanes.
+# GPU container environment shared by CUDA jobs.
 #
 # Drop the container's CUDA forward-compat libcuda so torch uses the host
 # driver (avoids CUDA init error 803 on newer-driver nodes).
@@ -49,7 +49,8 @@ print(
 if torch.version.cuda is None:
     sys.exit(
         "PyTorch has no CUDA support (CPU-only wheel). "
-        "Install from https://download.pytorch.org/whl/cu128"
+        "Install a wheel matching the build CUDA toolkit from "
+        "https://download.pytorch.org/whl/"
     )
 if not torch.cuda.is_available():
     sys.exit(

--- a/.github/ci/run_ci_gpu_work.sh
+++ b/.github/ci/run_ci_gpu_work.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# All GPU-allocation work in one Slurm job: build, CUDA tests, benchmarks.
+# Build and test inside one GPU allocation.
 #
 # Invoked inside apptainer on a gpu-train node (see ci.yml). CPU tests run in a
 # separate GitHub-hosted job and do not occupy the GPU allocation.
@@ -18,6 +18,15 @@ source .venv/bin/activate
 echo "=== build ==="
 .github/ci/build_package.sh
 
+echo "=== representative CUDA JIT compile ==="
+TMOL_USE_JIT=1 python - <<'PY'
+import torch
+from tmol.kinematics.compiled import forward_kin_op
+
+assert torch.cuda.is_available()
+print("loaded", forward_kin_op, "with torch", torch.__version__)
+PY
+
 echo "=== tests (CUDA) ==="
 .github/ci/run_gpu_tests.sh
 
@@ -26,6 +35,3 @@ python .github/scripts/smoke_tutorial_notebooks.py \
   docs/tutorial/02_gpu_batching.ipynb \
   docs/tutorial/06_fast_relax.ipynb \
   --execution-device cuda
-
-echo "=== benchmarks ==="
-.github/ci/run_benchmarks.sh

--- a/.github/ci/setup_ci_venv.sh
+++ b/.github/ci/setup_ci_venv.sh
@@ -26,7 +26,10 @@ if [ -z "$PYTHON_BIN" ]; then
 fi
 
 if [ ! -d .venv ]; then
-  "$PYTHON_BIN" -m venv .venv
+  # The GPU image already provides a CUDA-matched NVIDIA PyTorch build. Make it
+  # visible to the venv so clean CI jobs do not redownload several GB of CUDA
+  # wheels; build_package.sh still replaces it when the CUDA majors differ.
+  "$PYTHON_BIN" -m venv --system-site-packages .venv
 fi
 source .venv/bin/activate
 pip install pip --upgrade

--- a/.github/ci/srun_gpu_retry.sh
+++ b/.github/ci/srun_gpu_retry.sh
@@ -43,6 +43,7 @@ exclude="${SLURM_EXCLUDE:-}"
 attempt=1
 
 _gpu_retry_pattern='TaskProlog failed|Failed to get device handle|Unable to determine the device handle|GPU problem:|nvidia-smi failed'
+_node_failure_pattern='Node failure on|DUE TO NODE FAILURE'
 
 while (( attempt <= MAX_ATTEMPTS )); do
   echo "=== srun GPU attempt ${attempt}/${MAX_ATTEMPTS} (exclude: ${exclude:-none}) ==="
@@ -79,15 +80,26 @@ GPUCHECK
     exit 0
   fi
 
-  # If the inner job created the allocation sentinel, tests started — do not
-  # retry (real test failure, not a dirty GPU / TaskProlog rejection).
-  if [[ -n "${GPU_ALLOC_SENTINEL:-}" && -f "${GPU_ALLOC_SENTINEL}" ]]; then
+  # A Slurm node failure is unambiguously infrastructure-related and remains
+  # safe to retry after tests start. Other failures after the sentinel are
+  # treated as real build/test failures.
+  node_failed=0
+  if grep -qE "$_node_failure_pattern" "$log"; then
+    node_failed=1
+  fi
+  if (( ! node_failed )) \
+    && [[ -n "${GPU_ALLOC_SENTINEL:-}" && -f "${GPU_ALLOC_SENTINEL}" ]]; then
     echo "GPU_ALLOC_SENTINEL present — tests started; not retrying (rc=${rc})."
     exit "$rc"
   fi
 
-  if [[ "$rc" -eq 42 ]] || grep -qE "$_gpu_retry_pattern" "$log"; then
-    bad_node=$(grep -oE 'srun: error: [a-zA-Z0-9][a-zA-Z0-9_-]*' "$log" | head -1 | awk '{print $3}')
+  if (( node_failed )) \
+    || [[ "$rc" -eq 42 ]] \
+    || grep -qE "$_gpu_retry_pattern" "$log"; then
+    bad_node=$(sed -nE \
+      -e 's/.*Node failure on ([a-zA-Z0-9][a-zA-Z0-9_-]*).*/\1/p' \
+      -e 's/.*srun: error: ([a-zA-Z0-9][a-zA-Z0-9_-]*):.*/\1/p' \
+      "$log" | head -1)
     if [[ -n "$bad_node" ]]; then
       if [[ -n "$exclude" ]]; then
         exclude="${exclude},${bad_node}"
@@ -97,6 +109,9 @@ GPUCHECK
       echo "GPU node failure on ${bad_node}; excluding and retrying in ${RETRY_SLEEP}s"
     else
       echo "GPU allocation failure (node unknown); retrying in ${RETRY_SLEEP}s"
+    fi
+    if (( node_failed )) && [[ -n "${GPU_ALLOC_SENTINEL:-}" ]]; then
+      rm -f "$GPU_ALLOC_SENTINEL"
     fi
     sleep "$RETRY_SLEEP"
     ((attempt++))

--- a/.github/scripts/test_colab_release_config.py
+++ b/.github/scripts/test_colab_release_config.py
@@ -30,7 +30,7 @@ def test_colab_selects_the_published_wheel_for_each_supported_python():
     source = (ROOT / "docs/tutorial/colab_setup.py").read_text(encoding="utf-8")
 
     assert module.TUTORIAL_REF == "master"
-    assert module.TMOL_RELEASE == "0.1.53"
+    assert module.TMOL_RELEASE == "0.1.54"
     assert module.RELEASE_WHEEL_TORCH_MINOR == "2.11"
     assert module.RELEASE_WHEEL_CUDA == "12.8"
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -43,10 +43,10 @@ def test_colab_selects_the_published_wheel_for_each_supported_python():
     )
     assert module.RELEASE_WHEEL_PYTHONS == {(3, 12), (3, 13)}
     assert module._wheel_url((3, 12)).endswith(
-        "/v0.1.53/" "tmol-0.1.53+cu128torch2.11-cp312-cp312-manylinux_2_28_x86_64.whl"
+        "/v0.1.54/" "tmol-0.1.54+cu128torch2.11-cp312-cp312-manylinux_2_28_x86_64.whl"
     )
     assert module._wheel_url((3, 13)).endswith(
-        "/v0.1.53/" "tmol-0.1.53+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
+        "/v0.1.54/" "tmol-0.1.54+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
     )
     with pytest.raises(ValueError, match="Unsupported Colab Python version"):
         module._wheel_url((3, 14))
@@ -81,7 +81,7 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
 
     publish = _workflow(".github/workflows/publish.yml")
     publish_rows = publish["jobs"]["build_wheels"]["strategy"]["matrix"]["include"]
-    assert len(publish_rows) == 26
+    assert len(publish_rows) == 34
 
     colab_rows = [row for row in publish_rows if row.get("cuda-archs") == "75;80;89"]
     assert colab_rows == [
@@ -112,22 +112,44 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
         and row["runs-on"] == "ubuntu-22.04"
         for row in publish_rows
     )
+    assert {
+        (row["python-version"], row["runs-on"])
+        for row in publish_rows
+        if row["torch-version"] == "2.14"
+    } == {
+        (python_version, runner)
+        for python_version in ("3.11", "3.12", "3.13", "3.14")
+        for runner in ("ubuntu-22.04", "ubuntu-24.04-arm")
+    }
+    assert all(
+        row["pip-torch-cuda-url"].endswith("/cu132")
+        for row in publish_rows
+        if row["torch-version"] == "2.14"
+    )
+    assert publish["jobs"]["build_cpu_wheel"]["strategy"]["matrix"][
+        "torch-version"
+    ] == ["2.13", "2.14"]
+    assert publish["jobs"]["build_macos_cpu_wheel"]["strategy"]["matrix"][
+        "torch-version"
+    ] == ["2.13", "2.14"]
 
     manifest_step = next(
         step
         for step in publish["jobs"]["upload"]["steps"]
         if step.get("name") == "Validate release wheel manifest"
     )
-    assert "--gpu-count 26" in manifest_step["run"]
-    assert "--cpu-count 12" in manifest_step["run"]
+    assert "--gpu-count 34" in manifest_step["run"]
+    assert "--cpu-count 24" in manifest_step["run"]
     assert "--require cu128torch2.11:cp312:x86_64" in manifest_step["run"]
     assert "--require cu128torch2.11:cp313:x86_64" in manifest_step["run"]
     assert "--require cu128torch2.8:cp312:x86_64" not in manifest_step["run"]
+    assert "--require cu132torch2.14:cp314:aarch64" in manifest_step["run"]
+    assert "--require cputorch2.14:cp314:arm64" in manifest_step["run"]
 
     smoke = _workflow(".github/workflows/wheel-smoke.yml")
     build_rows = smoke["jobs"]["build"]["strategy"]["matrix"]["include"]
     test_rows = smoke["jobs"]["test"]["strategy"]["matrix"]["include"]
-    assert len(build_rows) == len(test_rows) == 33
+    assert len(build_rows) == len(test_rows) == 49
     assert any(
         row["python-version"] == "3.13"
         and row.get("local-tag") == "cu128torch2.11"
@@ -140,15 +162,32 @@ def test_colab_release_lanes_match_publish_and_smoke_matrices():
     )
     assert any(row.get("local-tag") == "cu129torch2.8" for row in build_rows)
     assert any(row.get("local-tag") == "cu129torch2.8" for row in test_rows)
-    assert smoke["jobs"]["build-macos-cpu"]["strategy"]["matrix"]["python-version"] == [
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ]
-    assert len(smoke["jobs"]["test-macos-cpu"]["strategy"]["matrix"]["include"]) == 4
-    assert len(smoke["jobs"]["build-linux-cpu"]["strategy"]["matrix"]["include"]) == 2
-    assert len(smoke["jobs"]["test-linux-cpu"]["strategy"]["matrix"]["include"]) == 2
+    assert sum(row.get("local-tag") == "cu132torch2.14" for row in build_rows) == 8
+    assert sum(row.get("local-tag") == "cu132torch2.14" for row in test_rows) == 8
+    assert sum(row.get("local-tag") == "cputorch2.14" for row in build_rows) == 8
+    assert sum(row.get("local-tag") == "cputorch2.14" for row in test_rows) == 8
+    mac_build_matrix = smoke["jobs"]["build-macos-cpu"]["strategy"]["matrix"]
+    assert "github.event_name == 'pull_request'" in mac_build_matrix["python-version"]
+    assert mac_build_matrix["torch-version"] == ["2.13", "2.14"]
+    mac_test_matrix = smoke["jobs"]["test-macos-cpu"]["strategy"]["matrix"]
+    assert "github.event_name == 'pull_request'" in mac_test_matrix["python"]
+    assert mac_test_matrix["torch-version"] == ["2.13", "2.14"]
+    expected_cpu_smoke = {
+        ("2.13", "x86_64"),
+        ("2.14", "aarch64"),
+    }
+    assert {
+        (row["torch-version"], row["arch"])
+        for row in smoke["jobs"]["build-linux-cpu"]["strategy"]["matrix"]["include"]
+    } == expected_cpu_smoke
+    assert {
+        (row["torch-version"], row["arch"])
+        for row in smoke["jobs"]["test-linux-cpu"]["strategy"]["matrix"]["include"]
+    } == expected_cpu_smoke
+    assert {
+        row["torch-version"]
+        for row in smoke["jobs"]["build-linux-cuda"]["strategy"]["matrix"]["include"]
+    } == {"2.14"}
 
 
 def test_docs_workflow_uses_hosted_cpu_and_gpu_ci_executes_gpu_cells():

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -83,8 +83,20 @@ jobs:
             /usr/local/share/chromium /usr/local/share/powershell \
             /usr/share/swift /usr/local/julia* 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
+          if [ "${{ inputs.use-manylinux-build }}" = "true" ] && \
+             [ "${{ inputs.enable-cuda }}" = "true" ]; then
+            # A single full-architecture nvcc process can exceed the standard
+            # runner's 16 GB RAM. Use freed ephemeral disk for bounded overflow
+            # rather than letting the host OOM-kill the Actions runner.
+            sudo fallocate -l 16G /mnt/tmol-build.swap
+            sudo chmod 600 /mnt/tmol-build.swap
+            sudo mkswap /mnt/tmol-build.swap
+            sudo swapon /mnt/tmol-build.swap
+          fi
           echo "=== After cleanup ==="
           df -h /
+          free -h
+          swapon --show
 
       - name: Checkout
         uses: actions/checkout@v5
@@ -217,6 +229,8 @@ jobs:
                 2.10) TORCH_INDEX_URL="https://download.pytorch.org/whl/cu128" ;;
                 2.11) TORCH_INDEX_URL="https://download.pytorch.org/whl/cu130" ;;
                 2.12) TORCH_INDEX_URL="https://download.pytorch.org/whl/cu132" ;;
+                2.13) TORCH_INDEX_URL="https://download.pytorch.org/whl/cu130" ;;
+                2.14) TORCH_INDEX_URL="https://download.pytorch.org/whl/cu132" ;;
                 *)
                   echo "ERROR: set pip-torch-cuda-url for torch ${{ inputs.torch-version }}"
                   exit 1
@@ -386,10 +400,18 @@ jobs:
 
       - name: Build wheel
         run: |
-          # Two independent nvcc jobs avoid the memory spike from nesting nvcc
-          # worker parallelism and are a stable baseline on both runtimes.
+          # Full-architecture nvcc compilations can exhaust standard hosted
+          # runners when two translation units compile concurrently. Keep those
+          # builds serial so the runner service retains CPU and memory headroom.
+          # Native/local builds retain the faster two-job default.
+          BUILD_MAX_JOBS=2
+          if [ "${{ inputs.use-manylinux-build }}" = "true" ] && \
+             [ "${{ inputs.enable-cuda }}" = "true" ] && \
+             [ "${{ inputs.runs-on }}" != "self-hosted" ]; then
+            BUILD_MAX_JOBS=1
+          fi
           $CONTAINER_EXEC \
-            "$CONTAINER_ENV_FLAG" MAX_JOBS=2 \
+            "$CONTAINER_ENV_FLAG" MAX_JOBS="$BUILD_MAX_JOBS" \
             "$CONTAINER_ENV_FLAG" CUDA_ARCHS_OVERRIDE="${{ inputs.cuda-archs }}" \
             "$CONTAINER_ENV_FLAG" CUDA_HOME="${CUDA_HOME}" \
             "$CONTAINER_ENV_FLAG" CUDAToolkit_ROOT="${CUDA_HOME}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
           MAX_JOBS: ${{ matrix.build_workers }}
         run: .github/ci/build_cpu_package.sh
 
+      - name: compile representative CPU JIT extension
+        if: matrix.platform == 'linux-x86_64'
+        env:
+          MAX_JOBS: ${{ matrix.build_workers }}
+          TMOL_USE_JIT: "1"
+        run: |
+          .venv/bin/python - <<'PY'
+          import torch
+          from tmol.kinematics.compiled import forward_kin_op
+
+          assert torch.version.cuda is None
+          print("loaded", forward_kin_op, "with torch", torch.__version__)
+          PY
+
       - name: report compiler cache
         if: always()
         run: ccache --show-stats
@@ -115,7 +129,7 @@ jobs:
           paths: testing.cpu.junit.xml
 
       - uses: codecov/codecov-action@v5
-        if: always() && matrix.platform == 'linux-x86_64'
+        if: always() && matrix.platform == 'linux-x86_64' && hashFiles('coverage.cpu.xml') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/coverage.cpu.xml
@@ -167,20 +181,13 @@ jobs:
             coverage.cuda.xml
           if-no-files-found: ignore
 
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: benchmark-results
-          path: benchmark/**/*
-          if-no-files-found: ignore
-
       - uses: test-summary/action@v2
         if: always()
         with:
           paths: testing.cuda.junit.xml
 
       - uses: codecov/codecov-action@v5
-        if: always()
+        if: always() && hashFiles('coverage.cuda.xml') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/coverage.cuda.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,8 +72,10 @@ jobs:
   deploy:
     name: publish docs
     if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/master' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     needs: docs
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
             runs-on: self-hosted
             label: "py3.11 pt2.12 x86_64 manylinux"
+          - python-version: "3.11"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-22.04
+            label: "py3.11 pt2.14 x86_64 cu132"
 
           # ── x86_64 py3.12 ──
           - python-version: "3.12"
@@ -133,6 +140,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-22.04
             label: "py3.12 pt2.13 x86_64 cu130"
+          - python-version: "3.12"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-22.04
+            label: "py3.12 pt2.14 x86_64 cu132"
 
           # ── x86_64 py3.12 cu128 torch2.10 (foundry torch-2.10 upgrade path) ──
           # Datacenter target (no sm_75); consumed by foundry upgrade_torch_cu12_to_210.sh.
@@ -172,6 +186,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
             runs-on: ubuntu-24.04-arm
             label: "py3.11 pt2.12 aarch64 manylinux"
+          - python-version: "3.11"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-24.04-arm
+            label: "py3.11 pt2.14 aarch64 cu132"
 
           # ── ARM64 py3.12 ──
           - python-version: "3.12"
@@ -216,6 +237,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-24.04-arm
             label: "py3.12 pt2.13 aarch64 cu130"
+          - python-version: "3.12"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-24.04-arm
+            label: "py3.12 pt2.14 aarch64 cu132"
 
           # ── x86_64 py3.13/py3.14 ──
           - python-version: "3.13"
@@ -232,6 +260,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-22.04
             label: "py3.13 pt2.13 x86_64 cu130"
+          - python-version: "3.13"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-22.04
+            label: "py3.13 pt2.14 x86_64 cu132"
           - python-version: "3.14"
             container-image: nvcr.io/nvidia/pytorch:26.04-py3
             torch-version: "2.12"
@@ -246,6 +281,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-22.04
             label: "py3.14 pt2.13 x86_64 cu130"
+          - python-version: "3.14"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-22.04
+            label: "py3.14 pt2.14 x86_64 cu132"
 
           # ── ARM64 py3.13/py3.14 ──
           - python-version: "3.13"
@@ -262,6 +304,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-24.04-arm
             label: "py3.13 pt2.13 aarch64 cu130"
+          - python-version: "3.13"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-24.04-arm
+            label: "py3.13 pt2.14 aarch64 cu132"
           - python-version: "3.14"
             container-image: nvcr.io/nvidia/pytorch:26.04-py3
             torch-version: "2.12"
@@ -276,6 +325,13 @@ jobs:
             pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
             runs-on: ubuntu-24.04-arm
             label: "py3.14 pt2.13 aarch64 cu130"
+          - python-version: "3.14"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            pip-torch-cuda-url: "https://download.pytorch.org/whl/cu132"
+            runs-on: ubuntu-24.04-arm
+            label: "py3.14 pt2.14 aarch64 cu132"
 
     uses: ./.github/workflows/_build_wheel.yml
     with:
@@ -293,62 +349,45 @@ jobs:
 
   # ── CPU-only wheel ─────────────────────────────────────────────────
   build_cpu_wheel:
-    name: "py${{ matrix.python-version }} CPU-only ${{ matrix.arch }}"
-    needs: verify_release_version
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: "3.11"
-            runs-on: ubuntu-22.04
-            arch: x86_64
-          - python-version: "3.12"
-            runs-on: ubuntu-22.04
-            arch: x86_64
-          - python-version: "3.13"
-            runs-on: ubuntu-22.04
-            arch: x86_64
-          - python-version: "3.14"
-            runs-on: ubuntu-22.04
-            arch: x86_64
-          - python-version: "3.11"
-            runs-on: ubuntu-24.04-arm
-            arch: aarch64
-          - python-version: "3.12"
-            runs-on: ubuntu-24.04-arm
-            arch: aarch64
-          - python-version: "3.13"
-            runs-on: ubuntu-24.04-arm
-            arch: aarch64
-          - python-version: "3.14"
-            runs-on: ubuntu-24.04-arm
-            arch: aarch64
-    uses: ./.github/workflows/_build_wheel.yml
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      container-image: unused-for-manylinux-cpu
-      torch-version: "2.13"
-      torch-package-version: "2.13.0"
-      python-version: ${{ matrix.python-version }}
-      label: "py${{ matrix.python-version }} CPU-only ${{ matrix.arch }}"
-      pip-torch-cuda-url: "https://download.pytorch.org/whl/cpu"
-      enable-cuda: false
-      use-manylinux-build: true
-      target-arch: ${{ matrix.arch }}
-
-  # ── Apple Silicon CPU-only wheel ───────────────────────────────────
-  build_macos_cpu_wheel:
-    name: "py${{ matrix.python-version }} CPU-only macOS arm64"
+    name: "py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU-only ${{ matrix.platform.arch }}"
     needs: verify_release_version
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+        torch-version: ["2.13", "2.14"]
+        platform:
+          - runs-on: ubuntu-22.04
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    uses: ./.github/workflows/_build_wheel.yml
+    with:
+      runs-on: ${{ matrix.platform.runs-on }}
+      container-image: unused-for-manylinux-cpu
+      torch-version: ${{ matrix.torch-version }}
+      torch-package-version: ${{ format('{0}.0', matrix.torch-version) }}
+      python-version: ${{ matrix.python-version }}
+      label: "py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU-only ${{ matrix.platform.arch }}"
+      pip-torch-cuda-url: "https://download.pytorch.org/whl/cpu"
+      enable-cuda: false
+      use-manylinux-build: true
+      target-arch: ${{ matrix.platform.arch }}
+
+  # ── Apple Silicon CPU-only wheel ───────────────────────────────────
+  build_macos_cpu_wheel:
+    name: "py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU-only macOS arm64"
+    needs: verify_release_version
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        torch-version: ["2.13", "2.14"]
     uses: ./.github/workflows/_build_macos_wheel.yml
     with:
       python-version: ${{ matrix.python-version }}
-      torch-package-version: "2.13.0"
-      label: "py${{ matrix.python-version }} CPU-only macOS arm64"
+      torch-package-version: ${{ format('{0}.0', matrix.torch-version) }}
+      label: "py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU-only macOS arm64"
 
   # ── sdist ──────────────────────────────────────────────────────────
   build_sdist:
@@ -422,8 +461,8 @@ jobs:
       - name: Validate release wheel manifest
         run: |
           python scripts/validate_release_manifest.py wheels \
-            --gpu-count 26 \
-            --cpu-count 12 \
+            --gpu-count 34 \
+            --cpu-count 24 \
             --platform manylinux_2_28_x86_64 \
             --platform manylinux_2_28_aarch64 \
             --platform macosx_14_0_arm64 \
@@ -453,6 +492,14 @@ jobs:
             --require cu130torch2.13:cp313:aarch64 \
             --require cu132torch2.12:cp314:aarch64 \
             --require cu130torch2.13:cp314:aarch64 \
+            --require cu132torch2.14:cp311:x86_64 \
+            --require cu132torch2.14:cp312:x86_64 \
+            --require cu132torch2.14:cp313:x86_64 \
+            --require cu132torch2.14:cp314:x86_64 \
+            --require cu132torch2.14:cp311:aarch64 \
+            --require cu132torch2.14:cp312:aarch64 \
+            --require cu132torch2.14:cp313:aarch64 \
+            --require cu132torch2.14:cp314:aarch64 \
             --require cputorch2.13:cp311:x86_64 \
             --require cputorch2.13:cp312:x86_64 \
             --require cputorch2.13:cp313:x86_64 \
@@ -464,7 +511,19 @@ jobs:
             --require cputorch2.13:cp311:arm64 \
             --require cputorch2.13:cp312:arm64 \
             --require cputorch2.13:cp313:arm64 \
-            --require cputorch2.13:cp314:arm64
+            --require cputorch2.13:cp314:arm64 \
+            --require cputorch2.14:cp311:x86_64 \
+            --require cputorch2.14:cp312:x86_64 \
+            --require cputorch2.14:cp313:x86_64 \
+            --require cputorch2.14:cp314:x86_64 \
+            --require cputorch2.14:cp311:aarch64 \
+            --require cputorch2.14:cp312:aarch64 \
+            --require cputorch2.14:cp313:aarch64 \
+            --require cputorch2.14:cp314:aarch64 \
+            --require cputorch2.14:cp311:arm64 \
+            --require cputorch2.14:cp312:arm64 \
+            --require cputorch2.14:cp313:arm64 \
+            --require cputorch2.14:cp314:arm64
 
       - name: Upload sdist to PyPI
         env:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -44,6 +44,17 @@ jobs:
             runs-on: ubuntu-22.04
             arch: x86_64
             label: "smoke py3.11 pt2.12 cu132 x86_64"
+          - python-version: "3.11"
+            python-tag: "311"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.11 pt2.14 cu132 x86_64"
           - python-version: "3.12"
             python-tag: "312"
             torch-version: "2.8"
@@ -147,6 +158,18 @@ jobs:
             arch: x86_64
             portability: true
             label: "smoke py3.12 pt2.13 cu130 x86_64"
+          - python-version: "3.12"
+            python-tag: "312"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            portability: true
+            label: "smoke py3.12 pt2.14 cu132 x86_64"
           - python-version: "3.13"
             python-tag: "313"
             torch-version: "2.12"
@@ -169,6 +192,17 @@ jobs:
             runs-on: ubuntu-22.04
             arch: x86_64
             label: "smoke py3.13 pt2.13 cu130 x86_64"
+          - python-version: "3.13"
+            python-tag: "313"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.13 pt2.14 cu132 x86_64"
           - python-version: "3.14"
             python-tag: "314"
             torch-version: "2.12"
@@ -191,6 +225,17 @@ jobs:
             runs-on: ubuntu-22.04
             arch: x86_64
             label: "smoke py3.14 pt2.13 cu130 x86_64"
+          - python-version: "3.14"
+            python-tag: "314"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.14 pt2.14 cu132 x86_64"
           - python-version: "3.11"
             python-tag: "311"
             torch-version: "2.12"
@@ -202,6 +247,17 @@ jobs:
             runs-on: ubuntu-24.04-arm
             arch: aarch64
             label: "smoke py3.11 pt2.12 cu132 aarch64"
+          - python-version: "3.11"
+            python-tag: "311"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.11 pt2.14 cu132 aarch64"
           - python-version: "3.12"
             python-tag: "312"
             torch-version: "2.8"
@@ -269,6 +325,18 @@ jobs:
             arch: aarch64
             portability: true
             label: "smoke py3.12 pt2.13 cu130 aarch64"
+          - python-version: "3.12"
+            python-tag: "312"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            portability: true
+            label: "smoke py3.12 pt2.14 cu132 aarch64"
           - python-version: "3.13"
             python-tag: "313"
             torch-version: "2.12"
@@ -291,6 +359,17 @@ jobs:
             runs-on: ubuntu-24.04-arm
             arch: aarch64
             label: "smoke py3.13 pt2.13 cu130 aarch64"
+          - python-version: "3.13"
+            python-tag: "313"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.13 pt2.14 cu132 aarch64"
           - python-version: "3.14"
             python-tag: "314"
             torch-version: "2.12"
@@ -313,6 +392,17 @@ jobs:
             runs-on: ubuntu-24.04-arm
             arch: aarch64
             label: "smoke py3.14 pt2.13 cu130 aarch64"
+          - python-version: "3.14"
+            python-tag: "314"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: "cu132torch2.14"
+            enable-cuda: true
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.14 pt2.14 cu132 aarch64"
           - python-version: "3.11"
             python-tag: "311"
             torch-version: "2.13"
@@ -403,6 +493,94 @@ jobs:
             runs-on: ubuntu-24.04-arm
             arch: aarch64
             label: "smoke py3.14 cpu aarch64"
+          - python-version: "3.11"
+            python-tag: "311"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.11 pt2.14 cpu x86_64"
+          - python-version: "3.12"
+            python-tag: "312"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.12 pt2.14 cpu x86_64"
+          - python-version: "3.13"
+            python-tag: "313"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.13 pt2.14 cpu x86_64"
+          - python-version: "3.14"
+            python-tag: "314"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-22.04
+            arch: x86_64
+            label: "smoke py3.14 pt2.14 cpu x86_64"
+          - python-version: "3.11"
+            python-tag: "311"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.11 pt2.14 cpu aarch64"
+          - python-version: "3.12"
+            python-tag: "312"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.12 pt2.14 cpu aarch64"
+          - python-version: "3.13"
+            python-tag: "313"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.13 pt2.14 cpu aarch64"
+          - python-version: "3.14"
+            python-tag: "314"
+            torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            torch-index-url: "https://download.pytorch.org/whl/cpu"
+            local-tag: "cputorch2.14"
+            enable-cuda: false
+            container-image: unused-for-manylinux-cpu
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+            label: "smoke py3.14 pt2.14 cpu aarch64"
     uses: ./.github/workflows/_build_wheel.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -418,24 +596,22 @@ jobs:
       target-arch: ${{ matrix.arch }}
 
   build-linux-cpu:
-    name: "smoke py3.12 CPU ${{ matrix.arch }}"
+    name: "smoke py3.12 pt${{ matrix.torch-version }} CPU ${{ matrix.arch }}"
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
+          - { torch-version: "2.13", runs-on: ubuntu-22.04, arch: x86_64 }
+          - { torch-version: "2.14", runs-on: ubuntu-24.04-arm, arch: aarch64 }
     uses: ./.github/workflows/_build_wheel.yml
     with:
       runs-on: ${{ matrix.runs-on }}
       container-image: unused-for-manylinux-cpu
-      torch-version: "2.13"
-      torch-package-version: "2.13.0"
+      torch-version: ${{ matrix.torch-version }}
+      torch-package-version: ${{ format('{0}.0', matrix.torch-version) }}
       python-version: "3.12"
-      label: "smoke py3.12 CPU ${{ matrix.arch }}"
+      label: "smoke py3.12 pt${{ matrix.torch-version }} CPU ${{ matrix.arch }}"
       pip-torch-cuda-url: "https://download.pytorch.org/whl/cpu"
       enable-cuda: false
       use-manylinux-build: true
@@ -445,24 +621,33 @@ jobs:
   # set used by tagged releases. CPU-only pull-request wheels cannot catch
   # dropped device images or unsupported nvcc flags.
   build-linux-cuda:
-    name: "smoke py3.12 CUDA 13 x86_64"
+    name: "smoke py3.12 pt${{ matrix.torch-version }} CUDA ${{ matrix.cuda-version }} x86_64"
     if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            cuda-version: "13.2"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            container-image: nvcr.io/nvidia/pytorch:26.04-py3
     uses: ./.github/workflows/_build_wheel.yml
     with:
       runs-on: ubuntu-22.04
-      container-image: nvidia/cuda:13.0.2-devel-ubuntu24.04
-      torch-version: "2.13"
-      torch-package-version: "2.13.0"
+      container-image: ${{ matrix.container-image }}
+      torch-version: ${{ matrix.torch-version }}
+      torch-package-version: ${{ matrix.torch-package-version }}
       python-version: "3.12"
-      label: "smoke py3.12 CUDA 13 x86_64"
-      pip-torch-cuda-url: "https://download.pytorch.org/whl/cu130"
+      label: "smoke py3.12 pt${{ matrix.torch-version }} CUDA ${{ matrix.cuda-version }} x86_64"
+      pip-torch-cuda-url: ${{ matrix.torch-index-url }}
       enable-cuda: true
       cuda-archs: all
       use-manylinux-build: true
       target-arch: x86_64
 
   test-linux-cpu:
-    name: "install cp312 cputorch2.13 ${{ matrix.arch }}"
+    name: "install cp312 cputorch${{ matrix.torch-version }} ${{ matrix.arch }}"
     needs: build-linux-cpu
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.runs-on }}
@@ -470,14 +655,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
+          - { torch-version: "2.13", runs-on: ubuntu-22.04, arch: x86_64 }
+          - { torch-version: "2.14", runs-on: ubuntu-24.04-arm, arch: aarch64 }
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheel-cp312-cputorch2.13-${{ matrix.arch }}
+          name: wheel-cp312-cputorch${{ matrix.torch-version }}-${{ matrix.arch }}
           path: wheels
 
       - uses: actions/setup-python@v5
@@ -489,7 +672,7 @@ jobs:
           set -euo pipefail
           set -- wheels/*.whl
           test "$#" -eq 1
-          expected="tmol-*+cputorch2.13-cp312-cp312-manylinux_2_28_${{ matrix.arch }}.whl"
+          expected="tmol-*+cputorch${{ matrix.torch-version }}-cp312-cp312-manylinux_2_28_${{ matrix.arch }}.whl"
           case "$(basename "$1")" in
             $expected) ;;
             *)
@@ -498,37 +681,50 @@ jobs:
               ;;
           esac
           python -m pip install --upgrade pip
-          python -m pip install 'torch==2.13.0' \
+          python -m pip install 'torch==${{ matrix.torch-version }}.0' \
             --index-url https://download.pytorch.org/whl/cpu
           python -m pip install "$1"
 
       - name: Load native extensions
         working-directory: /tmp
+        env:
+          EXPECTED_TORCH: ${{ matrix.torch-version }}
         run: |
           python - <<'PY'
+          import os
           from importlib.metadata import version
 
           import torch
           import tmol
           from tmol._cpp_lib import _ensure_loaded
 
-          assert torch.__version__.startswith("2.13.")
+          expected_torch = os.environ["EXPECTED_TORCH"]
+          assert torch.__version__.startswith(f"{expected_torch}.")
           assert torch.version.cuda is None
-          assert version("tmol").endswith("+cputorch2.13")
+          assert version("tmol").endswith(f"+cputorch{expected_torch}")
           _ensure_loaded()
           print("tmol", tmol.__version__)
           print("torch", torch.__version__)
           PY
 
   test-linux-cuda:
-    name: "install cp312 cu130torch2.13 x86_64"
+    name: "install cp312 ${{ matrix.local-tag }} x86_64"
     needs: build-linux-cuda
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - torch-version: "2.14"
+            torch-package-version: "2.14.0"
+            cuda-version: "13.2"
+            torch-index-url: "https://download.pytorch.org/whl/cu132"
+            local-tag: cu132torch2.14
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheel-cp312-cu130torch2.13-x86_64
+          name: wheel-cp312-${{ matrix.local-tag }}-x86_64
           path: wheels
 
       - uses: actions/setup-python@v5
@@ -541,68 +737,71 @@ jobs:
           set -- wheels/*.whl
           test "$#" -eq 1
           case "$(basename "$1")" in
-            tmol-*+cu130torch2.13-cp312-cp312-manylinux_2_28_x86_64.whl) ;;
+            tmol-*+${{ matrix.local-tag }}-cp312-cp312-manylinux_2_28_x86_64.whl) ;;
             *)
               echo "Unexpected Linux CUDA wheel: $1"
               exit 1
               ;;
           esac
           python -m pip install --upgrade pip
-          python -m pip install 'torch==2.13.0' \
-            --index-url https://download.pytorch.org/whl/cu130
+          python -m pip install 'torch==${{ matrix.torch-package-version }}' \
+            --index-url '${{ matrix.torch-index-url }}'
           python -m pip install "$1"
 
       - name: Load native extensions
         working-directory: /tmp
+        env:
+          EXPECTED_CUDA: ${{ matrix.cuda-version }}
+          EXPECTED_LOCAL_TAG: ${{ matrix.local-tag }}
+          EXPECTED_TORCH: ${{ matrix.torch-version }}
         run: |
           python - <<'PY'
+          import os
           from importlib.metadata import version
 
           import torch
           import tmol
           from tmol._cpp_lib import _ensure_loaded
 
-          assert torch.__version__.startswith("2.13.")
-          assert torch.version.cuda.startswith("13.0")
-          assert version("tmol").endswith("+cu130torch2.13")
+          assert torch.__version__.startswith(f"{os.environ['EXPECTED_TORCH']}.")
+          assert torch.version.cuda.startswith(os.environ["EXPECTED_CUDA"])
+          assert version("tmol").endswith(f"+{os.environ['EXPECTED_LOCAL_TAG']}")
           _ensure_loaded()
           print("tmol", tmol.__version__)
           print("torch", torch.__version__, "cuda", torch.version.cuda)
           PY
 
   build-macos-cpu:
-    name: "smoke py${{ matrix.python-version }} CPU macOS arm64"
+    name: "smoke py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU macOS arm64"
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.11", "3.12", "3.13", "3.14"]') }}
+        torch-version: ["2.13", "2.14"]
     uses: ./.github/workflows/_build_macos_wheel.yml
     with:
       python-version: ${{ matrix.python-version }}
-      torch-package-version: "2.13.0"
-      label: "smoke py${{ matrix.python-version }} CPU macOS arm64"
+      torch-package-version: ${{ format('{0}.0', matrix.torch-version) }}
+      label: "smoke py${{ matrix.python-version }} pt${{ matrix.torch-version }} CPU macOS arm64"
 
   test-macos-cpu:
-    name: "install cp${{ matrix.python-tag }} cputorch2.13 macOS arm64"
+    name: "install cp${{ matrix.python.tag }} cputorch${{ matrix.torch-version }} macOS arm64"
     needs: build-macos-cpu
     runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { python-version: "3.11", python-tag: "311" }
-          - { python-version: "3.12", python-tag: "312" }
-          - { python-version: "3.13", python-tag: "313" }
-          - { python-version: "3.14", python-tag: "314" }
+        python: ${{ fromJSON(github.event_name == 'pull_request' && '[{"version":"3.12","tag":"312"}]' || '[{"version":"3.11","tag":"311"},{"version":"3.12","tag":"312"},{"version":"3.13","tag":"313"},{"version":"3.14","tag":"314"}]') }}
+        torch-version: ["2.13", "2.14"]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheel-cp${{ matrix.python-tag }}-cputorch2.13-arm64
+          name: wheel-cp${{ matrix.python.tag }}-cputorch${{ matrix.torch-version }}-arm64
           path: wheels
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python.version }}
 
       - name: Install wheel with its PyTorch ABI
         run: |
@@ -610,20 +809,23 @@ jobs:
           set -- wheels/*.whl
           test "$#" -eq 1
           case "$(basename "$1")" in
-            tmol-*+cputorch2.13-cp${{ matrix.python-tag }}-cp${{ matrix.python-tag }}-macosx_14_0_arm64.whl) ;;
+            tmol-*+cputorch${{ matrix.torch-version }}-cp${{ matrix.python.tag }}-cp${{ matrix.python.tag }}-macosx_14_0_arm64.whl) ;;
             *)
               echo "Unexpected Apple Silicon wheel: $1"
               exit 1
               ;;
           esac
           python -m pip install --upgrade pip
-          python -m pip install 'torch==2.13.0'
+          python -m pip install 'torch==${{ matrix.torch-version }}.0'
           python -m pip install "$1"
 
       - name: Load native extensions
         working-directory: /tmp
+        env:
+          EXPECTED_TORCH: ${{ matrix.torch-version }}
         run: |
           python - <<'PY'
+          import os
           import platform
           from importlib.metadata import version
 
@@ -632,9 +834,10 @@ jobs:
           from tmol._cpp_lib import _ensure_loaded
 
           assert platform.machine() == "arm64"
-          assert torch.__version__.startswith("2.13.")
+          expected_torch = os.environ["EXPECTED_TORCH"]
+          assert torch.__version__.startswith(f"{expected_torch}.")
           assert torch.version.cuda is None
-          assert version("tmol").endswith("+cputorch2.13")
+          assert version("tmol").endswith(f"+cputorch{expected_torch}")
           _ensure_loaded()
           print("tmol", tmol.__version__)
           print("torch", torch.__version__)
@@ -681,6 +884,22 @@ jobs:
           - { python-version: "3.12", python-tag: "312", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64, portability: true }
           - { python-version: "3.13", python-tag: "313", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
           - { python-version: "3.14", python-tag: "314", torch-package-version: "2.13.0", torch-minor: "2.13", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.13", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cu132", local-tag: "cu132torch2.14", enable-cuda: true, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-22.04, arch: x86_64 }
+          - { python-version: "3.11", python-tag: "311", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.12", python-tag: "312", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64, portability: true }
+          - { python-version: "3.13", python-tag: "313", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
+          - { python-version: "3.14", python-tag: "314", torch-package-version: "2.14.0", torch-minor: "2.14", torch-index-url: "https://download.pytorch.org/whl/cpu", local-tag: "cputorch2.14", enable-cuda: false, runs-on: ubuntu-24.04-arm, arch: aarch64 }
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,9 +197,17 @@ if(TMOL_HAS_CUDA)
   # Set TORCH_CUDA_ARCH_LIST env var BEFORE find_package(Torch) so that
   # Caffe2's cuda.cmake uses our architectures instead of defaulting to
   # all archs nvcc supports (which includes sm_52 that lacks double atomicAdd).
+  # CMake resolves the symbolic `native` value while enabling CUDA; use that
+  # numeric result rather than passing an empty architecture list to Torch.
+  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    set(_TMOL_TORCH_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
+  else()
+    set(_TMOL_TORCH_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+  endif()
   set(_TORCH_ARCH_STR "")
-  foreach(_A ${CMAKE_CUDA_ARCHITECTURES})
+  foreach(_A ${_TMOL_TORCH_CUDA_ARCHITECTURES})
     string(REPLACE "-real" "" _A "${_A}")
+    string(REPLACE "-virtual" "" _A "${_A}")
     string(LENGTH "${_A}" _ALEN)
     if(_ALEN EQUAL 3)
       string(SUBSTRING "${_A}" 0 2 _MAJOR)
@@ -215,6 +223,37 @@ if(TMOL_HAS_CUDA)
   set(ENV{TORCH_CUDA_ARCH_LIST} "${_TORCH_ARCH_STR}")
   message(STATUS "tmol: Setting TORCH_CUDA_ARCH_LIST=${_TORCH_ARCH_STR} for find_package(Torch)")
 endif()
+
+# A Python wheel installs TorchConfig.cmake below the torch package rather than
+# a system CMake prefix. Discover it from the interpreter selected above so a
+# normal source build does not require a hand-written CMAKE_PREFIX_PATH.
+execute_process(
+  COMMAND ${Python_EXECUTABLE} -c "import torch; print(torch.utils.cmake_prefix_path)"
+  OUTPUT_VARIABLE _TMOL_TORCH_CMAKE_PREFIX_PATH
+  RESULT_VARIABLE _TMOL_TORCH_PREFIX_RESULT
+  ERROR_VARIABLE _TMOL_TORCH_PREFIX_ERROR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _TMOL_TORCH_PREFIX_RESULT EQUAL 0 OR NOT _TMOL_TORCH_CMAKE_PREFIX_PATH)
+  message(FATAL_ERROR
+    "tmol: could not locate Torch's CMake package with ${Python_EXECUTABLE}: "
+    "${_TMOL_TORCH_PREFIX_ERROR}")
+endif()
+list(PREPEND CMAKE_PREFIX_PATH "${_TMOL_TORCH_CMAKE_PREFIX_PATH}")
+
+execute_process(
+  COMMAND ${Python_EXECUTABLE} -m pybind11 --cmakedir
+  OUTPUT_VARIABLE _TMOL_PYBIND11_CMAKE_PREFIX_PATH
+  RESULT_VARIABLE _TMOL_PYBIND11_PREFIX_RESULT
+  ERROR_VARIABLE _TMOL_PYBIND11_PREFIX_ERROR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _TMOL_PYBIND11_PREFIX_RESULT EQUAL 0 OR NOT _TMOL_PYBIND11_CMAKE_PREFIX_PATH)
+  message(FATAL_ERROR
+    "tmol: could not locate pybind11's CMake package with ${Python_EXECUTABLE}: "
+    "${_TMOL_PYBIND11_PREFIX_ERROR}")
+endif()
+list(PREPEND CMAKE_PREFIX_PATH "${_TMOL_PYBIND11_CMAKE_PREFIX_PATH}")
 
 find_package(Torch REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
@@ -409,6 +448,8 @@ set(_C_SOURCES
   tmol/score/lk_ball/potentials/compiled.ops.cpp
   tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
   tmol/score/lk_ball/potentials/gen_pose_waters.cpu.cpp
+  # score/na_torsion (CUDA implementation registered separately below)
+  tmol/score/na_torsion/potentials/compiled.ops.cpp
 )
 
 if(TMOL_HAS_CUDA)
@@ -431,6 +472,7 @@ if(TMOL_HAS_CUDA)
     tmol/score/ljlk/potentials/ljlk_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/gen_pose_waters.cuda.cu
+    tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
   )
 endif()
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ git clone https://github.com/uw-ipd/tmol.git && cd tmol
 pip install -e ".[dev]"   # builds C++/CUDA extensions via CMake
 ```
 
-Requirements: Python 3.11+, PyTorch 2.8+, C++17 compiler, CMake 3.24+. CUDA toolkit (`nvcc`) is optional — without it, only CPU extensions are built. Pre-built wheels are published for Python `cp311`-`cp314`.
+Requirements: Python 3.11+, PyTorch 2.5+, a C++20-capable compiler (tmol uses C++17 with PyTorch 2.5–2.12 and C++20 with PyTorch 2.13+), and CMake 3.24+. CUDA toolkit (`nvcc`) is optional — without it, only CPU extensions are built. Pre-built wheels are published for Python `cp311`-`cp314`.
 
 ## Building Extensions
 
@@ -59,7 +59,7 @@ tmol's C++/CUDA kernels can be loaded in two ways:
 
 - **AOT (Ahead-Of-Time)**: Pre-compiled `.so` libraries are bundled inside the installed package (e.g., from a wheel). Operations are registered in `torch.ops.tmol_*` namespaces. This is the default and requires no compiler at runtime.
 
-- **JIT (Just-In-Time)**: Source files (`.cpp`, `.cu`) are compiled on first use via `torch.utils.cpp_extension.load()`. This requires `nvcc` and a C++ compiler to be available. Useful for kernel development where you want to edit and reload C++/CUDA code without rebuilding the whole package.
+- **JIT (Just-In-Time)**: Source files (`.cpp`, `.cu`) are compiled on first use via `torch.utils.cpp_extension.load()`. This requires a C++ compiler and `ninja`; `nvcc` is needed only for CUDA kernels. On CPU-only platforms, including Apple Silicon, CUDA sources are omitted automatically. Useful for kernel development where you want to edit and reload C++/CUDA code without rebuilding the whole package.
 
 Two environment variables control which path is taken:
 
@@ -96,10 +96,12 @@ flowchart TD
 | End user                      | `pip install tmol` (sdist) | None   | AOT (compiled at install time) |
 | Kernel developer              | `pip install -e .` | `TMOL_USE_JIT=1` | JIT |
 | CI without GPU                | Pre-built wheel    | None            | AOT  |
+| macOS / CPU-only from source  | `pip install -e .` (optionally force `TMOL_ENABLE_CUDA=OFF`) | None (or `TMOL_USE_JIT=1`) | AOT (or JIT) |
 
 ### CUDA toolkit for JIT mode
 
-JIT mode requires `nvcc` and CUDA headers. You can either:
+Building CUDA kernels in JIT mode requires `nvcc` and CUDA headers. CPU-only
+JIT needs only a C++ compiler and `ninja`. To build CUDA kernels, you can either:
 
 1. **Use a CUDA-enabled container** (NGC, conda) or set `CUDA_HOME` to point to your system CUDA toolkit.
 2. **Install the pip CUDA extra**, which downloads `nvcc` and runtime libraries:
@@ -185,8 +187,8 @@ tmol uses GitHub Actions for all CI:
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Push to `master`/`kdidi/**`, PRs | Lint, test (CPU + CUDA), benchmark. Runs on a **self-hosted GPU runner** (fela) inside an Apptainer NGC container. |
-| `wheel-smoke.yml` | Push to wheel feature branches, manual | Builds and installs the complete 32-wheel manylinux matrix, checks auditwheel metadata and glibc-2.28 portability, and loads a representative wheel on the self-hosted GPU runner. |
+| `ci.yml` | Push to `master`/`kdidi/**`, PRs | Lint and test on CPU and CUDA. CUDA runs on a **self-hosted GPU runner** (fela) inside an Apptainer NGC container. |
+| `wheel-smoke.yml` | Push to wheel feature branches, manual | Builds and installs the complete supported wheel matrix, checks auditwheel metadata and glibc-2.28 portability, and loads a representative wheel on the self-hosted GPU runner. |
 | `publish.yml` | Push `v*` tag, manual | Builds manylinux wheels (GPU + CPU) + sdist, uploads sdist to PyPI, uploads wheels to a GitHub Release. |
 
 ### CI architecture
@@ -201,7 +203,7 @@ Push/PR -> GitHub Actions -> self-hosted runner (fela, bare metal)
                           NGC PyTorch container (GPU access)
                                   |
                                   v
-                          Setup -> Lint -> Test CPU -> Test CUDA -> Benchmark
+                           Setup -> Lint -> Test CPU -> Test CUDA
 ```
 
 ### Self-hosted runner

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -5,7 +5,10 @@ The public :mod:`tmol.io` API converts common structure representations to and
 from :class:`tmol.pose.PoseStack`. The direct AtomWorks adapter uses its
 protein-only unified Atom37 representation. For differentiable Atom37
 coordinates with general Biotite topology, including nucleic acids and ligands,
-use :func:`tmol.io.pose_stack_from_atom37_and_biotite`.
+use :func:`tmol.io.pose_stack_from_atom37_and_biotite`. Repeated diffusion,
+guidance, and search workloads should bind their fixed topology once with
+:func:`tmol.io.prepare_pose_stack_from_atom37`; its returned callable accepts
+each coordinate batch and optimizes hydrogens by default.
 
 .. automodule:: tmol.io
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     # Pin the inventory to the current supported release. The ``stable`` URL
     # serves redirect stubs whose anchors cannot be validated by linkcheck.
-    "torch": ("https://docs.pytorch.org/docs/2.13", None),
+    "torch": ("https://docs.pytorch.org/docs/2.14", None),
 }
 # Documentation builds must not consume an entire GPU allocation when an
 # external inventory host is slow or unavailable.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,25 +25,27 @@ The most deterministic install path is an explicit wheel URL from the
 [GitHub Releases page](https://github.com/uw-ipd/tmol/releases):
 
 ```bash
-pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/vX.Y.Z/tmol-X.Y.Z+cu132torch2.12-cp313-cp313-manylinux_2_28_x86_64.whl"
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/vX.Y.Z/tmol-X.Y.Z+cu132torch2.14-cp313-cp313-manylinux_2_28_x86_64.whl"
 ```
 
 Install the matching PyTorch build first:
 
 ```bash
-pip install "torch==2.12.*" --index-url https://download.pytorch.org/whl/cu132
+pip install "torch==2.14.*" --index-url https://download.pytorch.org/whl/cu132
 ```
 
 Wheel tags select Python, PyTorch, and CUDA compatibility. For example,
-`cp313` selects Python 3.13 and `+cu130torch2.13` selects the CUDA/PyTorch lane.
-CPU wheels are also PyTorch-minor-specific: `+cputorch2.13` selects the CPU
-extension built against PyTorch 2.13. They do not replace the host C++ runtime.
+`cp313` selects Python 3.13 and `+cu132torch2.14` selects the CUDA/PyTorch lane.
+CPU wheels are also PyTorch-minor-specific: `+cputorch2.14` selects the CPU
+extension built against PyTorch 2.14. PyTorch 2.13 wheels remain available as
+the corresponding `torch2.13` lanes. TMol wheels do not replace the host C++
+runtime.
 
 Release builds provide CPU wheels for Linux x86-64, Linux aarch64, and Apple
-Silicon. For example, after installing PyTorch 2.13, an Apple Silicon wheel is:
+Silicon. For example, after installing PyTorch 2.14, an Apple Silicon wheel is:
 
 ```bash
-pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/vX.Y.Z/tmol-X.Y.Z+cputorch2.13-cp313-cp313-macosx_14_0_arm64.whl"
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/vX.Y.Z/tmol-X.Y.Z+cputorch2.14-cp313-cp313-macosx_14_0_arm64.whl"
 ```
 
 ## PyPI Source Distribution
@@ -63,7 +65,7 @@ Useful environment variables:
 - `TMOL_DISABLE_WHEEL_FETCH=1`: skip the pre-built lookup and build locally.
 - `TMOL_FORCE_BUILD=1`: force the local build path.
 - `TMOL_ENABLE_LOCAL_FETCH=1`: allow wheel fetch from a git checkout install.
-- `TMOL_WHEEL_LOCAL_TAG=cu132torch2.12`: pin the wheel lane.
+- `TMOL_WHEEL_LOCAL_TAG=cu132torch2.14`: pin the wheel lane.
 - `TMOL_WHEEL_RELEASE_TAG=vX.Y.Z`: override the GitHub release tag.
 - `TMOL_WHEEL_RELEASE_BASE_URL=...`: use a release mirror.
 - `TMOL_WHEEL_FETCH_RETRIES=2`: set HTTP retry attempts.
@@ -78,18 +80,23 @@ cd tmol
 pip install -e ".[dev]"
 ```
 
-This builds C++/CUDA extensions through CMake. If no CUDA toolkit is available,
-TMol can build CPU-only extensions:
+This builds C++/CUDA extensions through CMake. To request a CPU-only build
+(the normal source build on Apple Silicon), use:
 
 ```bash
 pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF
 ```
 
-The same CPU-only path is the normal macOS source install:
+CMake also falls back to CPU-only when it cannot find a CUDA compiler. This
+path needs CMake and a compatible C++ compiler, but no `nvcc`. Alternatively,
+CPU kernels can be compiled on first use:
 
 ```bash
-pip install -e . -Ccmake.define.TMOL_ENABLE_CUDA=OFF
+TMOL_USE_JIT=1 python -c "import tmol; print(tmol.__version__)"
 ```
+
+CPU-only JIT needs a C++ compiler and `ninja`; `nvcc` is required only for
+CUDA kernels.
 
 CPU source builds and release wheels are tested on Linux x86-64, Linux
 aarch64, and Apple Silicon. Native Windows is not currently supported; use a
@@ -99,7 +106,7 @@ Linux environment such as WSL2.
 
 Linux release wheels use `manylinux_2_28` platform tags on `x86_64` and
 `aarch64`. They require glibc 2.28 or newer. Apple Silicon wheels use
-`macosx_14_0_arm64`, matching the PyTorch 2.13 deployment target. PyTorch
+`macosx_14_0_arm64`, matching the PyTorch 2.13 and 2.14 deployment target. PyTorch
 supplies the matching shared libraries; TMol wheels do not bundle the PyTorch
 or NVIDIA runtime libraries.
 
@@ -110,7 +117,7 @@ If `import tmol` fails with a `GLIBCXX_* not found` error, the host
 # Build against system libraries
 TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .
 
-# Or allow just-in-time extension compilation if nvcc is available
+# Or allow just-in-time extension compilation (CPU-only needs no nvcc)
 export TMOL_JIT_FALLBACK=1
 ```
 
@@ -127,11 +134,11 @@ python -c "import sys, torch; print(f'Python {sys.version_info.major}.{sys.versi
 ## Google Colab
 
 Colab GPU runtimes currently use PyTorch 2.11.0 with CUDA 12.8 and may provide
-Python 3.12 or 3.13. TMol v0.1.53 provides separate Python-ABI wheels compiled
+Python 3.12 or 3.13. TMol v0.1.54 provides separate Python-ABI wheels compiled
 for T4 (`sm_75`), A100 (`sm_80`), and L4 (`sm_89`) GPUs. For Python 3.13:
 
 ```bash
-pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.53/tmol-0.1.53+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.54/tmol-0.1.54+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
 ```
 
 The tutorial bootstrap selects the wheel matching the runtime's Python ABI and

--- a/docs/tutorial/colab_setup.py
+++ b/docs/tutorial/colab_setup.py
@@ -10,7 +10,7 @@ from urllib.request import urlretrieve
 
 TUTORIAL_REF = "master"
 RAW_BASE = f"https://raw.githubusercontent.com/uw-ipd/tmol/{TUTORIAL_REF}"
-TMOL_RELEASE = "0.1.53"
+TMOL_RELEASE = "0.1.54"
 RELEASE_WHEEL_TORCH_MINOR = "2.11"
 RELEASE_WHEEL_CUDA = "12.8"
 RELEASE_WHEEL_PYTHONS = frozenset({(3, 12), (3, 13)})

--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -17,11 +17,23 @@ cd tmol
 pip install -e ".[dev]"
 ```
 
+The command above uses pip's isolated build environment. To reuse an existing
+PyTorch installation (especially in a CUDA container), install the small build
+tools once and disable build isolation:
+
+```bash
+python -m pip install "scikit-build-core>=0.10" "pybind11>=2.12" ninja packaging
+python -m pip install --no-build-isolation -e ".[dev]"
+```
+
+TMol locates the Torch and pybind11 CMake packages from this Python
+interpreter; `CMAKE_PREFIX_PATH` and `pybind11_DIR` do not need to be set.
+
 Requirements:
 
 - Python 3.11 or newer.
 - PyTorch 2.5 or newer.
-- A C++17 compiler.
+- A C++20-capable compiler (TMol uses C++17 with PyTorch 2.5–2.12).
 - CMake 3.24 or newer.
 - CUDA toolkit with `nvcc` for CUDA builds.
 
@@ -40,7 +52,8 @@ TMol builds extensions with CMake through `scikit-build-core`.
 pip install -e .
 
 # Include test-only C++/CUDA extensions
-pip install -e . -Ccmake.define.TMOL_BUILD_TESTS=ON
+pip install --no-build-isolation -e ".[dev]" \
+  -Ccmake.define.TMOL_BUILD_TESTS=ON
 
 # Select GPU architectures
 pip install -e . -Ccmake.define.CMAKE_CUDA_ARCHITECTURES="80;90"

--- a/docs/user_guide/integrations.md
+++ b/docs/user_guide/integrations.md
@@ -120,7 +120,7 @@ import torch
 
 from tmol.io import (
     build_context_from_biotite,
-    pose_stack_from_atom37_and_biotite,
+    prepare_pose_stack_from_atom37,
 )
 from tmol.score import beta2016_score_function
 
@@ -133,12 +133,11 @@ context = build_context_from_biotite(
     atom37_coords.device,
     prepare_ligands=True,
 )
+pose_builder = prepare_pose_stack_from_atom37(atom_array, context)
 
-pose_stack = pose_stack_from_atom37_and_biotite(
-    atom37_coords,  # [sample, token, 37, xyz], float32
-    atom_array,
-    context,
-)
+# One call accepts one sample or a same-topology batch. The builder can be
+# reused at every diffusion, guidance, or search step.
+pose_stack = pose_builder(atom37_coords)  # [sample, token, 37, xyz], float32
 sfxn = beta2016_score_function(
     pose_stack.device,
     param_db=context.parameter_database,
@@ -150,9 +149,11 @@ score.backward()
 
 A single call handles one sample or a whole same-topology batch; hydrogen
 optimization is enabled by default. For high-throughput diffusion or search,
-reuse `context` for every compatible candidate and render each scoring module
-once per topology and batch shape. Pass `no_optH=True` only when ideal hydrogen
-placement is an intentional speed/accuracy tradeoff.
+reuse both `pose_builder` and the scoring module for every compatible topology
+and batch shape. Pass `opt_h=False` to the builder only when ideal hydrogen
+placement is an intentional speed/accuracy tradeoff. For one-off conversion,
+`pose_stack_from_atom37_and_biotite(atom37_coords, atom_array, context)` remains
+available.
 
 A single `AtomArray` may provide topology for a batch of coordinate tensors. An
 `AtomArrayStack` must either have the same number of models as the tensor batch

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -140,3 +140,11 @@ The default minimizer is Cartesian and reads
 protocol but is not used by that minimizer. To minimize kinematic degrees of
 freedom, pass a configured `MoveMap`, a `FoldForest`, and a compatible
 kinematic `min_fn`.
+
+On CUDA, `fast_relax()` automatically uses graph replay for poses containing
+DNA or RNA, where repeated kernel-launch overhead is significant. Protein-only
+and protein–ligand poses remain eager. Pass `cuda_graph=True` or
+`cuda_graph=False` to override that choice; custom minimizers manage their own
+execution mode and cannot be combined with `cuda_graph=True`. Graph capture has
+a one-time startup cost, so explicitly disable it for a single latency-sensitive
+nucleic-acid relaxation that will not be repeated in the same process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.53"
+version = "0.1.54"
 
 dependencies = [
     # Core ML framework

--- a/tmol/_cpp_lib.py
+++ b/tmol/_cpp_lib.py
@@ -33,11 +33,12 @@ class TmolExtensionNotBuiltError(Exception):
             "tmol C++/CUDA extensions are not built.\n"
             "  Install tmol from a pre-built wheel:\n"
             "    pip install tmol\n"
-            "  Or build from source (requires CUDA toolkit):\n"
+            "  Or build from source (CPU-only builds need no CUDA toolkit):\n"
             "    pip install -e .\n"
             "  On older Linux clusters, prefer:\n"
             "    TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .\n"
-            "  or set TMOL_JIT_FALLBACK=1 if nvcc is available.\n"
+            "  or set TMOL_JIT_FALLBACK=1 (CPU-only needs a C++ compiler and "
+            "ninja; CUDA builds also need nvcc).\n"
         )
 
 
@@ -70,7 +71,8 @@ def extension_load_error_details(exc: OSError) -> str:
             "    - Use a container with a recent base image\n"
             "    - Build tmol on this machine:\n"
             "        TMOL_DISABLE_WHEEL_FETCH=1 pip install -e .\n"
-            "    - Or set TMOL_JIT_FALLBACK=1 (requires nvcc; slower first import)"
+            "    - Or set TMOL_JIT_FALLBACK=1 (CPU-only needs a C++ compiler and "
+            "ninja; CUDA also needs nvcc; slower first import)"
         )
 
     if "glibc_" in lower and "libc.so" in lower:

--- a/tmol/io/__init__.py
+++ b/tmol/io/__init__.py
@@ -69,12 +69,14 @@ from ._pose_stack_from_atomworks import (  # noqa: F401
 from tmol.chemical import get_element_from_atom_name  # noqa: F401
 from ._pose_stack_from_biotite import (  # noqa: F401
     Atom37MappingError,
+    PreparedAtom37PoseBuilder,
     build_context_from_biotite,
     pose_stack_from_biotite,
     biotite_from_pose_stack,
     canonical_form_from_biotite,
     canonical_ordering_for_biotite,
     packed_block_types_for_biotite,
+    prepare_pose_stack_from_atom37,
     biotite_from_canonical_form,
 )
 from ._pose_stack_from_openfold import (  # noqa: F401
@@ -102,6 +104,7 @@ __all__ = [
     "CanonicalForm",
     "CanonicalOrdering",
     "PoseBuildContext",
+    "PreparedAtom37PoseBuilder",
     "atom_records_from_coords",
     "atom_records_from_pose_stack",
     "atomworks_from_pose_stack",
@@ -126,6 +129,7 @@ __all__ = [
     "packed_block_types_for_openfold",
     "packed_block_types_for_rosettafold2",
     "pose_stack_from_atomworks",
+    "prepare_pose_stack_from_atom37",
     "pose_stack_from_atom37_and_biotite",
     "pose_stack_from_biotite",
     "pose_stack_from_openfold",

--- a/tmol/io/_build_context.py
+++ b/tmol/io/_build_context.py
@@ -55,10 +55,19 @@ class PoseBuildContext:
             self.packed_block_types.device,
             param_db=self.parameter_database,
         )
-        # OptH changes proton chis and terminal NHQ groups, never the protein
-        # backbone. Avoid scoring rama/omega for every candidate rotamer.
-        score_function.set_weight(ScoreType.rama, 0)
-        score_function.set_weight(ScoreType.omega, 0)
+        # OptH changes proton chis and terminal NHQ groups. These terms depend
+        # only on residue identity, disulfide geometry, protein backbone, or
+        # nucleic-acid heavy-atom torsions, so they are constant across every
+        # OptH candidate and cannot affect the selected assignment.
+        for score_type in (
+            ScoreType.disulfide,
+            ScoreType.omega,
+            ScoreType.rama,
+            ScoreType.ref,
+            ScoreType.na_torsion,
+            ScoreType.na_torsion_well,
+        ):
+            score_function.set_weight(score_type, 0)
         return score_function
 
     @cached_property

--- a/tmol/io/_pose_stack_from_atomworks.py
+++ b/tmol/io/_pose_stack_from_atomworks.py
@@ -128,7 +128,7 @@ def pose_stack_from_atom37_and_biotite(
     context: PoseBuildContext,
     no_optH: bool = False,
     **kwargs,
-) -> PoseStack:
+) -> PoseStack | tuple[PoseStack, dict] | tuple[PoseStack, PoseBuildContext]:
     """Build a differentiable PoseStack from atom37 coordinates and a topology.
 
     Unlike :func:`pose_stack_from_atomworks`, this supports any chemistry shared
@@ -140,11 +140,14 @@ def pose_stack_from_atom37_and_biotite(
     topology is scored repeatedly as coordinates move.
 
     Build ``context`` once with :func:`build_context_from_biotite` (with
-    ``prepare_ligands=True`` when ligands are present) and reuse it every step.
-    ``biotite_structure`` is used only for its chemical identity, so a single
-    reference structure can be reused across steps regardless of its coordinates.
-    It must carry two integer annotations that map each atom into the atom37
-    tensor: ``token_id`` (the token axis) and ``atom37_slot`` (the 0..36 slot).
+    ``prepare_ligands=True`` when ligands are present). For repeated diffusion
+    or search steps, bind the topology once with
+    :func:`prepare_pose_stack_from_atom37` and call the returned builder with
+    each coordinate batch. ``biotite_structure`` is used only for its chemical
+    identity, so a single reference structure can be reused regardless of its
+    coordinates. It must carry two integer annotations that map each atom into
+    the atom37 tensor: ``token_id`` (the token axis) and ``atom37_slot`` (the
+    0..36 slot).
 
     Topology is derived from chemical identity alone -- ``missing_density`` breaks
     and automatic disulfide detection (both coordinate-dependent) are disabled --

--- a/tmol/io/_pose_stack_from_biotite.py
+++ b/tmol/io/_pose_stack_from_biotite.py
@@ -1,3 +1,6 @@
+import copy
+from typing import TYPE_CHECKING
+
 import attr
 import torch
 import numpy
@@ -28,9 +31,355 @@ from tmol.utility import (
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from tmol.ligand import FragmentedLigandPoseMapping
+
+_MAX_PREPARED_BATCH_SIZES = 4
+
 
 class Atom37MappingError(ValueError):
     """An AtomArray cannot be routed unambiguously into an Atom37 tensor."""
+
+
+@attr.s(auto_attribs=True, frozen=True, slots=True)
+class _PreparedAtom37PoseTopology:
+    """Fixed pose layout plus the masks needed to rebuild missing leaf atoms."""
+
+    pose_stack: PoseStack
+    canonical_atom_mapping: torch.Tensor
+    pose_atom_mapping: torch.Tensor
+    block_leaf_atom_is_missing: torch.Tensor
+    pose_atom_is_missing: torch.Tensor
+    block_has_missing_atoms: torch.Tensor
+    real_atoms: torch.Tensor
+
+    @classmethod
+    def from_pose(
+        cls,
+        pose_stack: PoseStack,
+        canonical_coords: torch.Tensor,
+        canonical_atom_mapping: torch.Tensor,
+        pose_atom_mapping: torch.Tensor,
+        block_has_missing_atoms: torch.Tensor,
+    ) -> "_PreparedAtom37PoseTopology":
+        canonical_atom_mapping = canonical_atom_mapping.to(torch.int64)
+        pose_atom_mapping = pose_atom_mapping.to(torch.int64)
+        source_coords = canonical_coords[
+            canonical_atom_mapping[:, 0],
+            canonical_atom_mapping[:, 1],
+            canonical_atom_mapping[:, 2],
+        ]
+        missing = ~torch.isfinite(source_coords).all(dim=-1)
+        pose_ind = pose_atom_mapping[:, 0]
+        pose_atom = pose_atom_mapping[:, 1]
+        block_ind = canonical_atom_mapping[:, 1]
+        block_atom = pose_atom - pose_stack.block_coord_offset64[pose_ind, block_ind]
+
+        block_leaf_atom_is_missing = torch.zeros(
+            (
+                pose_stack.n_poses,
+                pose_stack.max_n_blocks,
+                pose_stack.max_n_block_atoms,
+            ),
+            dtype=torch.bool,
+            device=pose_stack.device,
+        )
+        block_leaf_atom_is_missing[pose_ind, block_ind, block_atom] = missing
+        pose_atom_is_missing = torch.zeros(
+            pose_stack.coords.shape[:2], dtype=torch.bool, device=pose_stack.device
+        )
+        pose_atom_is_missing[pose_ind, pose_atom] = missing
+        canonical_atom_mapping = canonical_atom_mapping[~missing]
+        pose_atom_mapping = pose_atom_mapping[~missing]
+        pose_template = pose_stack.clone()
+        return cls(
+            pose_stack=pose_template,
+            canonical_atom_mapping=canonical_atom_mapping,
+            pose_atom_mapping=pose_atom_mapping,
+            block_leaf_atom_is_missing=block_leaf_atom_is_missing,
+            pose_atom_is_missing=pose_atom_is_missing,
+            block_has_missing_atoms=block_has_missing_atoms,
+            real_atoms=pose_stack.real_atoms,
+        )
+
+    def pose_from_canonical(self, canonical_coords: torch.Tensor) -> PoseStack:
+        """Rebind coordinates and rebuild leaf atoms in the prepared pose layout."""
+        mapping = self.canonical_atom_mapping
+        pose_mapping = self.pose_atom_mapping
+        source_coords = canonical_coords[mapping[:, 0], mapping[:, 1], mapping[:, 2]]
+        coords = torch.zeros_like(self.pose_stack.coords)
+        coords[pose_mapping[:, 0], pose_mapping[:, 1]] = source_coords
+
+        pbt = self.pose_stack.packed_block_types
+        from tmol.io.details._build_missing_leaf_atoms import (
+            _apply_h_geometric_completion,
+        )
+        from tmol.io.details.compiled import gen_pose_leaf_atoms
+
+        coords = gen_pose_leaf_atoms(
+            coords,
+            self.block_leaf_atom_is_missing,
+            self.pose_atom_is_missing,
+            self.pose_stack.block_coord_offset,
+            self.pose_stack.block_type_ind,
+            self.pose_stack.inter_residue_connections,
+            pbt.n_atoms,
+            pbt.atom_downstream_of_conn,
+            pbt.build_missing_leaf_atom_icoor_ann.anc_uaids,
+            pbt.build_missing_leaf_atom_icoor_ann.geom,
+            pbt.build_missing_leaf_atom_icoor_ann.anc_uaids_backup,
+            pbt.build_missing_leaf_atom_icoor_ann.geom_backup,
+        )
+        coords = _apply_h_geometric_completion(
+            pbt,
+            coords,
+            self.block_leaf_atom_is_missing,
+            self.pose_stack.block_coord_offset,
+            self.pose_stack.block_type_ind,
+        )
+        pose_stack = copy.copy(self.pose_stack)
+        pose_stack.coords = coords
+        return pose_stack
+
+
+@attr.s(auto_attribs=True, frozen=True, slots=True)
+class PreparedAtom37PoseBuilder:
+    """Bind immutable Biotite topology for repeated Atom37 pose construction."""
+
+    context: PoseBuildContext
+    canonical_template: CanonicalForm
+    mapped_token_id: torch.Tensor
+    mapped_slot: torch.Tensor
+    mapped_residue: torch.Tensor
+    mapped_atom: torch.Tensor
+    max_token_id: int
+    fragment_mapping: "FragmentedLigandPoseMapping | None" = None
+    _topology_cache_safe: bool = True
+    _pose_topologies: dict[int, _PreparedAtom37PoseTopology] = attr.ib(
+        factory=dict, eq=False, repr=False
+    )
+
+    def __call__(
+        self,
+        atom37_coords: torch.Tensor,
+        *,
+        opt_h: bool = True,
+    ) -> PoseStack:
+        """Build a differentiable pose batch; optimize hydrogens by default."""
+        canonical_coords = self._canonical_coords(atom37_coords)
+        if not self._topology_cache_safe:
+            return _pose_stack_from_canonical_and_context(
+                self._canonical_form(canonical_coords),
+                self.context,
+                no_optH=not opt_h,
+                atom37_coords=atom37_coords,
+                fragment_mapping=self.fragment_mapping,
+            )
+        n_poses = atom37_coords.shape[0]
+        topology = self._pose_topologies.pop(n_poses, None)
+        topology_was_cached = topology is not None
+        if topology is None:
+            cf = self._canonical_form(canonical_coords)
+            pose_stack, details = _pose_stack_from_canonical_and_context(
+                cf,
+                self.context,
+                no_optH=True,
+                atom37_coords=atom37_coords,
+                fragment_mapping=self.fragment_mapping,
+                return_atom_mapping=True,
+            )
+            block_has_missing_atoms = details["block_has_missing_atoms"]
+            if bool(torch.any(block_has_missing_atoms)):
+                if not opt_h:
+                    return pose_stack
+                return _pose_stack_from_canonical_and_context(
+                    cf,
+                    self.context,
+                    no_optH=False,
+                    atom37_coords=atom37_coords,
+                    fragment_mapping=self.fragment_mapping,
+                )
+            topology = _PreparedAtom37PoseTopology.from_pose(
+                pose_stack,
+                canonical_coords,
+                details["can_atom_mapping"],
+                details["ps_atom_mapping"],
+                block_has_missing_atoms,
+            )
+        else:
+            pose_stack = topology.pose_from_canonical(canonical_coords)
+        if len(self._pose_topologies) >= _MAX_PREPARED_BATCH_SIZES:
+            self._pose_topologies.pop(next(iter(self._pose_topologies)))
+        self._pose_topologies[n_poses] = topology
+
+        if opt_h:
+            from tmol.pack import build_missing_sidechains
+
+            pose_stack = build_missing_sidechains(
+                pose_stack,
+                self.context._opth_score_function,
+                self.context._dunbrack_sampler,
+                topology.block_has_missing_atoms,
+                no_optH=False,
+                has_missing_atoms=False,
+            )
+            pose_stack = _restore_canonical_input_coords(
+                pose_stack,
+                canonical_coords,
+                topology.canonical_atom_mapping,
+                topology.pose_atom_mapping,
+                mappings_are_finite=True,
+            )
+        # Pose construction validates the initial topology. Check the initial
+        # packed result too, but do not force a CUDA-to-host synchronization on
+        # every replay of an already validated fixed topology.
+        if opt_h and not topology_was_cached:
+            _assert_no_nan_coords(pose_stack, topology.real_atoms)
+        return pose_stack
+
+    def _canonical_coords(self, atom37_coords: torch.Tensor) -> torch.Tensor:
+        """Overlay one coordinate batch without expanding static topology data."""
+        device = self.context.packed_block_types.device
+        _validate_atom37_coords(atom37_coords, device)
+        if self.max_token_id >= atom37_coords.shape[1]:
+            raise Atom37MappingError(
+                f"token_id {self.max_token_id} exceeds atom37_coords token count "
+                f"{atom37_coords.shape[1]}"
+            )
+
+        n_poses = atom37_coords.shape[0]
+        template = self.canonical_template
+        template_n_poses = template.coords.shape[0]
+        if template_n_poses not in (1, n_poses):
+            raise ValueError(
+                f"Biotite structure has {template_n_poses} poses but "
+                f"atom37_coords has {n_poses}"
+            )
+
+        coords = template.coords
+        coords = (
+            coords.clone()
+            if template_n_poses == n_poses
+            else coords.expand(n_poses, *coords.shape[1:]).clone()
+        )
+        source_coords = atom37_coords[:, self.mapped_token_id, self.mapped_slot]
+        finite = torch.isfinite(source_coords).all(dim=-1)
+        coords[:, self.mapped_residue, self.mapped_atom] = torch.where(
+            finite.unsqueeze(-1),
+            source_coords,
+            coords[:, self.mapped_residue, self.mapped_atom],
+        )
+        return coords
+
+    def _canonical_form(self, coords: torch.Tensor) -> CanonicalForm:
+        """Expand the static canonical topology for an uncached batch size."""
+        template = self.canonical_template
+        n_poses = coords.shape[0]
+
+        def tensor_for_poses(value):
+            if value is None or value.shape[0] == n_poses:
+                return value
+            return value.expand(n_poses, *value.shape[1:]).clone()
+
+        def array_for_poses(value):
+            if value is None or value.shape[0] == n_poses:
+                return value
+            return numpy.repeat(value, n_poses, axis=0)
+
+        return CanonicalForm(
+            chain_id=tensor_for_poses(template.chain_id),
+            res_types=tensor_for_poses(template.res_types),
+            coords=coords,
+            res_labels=array_for_poses(template.res_labels),
+            residue_insertion_codes=array_for_poses(template.residue_insertion_codes),
+            chain_labels=array_for_poses(template.chain_labels),
+            atom_occupancy=array_for_poses(template.atom_occupancy),
+            atom_b_factor=array_for_poses(template.atom_b_factor),
+            disulfides=template.disulfides,
+            res_not_connected=tensor_for_poses(template.res_not_connected),
+        )
+
+
+@validate_args
+def prepare_pose_stack_from_atom37(
+    biotite_structure: biotite.structure.AtomArray | biotite.structure.AtomArrayStack,
+    context: PoseBuildContext,
+) -> PreparedAtom37PoseBuilder:
+    """Prepare a callable for repeatedly binding Atom37 coordinates to topology.
+
+    This is the campaign-oriented counterpart to
+    :func:`pose_stack_from_atom37_and_biotite`: immutable residue identity,
+    connectivity, fragmentation, and Atom37 routing are resolved once. Calling
+    the returned builder with a coordinate tensor constructs a differentiable
+    pose while retaining TMol's usual missing-atom behavior. The returned
+    builder optimizes hydrogens by default; pass ``opt_h=False`` to disable it.
+    """
+    device = context.packed_block_types.device
+    fragment_mapping = None
+    if context.fragment_definitions:
+        from tmol.ligand import expand_fragmented_ligands
+
+        biotite_structure, fragment_mapping = expand_fragmented_ligands(
+            biotite_structure, context.fragment_definitions
+        )
+
+    canonical_template = canonical_form_from_biotite(
+        biotite_structure,
+        device,
+        co=context.canonical_ordering,
+        missing_density_distance_threshold=0.0,
+    )
+    filtered, _ = _filter_supported_atoms_and_connectivity(
+        biotite_structure, context.canonical_ordering
+    )
+    atom_residue = get_all_residue_positions(filtered)
+    valid_mask, valid_atom, valid_residue = _map_atoms_to_canonical(
+        context.canonical_ordering,
+        atom_residue,
+        filtered.res_name,
+        filtered.atom_name,
+    )
+    token_id, slot, mapped_residue, mapped_atom = _atom37_mapping(
+        filtered, valid_mask, valid_residue, valid_atom
+    )
+    mapped_token_id = torch.as_tensor(token_id, device=device)
+    mapped_slot = torch.as_tensor(slot, device=device)
+    mapped_residue = torch.as_tensor(mapped_residue, device=device)
+    mapped_atom = torch.as_tensor(mapped_atom, device=device)
+    mapped_reference_coords = canonical_template.coords[
+        :,
+        mapped_residue,
+        mapped_atom,
+    ]
+    his_inds = context.canonical_ordering.his_inds
+    ambiguous_his = False
+    if his_inds.his_co_aa_ind >= 0:
+        ambiguous_atom_inds = torch.tensor(
+            [his_inds.his_HN_in_co, his_inds.his_NH_in_co, his_inds.his_NN_in_co],
+            device=device,
+        )
+        is_his = canonical_template.res_types == his_inds.his_co_aa_ind
+        ambiguous_his = bool(
+            torch.any(
+                is_his.unsqueeze(-1)
+                & torch.isfinite(
+                    canonical_template.coords[:, :, ambiguous_atom_inds]
+                ).all(dim=-1)
+            )
+        )
+    return PreparedAtom37PoseBuilder(
+        context=context,
+        canonical_template=canonical_template,
+        mapped_token_id=mapped_token_id,
+        mapped_slot=mapped_slot,
+        mapped_residue=mapped_residue,
+        mapped_atom=mapped_atom,
+        max_token_id=int(token_id.max()),
+        fragment_mapping=fragment_mapping,
+        topology_cache_safe=(
+            bool(torch.isfinite(mapped_reference_coords).all()) and not ambiguous_his
+        ),
+    )
 
 
 @validate_args
@@ -150,9 +499,7 @@ def pose_stack_from_biotite(  # noqa: C901
     context: PoseBuildContext | None = None,
     atom37_coords: torch.Tensor | None = None,
     **kwargs: object,
-) -> (
-    PoseStack | tuple[PoseStack, dict[str, object]] | tuple[PoseStack, PoseBuildContext]
-):
+) -> PoseStack | tuple[PoseStack, dict] | tuple[PoseStack, PoseBuildContext]:
     """Build a PoseStack from the output generated by Biotite.
 
     To score many structures that share the same ligand(s) efficiently, build
@@ -219,9 +566,6 @@ def pose_stack_from_biotite(  # noqa: C901
     """
     torch_device = resolve_device(torch_device)
 
-    from tmol.io import pose_stack_from_canonical_form
-    from tmol.pack import build_missing_sidechains
-
     if context is not None:
         if param_db is not None:
             raise ValueError(
@@ -272,6 +616,31 @@ def pose_stack_from_biotite(  # noqa: C901
         missing_density_distance_threshold=missing_density_distance_threshold,
         atom37_coords=atom37_coords,
     )
+
+    return _pose_stack_from_canonical_and_context(
+        cf,
+        context,
+        no_optH=no_optH,
+        atom37_coords=atom37_coords,
+        fragment_mapping=fragment_mapping,
+        return_context=return_context,
+        **kwargs,
+    )
+
+
+def _pose_stack_from_canonical_and_context(
+    cf: CanonicalForm,
+    context: PoseBuildContext,
+    *,
+    no_optH: bool,
+    atom37_coords: torch.Tensor | None,
+    fragment_mapping=None,
+    return_context: bool = False,
+    **kwargs: object,
+) -> PoseStack | tuple[PoseStack, dict] | tuple[PoseStack, PoseBuildContext]:
+    """Finish pose construction from a canonical form and reusable context."""
+    from tmol.io import pose_stack_from_canonical_form
+    from tmol.pack import build_missing_sidechains
 
     if atom37_coords is not None:
         kwargs.setdefault("find_additional_disulfides", False)
@@ -329,6 +698,7 @@ def pose_stack_from_biotite(  # noqa: C901
             block_has_missing_atoms,
             no_optH=no_optH,
             na_sampler=na_sampler,
+            has_missing_atoms=has_missing_atoms,
         )
 
     if atom37_coords is not None and needs_packing:
@@ -366,6 +736,7 @@ def _restore_canonical_input_coords(
     canonical_coords: torch.Tensor,
     canonical_atom_mapping: torch.Tensor,
     pose_atom_mapping: torch.Tensor,
+    mappings_are_finite: bool = False,
 ) -> PoseStack:
     """Restore finite canonical inputs after coordinate rebuilding or packing.
 
@@ -383,14 +754,18 @@ def _restore_canonical_input_coords(
         canonical_atom_mapping[:, 1],
         canonical_atom_mapping[:, 2],
     ]
-    finite = torch.isfinite(source_coords).all(dim=-1)
-
     coords = pose_stack.coords.clone()
-    coords[
-        pose_atom_mapping[finite, 0],
-        pose_atom_mapping[finite, 1],
-    ] = source_coords[finite]
-    return attr.evolve(pose_stack, coords=coords)
+    if mappings_are_finite:
+        coords[pose_atom_mapping[:, 0], pose_atom_mapping[:, 1]] = source_coords
+    else:
+        finite = torch.isfinite(source_coords).all(dim=-1)
+        coords[
+            pose_atom_mapping[finite, 0],
+            pose_atom_mapping[finite, 1],
+        ] = source_coords[finite]
+    result = copy.copy(pose_stack)
+    result.coords = coords
+    return result
 
 
 def _assert_no_ligand_with_missing_atoms(
@@ -447,7 +822,9 @@ def _assert_no_ligand_with_missing_atoms(
         )
 
 
-def _assert_no_nan_coords(pose_stack: PoseStack) -> None:
+def _assert_no_nan_coords(
+    pose_stack: PoseStack, real_atoms: torch.Tensor | None = None
+) -> None:
     """Raise a descriptive error if any real atom in the PoseStack has NaN coords.
 
     Reports the offending pose, residue label/chain, block-type name, and atom
@@ -455,7 +832,7 @@ def _assert_no_nan_coords(pose_stack: PoseStack) -> None:
     rebuild, sidechain build) can be traced to a specific residue.
     """
     coords = pose_stack.coords
-    real = pose_stack.real_atoms
+    real = pose_stack.real_atoms if real_atoms is None else real_atoms
     nan_atom_mask = torch.isnan(coords).any(dim=-1) & real
     if not torch.any(nan_atom_mask):
         return
@@ -830,26 +1207,10 @@ def _populate_optional_atom_metadata(
     return biotite_b_factors, biotite_occupancy
 
 
-def _populate_canonical_coords_from_atom37(
-    atom37_coords: torch.Tensor,
-    biotite_structure: biotite.structure.AtomArray | biotite.structure.AtomArrayStack,
-    torch_device: torch.device,
-    co: CanonicalOrdering,
-    biotite_residues,
-    valid_atom_mask: numpy.ndarray,
-    valid_res_inds: numpy.ndarray,
-    valid_atom_inds: numpy.ndarray,
-) -> tuple[torch.Tensor, int]:
-    """Overlay mapped atom37 coordinates on the Biotite canonical coordinates.
-
-    Finite tensor values replace their matching Biotite atoms through one
-    differentiable indexed assignment. Unmapped and non-finite tensor entries
-    retain the reference coordinates, which is important for hydrogens and for
-    atoms that TMol may need to rebuild.
-
-    Returns:
-        The canonical coordinate tensor and its pose count.
-    """
+def _validate_atom37_coords(
+    atom37_coords: torch.Tensor, torch_device: torch.device
+) -> None:
+    """Validate the tensor contract shared by direct and prepared adapters."""
     if atom37_coords.ndim != 4 or atom37_coords.shape[-2:] != (37, 3):
         raise ValueError(
             "atom37_coords must have shape [n_poses, n_tokens, 37, 3]; "
@@ -865,6 +1226,15 @@ def _populate_canonical_coords_from_atom37(
             f"'{torch_device}'; they must match"
         )
 
+
+def _atom37_mapping(
+    biotite_structure: biotite.structure.AtomArray | biotite.structure.AtomArrayStack,
+    valid_atom_mask: numpy.ndarray,
+    valid_res_inds: numpy.ndarray,
+    valid_atom_inds: numpy.ndarray,
+    max_n_tokens: int | None = None,
+) -> tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]:
+    """Validate and return source/target indices for Atom37 routing."""
     categories = set(biotite_structure.get_annotation_categories())
     missing = {"token_id", "atom37_slot"} - categories
     if missing:
@@ -892,20 +1262,55 @@ def _populate_canonical_coords_from_atom37(
         raise Atom37MappingError(
             f"atom37_slot values must be less than 37; got {maximum}"
         )
-    if numpy.any(token_id[mapped] >= atom37_coords.shape[1]):
-        maximum = int(token_id[mapped].max())
-        raise Atom37MappingError(
-            f"token_id {maximum} exceeds atom37_coords token count "
-            f"{atom37_coords.shape[1]}"
-        )
     if not numpy.any(mapped):
         raise Atom37MappingError("No supported Biotite atoms map to atom37_coords")
+    if max_n_tokens is not None and numpy.any(token_id[mapped] >= max_n_tokens):
+        maximum = int(token_id[mapped].max())
+        raise Atom37MappingError(
+            f"token_id {maximum} exceeds atom37_coords token count {max_n_tokens}"
+        )
 
     source_pairs = numpy.column_stack((token_id[mapped], slot[mapped]))
     if numpy.unique(source_pairs, axis=0).shape[0] != source_pairs.shape[0]:
         raise Atom37MappingError(
             "Each mapped Biotite atom must use a unique (token_id, atom37_slot) pair"
         )
+    return (
+        token_id[mapped],
+        slot[mapped],
+        numpy.asarray(valid_res_inds)[mapped],
+        numpy.asarray(valid_atom_inds)[mapped],
+    )
+
+
+def _populate_canonical_coords_from_atom37(
+    atom37_coords: torch.Tensor,
+    biotite_structure: biotite.structure.AtomArray | biotite.structure.AtomArrayStack,
+    torch_device: torch.device,
+    co: CanonicalOrdering,
+    biotite_residues,
+    valid_atom_mask: numpy.ndarray,
+    valid_res_inds: numpy.ndarray,
+    valid_atom_inds: numpy.ndarray,
+) -> tuple[torch.Tensor, int]:
+    """Overlay mapped atom37 coordinates on the Biotite canonical coordinates.
+
+    Finite tensor values replace their matching Biotite atoms through one
+    differentiable indexed assignment. Unmapped and non-finite tensor entries
+    retain the reference coordinates, which is important for hydrogens and for
+    atoms that TMol may need to rebuild.
+
+    Returns:
+        The canonical coordinate tensor and its pose count.
+    """
+    _validate_atom37_coords(atom37_coords, torch_device)
+    token_id, slot, mapped_res_inds, mapped_atom_inds = _atom37_mapping(
+        biotite_structure,
+        valid_atom_mask,
+        valid_res_inds,
+        valid_atom_inds,
+        atom37_coords.shape[1],
+    )
 
     reference_coords, reference_n_poses = _populate_canonical_coords(
         biotite_structure,
@@ -925,16 +1330,12 @@ def _populate_canonical_coords_from_atom37(
     if reference_n_poses == 1 and n_poses != 1:
         reference_coords = reference_coords.expand(n_poses, -1, -1, -1).clone()
 
-    mapped_token_id = torch.as_tensor(token_id[mapped], device=torch_device)
-    mapped_slot = torch.as_tensor(slot[mapped], device=torch_device)
+    mapped_token_id = torch.as_tensor(token_id, device=torch_device)
+    mapped_slot = torch.as_tensor(slot, device=torch_device)
     source_coords = atom37_coords[:, mapped_token_id, mapped_slot]
     finite = torch.isfinite(source_coords).all(dim=-1)
-    mapped_res_inds = torch.as_tensor(
-        numpy.asarray(valid_res_inds)[mapped], device=torch_device
-    )
-    mapped_atom_inds = torch.as_tensor(
-        numpy.asarray(valid_atom_inds)[mapped], device=torch_device
-    )
+    mapped_res_inds = torch.as_tensor(mapped_res_inds, device=torch_device)
+    mapped_atom_inds = torch.as_tensor(mapped_atom_inds, device=torch_device)
     reference_coords[:, mapped_res_inds, mapped_atom_inds] = torch.where(
         finite.unsqueeze(-1),
         source_coords,

--- a/tmol/ligand/_conformer_generation.py
+++ b/tmol/ligand/_conformer_generation.py
@@ -55,6 +55,22 @@ STAGE_A_ANNEAL = (0.0, 0.5, 5.0, 50.0)  # 4th-dimension penalty ramp
 N_RESTART = 5  # max random stage-A restarts; stop on all chiral signs correct
 TORCH_DTYPE = torch.float32
 
+# Optimizer construction normally enters ``torch._disable_dynamo`` through
+# ``add_param_group`` and imports the full TorchDynamo stack on first use. This
+# ligand-only optimizer is never compiled; bypassing that wrapper saves seconds
+# of cold-start work while retaining the same validation and state setup.
+_ADD_PARAM_GROUP = getattr(
+    torch.optim.Optimizer.add_param_group,
+    "__wrapped__",
+    torch.optim.Optimizer.add_param_group,
+)
+
+
+class _LigandLBFGS(torch.optim.LBFGS):
+    def add_param_group(self, param_group: dict[str, object]) -> None:
+        _ADD_PARAM_GROUP(self, param_group)
+
+
 _ELECTRONEGATIVITY = {
     1: 2.20,
     6: 2.55,
@@ -361,10 +377,12 @@ def _planar_component_distances(atoms, r0, ang, max_iters: int = 150):
     pair_j = torch.tensor([p[1] for p in tp])
     target_distance = torch.tensor([p[2] for p in tp], dtype=torch.double)
     Y = torch.tensor(np.ascontiguousarray(Y0), dtype=torch.double, requires_grad=True)
-    opt = torch.optim.LBFGS([Y], max_iter=max_iters, line_search_fn="strong_wolfe")
+    opt = _LigandLBFGS(
+        [Y], max_iter=max_iters, history_size=50, line_search_fn="strong_wolfe"
+    )
 
     def closure():
-        opt.zero_grad()
+        Y.grad = None
         d = ((Y[pair_i] - Y[pair_j]) ** 2).sum(1).clamp_min(1e-12).sqrt()
         loss = ((d - target_distance) ** 2).sum()
         loss.backward()
@@ -519,10 +537,15 @@ def _chiral_anneal(X0, L0, U0, L, U, components, chirals, rng_seed: int) -> np.n
         return (torch.relu(CHIRAL_MARGIN - csgn * v) ** 2).sum()
 
     def run(iters, w_dim4):
-        opt = torch.optim.LBFGS([X], max_iter=iters, line_search_fn="strong_wolfe")
+        opt = _LigandLBFGS(
+            [X], max_iter=iters, history_size=50, line_search_fn="strong_wolfe"
+        )
 
         def closure():
-            opt.zero_grad()
+            # This optimizer owns only X. Clearing it directly is equivalent to
+            # zero_grad(set_to_none=True) and avoids importing TorchDynamo just
+            # to reset one gradient during ligand preparation.
+            X.grad = None
             loss = W_EXACT * ((pd(ei, ej) - tgt) ** 2).sum()
             loss = loss + W_BOUND * (torch.relu(lo - pd(ni, nj)) ** 2).sum()
             loss = loss + W_BOUND * (torch.relu(pd(fi, fj) - hi) ** 2).sum()
@@ -547,6 +570,10 @@ def _stress_refine(X0, L0, U0, L, U, components, chirals) -> np.ndarray:
 
     Full-weight 3D refine."""
     ei, ej, ni, nj, fi, fj, tgt, lo, hi = _pair_masks(L0, U0, L, U)
+    n_exact = len(ei)
+    n_lower = len(ni)
+    pair_i = torch.cat((ei, ni, fi))
+    pair_j = torch.cat((ej, nj, fj))
     X = torch.tensor(np.ascontiguousarray(X0), dtype=TORCH_DTYPE, requires_grad=True)
     comps = [torch.as_tensor(c, dtype=torch.long) for c in components if len(c) >= 4]
     ch = np.array(chirals, float).reshape(-1, 5)
@@ -555,8 +582,8 @@ def _stress_refine(X0, L0, U0, L, U, components, chirals) -> np.ndarray:
     )
     csgn = torch.as_tensor(ch[:, 4], dtype=TORCH_DTYPE)
 
-    def pd(i, j):
-        return ((X[i] - X[j]) ** 2).sum(1).clamp_min(1e-12).sqrt()
+    def pair_distances():
+        return ((X[pair_i] - X[pair_j]) ** 2).sum(1).clamp_min(1e-12).sqrt()
 
     def chiral_penalty():
         if len(csgn) == 0:
@@ -564,13 +591,20 @@ def _stress_refine(X0, L0, U0, L, U, components, chirals) -> np.ndarray:
         v = ((X[c1] - X[c0]) * torch.linalg.cross(X[c2] - X[c0], X[c3] - X[c0])).sum(1)
         return (torch.relu(CHIRAL_MARGIN - csgn * v) ** 2).sum()
 
-    opt = torch.optim.LBFGS([X], max_iter=REFINE_ITERS, line_search_fn="strong_wolfe")
+    opt = _LigandLBFGS(
+        [X], max_iter=REFINE_ITERS, history_size=50, line_search_fn="strong_wolfe"
+    )
 
     def closure():
-        opt.zero_grad()
-        loss = W_EXACT * ((pd(ei, ej) - tgt) ** 2).sum()
-        loss = loss + W_BOUND * (torch.relu(lo - pd(ni, nj)) ** 2).sum()
-        loss = loss + W_BOUND * (torch.relu(pd(fi, fj) - hi) ** 2).sum()
+        # See the stage-A closure above: X is the optimizer's sole parameter.
+        X.grad = None
+        distances = pair_distances()
+        exact = distances[:n_exact]
+        lower = distances[n_exact : n_exact + n_lower]
+        upper = distances[n_exact + n_lower :]
+        loss = W_EXACT * ((exact - tgt) ** 2).sum()
+        loss = loss + W_BOUND * (torch.relu(lo - lower) ** 2).sum()
+        loss = loss + W_BOUND * (torch.relu(upper - hi) ** 2).sum()
         for c in comps:
             P = X[c] - X[c].mean(0)
             loss = loss + W_PLANE * torch.linalg.eigvalsh(P.t() @ P)[0]

--- a/tmol/ligand/_detect.py
+++ b/tmol/ligand/_detect.py
@@ -586,18 +586,21 @@ def detect_nonstandard_residues(
     known_names = set(canonical_ordering.restype_io_equiv_classes)
     seen: set[str] = set()
     results: list[NonStandardResidueInfo] = []
-
-    covalently_linked_names = _residue_names_with_cross_residue_bonds(atom_array)
-
     residue_starts = struc.get_residue_starts(atom_array)
-
+    unknown_residues: list[tuple[int, str]] = []
     for start in residue_starts:
         res_name = atom_array.res_name[start].strip()
-
         if res_name in known_names or res_name in SKIP_RESIDUES or res_name in seen:
             continue
         seen.add(res_name)
+        unknown_residues.append((start, res_name))
 
+    if not unknown_residues:
+        return results
+
+    covalently_linked_names = _residue_names_with_cross_residue_bonds(atom_array)
+
+    for start, res_name in unknown_residues:
         mask = atom_array.res_name == atom_array.res_name[start]
         if hasattr(atom_array, "res_id"):
             mask &= atom_array.res_id == atom_array.res_id[start]

--- a/tmol/ligand/_params_file.py
+++ b/tmol/ligand/_params_file.py
@@ -31,7 +31,10 @@ YAML so entries can be copy-pasted between params files and
 ``chemical.yaml`` / ``cartbonded.yaml`` / ``elec.yaml``.
 """
 
+import copy
+import functools
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -55,6 +58,7 @@ if TYPE_CHECKING:
 # schema changes; bump the minor version on backward-compatible additions.
 # The version string is written into every .tmol file and checked on load.
 TMOL_FORMAT_VERSION: str = "1.0"
+
 
 _RAW_RESIDUE_DEFAULTS: dict[str, Any] = {
     "atom_aliases": [],
@@ -107,6 +111,7 @@ def _fill_properties_defaults(props: dict[str, Any]) -> dict[str, Any]:
 def _structure_residue(item: dict[str, Any]) -> RawResidueType:
     """Apply defaults for optional fields, then structure into RawResidueType."""
     populated = {**_RAW_RESIDUE_DEFAULTS, **item}
+    normalize_bond_tuples([populated])
     if "properties" in populated:
         populated["properties"] = _fill_properties_defaults(populated["properties"])
     return cattr.structure(populated, RawResidueType)
@@ -126,11 +131,38 @@ def load_params_file(path: str | Path) -> list["LigandPreparation"]:
     legacy flat schema (top-level ``residues:`` etc.) raise a
     ``ValueError`` pointing at the migration.
     """
+    path = Path(path).resolve()
+    stat = path.stat()
+    cached = _load_params_file_cached(
+        str(path), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size
+    )
+    return [
+        replace(
+            prep,
+            residue_type=copy.copy(prep.residue_type),
+            partial_charges=prep.partial_charges.copy(),
+            atom_type_elements=(
+                None
+                if prep.atom_type_elements is None
+                else prep.atom_type_elements.copy()
+            ),
+        )
+        for prep in cached
+    ]
+
+
+@functools.lru_cache(maxsize=32)
+def _load_params_file_cached(
+    path: str, _mtime_ns: int, _ctime_ns: int, _size: int
+) -> tuple["LigandPreparation", ...]:
+    """Load immutable-ish prototypes, invalidating when file metadata changes."""
+    return tuple(_load_params_file_uncached(Path(path)))
+
+
+def _load_params_file_uncached(path: Path) -> list["LigandPreparation"]:
     from tmol.ligand._registry import LigandPreparation
 
-    path = Path(path)
-    with path.open() as f:
-        raw = safe_load(f)
+    raw = safe_load(path.read_text())
 
     if not isinstance(raw, dict):
         raise ValueError(f"Expected mapping at YAML root, got {type(raw).__name__}")
@@ -183,7 +215,6 @@ def load_params_file(path: str | Path) -> list["LigandPreparation"]:
     cart = raw.get("cartbonded") or {}
 
     res_list = chem.get("residues") or []
-    normalize_bond_tuples({"residues": res_list})
     residues = [_structure_residue(item) for item in res_list]
 
     cb_raw = cart.get("residue_params") or {}

--- a/tmol/ligand/_preparation.py
+++ b/tmol/ligand/_preparation.py
@@ -459,27 +459,30 @@ def prepare_ligands(  # noqa: C901
 
     fragment_layouts_by_name = {}
     first_residue_by_name: dict[str, struc.AtomArray] = {}
-    starts = struc.get_residue_starts(atom_array)
-    ends = np.append(starts[1:], atom_array.array_length())
-    for start, end in zip(starts, ends):
-        residue = atom_array[start:end]
-        fragment_ids = fragment_ids_from_atom_array(residue)
-        layout = (
-            None
-            if fragment_ids is None
-            else tuple(sorted(zip(map(str, residue.atom_name), map(int, fragment_ids))))
-        )
-        ligand_name = str(residue.res_name[0])
-        if (
-            ligand_name in fragment_layouts_by_name
-            and fragment_layouts_by_name[ligand_name] != layout
-        ):
-            raise LigandPreparationError(
-                f"{ligand_name}: all residues with the same name must use the "
-                f"same {FRAGMENT_ID_ANNOTATION} annotation"
+    if FRAGMENT_ID_ANNOTATION in atom_array.get_annotation_categories():
+        starts = struc.get_residue_starts(atom_array)
+        ends = np.append(starts[1:], atom_array.array_length())
+        for start, end in zip(starts, ends):
+            residue = atom_array[start:end]
+            fragment_ids = fragment_ids_from_atom_array(residue)
+            layout = (
+                None
+                if fragment_ids is None
+                else tuple(
+                    sorted(zip(map(str, residue.atom_name), map(int, fragment_ids)))
+                )
             )
-        fragment_layouts_by_name[ligand_name] = layout
-        first_residue_by_name.setdefault(ligand_name, residue)
+            ligand_name = str(residue.res_name[0])
+            if (
+                ligand_name in fragment_layouts_by_name
+                and fragment_layouts_by_name[ligand_name] != layout
+            ):
+                raise LigandPreparationError(
+                    f"{ligand_name}: all residues with the same name must use the "
+                    f"same {FRAGMENT_ID_ANNOTATION} annotation"
+                )
+            fragment_layouts_by_name[ligand_name] = layout
+            first_residue_by_name.setdefault(ligand_name, residue)
 
     params_preparations: list[LigandPreparation] = []
     if params_files:

--- a/tmol/ops/_score_utils.py
+++ b/tmol/ops/_score_utils.py
@@ -187,13 +187,16 @@ def calculate_block_pair_ddg(
         )
         pose_stack = run_cart_min(pose_stack, sfxn, coord_mask)
 
-    scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    other_mask = mask2 if mask2 is not None else ~mask
+    sets_are_disjoint = mask2 is None or not bool((mask & other_mask).any())
+    scorer = sfxn.render_block_pair_scoring_module(
+        pose_stack, interaction_only=sets_are_disjoint
+    )
     defer_weights = single_block_indices is not None
     block_pair_scores = scorer(
         pose_stack.coords, sum_terms=False, apply_weights=not defer_weights
     )
 
-    other_mask = mask2 if mask2 is not None else ~mask
     if single_block_indices is None:
         ddg_scores = _sum_cross_block_scores(
             block_pair_scores, mask, other_mask, memory_efficient=memory_efficient
@@ -203,7 +206,7 @@ def calculate_block_pair_ddg(
             block_pair_scores,
             single_block_indices,
             other_mask,
-            sets_are_disjoint=mask2 is None,
+            sets_are_disjoint=sets_are_disjoint,
         )
         term_weights = scorer.weights[:, 0, 0, 0].unsqueeze(1)
         ddg_scores = ddg_scores * term_weights

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -199,6 +199,7 @@ def run_cart_min(
     optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
     optimizer_kwargs: dict[str, object] | None = None,
     verbose: bool = False,
+    cuda_graph: bool = False,
 ) -> PoseStack:
     """Run minimization on a PoseStack in Cartesian coordinate space.
 
@@ -211,13 +212,19 @@ def run_cart_min(
         optimizer_cls: Closure-based PyTorch optimizer class.
         optimizer_kwargs: Optional optimizer constructor arguments.
         verbose: Print synchronized setup and minimization timings.
+        cuda_graph: Capture the fixed-shape CUDA scoring forward/backward path.
 
     Returns:
         A new pose stack containing the minimized coordinates.
     """
     from tmol.optimization import CartesianSfxnNetwork
 
-    cart_network = CartesianSfxnNetwork(sfxn, pose_stack, coord_mask)
+    cart_network = CartesianSfxnNetwork(
+        sfxn,
+        pose_stack,
+        coord_mask,
+        cuda_graph="forward_backward" if cuda_graph else False,
+    )
 
     return run_min(
         cart_network,

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -16,12 +16,23 @@ class CartesianSfxnNetwork(torch.nn.Module):
     """Differentiable score network over selected Cartesian coordinates."""
 
     def __init__(
-        self, score_function: ScoreFunction, pose_stack: PoseStack, coord_mask=None
+        self,
+        score_function: ScoreFunction,
+        pose_stack: PoseStack,
+        coord_mask=None,
+        cuda_graph: bool | str = False,
     ):
         super(CartesianSfxnNetwork, self).__init__()
 
-        wpsm = score_function.render_whole_pose_scoring_module(pose_stack)
+        wpsm = score_function.render_whole_pose_scoring_module(
+            pose_stack, cuda_graph=cuda_graph
+        )
         self.whole_pose_scoring_module = wpsm
+        self._score_function = score_function
+        self._score_function_versions = (
+            score_function._terms_version,
+            score_function._options_version,
+        )
 
         self.pose_stack = pose_stack
         # clone: forward() writes into full_coords in place, which would
@@ -57,6 +68,57 @@ class CartesianSfxnNetwork(torch.nn.Module):
             rounding_mode="floor",
         )
         self.segment_ids = pose_for_atom.repeat_interleave(self.full_coords.shape[-1])
+
+    def _reusable_for(
+        self,
+        score_function: ScoreFunction,
+        pose_stack: PoseStack,
+        coord_mask=None,
+    ) -> bool:
+        """Return whether this network can score another pose without rendering."""
+        if coord_mask is None:
+            coord_mask = pose_stack.real_atoms
+        return (
+            score_function is self._score_function
+            and self._score_function_versions
+            == (
+                self._score_function._terms_version,
+                self._score_function._options_version,
+            )
+            and pose_stack.packed_block_types is self.pose_stack.packed_block_types
+            and pose_stack.constraint_set is self.pose_stack.constraint_set
+            and pose_stack.coords.shape == self.pose_stack.coords.shape
+            and torch.equal(coord_mask, self.coord_mask)
+            and torch.equal(pose_stack.block_type_ind, self.pose_stack.block_type_ind)
+            and torch.equal(
+                pose_stack.block_coord_offset, self.pose_stack.block_coord_offset
+            )
+            and pose_stack.inter_residue_connections
+            is self.pose_stack.inter_residue_connections
+            and pose_stack.inter_block_bondsep is self.pose_stack.inter_block_bondsep
+        )
+
+    def _reset(
+        self, score_function: ScoreFunction, pose_stack: PoseStack, coord_mask=None
+    ) -> bool:
+        """Reset for a compatible pose topology; report whether it was reused."""
+        if not self._reusable_for(score_function, pose_stack, coord_mask):
+            return False
+
+        self.pose_stack = pose_stack
+        with torch.no_grad():
+            self.whole_pose_scoring_module.weights.copy_(
+                score_function.weights_tensor().unsqueeze(1)
+            )
+            if self._all_coords_movable:
+                self.masked_coords.copy_(pose_stack.coords.reshape(-1, 3))
+            else:
+                self.full_coords.copy_(pose_stack.coords)
+                self.masked_coords.copy_(
+                    pose_stack.coords.reshape(-1, 3)[self._coord_flat_idx]
+                )
+        self.masked_coords.grad = None
+        return True
 
     def forward(self) -> torch.Tensor:
         if not self._all_coords_movable:

--- a/tmol/pack/_build_missing_sidechains.py
+++ b/tmol/pack/_build_missing_sidechains.py
@@ -22,6 +22,7 @@ def build_missing_sidechains(
     block_has_missing_atoms: Tensor[torch.bool][:, :],
     no_optH: bool = False,
     na_sampler: NaChiRotamerSampler = None,
+    has_missing_atoms: bool | None = None,
 ) -> PoseStack:
     """Build missing sidechains and place hydrogens using per-block sampler assignment.
 
@@ -55,6 +56,8 @@ def build_missing_sidechains(
         block_has_missing_atoms: Boolean tensor [n_poses, max_n_blocks]; True
             for blocks that have missing non-leaf (heavy) atoms.
         no_optH: When True, skip OptH and preserve old Dunbrack-only behavior.
+        has_missing_atoms: Cached value of ``block_has_missing_atoms.any()``.
+            Supplying it avoids a device synchronization in repeated builds.
 
     Returns:
         PoseStack with missing sidechains built and (by default) hydrogens
@@ -64,6 +67,9 @@ def build_missing_sidechains(
 
     assert block_has_missing_atoms.device == pose_stack.device
 
+    if has_missing_atoms is None:
+        has_missing_atoms = bool(torch.any(block_has_missing_atoms))
+
     palette = PackerPalette()
     task = PackerTask(pose_stack, palette)
     task.restrict_to_repacking()
@@ -71,11 +77,14 @@ def build_missing_sidechains(
     fixed_sampler = FixedAAChiSampler()
     opth_sampler = None if no_optH else OptHSampler()
 
-    task.add_conformer_sampler_by_block_mask(dunbrack_sampler, block_has_missing_atoms)
-    task.add_conformer_sampler_by_block_mask(fixed_sampler, block_has_missing_atoms)
+    if has_missing_atoms:
+        task.add_conformer_sampler_by_block_mask(
+            dunbrack_sampler, block_has_missing_atoms
+        )
+        task.add_conformer_sampler_by_block_mask(fixed_sampler, block_has_missing_atoms)
     # An empty sampler mask still makes the general rotamer builder execute the
     # sampler's setup path. Avoid that overhead for complete protein batches.
-    if na_sampler is not None and torch.any(block_has_missing_atoms):
+    if na_sampler is not None and has_missing_atoms:
         block_type_ind = pose_stack.block_type_ind64
         real_blocks = block_type_ind >= 0
         na_blocks = na_sampler.defines_rotamers_for_bts(

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -634,6 +634,9 @@ struct Annealer {
       }
 
       // Full SA run with geometric cooling
+      // Match the CPU annealer's per-pose work: a large neighbor in a jagged
+      // batch must not inflate this pose's trajectory length.
+      int const pose_inner_iterations = n_rotamers + n_rotamers / 2;
       warp_wide_sim_annealing<ChunkSize, false, false, true>(
           pose,
           &state,
@@ -645,7 +648,7 @@ struct Annealer {
           high_temp_initial,
           low_temp_initial,
           n_outer_iterations_hitemp,
-          n_inner_iterations_hitemp,
+          pose_inner_iterations,
           n_rotamers,
           false,
           false);
@@ -683,13 +686,14 @@ struct Annealer {
     // Phase 2: low-temp SA seeded from top hitemp trajectories (each seeds
     // n_lotemp_expansions independent lotemp runs).
     auto lotemp_simulated_annealing = [=] MGPU_DEVICE(int thread_id) {
-      auto seeds = at::cuda::philox::unpack(lotemp_philox_state);
-      curandStatePhilox4_32_10_t state;
-      curand_init(std::get<0>(seeds), thread_id, std::get<1>(seeds), &state);
-
       cooperative_groups::thread_block_tile<32> g =
           cooperative_groups::tiled_partition<32>(
               cooperative_groups::this_thread_block());
+      curandStatePhilox4_32_10_t state;
+      if (g.thread_rank() == 0) {
+        auto seeds = at::cuda::philox::unpack(lotemp_philox_state);
+        curand_init(std::get<0>(seeds), thread_id, std::get<1>(seeds), &state);
+      }
 
       int const cta_id = thread_id / 32;
       int const pose = cta_id / n_lotemp_simA_traj;
@@ -718,6 +722,7 @@ struct Annealer {
       }
 
       // Low-temperature cooling trajectory
+      int const pose_inner_iterations = n_rotamers / 2;
       warp_wide_sim_annealing<ChunkSize, false, false, true>(
           pose,
           &state,
@@ -729,7 +734,7 @@ struct Annealer {
           high_temp_later,
           low_temp_later,
           n_outer_iterations_lotemp,
-          n_inner_iterations_lotemp,
+          pose_inner_iterations,
           n_rotamers,
           false,
           false);
@@ -762,13 +767,14 @@ struct Annealer {
 
     // Phase 3: full greedy quench from top lotemp trajectories.
     auto fullquench = ([=] MGPU_DEVICE(int thread_id) {
-      auto seeds = at::cuda::philox::unpack(quench_philox_state);
-      curandStatePhilox4_32_10_t state;
-      curand_init(std::get<0>(seeds), thread_id, std::get<1>(seeds), &state);
-
       cooperative_groups::thread_block_tile<32> g =
           cooperative_groups::tiled_partition<32>(
               cooperative_groups::this_thread_block());
+      curandStatePhilox4_32_10_t state;
+      if (g.thread_rank() == 0) {
+        auto seeds = at::cuda::philox::unpack(quench_philox_state);
+        curand_init(std::get<0>(seeds), thread_id, std::get<1>(seeds), &state);
+      }
       int const cta_id = thread_id / 32;
       int const pose = cta_id / n_fullquench_traj;
       int const traj_id = cta_id % n_fullquench_traj;
@@ -836,9 +842,21 @@ struct Annealer {
 
     // Now launch the kernels we have created
     std::shared_ptr<mgpu::standard_context_t> context = current_context(mgr);
+    // Pack four independent trajectory warps per CTA. Their global thread IDs
+    // and Philox streams stay unchanged while CTA scheduling overhead falls.
+    constexpr int annealer_cta_threads = 128;
 
-    mgpu::transform<32, 1>(
-        hitemp_simulated_annealing, n_hitemp_simA_threads, *context);
+    // On Ampere and newer, longer trajectories amortize a small amount of spill
+    // traffic and benefit from extra latency hiding. Short and older-GPU
+    // workloads retain the unconstrained kernel.
+    using HitempLaunch = mgpu::launch_params_t<annealer_cta_threads, 1, 1, 6>;
+    if (max_n_rotamers >= 128 && context->ptx_version() >= 80) {
+      mgpu::transform<HitempLaunch>(
+          hitemp_simulated_annealing, n_hitemp_simA_threads, *context);
+    } else {
+      mgpu::transform<annealer_cta_threads, 1>(
+          hitemp_simulated_annealing, n_hitemp_simA_threads, *context);
+    }
 
     mgpu::segmented_sort(
         scores_hitemp.data(),
@@ -849,7 +867,7 @@ struct Annealer {
         mgpu::less_t<float>(),
         *context);
 
-    mgpu::transform<32, 1>(
+    mgpu::transform<annealer_cta_threads, 1>(
         lotemp_simulated_annealing, n_lotemp_simA_threads, *context);
 
     mgpu::segmented_sort(
@@ -861,7 +879,8 @@ struct Annealer {
         mgpu::less_t<float>(),
         *context);
 
-    mgpu::transform<32, 1>(fullquench, n_fullquench_threads, *context);
+    mgpu::transform<annealer_cta_threads, 1>(
+        fullquench, n_fullquench_threads, *context);
 
     mgpu::segmented_sort(
         scores_fullquench.data(),
@@ -872,7 +891,8 @@ struct Annealer {
         mgpu::less_t<float>(),
         *context);
 
-    mgpu::transform<32, 1>(final_reindexing, n_fullquench_threads, *context);
+    mgpu::transform<annealer_cta_threads, 1>(
+        final_reindexing, n_fullquench_threads, *context);
 
     return {scores_final_t, rotamer_assignments_final_t};
   }

--- a/tmol/pose/_packed_block_types.py
+++ b/tmol/pose/_packed_block_types.py
@@ -15,7 +15,6 @@ from tmol.chemical import (
 )
 from tmol.database import PatchedChemicalDatabase
 from tmol.utility._device import resolve_device
-from tmol.utility.tensor import join_tensors_and_report_real_entries
 
 
 def residue_types_from_residues(residues):
@@ -248,16 +247,13 @@ class PackedBlockTypes:
         active_block_types,
         device: torch.device,
     ):
-        atom_is_hydrogen = torch.zeros(
-            (n_atoms.shape[0], max_n_atoms), dtype=torch.int32
-        )
         atype_element = {atype.name: atype.element for atype in chem_db.atom_types}
-
-        for i, bt in enumerate(active_block_types):
-            for j, at in enumerate(bt.atoms):
-                atype_is_h = atype_element[at.atom_type] == "H"
-                atom_is_hydrogen[i, j] = atype_is_h
-        return atom_is_hydrogen.to(device=device)
+        atom_is_hydrogen = [
+            [int(atype_element[atom.atom_type] == "H") for atom in bt.atoms]
+            + [0] * (max_n_atoms - len(bt.atoms))
+            for bt in active_block_types
+        ]
+        return torch.tensor(atom_is_hydrogen, dtype=torch.int32, device=device)
 
     @classmethod
     def join_atom_downstream_of_conn(
@@ -266,15 +262,13 @@ class PackedBlockTypes:
         n_restypes = len(active_block_types)
         max_n_conn = max(len(rt.connections) for rt in active_block_types)
         max_n_atoms = max(len(rt.atoms) for rt in active_block_types)
-        atom_downstream_of_conn = torch.full(
-            (n_restypes, max_n_conn, max_n_atoms), -1, dtype=torch.int32, device=device
+        atom_downstream_of_conn = numpy.full(
+            (n_restypes, max_n_conn, max_n_atoms), -1, dtype=numpy.int32
         )
         for i, rt in enumerate(active_block_types):
             rt_adoc = rt.atom_downstream_of_conn
-            atom_downstream_of_conn[i, : rt_adoc.shape[0], : rt_adoc.shape[1]] = (
-                torch.tensor(rt_adoc, dtype=torch.int32, device=device)
-            )
-        return atom_downstream_of_conn
+            atom_downstream_of_conn[i, : rt_adoc.shape[0], : rt_adoc.shape[1]] = rt_adoc
+        return torch.from_numpy(atom_downstream_of_conn).to(device=device)
 
     @classmethod
     def join_atom_paths_from_conn(
@@ -283,7 +277,7 @@ class PackedBlockTypes:
         n_restypes = len(active_block_types)
         max_n_conn = max(len(bt.connections) for bt in active_block_types)
 
-        atom_paths_from_conn = torch.full(
+        atom_paths_from_conn = numpy.full(
             (
                 n_restypes,
                 max_n_conn,
@@ -291,34 +285,43 @@ class PackedBlockTypes:
                 3,
             ),
             -1,
-            dtype=torch.int32,
-            device=device,
+            dtype=numpy.int32,
         )
 
         for i, bt in enumerate(active_block_types):
             paths = bt.atom_paths_from_conn
-            atom_paths_from_conn[i][0 : len(bt.connections)] = torch.tensor(
-                paths, device=device
-            )
+            atom_paths_from_conn[i, : len(bt.connections)] = paths
 
-        return atom_paths_from_conn
+        return torch.from_numpy(atom_paths_from_conn).to(device=device)
 
     @classmethod
-    def _list_of_tensors_of_bt_attribute(
-        cls, active_block_types, attribute_name, device, dtype=None
+    def _join_block_type_attribute(
+        cls,
+        active_block_types,
+        attribute_name,
+        device,
+        dtype=None,
+        sentinel=-1,
     ):
-        return (
-            [
-                torch.tensor(
-                    getattr(bt, attribute_name).copy().astype(dtype), device=device
-                )
-                for bt in active_block_types
-            ]
-            if dtype is not None
-            else [
-                torch.tensor(getattr(bt, attribute_name).copy(), device=device)
-                for bt in active_block_types
-            ]
+        arrays = [
+            numpy.asarray(getattr(bt, attribute_name), dtype=dtype)
+            for bt in active_block_types
+        ]
+        n_elements = numpy.asarray(
+            [array.shape[0] for array in arrays], dtype=numpy.int32
+        )
+        joined = numpy.full(
+            (len(arrays), int(n_elements.max()), *arrays[0].shape[1:]),
+            sentinel,
+            dtype=arrays[0].dtype,
+        )
+        for i, array in enumerate(arrays):
+            joined[i, : array.shape[0]] = array
+
+        real = numpy.arange(joined.shape[1])[None, :] < n_elements[:, None]
+        return tuple(
+            torch.from_numpy(array).to(device=device)
+            for array in (n_elements, real, joined)
         )
 
     @classmethod
@@ -329,56 +332,50 @@ class PackedBlockTypes:
         #               is on ther other side of, -1 if
         #  3rd integer: the number of chemical bonds into the other block that the
         #               unresolved atom is found.
-        ordered_torsions = cls._list_of_tensors_of_bt_attribute(
+        return cls._join_block_type_attribute(
             active_block_types, "ordered_torsions", device
         )
-        return join_tensors_and_report_real_entries(ordered_torsions)
 
     @classmethod
     def join_is_torsion_mcs(cls, active_block_types, device):
-        is_torsion_mc = cls._list_of_tensors_of_bt_attribute(
-            active_block_types, "is_torsion_mc", device, dtype=numpy.int32
-        )
-        return join_tensors_and_report_real_entries(is_torsion_mc, sentinel=0)[2].to(
-            torch.bool
-        )
+        return cls._join_block_type_attribute(
+            active_block_types,
+            "is_torsion_mc",
+            device,
+            dtype=numpy.int32,
+            sentinel=0,
+        )[2].to(torch.bool)
 
     @classmethod
     def join_mc_torsion_inds(cls, active_block_types, device):
-        mc_torsions = cls._list_of_tensors_of_bt_attribute(
-            active_block_types, "mc_torsions", device
-        )
-        return join_tensors_and_report_real_entries(mc_torsions)
+        return cls._join_block_type_attribute(active_block_types, "mc_torsions", device)
 
     @classmethod
     def join_sc_torsion_inds(cls, active_block_types, device):
-        sc_torsions = cls._list_of_tensors_of_bt_attribute(
-            active_block_types, "sc_torsions", device
-        )
-        return join_tensors_and_report_real_entries(sc_torsions)
+        return cls._join_block_type_attribute(active_block_types, "sc_torsions", device)
 
     @classmethod
     def join_mcsc_torsion_inds(cls, active_block_types, device):
         # only return the joined tensor of mcsc indices, index 2 of the tuple
         # returned by join_tensors_and_report_real_entries
-        which_mcsc_torsions = cls._list_of_tensors_of_bt_attribute(
+        return cls._join_block_type_attribute(
             active_block_types, "which_mcsc_torsion", device
-        )
-        return join_tensors_and_report_real_entries(which_mcsc_torsions)[2]
+        )[2]
 
     @classmethod
     def join_bond_indices(cls, active_block_types, device):
-        bond_indices = cls._list_of_tensors_of_bt_attribute(
+        return cls._join_block_type_attribute(
             active_block_types, "bond_indices", device, dtype=numpy.int32
         )
-        return join_tensors_and_report_real_entries(bond_indices)
 
     @classmethod
     def join_conn_indices(cls, active_block_types, device):
-        conn_atoms = cls._list_of_tensors_of_bt_attribute(
-            active_block_types, "ordered_connection_atoms", device, dtype=numpy.int32
+        return cls._join_block_type_attribute(
+            active_block_types,
+            "ordered_connection_atoms",
+            device,
+            dtype=numpy.int32,
         )
-        return join_tensors_and_report_real_entries(conn_atoms)
 
     @classmethod
     def join_polymeric_connections(cls, active_block_types, device):

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -25,7 +25,12 @@ from tmol.pack.rotamer import (
     FixedAAChiSampler,
     IncludeCurrentSampler,
 )
-from tmol.optimization import run_cart_min, run_kin_min
+from tmol.optimization import (
+    CartesianSfxnNetwork,
+    run_cart_min,
+    run_kin_min,
+    run_min,
+)
 from tmol.types import Tensor
 from tmol.utility._device import synchronize_device
 
@@ -142,6 +147,7 @@ def _default_cart_min_fn(
     fold_forest: FoldForest,
     move_map: MoveMap | CartesianMoveMap,
     verbose: bool,
+    cuda_graph: bool = False,
 ) -> PoseStack:
     """Run Cartesian LBFGS using a Cartesian move map's coordinate mask."""
     coord_mask = move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
@@ -150,7 +156,61 @@ def _default_cart_min_fn(
         sfxn,
         coord_mask=coord_mask,
         verbose=verbose,
+        cuda_graph=cuda_graph,
         optimizer_kwargs={"verbose": verbose},
+    )
+
+
+class _DefaultCartesianMinimizer:
+    """Cartesian minimizer that reuses rendering for unchanged pose topology."""
+
+    def __init__(self, cuda_graph: bool):
+        self.cuda_graph = cuda_graph
+        self.network: CartesianSfxnNetwork | None = None
+
+    def __call__(
+        self,
+        pose_stack: PoseStack,
+        sfxn: ScoreFunction,
+        *,
+        fold_forest: FoldForest,
+        move_map: MoveMap | CartesianMoveMap,
+        verbose: bool,
+    ) -> PoseStack:
+        del fold_forest
+        coord_mask = (
+            move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
+        )
+        if self.network is None or not self.network._reset(
+            sfxn, pose_stack, coord_mask
+        ):
+            self.network = CartesianSfxnNetwork(
+                sfxn,
+                pose_stack,
+                coord_mask,
+                cuda_graph="forward_backward" if self.cuda_graph else False,
+            )
+        return run_min(
+            self.network,
+            verbose=verbose,
+            optimizer_kwargs={"verbose": verbose},
+        )
+
+
+def _resolve_cuda_graph_mode(pose_stack: PoseStack, cuda_graph: bool | None) -> bool:
+    """Choose graph replay automatically where launch overhead dominates."""
+    if cuda_graph is not None:
+        return cuda_graph
+    if pose_stack.device.type != "cuda":
+        return False
+
+    used_block_types = torch.unique(pose_stack.block_type_ind).tolist()
+    active_block_types = pose_stack.packed_block_types.active_block_types
+    return any(
+        block_type_ind >= 0
+        and active_block_types[block_type_ind].properties.polymer.backbone_type
+        in ("dna", "rna")
+        for block_type_ind in used_block_types
     )
 
 
@@ -166,6 +226,7 @@ def fast_relax(  # noqa: C901
     ramp_constraints: bool | None = None,  # default True
     schedule: Sequence[RelaxScheduleEntry] | None = None,
     min_fn: RelaxMinimizer | None = None,
+    cuda_graph: bool | None = None,
     verbose: bool = False,
 ) -> PoseStack:
     """Relax poses through repeated side-chain packing and minimization.
@@ -190,13 +251,17 @@ def fast_relax(  # noqa: C901
             ``DEFAULT_RELAX_SCHEDULE``.
         min_fn: Minimizer called with the pose, score function, fold forest,
             move map, and verbosity. Defaults to Cartesian minimization.
+        cuda_graph: Capture the default Cartesian minimizer's repeated CUDA
+            scoring path. By default, enable it automatically for CUDA poses
+            containing DNA or RNA, where launch overhead dominates. Pass ``False``
+            to disable it. It cannot be combined with a custom ``min_fn``.
         verbose: Print timing information for each step.
 
     Returns:
         Best-scoring relaxed poses across all repeats.
     """
-    if min_fn is None:
-        min_fn = _default_cart_min_fn
+    if min_fn is not None and cuda_graph is True:
+        raise ValueError("cuda_graph cannot be combined with a custom min_fn")
     if schedule is None:
         schedule = DEFAULT_RELAX_SCHEDULE
 
@@ -249,6 +314,11 @@ def fast_relax(  # noqa: C901
     wpsm = sfxn.render_whole_pose_scoring_module(pose_stack)
     best_score = wpsm(pose_stack.coords)
     best_ps = pose_stack.clone()
+
+    if min_fn is None:
+        min_fn = _DefaultCartesianMinimizer(
+            _resolve_cuda_graph_mode(pose_stack, cuda_graph)
+        )
 
     ps = pose_stack
     for _ in range(num_repeats):

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -112,9 +112,31 @@ class EnergyTerm:
     def get_rotamer_score_term_function(self):
         raise NotImplementedError()
 
+    def get_rotamer_score_term_attributes(
+        self, pose_stack: PoseStack, rotamer_set: RotamerSet
+    ):
+        """Return immutable parameters for a rendered rotamer scorer.
+
+        Most terms use the same topology data for pose and rotamer scoring.
+        Terms whose candidate topology can be resolved once at render time may
+        override this hook instead of repeating that work on every score call.
+        """
+        return self.get_score_term_attributes(pose_stack)
+
     def pose_score_term_is_invariant_zero(self, pose_stack: PoseStack):
         """Whether this term is identically zero for this fixed pose topology."""
         return False
+
+    def block_pair_score_term_is_invariant_zero_off_diagonal(
+        self, pose_stack: PoseStack
+    ):
+        """Whether this term contributes only to self-block matrix entries.
+
+        One-body terms are diagonal by definition. Terms with a higher body
+        count may override this when their block-pair attribution is still
+        strictly diagonal.
+        """
+        return self.n_bodies() == 1
 
     def render_whole_pose_scoring_module(self, pose_stack: PoseStack):
         if self.pose_score_term_is_invariant_zero(pose_stack):
@@ -133,8 +155,13 @@ class EnergyTerm:
             f,
         )
 
-    def render_block_pair_scoring_module(self, pose_stack: PoseStack):
-        if self.pose_score_term_is_invariant_zero(pose_stack):
+    def render_block_pair_scoring_module(
+        self, pose_stack: PoseStack, *, interaction_only: bool = False
+    ):
+        if self.pose_score_term_is_invariant_zero(pose_stack) or (
+            interaction_only
+            and self.block_pair_score_term_is_invariant_zero_off_diagonal(pose_stack)
+        ):
             return ZeroTermPoseScoringModule(
                 self.class_name(),
                 len(self.score_types()),
@@ -161,6 +188,6 @@ class EnergyTerm:
         return TermRotamerScoringModule(
             self.class_name(),
             rotamer_set,
-            self.get_score_term_attributes(pose_stack),
+            self.get_rotamer_score_term_attributes(pose_stack, rotamer_set),
             f,
         )

--- a/tmol/score/_fragment_interactions.py
+++ b/tmol/score/_fragment_interactions.py
@@ -253,7 +253,7 @@ def calculate_fragment_interactions(
     if bool(partner_mask.flatten()[mapping_data.record_linear_indices].any()):
         raise ValueError("partner_mask must not include ligand fragment blocks")
 
-    scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    scorer = sfxn.render_block_pair_scoring_module(pose_stack, interaction_only=True)
     block_pair_scores = scorer(pose_stack.coords, sum_terms=False)
     result = _sum_fragment_partner_scores(
         block_pair_scores,

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -472,7 +472,9 @@ class ScoreFunction:
             scoring_module.enable_cuda_graphs(pose_stack.coords, mode=mode)
         return scoring_module
 
-    def render_block_pair_scoring_module(self, pose_stack: PoseStack):
+    def render_block_pair_scoring_module(
+        self, pose_stack: PoseStack, *, interaction_only: bool = False
+    ):
         """Create an object designed to evaluate the score of a set of Poses
         repeatedly as the Poses change their conformation, e.g., as in
         minimization. This object will derive from torch.nn.Module and
@@ -480,10 +482,18 @@ class ScoreFunction:
         terms that themselves are derived from torch.nn.Module. This
         object's __call__ will return a tensor of weighted energies of
         shape (n_poses, max_n_blocks, max_n_blocks).
+
+        Set ``interaction_only=True`` when only strictly off-diagonal block
+        pairs will be consumed. Terms whose block-pair scores are known to be
+        diagonal-only are then omitted. Diagonal entries in the returned
+        matrix are incomplete in this mode.
         """
         self.pre_work_initialization(pose_stack)
         term_modules = [
-            t.render_block_pair_scoring_module(pose_stack) for t in self.all_terms()
+            t.render_block_pair_scoring_module(
+                pose_stack, interaction_only=interaction_only
+            )
+            for t in self.all_terms()
         ]
         return BlockPairScoringModule(self.weights_tensor(), term_modules)
 
@@ -919,6 +929,41 @@ class BlockPairScoringModule:
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
 
         return summed
+
+    def score_interactions(
+        self,
+        coords: torch.Tensor,
+        block_pair_indices: torch.Tensor,
+        *,
+        sum_terms: bool = True,
+        apply_weights: bool = True,
+    ) -> torch.Tensor:
+        """Sum selected block-pair entries with one indexed reduction.
+
+        Args:
+            coords: Pose coordinates accepted by this rendered scorer.
+            block_pair_indices: Shared block pairs shaped ``[n_pairs, 2]``.
+                Each row contains ``(block_i, block_j)`` and is applied to
+                every pose in the coordinate batch.
+            sum_terms: Sum the score-type dimension when true.
+            apply_weights: Apply the score function's weights when true.
+
+        Returns:
+            Scores shaped ``[n_poses]`` when ``sum_terms`` is true, otherwise
+            ``[n_score_types, n_poses]``.
+        """
+        if block_pair_indices.ndim != 2 or block_pair_indices.shape[1] != 2:
+            raise ValueError("block_pair_indices must have shape [n_pairs, 2]")
+        if block_pair_indices.device != coords.device:
+            raise ValueError(
+                "block_pair_indices must be on the same device as coordinates"
+            )
+        if block_pair_indices.dtype not in (torch.int32, torch.int64):
+            raise TypeError("block_pair_indices must have an integer dtype")
+        block_i, block_j = block_pair_indices.to(torch.int64).unbind(dim=1)
+        scores = self(coords, sum_terms=sum_terms, apply_weights=apply_weights)
+        pair_dimension = 1 if sum_terms else 2
+        return scores[..., block_i, block_j].sum(dim=pair_dimension)
 
     def unweighted_scores(self, coords: torch.Tensor) -> torch.Tensor:
         parallel_scores = self._parallel_forward_scores(coords)

--- a/tmol/score/common/tile_atom_pair_evaluation.hh
+++ b/tmol/score/common/tile_atom_pair_evaluation.hh
@@ -7,6 +7,8 @@ namespace tmol {
 namespace score {
 namespace common {
 
+enum class TilePairMode { InterAndIntra, Inter, Intra };
+
 // Returns the count of items to iterate over within a single tile of block 1
 // or block 2. The selector knows the meaning of `n_atoms` / `n_heavy` in the
 // surrounding data structure and how those map to a per-tile count.
@@ -362,6 +364,7 @@ template <
     typename IntraResScoringData,
     typename Real,
     int TILE,
+    TilePairMode Mode = TilePairMode::InterAndIntra,
     typename SharedMemData,
     typename LoadInvarInterFunc,
     typename LoadInvarIntraFunc,
@@ -400,7 +403,8 @@ TMOL_DEVICE_FUNC void tile_evaluate_rot_pair(
   assert(
       !(block_ind1 == block_ind2
         && rot_ind1 != rot_ind2));  // working under this assumption
-  if (block_ind1 != block_ind2) {
+  if (Mode == TilePairMode::Inter
+      || (Mode == TilePairMode::InterAndIntra && block_ind1 != block_ind2)) {
     // Step 1: load any data that is consistent across all tile pairs
     InterResScoringData interres_data;
     load_tile_invariant_interres_data(

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -33,24 +33,25 @@ using Vec = Eigen::Matrix<Real, N, 1>;
 
 def connectivity_weight(Real bonded_path_length) -> Real {
   if (bonded_path_length > 4) {
-    return 1.0;
+    return Real(1);
   } else if (bonded_path_length == 4) {
-    return 0.2;
+    return Real(0.2);
   } else {
-    return 0.0;
+    return Real(0);
   }
 }
 
 // sigmoidal distance-dependant dielectric
-def eps(Real dist, float D, float D0, float S) -> Real {
+def eps(Real dist, Real D, Real D0, Real S) -> Real {
   return (
       D
-      - 0.5 * (D - D0) * (2 + 2 * dist * S + dist * dist * S * S)
+      - Real(0.5) * (D - D0)
+            * (Real(2) + Real(2) * dist * S + dist * dist * S * S)
             * std::exp(-dist * S));
 }
 
-def deps_ddist(Real dist, float D, float D0, float S) -> Real {
-  return (0.5 * (D - D0) * dist * dist * S * S * S * std::exp(-dist * S));
+def deps_ddist(Real dist, Real D, Real D0, Real S) -> Real {
+  return Real(0.5) * (D - D0) * dist * dist * S * S * S * std::exp(-dist * S);
 }
 
 def elec_delec_ddist(
@@ -59,9 +60,9 @@ def elec_delec_ddist(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> tuple<Real, Real> {
-  Real low_poly_start = params.min_dis - 0.25;
-  Real low_poly_end = params.min_dis + 0.25;
-  Real hi_poly_start = params.max_dis - 1.0;
+  Real low_poly_start = params.min_dis - Real(0.25);
+  Real low_poly_end = params.min_dis + Real(0.25);
+  Real hi_poly_start = params.max_dis - Real(1);
   Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);
@@ -120,9 +121,9 @@ def elec(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> Real {
-  Real low_poly_start = params.min_dis - 0.25;
-  Real low_poly_end = params.min_dis + 0.25;
-  Real hi_poly_start = params.max_dis - 1.0;
+  Real low_poly_start = params.min_dis - Real(0.25);
+  Real low_poly_end = params.min_dis + Real(0.25);
+  Real hi_poly_start = params.max_dis - Real(1);
   Real hi_poly_end = params.max_dis;
 
   Real weight = connectivity_weight<Real>(bonded_path_length);

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -63,7 +63,7 @@ struct lk_fraction {
   static def square(Real v) -> Real { return v * v; }
 
   static def V(WatersMat WI, Real3 J, Real lj_radius_j) -> Real {
-    Real d2_low = square(1.4 + lj_radius_j) - ramp_width_A2;
+    Real d2_low = square(Real(1.4) + lj_radius_j) - ramp_width_A2;
     if (d2_low < 0.0) d2_low = 0.0;
 
     Real wted_d2_delta = 0;
@@ -91,7 +91,7 @@ struct lk_fraction {
   }
 
   static def V_dV(WatersMat WI, Real3 J, Real lj_radius_j) -> V_dV_t {
-    Real d2_low = square(1.4 + lj_radius_j) - ramp_width_A2;
+    Real d2_low = square(Real(1.4) + lj_radius_j) - ramp_width_A2;
     if (d2_low < 0.0) d2_low = 0.0;
 
     Real wted_d2_delta = 0.0;
@@ -125,7 +125,7 @@ struct lk_fraction {
     } else if (wted_d2_delta < ramp_width_A2) {
       frac = square(1 - square(wted_d2_delta / ramp_width_A2));
       if (wted_d2_delta > 0) {
-        dfrac_dwted_d2 = -4.0 * wted_d2_delta
+        dfrac_dwted_d2 = Real(-4) * wted_d2_delta
                          * (square(ramp_width_A2) - square(wted_d2_delta))
                          / square(square(ramp_width_A2));
       }
@@ -183,7 +183,7 @@ struct lk_bridge_fraction {
       -> Real {
     // The bridge score has compact support in the base-atom separation. Test
     // that inexpensive condition before evaluating any water-pair exponentials.
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real overlap_target_len2 = Real(8) / Real(3) * square(lkb_water_dist);
     Real overlap_len2 = (I - J).squaredNorm();
     Real base_delta = fabs(overlap_len2 - overlap_target_len2);
     if (base_delta > angle_overlap_A2) return Real(0);
@@ -217,19 +217,19 @@ struct lk_bridge_fraction {
       Real3 I, Real3 J, WatersMat WI, WatersMat WJ, Real lkb_water_dist)
       -> V_dV_t {
     // Reject geometrically impossible bridges before the water-overlap loop.
-    Real overlap_target_len2 = 8.0 / 3.0 * square(lkb_water_dist);
+    Real overlap_target_len2 = Real(8) / Real(3) * square(lkb_water_dist);
     Real3 delta_ij = I - J;
     Real overlap_len2 = delta_ij.squaredNorm();
     Real base_delta = overlap_len2 - overlap_target_len2;
     if (std::abs(base_delta) > angle_overlap_A2) {
       return V_dV_t{Real(0), dV_t::Zero()};
     }
-    Real3 d_wted_d2_delta_d_I = 2.0 * delta_ij;
-    Real3 d_wted_d2_delta_d_J = -2.0 * delta_ij;
+    Real3 d_wted_d2_delta_d_I = Real(2) * delta_ij;
+    Real3 d_wted_d2_delta_d_J = Real(-2) * delta_ij;
     Real anglefrac = square(1 - square(base_delta / angle_overlap_A2));
     Real d_anglefrac_d_base_delta =
         std::abs(base_delta) > 0.0
-            ? -4.0 * base_delta
+            ? Real(-4) * base_delta
                   * (square(angle_overlap_A2) - square(base_delta))
                   / square(square(angle_overlap_A2))
             : Real(0);
@@ -268,7 +268,7 @@ struct lk_bridge_fraction {
       wted_d2_delta = -std::log(wted_d2_delta);
       overlapfrac = square(1 - square(wted_d2_delta / overlap_width_A2));
       d_overlapfrac_d_wted_d2 =
-          -4.0 * wted_d2_delta
+          Real(-4) * wted_d2_delta
           * (square(overlap_width_A2) - square(wted_d2_delta))
           / square(square(overlap_width_A2));
     }
@@ -578,8 +578,8 @@ struct lk_ball_score {
     Real const iso_scale = weights[w_lk_ball_iso]
                            + weights[w_lk_ball] * frac_desolv.V
                            + weights[w_lk_bridge] * frac_bridge.V;
-    Real const bridge_scale =
-        weights[w_lk_bridge] * lk_iso.V + weights[w_lk_bridge_uncpl] * 0.5;
+    Real const bridge_scale = weights[w_lk_bridge] * lk_iso.V
+                              + weights[w_lk_bridge_uncpl] * Real(0.5);
     Real3 const d_iso_dI = lk_iso.dV_ddist * dist.dV_dA;
 
     return lk_ball_weighted_dVt<Real, MAX_WATER>{
@@ -1285,7 +1285,7 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
         MAX_N_WATER * occluder_atom_tile_ind + wi);
   }
 
-  auto dV = lk_ball_score<Real, 4>::weighted_dV(
+  auto dV = lk_ball_score<Real, MAX_N_WATER>::weighted_dV(
       polar_xyz,
       occluder_xyz,
       wmat_polar,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -30,6 +30,7 @@
 #include <moderngpu/operators.hxx>
 
 #include <chrono>
+#include <type_traits>
 
 // Definitions for TILE_SIZE and MAX_N_WATERS
 // Shared between this file and gen_pose_waters.impl.hh
@@ -333,6 +334,9 @@ namespace potentials {
 template <typename Real, int N>
 using Vec = Eigen::Matrix<Real, N, 1>;
 
+template <common::TilePairMode Mode>
+using TilePairModeTag = std::integral_constant<common::TilePairMode, Mode>;
+
 // TO DO: standardize tiled inter-block count pair
 template <int TILE, typename InterEnergyData>
 EIGEN_DEVICE_FUNC int interres_count_pair_separation(
@@ -350,6 +354,63 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         inter_dat.pair_data.conn_seps);
   }
   return separation;
+}
+
+template <common::TilePairMode Mode>
+inline TMOL_DEVICE_FUNC common::tuple<int, int, int> lk_ball_pose_pair_indices(
+    int cta, int max_n_blocks) {
+  if constexpr (Mode == common::TilePairMode::Inter) {
+    int const n_pairs = max_n_blocks * (max_n_blocks - 1) / 2;
+    auto pair = common::upper_triangle_inds_from_linear_index(
+        cta % n_pairs, max_n_blocks);
+    return common::make_tuple(
+        cta / n_pairs, common::get<0>(pair), common::get<1>(pair));
+  } else if constexpr (Mode == common::TilePairMode::Intra) {
+    int const block = cta % max_n_blocks;
+    return common::make_tuple(cta / max_n_blocks, block, block);
+  } else {
+    int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+    auto pair = common::upper_triangle_inds_from_linear_index(
+        cta % n_pairs, max_n_blocks + 1);
+    return common::make_tuple(
+        cta / n_pairs, common::get<0>(pair), common::get<1>(pair) - 1);
+  }
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device Dev,
+    typename Launch,
+    typename Eval>
+void launch_lk_ball_pose_pair_workgroups(
+    ContextManager& mgr, int n_poses, int max_n_blocks, Eval eval) {
+  int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+#ifdef __NVCC__
+  auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
+    eval(cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
+  });
+  // The specialized kernels remove the cold intra/inter instruction path.
+  // Use them only once their throughput gain exceeds the extra launch cost.
+  constexpr int min_split_workgroups = 1 << 15;
+  if (max_n_blocks > 1 && n_poses * n_pairs >= min_split_workgroups) {
+    auto eval_interres = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval(cta, TilePairModeTag<common::TilePairMode::Inter>{});
+    });
+    auto eval_intrares = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval(cta, TilePairModeTag<common::TilePairMode::Intra>{});
+    });
+    DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
+        mgr, n_poses, max_n_blocks * (max_n_blocks - 1) / 2, eval_interres);
+    DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
+        mgr, n_poses, max_n_blocks, eval_intrares);
+    return;
+  }
+  DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
+      mgr, n_poses, n_pairs, eval_all);
+#else
+  DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
+      mgr, n_poses, n_pairs, eval);
+#endif
 }
 
 template <
@@ -464,11 +525,14 @@ class LKBallPoseScoreDispatch {
     // Define nt and reduce_t
     CTA_REAL_REDUCE_T_TYPEDEF;
 
-    // The total number of unique block pairs (including self-pairs)
-    int const max_n_upper_triangle_inds =
-        (max_n_blocks * (max_n_blocks + 1)) / 2;
-
-    auto eval_energies_by_block = ([=] TMOL_DEVICE_FUNC(int cta) {
+    auto eval_energies_by_block = ([=] TMOL_DEVICE_FUNC(
+#ifdef __NVCC__
+                                       int cta, auto pair_mode_tag) {
+      constexpr auto pair_mode = decltype(pair_mode_tag)::value;
+#else
+                                       int cta) {
+      constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
+#endif
       auto score_inter_lk_ball_atom_pair =
           ([=] TMOL_DEVICE_FUNC(
                int pol_start,
@@ -546,17 +610,11 @@ class LKBallPoseScoreDispatch {
 
       int const max_important_bond_separation = 4;
 
-      int const pose_ind = cta / (max_n_upper_triangle_inds);
-      int const block_ind_pair = cta % (max_n_upper_triangle_inds);
-
-      // We do not have to kill half of our thread blocks simply because they
-      // represent the lower triangle now that we're using upper-triangle
-      // indices
-      auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
-          block_ind_pair, max_n_blocks + 1);
-
-      int const block_ind1 = common::get<0>(upper_triangle_ind);
-      int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
+      auto pair_indices =
+          lk_ball_pose_pair_indices<pair_mode>(cta, max_n_blocks);
+      int const pose_ind = common::get<0>(pair_indices);
+      int const block_ind1 = common::get<1>(pair_indices);
+      int const block_ind2 = common::get<2>(pair_indices);
 
       // We still kill CTAs targetting non-neighboring block pairs, though,
       // and that can be a lot
@@ -616,7 +674,8 @@ class LKBallPoseScoreDispatch {
           LKBallScoringData<Real>,
           LKBallScoringData<Real>,
           Real,
-          TILE_SIZE>(
+          TILE_SIZE,
+          pair_mode>(
           shared,
           pose_ind,
           rot_ind1,
@@ -674,8 +733,8 @@ class LKBallPoseScoreDispatch {
             scratch_rot_neighbors,
             max_dis);
     // 3 Only the forward pass in this calculation
-    DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
-        mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
+    launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
+        mgr, n_poses, max_n_blocks, eval_energies_by_block);
 
     return {output_t, scratch_rot_neighbors_t};
   }
@@ -775,17 +834,19 @@ class LKBallPoseScoreDispatch {
     LAUNCH_BOX_32_OCC(16);
     // Define nt and reduce_t
     CTA_REAL_REDUCE_T_TYPEDEF;
-    int const max_n_upper_triangle_inds =
-        (max_n_blocks * (max_n_blocks + 1)) / 2;
-
-    auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
-      int const pose_ind = cta / max_n_upper_triangle_inds;
-      int const block_ind_pair = cta % max_n_upper_triangle_inds;
-
-      auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
-          block_ind_pair, max_n_blocks + 1);
-      int const block_ind1 = common::get<0>(upper_triangle_ind);
-      int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
+    auto eval_derivs = ([=] TMOL_DEVICE_FUNC(
+#ifdef __NVCC__
+                            int cta, auto pair_mode_tag) {
+      constexpr auto pair_mode = decltype(pair_mode_tag)::value;
+#else
+                            int cta) {
+      constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
+#endif
+      auto pair_indices =
+          lk_ball_pose_pair_indices<pair_mode>(cta, max_n_blocks);
+      int const pose_ind = common::get<0>(pair_indices);
+      int const block_ind1 = common::get<1>(pair_indices);
+      int const block_ind2 = common::get<2>(pair_indices);
 
       // Reject empty work before setting up the derivative machinery below.
       if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
@@ -954,7 +1015,8 @@ class LKBallPoseScoreDispatch {
           LKBallScoringData<Real>,
           LKBallScoringData<Real>,
           Real,
-          TILE_SIZE>(
+          TILE_SIZE,
+          pair_mode>(
           shared,
           pose_ind,
           rot_ind1,
@@ -979,10 +1041,33 @@ class LKBallPoseScoreDispatch {
           store_calculated_energies);
     });
 
-    // Since we have the sphere overlap results from the forward pass,
-    // there's only a single kernel launch here
-    DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
-        mgr, n_poses, max_n_upper_triangle_inds, eval_derivs);
+    // Large, spatially sparse pose stacks can contain far more candidate
+    // block pairs than neighboring pairs.  A CTA for every candidate then
+    // spends most of the launch scheduling budget only checking a zero in the
+    // neighbor matrix.  Keep a sufficiently large resident grid and let each
+    // warp stride over candidates instead.  Unlike compacting the matrix with
+    // a prefix scan, this has no device-to-host synchronization and is safe to
+    // capture in a CUDA graph.
+#ifdef __NVCC__
+    int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+    int const n_candidate_pairs = n_poses * n_pairs;
+    constexpr int max_persistent_workgroups = 1 << 14;
+    int const n_workgroups = n_candidate_pairs < max_persistent_workgroups
+                                 ? n_candidate_pairs
+                                 : max_persistent_workgroups;
+    auto eval_derivs_strided = ([=] TMOL_DEVICE_FUNC(int cta) {
+      for (int workgroup = cta; workgroup < n_candidate_pairs;
+           workgroup += n_workgroups) {
+        eval_derivs(
+            workgroup, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
+      }
+    });
+    DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
+        mgr, n_workgroups, eval_derivs_strided);
+#else
+    launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
+        mgr, n_poses, max_n_blocks, eval_derivs);
+#endif
 
     return {dV_d_pose_coords_t, dV_d_water_coords_t};
   }

--- a/tmol/score/na_torsion/_na_torsion_energy_term.py
+++ b/tmol/score/na_torsion/_na_torsion_energy_term.py
@@ -133,6 +133,11 @@ class NaTorsionEnergyTerm(EnergyTerm):
     def pose_score_term_is_invariant_zero(self, pose_stack):
         return not self._pose_has_na(pose_stack)
 
+    def block_pair_score_term_is_invariant_zero_off_diagonal(self, pose_stack):
+        # The torsions may read atoms from a bonded neighbour, but their energy
+        # is attributed to the nucleotide's diagonal block-pair entry.
+        return True
+
     def get_score_term_attributes(self, pose_stack):
         p = self.params
         has_na = self._pose_has_na(pose_stack)
@@ -173,6 +178,25 @@ class NaTorsionEnergyTerm(EnergyTerm):
             p.pucker_temperature,
             p.bin_blend_sdev,
         ]
+
+    def get_rotamer_score_term_attributes(self, pose_stack, rotamer_set):
+        """Resolve candidate torsion atom indices once when rendering."""
+        pbt = pose_stack.packed_block_types
+        indices = _rotamer_indices(
+            rotamer_set.block_type_ind_for_rot,
+            rotamer_set.pose_for_rot,
+            rotamer_set.block_ind_for_rot,
+            rotamer_set.coord_offset_for_rot,
+            rotamer_set.rot_offset_for_block,
+            rotamer_set.first_rot_block_type,
+            pose_stack.inter_residue_connections,
+            pbt.atom_downstream_of_conn,
+            pbt.na_torsion_base,
+            pbt.na_torsion_uaids,
+            pbt.na_torsion_ring,
+            pbt.na_torsion_down,
+        )
+        return [*self.get_score_term_attributes(pose_stack), *indices]
 
 
 def _resolve_uaids(
@@ -290,6 +314,37 @@ def eval_na_torsion_for_pose(
             (n_poses, max_n_blocks), dtype=rot_coords.dtype, device=rot_coords.device
         )
         return _finish((zero, zero), output_block_pair_energies)
+
+    if rot_coords.is_cuda and not output_block_pair_energies:
+        from .potentials import na_torsion_pose_score
+
+        return na_torsion_pose_score(
+            rot_coords,
+            pose_base,
+            pose_is_na,
+            pose_torsion_indices,
+            pose_torsion_ok,
+            pose_ring_indices,
+            pose_ring_ok,
+            pose_prev,
+            backbone_means,
+            backbone_sdev,
+            sugar_means,
+            chi_means,
+            sdev_sugar,
+            sdev_chi,
+            well_pucker,
+            well_alpha_gamma,
+            well_bibii_pucker,
+            well_alphanext_bibii,
+            well_chi_syn,
+            is_north,
+            weight_bb,
+            weight_chi,
+            weight_sugar,
+            pucker_temperature,
+            bin_blend_sdev,
+        )
 
     e_bb, e_chi, e_sugar, e_well = _pose_subterms(
         rot_coords,
@@ -678,6 +733,68 @@ def _resolve_rotamer_uaids(
     return rot_coord_offset.to(torch.int64)[rot] + local, ok
 
 
+def _rotamer_indices(
+    block_type_ind_for_rot,
+    pose_ind_for_rot,
+    block_ind_for_rot,
+    rot_coord_offset,
+    first_rot_for_block,
+    first_rot_block_type,
+    inter_residue_connections,
+    atom_downstream_of_conn,
+    bt_base,
+    bt_uaids,
+    bt_ring,
+    bt_down,
+):
+    """Resolve immutable candidate atom indices for rotamer/search scoring."""
+    bt = block_type_ind_for_rot.to(torch.int64)
+    bt_safe = bt.clamp_min(0)
+    base = torch.where(bt >= 0, bt_base.to(torch.int64)[bt_safe], -1)
+    pose = pose_ind_for_rot.to(torch.int64)
+    block = block_ind_for_rot.to(torch.int64)
+
+    torsion_indices, atom_ok = _resolve_rotamer_uaids(
+        bt_uaids[bt_safe],
+        pose,
+        block,
+        rot_coord_offset,
+        first_rot_for_block,
+        first_rot_block_type,
+        inter_residue_connections,
+        atom_downstream_of_conn,
+    )
+    is_na = base >= 0
+    torsion_ok = atom_ok.all(-1) & is_na.unsqueeze(-1)
+
+    ring_local = bt_ring.to(torch.int64)[bt_safe]
+    ring_ok = (ring_local >= 0) & is_na.unsqueeze(-1)
+    ring_indices = rot_coord_offset.to(torch.int64).unsqueeze(-1) + ring_local
+
+    # A candidate's beta term reads the BI/BII state of the preceding
+    # nucleotide from that block's first (background) rotamer.
+    down = bt_down.to(torch.int64)[bt_safe]
+    prev_block = inter_residue_connections.to(torch.int64)[
+        pose, block, down.clamp_min(0), 0
+    ]
+    has_prev = (down >= 0) & (prev_block >= 0)
+    prev = torch.where(
+        has_prev,
+        first_rot_for_block.to(torch.int64)[pose, prev_block.clamp_min(0)],
+        torch.full_like(prev_block, -1),
+    )
+    return (
+        base,
+        is_na,
+        torsion_indices,
+        atom_ok,
+        torsion_ok,
+        ring_indices,
+        ring_ok,
+        prev,
+    )
+
+
 def eval_na_torsion_for_rotamers(
     # common args
     rot_coords,
@@ -726,6 +843,14 @@ def eval_na_torsion_for_rotamers(
     weight_bb,
     weight_chi,
     weight_sugar,
+    rotamer_base,
+    rotamer_is_na,
+    rotamer_torsion_indices,
+    rotamer_atom_ok,
+    rotamer_torsion_ok,
+    rotamer_ring_indices,
+    rotamer_ring_ok,
+    rotamer_prev,
     output_block_pair_energies: bool,
 ):
     device = rot_coords.device
@@ -736,79 +861,77 @@ def eval_na_torsion_for_rotamers(
     if not has_na:
         score = torch.zeros((2, n_rots), dtype=dtype, device=device)
     else:
-        bt = block_type_ind_for_rot.to(torch.int64)
-        base = torch.where(bt >= 0, bt_base.to(torch.int64)[bt.clamp_min(0)], -1)
-        pose = pose_ind_for_rot.to(torch.int64)
-        block = block_ind_for_rot.to(torch.int64)
-        bt_safe = bt.clamp_min(0)
+        base = rotamer_base
+        is_na = rotamer_is_na
+        if rot_coords.is_cuda and not rot_coords.requires_grad:
+            from .potentials import na_torsion_pose_score
 
-        index, ok = _resolve_rotamer_uaids(
-            bt_uaids[bt_safe],
-            pose,
-            block,
-            rot_coord_offset,
-            first_rot_for_block,
-            first_rot_block_type,
-            inter_residue_connections,
-            atom_downstream_of_conn,
-        )
-        is_na = base >= 0
-        tor_ok = ok.all(-1) & is_na.unsqueeze(-1)
+            score = na_torsion_pose_score(
+                rot_coords,
+                base.unsqueeze(1),
+                is_na.unsqueeze(1),
+                rotamer_torsion_indices.unsqueeze(1),
+                rotamer_torsion_ok.unsqueeze(1),
+                rotamer_ring_indices.unsqueeze(1),
+                rotamer_ring_ok.unsqueeze(1),
+                rotamer_prev.unsqueeze(1),
+                backbone_means,
+                backbone_sdev,
+                sugar_means,
+                chi_means,
+                sdev_sugar,
+                sdev_chi,
+                well_pucker,
+                well_alpha_gamma,
+                well_bibii_pucker,
+                well_alphanext_bibii,
+                well_chi_syn,
+                is_north,
+                weight_bb,
+                weight_chi,
+                weight_sugar,
+                pucker_temperature,
+                bin_blend_sdev,
+            )[0]
+        else:
 
-        def gather_coords(index, ok):
-            xyz = rot_coords[index.clamp_min(0).reshape(-1)].reshape(*index.shape, 3)
-            return torch.where(ok.unsqueeze(-1), xyz, torch.zeros_like(xyz))
+            def gather_coords(index, ok):
+                xyz = rot_coords[index.clamp_min(0).reshape(-1)].reshape(
+                    *index.shape, 3
+                )
+                return torch.where(ok.unsqueeze(-1), xyz, torch.zeros_like(xyz))
 
-        xyz = gather_coords(index, ok)
-
-        ring_local = bt_ring.to(torch.int64)[bt_safe]
-        ring_ok = (ring_local >= 0) & is_na.unsqueeze(-1)
-        ring_xyz = gather_coords(
-            rot_coord_offset.to(torch.int64).unsqueeze(-1) + ring_local, ring_ok
-        )
-
-        # the preceding nucleotide is never itself a rotamer being built, so
-        # beta reads the BI/BII state off that block's background rotamer
-        down = bt_down.to(torch.int64)[bt_safe]
-        prev_block = inter_residue_connections.to(torch.int64)[
-            pose, block, down.clamp_min(0), 0
-        ]
-        has_prev = (down >= 0) & (prev_block >= 0)
-        prev = torch.where(
-            has_prev,
-            first_rot_for_block.to(torch.int64)[pose, prev_block.clamp_min(0)],
-            torch.full_like(prev_block, -1),
-        )
-
-        e_bb, e_chi, e_sugar, e_well = _subterm_energies(
-            xyz,
-            tor_ok,
-            ring_xyz,
-            base,
-            prev,
-            backbone_means,
-            backbone_sdev,
-            sugar_means,
-            chi_means,
-            sdev_sugar,
-            sdev_chi,
-            well_pucker,
-            well_alpha_gamma,
-            well_bibii_pucker,
-            well_alphanext_bibii,
-            well_chi_syn,
-            is_north,
-            pucker_temperature,
-            bin_blend_sdev,
-        )
-        poly = polymer_index(base)
-        harmonic = (
-            weight_bb[poly] * e_bb
-            + weight_chi[poly] * e_chi
-            + weight_sugar[poly] * e_sugar
-        )
-        score = torch.stack([harmonic, e_well])
-        score = torch.where(is_na.unsqueeze(0), score, torch.zeros_like(score))
+            xyz = gather_coords(rotamer_torsion_indices, rotamer_atom_ok)
+            ring_xyz = gather_coords(rotamer_ring_indices, rotamer_ring_ok)
+            e_bb, e_chi, e_sugar, e_well = _subterm_energies(
+                xyz,
+                rotamer_torsion_ok,
+                ring_xyz,
+                base,
+                rotamer_prev,
+                backbone_means,
+                backbone_sdev,
+                sugar_means,
+                chi_means,
+                sdev_sugar,
+                sdev_chi,
+                well_pucker,
+                well_alpha_gamma,
+                well_bibii_pucker,
+                well_alphanext_bibii,
+                well_chi_syn,
+                is_north,
+                pucker_temperature,
+                bin_blend_sdev,
+            )
+            poly = polymer_index(base)
+            harmonic = (
+                weight_bb[poly] * e_bb
+                + weight_chi[poly] * e_chi
+                + weight_sugar[poly] * e_sugar
+            )
+            score = torch.stack([harmonic, e_well])
+            score = torch.where(is_na.unsqueeze(0), score, torch.zeros_like(score))
 
     if output_block_pair_energies:
         # a one-body term: each energy sits on the diagonal of the rotamer pair

--- a/tmol/score/na_torsion/potentials/__init__.py
+++ b/tmol/score/na_torsion/potentials/__init__.py
@@ -1,0 +1,3 @@
+"""Compiled nucleic-acid torsion potentials."""
+
+from ._compiled import na_torsion_pose_score  # noqa: F401

--- a/tmol/score/na_torsion/potentials/_compiled.py
+++ b/tmol/score/na_torsion/potentials/_compiled.py
@@ -1,0 +1,10 @@
+from tmol._load_ext import load_ops
+
+_ops = load_ops(
+    __name__,
+    __file__,
+    ["compiled.ops.cpp", "na_torsion_pose_score.cuda.cu"],
+    "tmol_na_torsion",
+)
+
+na_torsion_pose_score = _ops.na_torsion_pose_score

--- a/tmol/score/na_torsion/potentials/compiled.ops.cpp
+++ b/tmol/score/na_torsion/potentials/compiled.ops.cpp
@@ -1,0 +1,174 @@
+#include <torch/library.h>
+
+#ifdef WITH_CUDA
+#include <torch/torch.h>
+
+#include "na_torsion_pose_score.hh"
+#endif
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+#ifdef WITH_CUDA
+using torch::Tensor;
+using torch::autograd::AutogradContext;
+using torch::autograd::Function;
+using torch::autograd::tensor_list;
+
+class NaTorsionPoseScoreOp
+    : public torch::autograd::Function<NaTorsionPoseScoreOp> {
+ public:
+  static std::vector<Tensor> forward(
+      AutogradContext* ctx,
+      Tensor coords,
+      Tensor base,
+      Tensor is_na,
+      Tensor torsion_indices,
+      Tensor torsion_ok,
+      Tensor ring_indices,
+      Tensor ring_ok,
+      Tensor prev,
+      Tensor backbone_means,
+      Tensor backbone_sdev,
+      Tensor sugar_means,
+      Tensor chi_means,
+      Tensor sdev_sugar,
+      Tensor sdev_chi,
+      Tensor well_pucker,
+      Tensor well_alpha_gamma,
+      Tensor well_bibii_pucker,
+      Tensor well_alphanext_bibii,
+      Tensor well_chi_syn,
+      Tensor is_north,
+      Tensor weight_bb,
+      Tensor weight_chi,
+      Tensor weight_sugar,
+      double pucker_temperature,
+      double bin_blend_sdev) {
+    auto result = na_torsion_pose_score_cuda(
+        coords,
+        base,
+        is_na,
+        torsion_indices,
+        torsion_ok,
+        ring_indices,
+        ring_ok,
+        prev,
+        backbone_means,
+        backbone_sdev,
+        sugar_means,
+        chi_means,
+        sdev_sugar,
+        sdev_chi,
+        well_pucker,
+        well_alpha_gamma,
+        well_bibii_pucker,
+        well_alphanext_bibii,
+        well_chi_syn,
+        is_north,
+        weight_bb,
+        weight_chi,
+        weight_sugar,
+        pucker_temperature,
+        bin_blend_sdev,
+        coords.requires_grad());
+    auto score = std::get<0>(result);
+    auto derivatives = std::get<1>(result);
+    ctx->save_for_backward({derivatives});
+    ctx->mark_non_differentiable({derivatives});
+    return {score, derivatives};
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    auto saved = ctx->get_saved_variables();
+    auto grad_coords =
+        na_torsion_pose_score_backward_cuda(saved[0], grad_outputs[0]);
+    return {
+        grad_coords, Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(),
+        Tensor(),    Tensor(), Tensor(), Tensor(),
+    };
+  }
+};
+
+std::tuple<Tensor, Tensor> na_torsion_pose_score(
+    Tensor coords,
+    Tensor base,
+    Tensor is_na,
+    Tensor torsion_indices,
+    Tensor torsion_ok,
+    Tensor ring_indices,
+    Tensor ring_ok,
+    Tensor prev,
+    Tensor backbone_means,
+    Tensor backbone_sdev,
+    Tensor sugar_means,
+    Tensor chi_means,
+    Tensor sdev_sugar,
+    Tensor sdev_chi,
+    Tensor well_pucker,
+    Tensor well_alpha_gamma,
+    Tensor well_bibii_pucker,
+    Tensor well_alphanext_bibii,
+    Tensor well_chi_syn,
+    Tensor is_north,
+    Tensor weight_bb,
+    Tensor weight_chi,
+    Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev) {
+  auto result = NaTorsionPoseScoreOp::apply(
+      coords,
+      base,
+      is_na,
+      torsion_indices,
+      torsion_ok,
+      ring_indices,
+      ring_ok,
+      prev,
+      backbone_means,
+      backbone_sdev,
+      sugar_means,
+      chi_means,
+      sdev_sugar,
+      sdev_chi,
+      well_pucker,
+      well_alpha_gamma,
+      well_bibii_pucker,
+      well_alphanext_bibii,
+      well_chi_syn,
+      is_north,
+      weight_bb,
+      weight_chi,
+      weight_sugar,
+      pucker_temperature,
+      bin_blend_sdev);
+  return {result[0], result[1]};
+}
+#endif
+
+TORCH_LIBRARY(tmol_na_torsion, m) {
+#ifdef WITH_CUDA
+  m.def("na_torsion_pose_score", &na_torsion_pose_score);
+#else
+  m.def(
+      "na_torsion_pose_score("
+      "Tensor coords, Tensor base, Tensor is_na, Tensor torsion_indices, "
+      "Tensor torsion_ok, Tensor ring_indices, Tensor ring_ok, Tensor prev, "
+      "Tensor backbone_means, Tensor backbone_sdev, Tensor sugar_means, "
+      "Tensor chi_means, Tensor sdev_sugar, Tensor sdev_chi, "
+      "Tensor well_pucker, Tensor well_alpha_gamma, "
+      "Tensor well_bibii_pucker, Tensor well_alphanext_bibii, "
+      "Tensor well_chi_syn, Tensor is_north, Tensor weight_bb, "
+      "Tensor weight_chi, Tensor weight_sugar, float pucker_temperature, "
+      "float bin_blend_sdev) -> (Tensor, Tensor)");
+#endif
+}
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
+++ b/tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
@@ -1,0 +1,1129 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+
+#include <cmath>
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+constexpr int N_TORSION = 10;
+constexpr int N_PUCKER = 10;
+constexpr int ALPHA = 0;
+constexpr int BETA = 1;
+constexpr int GAMMA = 2;
+constexpr int DELTA = 3;
+constexpr int EPSILON = 4;
+constexpr int ZETA = 5;
+constexpr int CHI = 9;
+
+template <typename Real>
+struct Vec3 {
+  Real x, y, z;
+};
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator+(Vec3<Real> a, Vec3<Real> b) {
+  return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator-(Vec3<Real> a, Vec3<Real> b) {
+  return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> operator*(Vec3<Real> a, Real s) {
+  return {a.x * s, a.y * s, a.z * s};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real>& operator+=(Vec3<Real>& a, Vec3<Real> b) {
+  a.x += b.x;
+  a.y += b.y;
+  a.z += b.z;
+  return a;
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real>& operator-=(Vec3<Real>& a, Vec3<Real> b) {
+  a.x -= b.x;
+  a.y -= b.y;
+  a.z -= b.z;
+  return a;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real dot(Vec3<Real> a, Vec3<Real> b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real norm(Vec3<Real> value) {
+  return sqrt(dot(value, value));
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> cross(Vec3<Real> a, Vec3<Real> b) {
+  return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> unit(Vec3<Real> value) {
+  Real magnitude = norm(value);
+  Real inv = Real(1) / (magnitude > Real(1e-9) ? magnitude : Real(1e-9));
+  return value * inv;
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> reverse_unit(
+    Vec3<Real> value, Vec3<Real> normalized, Vec3<Real> d_normalized) {
+  Real magnitude = norm(value);
+  if (magnitude <= Real(1e-9)) return d_normalized * Real(1e9);
+  return (d_normalized - normalized * dot(normalized, d_normalized))
+         * (Real(1) / magnitude);
+}
+
+template <typename Real>
+__device__ __forceinline__ Vec3<Real> load_coord(
+    Real const* coords, int64_t atom) {
+  Real const* xyz = coords + atom * 3;
+  return {xyz[0], xyz[1], xyz[2]};
+}
+
+template <typename Real>
+__device__ __forceinline__ Real mod360(Real angle) {
+  angle = fmod(angle, Real(360));
+  return angle < Real(0) ? angle + Real(360) : angle;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real wrap_degrees(Real angle) {
+  return mod360(angle + Real(180)) - Real(180);
+}
+
+template <typename Real>
+__device__ __forceinline__ Real sigmoid(Real value) {
+  return Real(1) / (Real(1) + exp(-value));
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+dihedral_degrees(Vec3<Real> p0, Vec3<Real> p1, Vec3<Real> p2, Vec3<Real> p3) {
+  Vec3<Real> b0 = p0 - p1;
+  Vec3<Real> b1 = unit(p2 - p1);
+  Vec3<Real> b2 = p3 - p2;
+  Vec3<Real> v = b0 - b1 * dot(b0, b1);
+  Vec3<Real> w = b2 - b1 * dot(b2, b1);
+  Real y = dot(cross(b1, v), w);
+  Real x = dot(v, w);
+  return mod360(atan2(y, x) * Real(180.0 / 3.14159265358979323846));
+}
+
+template <typename Real>
+__device__ __forceinline__ Real torsion_angle(
+    Real const* coords,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int flat_block,
+    int torsion) {
+  if (!torsion_ok[flat_block * N_TORSION + torsion]) return Real(0);
+  int offset = (flat_block * N_TORSION + torsion) * 4;
+  return dihedral_degrees(
+      load_coord(coords, torsion_indices[offset]),
+      load_coord(coords, torsion_indices[offset + 1]),
+      load_coord(coords, torsion_indices[offset + 2]),
+      load_coord(coords, torsion_indices[offset + 3]));
+}
+
+template <typename Real>
+__device__ __forceinline__ void pucker_weights(
+    Real const* coords,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int flat_block,
+    Real temperature,
+    Real* pucker) {
+  Vec3<Real> ring[5];
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    ring[atom] = ring_ok[offset] ? load_coord(coords, ring_indices[offset])
+                                 : Vec3<Real>{Real(0), Real(0), Real(0)};
+  }
+
+  Real plane[5];
+  Real exxo[5];
+  Real min_plane = Real(1e20);
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Vec3<Real> a0 = ring[rotation];
+    Vec3<Real> a1 = ring[(rotation + 1) % 5];
+    Vec3<Real> a2 = ring[(rotation + 2) % 5];
+    Vec3<Real> a3 = ring[(rotation + 3) % 5];
+    Vec3<Real> a4 = ring[(rotation + 4) % 5];
+    Vec3<Real> normal = unit(cross(a1 - a0, a2 - a1));
+    plane[rotation] = abs(dot(normal, unit(a3 - a2)));
+    exxo[rotation] = dot(normal, unit(a4 - (a3 + a0) * Real(0.5)));
+    min_plane = plane[rotation] < min_plane ? plane[rotation] : min_plane;
+  }
+
+  Real rotation_weight[5];
+  Real weight_sum = Real(0);
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    rotation_weight[rotation] =
+        exp(-(plane[rotation] - min_plane) / temperature);
+    weight_sum += rotation_weight[rotation];
+  }
+
+  constexpr int slot[10] = {9, 0, 6, 2, 8, 4, 5, 1, 7, 3};
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Real weight = rotation_weight[rotation] / weight_sum;
+    Real endo = sigmoid(Real(-2) * exxo[rotation] / temperature);
+    pucker[slot[rotation]] = weight * endo;
+    pucker[slot[rotation + 5]] = weight * (Real(1) - endo);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ void triple_bin_weights(
+    Real angle, Real const* means, Real sdev, Real* weights) {
+  Real total = Real(0);
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    weights[bin] = exp(-dev * dev / (Real(2) * sdev * sdev));
+    total += weights[bin];
+  }
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) weights[bin] /= total;
+}
+
+template <typename Real>
+__device__ __forceinline__ void triple_bin_weights_deriv(
+    Real angle,
+    Real const* means,
+    Real sdev,
+    Real* weights,
+    Real* derivatives) {
+  triple_bin_weights(angle, means, sdev, weights);
+  Real mean_log_deriv = Real(0);
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    derivatives[bin] = -dev / (sdev * sdev);
+    mean_log_deriv += weights[bin] * derivatives[bin];
+  }
+#pragma unroll
+  for (int bin = 0; bin < 3; ++bin) {
+    derivatives[bin] = weights[bin] * (derivatives[bin] - mean_log_deriv);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+blended_devsq(Real angle, Real const* means, Real const* weights, int n_bins) {
+  Real value = Real(0);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    value += weights[bin] * dev * dev;
+  }
+  return value;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real blended_devsq_deriv(
+    Real angle,
+    Real const* means,
+    Real const* weights,
+    Real const* weight_derivatives,
+    int n_bins) {
+  Real derivative = Real(0);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    Real dev = wrap_degrees(angle - means[bin]);
+    derivative +=
+        weight_derivatives[bin] * dev * dev + Real(2) * weights[bin] * dev;
+  }
+  return derivative;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real
+bi_bii_weight_deriv(Real epsilon, Real zeta, Real weight) {
+  constexpr Real rad = Real(3.14159265358979323846 / 180.0);
+  Real delta = wrap_degrees(epsilon - zeta) * rad;
+  return weight * (Real(1) - weight) * Real(-40) * cos(delta) * rad;
+}
+
+template <typename Real>
+__device__ __forceinline__ Real syn_weight_deriv(Real chi, Real& weight) {
+  Real wrapped = mod360(chi);
+  Real lower = sigmoid((wrapped - Real(20)) / Real(5));
+  Real upper = sigmoid((Real(100) - wrapped) / Real(5));
+  weight = lower * upper;
+  return lower * (Real(1) - lower) * upper / Real(5)
+         - lower * upper * (Real(1) - upper) / Real(5);
+}
+
+template <typename Real>
+struct DihedralDeriv {
+  Vec3<Real> atom[4];
+};
+
+template <typename Real>
+__device__ __forceinline__ DihedralDeriv<Real> dihedral_deriv(
+    Vec3<Real> i, Vec3<Real> j, Vec3<Real> k, Vec3<Real> l) {
+  Vec3<Real> f = i - j;
+  Vec3<Real> g = j - k;
+  Vec3<Real> h = l - k;
+  Vec3<Real> a = cross(f, g);
+  Vec3<Real> b = cross(h, g);
+  Real a2 = dot(a, a);
+  Real b2 = dot(b, b);
+  Real gnorm = norm(g);
+  Real fg = dot(f, g);
+  Real hg = dot(h, g);
+  DihedralDeriv<Real> result;
+  result.atom[0] = a * (-gnorm / a2);
+  result.atom[1] =
+      a * (gnorm / a2 + fg / (a2 * gnorm)) - b * (hg / (b2 * gnorm));
+  result.atom[2] =
+      b * (-gnorm / b2 + hg / (b2 * gnorm)) - a * (fg / (a2 * gnorm));
+  result.atom[3] = b * (gnorm / b2);
+  return result;
+}
+
+template <typename Real>
+__device__ __forceinline__ void add_torsion_gradient(
+    Real const* coords,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int flat_block,
+    int torsion,
+    Real harmonic_deriv,
+    Real well_deriv,
+    int n_atoms,
+    Real* derivatives) {
+  if (!torsion_ok[flat_block * N_TORSION + torsion]) return;
+  int offset = (flat_block * N_TORSION + torsion) * 4;
+  int64_t atom[4];
+  Vec3<Real> xyz[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    atom[i] = torsion_indices[offset + i];
+    xyz[i] = load_coord(coords, atom[i]);
+  }
+  auto d_angle = dihedral_deriv(xyz[0], xyz[1], xyz[2], xyz[3]);
+  constexpr Real degrees_per_radian = Real(180.0 / 3.14159265358979323846);
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    int64_t coord = atom[i] * 3;
+    Vec3<Real> d = d_angle.atom[i] * degrees_per_radian;
+    atomicAdd(derivatives + coord, harmonic_deriv * d.x);
+    atomicAdd(derivatives + coord + 1, harmonic_deriv * d.y);
+    atomicAdd(derivatives + coord + 2, harmonic_deriv * d.z);
+    atomicAdd(derivatives + n_atoms * 3 + coord, well_deriv * d.x);
+    atomicAdd(derivatives + n_atoms * 3 + coord + 1, well_deriv * d.y);
+    atomicAdd(derivatives + n_atoms * 3 + coord + 2, well_deriv * d.z);
+  }
+}
+
+template <typename Real>
+__device__ __forceinline__ void add_pucker_gradient(
+    Real const* coords,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int flat_block,
+    Real temperature,
+    Real const* pucker,
+    Real const d_energy_dpucker[2][N_PUCKER],
+    int n_atoms,
+    Real* derivatives) {
+  constexpr int slot[N_PUCKER] = {9, 0, 6, 2, 8, 4, 5, 1, 7, 3};
+  Vec3<Real> ring[5];
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    ring[atom] = ring_ok[offset] ? load_coord(coords, ring_indices[offset])
+                                 : Vec3<Real>{Real(0), Real(0), Real(0)};
+  }
+
+  Real mean_coeff[2] = {Real(0), Real(0)};
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    Real endo = pucker[slot[rotation]];
+    Real exo = pucker[slot[rotation + 5]];
+    Real weight = endo + exo;
+    Real p_endo = endo / weight;
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real coeff =
+          p_endo * d_energy_dpucker[score][slot[rotation]]
+          + (Real(1) - p_endo) * d_energy_dpucker[score][slot[rotation + 5]];
+      mean_coeff[score] += weight * coeff;
+    }
+  }
+
+  Vec3<Real> ring_gradient[2][5];
+#pragma unroll
+  for (int score = 0; score < 2; ++score) {
+#pragma unroll
+    for (int atom = 0; atom < 5; ++atom) {
+      ring_gradient[score][atom] = {Real(0), Real(0), Real(0)};
+    }
+  }
+
+#pragma unroll
+  for (int rotation = 0; rotation < 5; ++rotation) {
+    int i0 = rotation;
+    int i1 = (rotation + 1) % 5;
+    int i2 = (rotation + 2) % 5;
+    int i3 = (rotation + 3) % 5;
+    int i4 = (rotation + 4) % 5;
+    Vec3<Real> u = ring[i1] - ring[i0];
+    Vec3<Real> v = ring[i2] - ring[i1];
+    Vec3<Real> c = cross(u, v);
+    Vec3<Real> n = unit(c);
+    Vec3<Real> edge = ring[i3] - ring[i2];
+    Vec3<Real> m = unit(edge);
+    Real q = dot(n, m);
+    Vec3<Real> apex = ring[i4] - (ring[i3] + ring[i0]) * Real(0.5);
+    Vec3<Real> h = unit(apex);
+    Real exxo = dot(n, h);
+    Real endo = pucker[slot[rotation]];
+    Real exo = pucker[slot[rotation + 5]];
+    Real weight = endo + exo;
+    Real p_endo = endo / weight;
+
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real endo_coeff = d_energy_dpucker[score][slot[rotation]];
+      Real exo_coeff = d_energy_dpucker[score][slot[rotation + 5]];
+      Real coeff = p_endo * endo_coeff + (Real(1) - p_endo) * exo_coeff;
+      Real d_plane = -weight * (coeff - mean_coeff[score]) / temperature;
+      Real d_exxo = weight * (endo_coeff - exo_coeff) * p_endo
+                    * (Real(1) - p_endo) * Real(-2) / temperature;
+      Real abs_deriv =
+          q > Real(0) ? Real(1) : (q < Real(0) ? Real(-1) : Real(0));
+      Real d_q = d_plane * abs_deriv;
+
+      Vec3<Real> d_n = m * d_q + h * d_exxo;
+      Vec3<Real> d_m = n * d_q;
+      Vec3<Real> d_h = n * d_exxo;
+      Vec3<Real> d_c = reverse_unit(c, n, d_n);
+      Vec3<Real> d_u = cross(v, d_c);
+      Vec3<Real> d_v = cross(d_c, u);
+      Vec3<Real> d_edge = reverse_unit(edge, m, d_m);
+      Vec3<Real> d_apex = reverse_unit(apex, h, d_h);
+
+      ring_gradient[score][i0] -= d_u + d_apex * Real(0.5);
+      ring_gradient[score][i1] += d_u - d_v;
+      ring_gradient[score][i2] += d_v - d_edge;
+      ring_gradient[score][i3] += d_edge - d_apex * Real(0.5);
+      ring_gradient[score][i4] += d_apex;
+    }
+  }
+
+#pragma unroll
+  for (int atom = 0; atom < 5; ++atom) {
+    int offset = flat_block * 5 + atom;
+    if (!ring_ok[offset]) continue;
+    int64_t coord = ring_indices[offset] * 3;
+#pragma unroll
+    for (int score = 0; score < 2; ++score) {
+      Real* out = derivatives + score * n_atoms * 3 + coord;
+      atomicAdd(out, ring_gradient[score][atom].x);
+      atomicAdd(out + 1, ring_gradient[score][atom].y);
+      atomicAdd(out + 2, ring_gradient[score][atom].z);
+    }
+  }
+}
+
+template <typename Real>
+__global__ void na_torsion_forward_kernel(
+    Real const* coords,
+    int64_t const* base,
+    bool const* is_na,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int64_t const* prev,
+    Real const* backbone_means,
+    Real const* backbone_sdev,
+    Real const* sugar_means,
+    Real const* chi_means,
+    Real const* sdev_sugar,
+    Real const* sdev_chi,
+    Real const* well_pucker,
+    Real const* well_alpha_gamma,
+    Real const* well_bibii_pucker,
+    Real const* well_alphanext_bibii,
+    Real const* well_chi_syn,
+    bool const* is_north,
+    Real const* weight_bb,
+    Real const* weight_chi,
+    Real const* weight_sugar,
+    Real pucker_temperature,
+    Real bin_blend_sdev,
+    int n_poses,
+    int max_n_blocks,
+    Real* output) {
+  int flat_block = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_blocks = n_poses * max_n_blocks;
+  if (flat_block >= n_blocks || !is_na[flat_block]) return;
+
+  int pose = flat_block / max_n_blocks;
+  int base_ind = int(base[flat_block]);
+  int polymer = base_ind >> 2;
+  Real torsion[N_TORSION];
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    torsion[tor] =
+        torsion_angle(coords, torsion_indices, torsion_ok, flat_block, tor);
+  }
+  Real pucker[N_PUCKER];
+  pucker_weights(
+      coords, ring_indices, ring_ok, flat_block, pucker_temperature, pucker);
+
+  Real const* means = backbone_means + polymer * 6 * 3;
+  Real const* sdev_bb = backbone_sdev + polymer * 6;
+  Real zero = Real(0);
+  Real e_bb = zero;
+  Real alpha_w[3], gamma_w[3];
+  triple_bin_weights(
+      torsion[ALPHA], means + ALPHA * 3, bin_blend_sdev, alpha_w);
+  triple_bin_weights(
+      torsion[GAMMA], means + GAMMA * 3, bin_blend_sdev, gamma_w);
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    e_bb += blended_devsq(torsion[ALPHA], means + ALPHA * 3, alpha_w, 3)
+            / (sdev_bb[ALPHA] * sdev_bb[ALPHA]);
+  }
+  if (torsion_ok[flat_block * N_TORSION + GAMMA]) {
+    e_bb += blended_devsq(torsion[GAMMA], means + GAMMA * 3, gamma_w, 3)
+            / (sdev_bb[GAMMA] * sdev_bb[GAMMA]);
+  }
+
+  bool both = torsion_ok[flat_block * N_TORSION + EPSILON]
+              && torsion_ok[flat_block * N_TORSION + ZETA];
+  Real w_bi = sigmoid(
+      Real(-40)
+      * sin(
+          wrap_degrees(torsion[EPSILON] - torsion[ZETA])
+          * Real(3.14159265358979323846 / 180.0)));
+  Real bibii_w[2] = {w_bi, Real(1) - w_bi};
+  if (both) {
+    for (int tor = EPSILON; tor <= ZETA; ++tor) {
+      e_bb += blended_devsq(torsion[tor], means + tor * 3, bibii_w, 2)
+              / (sdev_bb[tor] * sdev_bb[tor]);
+    }
+  }
+
+  int prev_block = int(prev[flat_block]);
+  bool prev_ok = prev_block >= 0 && torsion_ok[prev_block * N_TORSION + EPSILON]
+                 && torsion_ok[prev_block * N_TORSION + ZETA];
+  Real w_beta = Real(1);
+  if (prev_ok) {
+    Real prev_epsilon =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, EPSILON);
+    Real prev_zeta =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, ZETA);
+    w_beta = sigmoid(
+        Real(-40)
+        * sin(
+            wrap_degrees(prev_epsilon - prev_zeta)
+            * Real(3.14159265358979323846 / 180.0)));
+  }
+  Real beta_w[2] = {w_beta, Real(1) - w_beta};
+  if (torsion_ok[flat_block * N_TORSION + BETA]) {
+    e_bb += blended_devsq(torsion[BETA], means + BETA * 3, beta_w, 2)
+            / (sdev_bb[BETA] * sdev_bb[BETA]);
+  }
+
+  Real chi = torsion[CHI];
+  Real chi_mod = mod360(chi);
+  Real w_syn = sigmoid((chi_mod - Real(20)) / Real(5))
+               * sigmoid((Real(100) - chi_mod) / Real(5));
+  Real e_chi = zero;
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real dev_syn = wrap_degrees(chi - Real(50));
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(chi - chi_means[base_ind * N_PUCKER + puck]);
+      e_chi += pucker[puck]
+               * ((Real(1) - w_syn) * dev * dev + w_syn * dev_syn * dev_syn);
+    }
+    e_chi /= sdev_chi[polymer] * sdev_chi[polymer];
+  }
+
+  constexpr int sugar_torsion[4] = {DELTA, 6, 7, 8};
+  Real e_sugar = zero;
+#pragma unroll
+  for (int slot = 0; slot < 4; ++slot) {
+    int tor = sugar_torsion[slot];
+    if (!torsion_ok[flat_block * N_TORSION + tor]) continue;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(
+          torsion[tor] - sugar_means[(polymer * N_PUCKER + puck) * 4 + slot]);
+      e_sugar += pucker[puck] * dev * dev;
+    }
+  }
+  e_sugar /= sdev_sugar[polymer] * sdev_sugar[polymer];
+
+  Real e_well = zero;
+#pragma unroll
+  for (int puck = 0; puck < N_PUCKER; ++puck) {
+    e_well += pucker[puck] * well_pucker[polymer * N_PUCKER + puck];
+  }
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]
+      && torsion_ok[flat_block * N_TORSION + GAMMA]) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int g = 0; g < 3; ++g) {
+        e_well += alpha_w[a] * well_alpha_gamma[(polymer * 3 + a) * 3 + g]
+                  * gamma_w[g];
+      }
+    }
+  }
+  if (both) {
+    Real north = zero;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) north += pucker[puck];
+    }
+    Real ns[2] = {north, Real(1) - north};
+#pragma unroll
+    for (int bi = 0; bi < 2; ++bi) {
+#pragma unroll
+      for (int state = 0; state < 2; ++state) {
+        e_well += bibii_w[bi]
+                  * well_bibii_pucker[(polymer * 2 + bi) * 2 + state]
+                  * ns[state];
+      }
+    }
+  }
+  if (prev_ok && torsion_ok[flat_block * N_TORSION + ALPHA]) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int bi = 0; bi < 2; ++bi) {
+        e_well += alpha_w[a] * well_alphanext_bibii[(polymer * 3 + a) * 2 + bi]
+                  * beta_w[bi];
+      }
+    }
+  }
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+#pragma unroll
+    for (int syn = 0; syn < 2; ++syn) {
+      Real syn_w = syn == 0 ? Real(1) - w_syn : w_syn;
+#pragma unroll
+      for (int puck = 0; puck < N_PUCKER; ++puck) {
+        e_well += syn_w * well_chi_syn[(syn * N_PUCKER + puck) * 8 + base_ind]
+                  * pucker[puck];
+      }
+    }
+  }
+
+  Real harmonic = weight_bb[polymer] * e_bb + weight_chi[polymer] * e_chi
+                  + weight_sugar[polymer] * e_sugar;
+  atomicAdd(output + pose, harmonic);
+  atomicAdd(output + n_poses + pose, e_well);
+}
+
+template <typename Real>
+// The gradient path accumulates the two energies while their shared torsion,
+// pucker, and bin intermediates are live, avoiding a separate forward kernel.
+__global__ void na_torsion_derivative_kernel(
+    Real const* coords,
+    int64_t const* base,
+    bool const* is_na,
+    int64_t const* torsion_indices,
+    bool const* torsion_ok,
+    int64_t const* ring_indices,
+    bool const* ring_ok,
+    int64_t const* prev,
+    Real const* backbone_means,
+    Real const* backbone_sdev,
+    Real const* sugar_means,
+    Real const* chi_means,
+    Real const* sdev_sugar,
+    Real const* sdev_chi,
+    Real const* well_pucker,
+    Real const* well_alpha_gamma,
+    Real const* well_bibii_pucker,
+    Real const* well_alphanext_bibii,
+    Real const* well_chi_syn,
+    bool const* is_north,
+    Real const* weight_bb,
+    Real const* weight_chi,
+    Real const* weight_sugar,
+    Real pucker_temperature,
+    Real bin_blend_sdev,
+    int n_poses,
+    int max_n_blocks,
+    int n_atoms,
+    Real* derivatives,
+    Real* output) {
+  int flat_block = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_blocks = n_poses * max_n_blocks;
+  if (flat_block >= n_blocks || !is_na[flat_block]) return;
+
+  int pose = flat_block / max_n_blocks;
+  int base_ind = int(base[flat_block]);
+  int polymer = base_ind >> 2;
+  Real torsion[N_TORSION];
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    torsion[tor] =
+        torsion_angle(coords, torsion_indices, torsion_ok, flat_block, tor);
+  }
+  Real pucker[N_PUCKER];
+  pucker_weights(
+      coords, ring_indices, ring_ok, flat_block, pucker_temperature, pucker);
+
+  Real d_angle[2][N_TORSION] = {};
+  Real d_pucker[2][N_PUCKER] = {};
+  Real d_prev[2][2] = {};
+  Real energy[2] = {};
+  Real const* means = backbone_means + polymer * 6 * 3;
+  Real const* sdev_bb = backbone_sdev + polymer * 6;
+  Real bb_weight = weight_bb[polymer];
+  Real chi_weight = weight_chi[polymer];
+  Real sugar_weight = weight_sugar[polymer];
+
+  Real alpha_w[3], alpha_dw[3], gamma_w[3], gamma_dw[3];
+  triple_bin_weights_deriv(
+      torsion[ALPHA], means + ALPHA * 3, bin_blend_sdev, alpha_w, alpha_dw);
+  triple_bin_weights_deriv(
+      torsion[GAMMA], means + GAMMA * 3, bin_blend_sdev, gamma_w, gamma_dw);
+  if (torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    Real inv_var = Real(1) / (sdev_bb[ALPHA] * sdev_bb[ALPHA]);
+    energy[0] += bb_weight
+                 * blended_devsq(torsion[ALPHA], means + ALPHA * 3, alpha_w, 3)
+                 * inv_var;
+    d_angle[0][ALPHA] +=
+        bb_weight
+        * blended_devsq_deriv(
+            torsion[ALPHA], means + ALPHA * 3, alpha_w, alpha_dw, 3)
+        * inv_var;
+  }
+  if (torsion_ok[flat_block * N_TORSION + GAMMA]) {
+    Real inv_var = Real(1) / (sdev_bb[GAMMA] * sdev_bb[GAMMA]);
+    energy[0] += bb_weight
+                 * blended_devsq(torsion[GAMMA], means + GAMMA * 3, gamma_w, 3)
+                 * inv_var;
+    d_angle[0][GAMMA] +=
+        bb_weight
+        * blended_devsq_deriv(
+            torsion[GAMMA], means + GAMMA * 3, gamma_w, gamma_dw, 3)
+        * inv_var;
+  }
+
+  bool both = torsion_ok[flat_block * N_TORSION + EPSILON]
+              && torsion_ok[flat_block * N_TORSION + ZETA];
+  Real w_bi = sigmoid(
+      Real(-40)
+      * sin(
+          wrap_degrees(torsion[EPSILON] - torsion[ZETA])
+          * Real(3.14159265358979323846 / 180.0)));
+  Real dw_bi = bi_bii_weight_deriv(torsion[EPSILON], torsion[ZETA], w_bi);
+  if (both) {
+    Real weight_derivative = Real(0);
+    for (int tor = EPSILON; tor <= ZETA; ++tor) {
+      Real dev_bi = wrap_degrees(torsion[tor] - means[tor * 3]);
+      Real dev_bii = wrap_degrees(torsion[tor] - means[tor * 3 + 1]);
+      Real inv_var = Real(1) / (sdev_bb[tor] * sdev_bb[tor]);
+      energy[0] +=
+          bb_weight
+          * (w_bi * dev_bi * dev_bi + (Real(1) - w_bi) * dev_bii * dev_bii)
+          * inv_var;
+      d_angle[0][tor] += bb_weight * Real(2)
+                         * (w_bi * dev_bi + (Real(1) - w_bi) * dev_bii)
+                         * inv_var;
+      weight_derivative += (dev_bi * dev_bi - dev_bii * dev_bii) * inv_var;
+    }
+    d_angle[0][EPSILON] += bb_weight * weight_derivative * dw_bi;
+    d_angle[0][ZETA] -= bb_weight * weight_derivative * dw_bi;
+  }
+
+  int prev_block = int(prev[flat_block]);
+  bool prev_ok = prev_block >= 0 && torsion_ok[prev_block * N_TORSION + EPSILON]
+                 && torsion_ok[prev_block * N_TORSION + ZETA];
+  Real prev_w_bi = Real(1);
+  Real prev_dw_bi = Real(0);
+  if (prev_ok) {
+    Real prev_epsilon =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, EPSILON);
+    Real prev_zeta =
+        torsion_angle(coords, torsion_indices, torsion_ok, prev_block, ZETA);
+    prev_w_bi = sigmoid(
+        Real(-40)
+        * sin(
+            wrap_degrees(prev_epsilon - prev_zeta)
+            * Real(3.14159265358979323846 / 180.0)));
+    prev_dw_bi = bi_bii_weight_deriv(prev_epsilon, prev_zeta, prev_w_bi);
+  }
+  if (torsion_ok[flat_block * N_TORSION + BETA]) {
+    Real dev_bi = wrap_degrees(torsion[BETA] - means[BETA * 3]);
+    Real dev_bii = wrap_degrees(torsion[BETA] - means[BETA * 3 + 1]);
+    Real inv_var = Real(1) / (sdev_bb[BETA] * sdev_bb[BETA]);
+    energy[0] += bb_weight
+                 * (prev_w_bi * dev_bi * dev_bi
+                    + (Real(1) - prev_w_bi) * dev_bii * dev_bii)
+                 * inv_var;
+    d_angle[0][BETA] += bb_weight * Real(2)
+                        * (prev_w_bi * dev_bi + (Real(1) - prev_w_bi) * dev_bii)
+                        * inv_var;
+    if (prev_ok) {
+      Real through_weight = bb_weight * (dev_bi * dev_bi - dev_bii * dev_bii)
+                            * inv_var * prev_dw_bi;
+      d_prev[0][0] += through_weight;
+      d_prev[0][1] -= through_weight;
+    }
+  }
+
+  Real w_syn;
+  Real dw_syn = syn_weight_deriv(torsion[CHI], w_syn);
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real dev_syn = wrap_degrees(torsion[CHI] - Real(50));
+    Real inv_var = Real(1) / (sdev_chi[polymer] * sdev_chi[polymer]);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev =
+          wrap_degrees(torsion[CHI] - chi_means[base_ind * N_PUCKER + puck]);
+      Real coeff =
+          ((Real(1) - w_syn) * dev * dev + w_syn * dev_syn * dev_syn) * inv_var;
+      energy[0] += chi_weight * pucker[puck] * coeff;
+      d_pucker[0][puck] += chi_weight * coeff;
+      d_angle[0][CHI] +=
+          chi_weight * pucker[puck]
+          * (Real(2) * ((Real(1) - w_syn) * dev + w_syn * dev_syn)
+             + dw_syn * (dev_syn * dev_syn - dev * dev))
+          * inv_var;
+    }
+  }
+
+  constexpr int sugar_torsion[4] = {DELTA, 6, 7, 8};
+  Real sugar_inv_var = Real(1) / (sdev_sugar[polymer] * sdev_sugar[polymer]);
+#pragma unroll
+  for (int slot = 0; slot < 4; ++slot) {
+    int tor = sugar_torsion[slot];
+    if (!torsion_ok[flat_block * N_TORSION + tor]) continue;
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real dev = wrap_degrees(
+          torsion[tor] - sugar_means[(polymer * N_PUCKER + puck) * 4 + slot]);
+      energy[0] += sugar_weight * pucker[puck] * dev * dev * sugar_inv_var;
+      d_pucker[0][puck] += sugar_weight * dev * dev * sugar_inv_var;
+      d_angle[0][tor] +=
+          sugar_weight * pucker[puck] * Real(2) * dev * sugar_inv_var;
+    }
+  }
+
+#pragma unroll
+  for (int puck = 0; puck < N_PUCKER; ++puck) {
+    Real well = well_pucker[polymer * N_PUCKER + puck];
+    energy[1] += pucker[puck] * well;
+    d_pucker[1][puck] += well;
+  }
+
+  bool alpha_gamma_ok = torsion_ok[flat_block * N_TORSION + ALPHA]
+                        && torsion_ok[flat_block * N_TORSION + GAMMA];
+  if (alpha_gamma_ok) {
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+#pragma unroll
+      for (int g = 0; g < 3; ++g) {
+        Real table = well_alpha_gamma[(polymer * 3 + a) * 3 + g];
+        energy[1] += alpha_w[a] * table * gamma_w[g];
+        d_angle[1][ALPHA] += alpha_dw[a] * table * gamma_w[g];
+        d_angle[1][GAMMA] += alpha_w[a] * table * gamma_dw[g];
+      }
+    }
+  }
+
+  if (both) {
+    Real north = Real(0);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) north += pucker[puck];
+    }
+    Real ns[2] = {north, Real(1) - north};
+    Real state_value[2] = {Real(0), Real(0)};
+    Real weight_derivative = Real(0);
+#pragma unroll
+    for (int state = 0; state < 2; ++state) {
+      Real bi = well_bibii_pucker[(polymer * 2) * 2 + state];
+      Real bii = well_bibii_pucker[(polymer * 2 + 1) * 2 + state];
+      state_value[state] = w_bi * bi + (Real(1) - w_bi) * bii;
+      energy[1] += ns[state] * state_value[state];
+      weight_derivative += ns[state] * (bi - bii);
+    }
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      if (is_north[puck]) {
+        d_pucker[1][puck] += state_value[0] - state_value[1];
+      }
+    }
+    d_angle[1][EPSILON] += weight_derivative * dw_bi;
+    d_angle[1][ZETA] -= weight_derivative * dw_bi;
+  }
+
+  if (prev_ok && torsion_ok[flat_block * N_TORSION + ALPHA]) {
+    Real prev_weight_derivative = Real(0);
+#pragma unroll
+    for (int a = 0; a < 3; ++a) {
+      Real bi = well_alphanext_bibii[(polymer * 3 + a) * 2];
+      Real bii = well_alphanext_bibii[(polymer * 3 + a) * 2 + 1];
+      Real state_value = prev_w_bi * bi + (Real(1) - prev_w_bi) * bii;
+      energy[1] += alpha_w[a] * state_value;
+      d_angle[1][ALPHA] += alpha_dw[a] * state_value;
+      prev_weight_derivative += alpha_w[a] * (bi - bii);
+    }
+    Real through_weight = prev_weight_derivative * prev_dw_bi;
+    d_prev[1][0] += through_weight;
+    d_prev[1][1] -= through_weight;
+  }
+
+  if (torsion_ok[flat_block * N_TORSION + CHI]) {
+    Real chi_weight_derivative = Real(0);
+#pragma unroll
+    for (int puck = 0; puck < N_PUCKER; ++puck) {
+      Real anti = well_chi_syn[puck * 8 + base_ind];
+      Real syn = well_chi_syn[(N_PUCKER + puck) * 8 + base_ind];
+      Real state_value = (Real(1) - w_syn) * anti + w_syn * syn;
+      energy[1] += pucker[puck] * state_value;
+      d_pucker[1][puck] += state_value;
+      chi_weight_derivative += pucker[puck] * (syn - anti);
+    }
+    d_angle[1][CHI] += dw_syn * chi_weight_derivative;
+  }
+
+  atomicAdd(output + pose, energy[0]);
+  atomicAdd(output + n_poses + pose, energy[1]);
+
+#pragma unroll
+  for (int tor = 0; tor < N_TORSION; ++tor) {
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        flat_block,
+        tor,
+        d_angle[0][tor],
+        d_angle[1][tor],
+        n_atoms,
+        derivatives);
+  }
+  if (prev_ok) {
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        prev_block,
+        EPSILON,
+        d_prev[0][0],
+        d_prev[1][0],
+        n_atoms,
+        derivatives);
+    add_torsion_gradient(
+        coords,
+        torsion_indices,
+        torsion_ok,
+        prev_block,
+        ZETA,
+        d_prev[0][1],
+        d_prev[1][1],
+        n_atoms,
+        derivatives);
+  }
+  add_pucker_gradient(
+      coords,
+      ring_indices,
+      ring_ok,
+      flat_block,
+      pucker_temperature,
+      pucker,
+      d_pucker,
+      n_atoms,
+      derivatives);
+}
+
+std::tuple<at::Tensor, at::Tensor> na_torsion_pose_score_cuda(
+    at::Tensor coords,
+    at::Tensor base,
+    at::Tensor is_na,
+    at::Tensor torsion_indices,
+    at::Tensor torsion_ok,
+    at::Tensor ring_indices,
+    at::Tensor ring_ok,
+    at::Tensor prev,
+    at::Tensor backbone_means,
+    at::Tensor backbone_sdev,
+    at::Tensor sugar_means,
+    at::Tensor chi_means,
+    at::Tensor sdev_sugar,
+    at::Tensor sdev_chi,
+    at::Tensor well_pucker,
+    at::Tensor well_alpha_gamma,
+    at::Tensor well_bibii_pucker,
+    at::Tensor well_alphanext_bibii,
+    at::Tensor well_chi_syn,
+    at::Tensor is_north,
+    at::Tensor weight_bb,
+    at::Tensor weight_chi,
+    at::Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev,
+    bool compute_derivs) {
+  TORCH_CHECK(coords.is_cuda(), "na_torsion_pose_score requires CUDA tensors");
+  TORCH_CHECK(coords.is_contiguous(), "coords must be contiguous");
+  int n_poses = int(base.size(0));
+  int max_n_blocks = int(base.size(1));
+  auto output = at::zeros({2, n_poses}, coords.options());
+  auto derivatives = compute_derivs
+                         ? at::zeros({2, coords.size(0), 3}, coords.options())
+                         : at::empty({0}, coords.options());
+  c10::cuda::CUDAGuard guard(coords.device());
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int threads = 128;
+  int blocks = (n_poses * max_n_blocks + threads - 1) / threads;
+  AT_DISPATCH_FLOATING_TYPES(
+      coords.scalar_type(), "na_torsion_pose_score_cuda", [&] {
+        if (!compute_derivs) {
+          na_torsion_forward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+              coords.const_data_ptr<scalar_t>(),
+              base.const_data_ptr<int64_t>(),
+              is_na.const_data_ptr<bool>(),
+              torsion_indices.const_data_ptr<int64_t>(),
+              torsion_ok.const_data_ptr<bool>(),
+              ring_indices.const_data_ptr<int64_t>(),
+              ring_ok.const_data_ptr<bool>(),
+              prev.const_data_ptr<int64_t>(),
+              backbone_means.const_data_ptr<scalar_t>(),
+              backbone_sdev.const_data_ptr<scalar_t>(),
+              sugar_means.const_data_ptr<scalar_t>(),
+              chi_means.const_data_ptr<scalar_t>(),
+              sdev_sugar.const_data_ptr<scalar_t>(),
+              sdev_chi.const_data_ptr<scalar_t>(),
+              well_pucker.const_data_ptr<scalar_t>(),
+              well_alpha_gamma.const_data_ptr<scalar_t>(),
+              well_bibii_pucker.const_data_ptr<scalar_t>(),
+              well_alphanext_bibii.const_data_ptr<scalar_t>(),
+              well_chi_syn.const_data_ptr<scalar_t>(),
+              is_north.const_data_ptr<bool>(),
+              weight_bb.const_data_ptr<scalar_t>(),
+              weight_chi.const_data_ptr<scalar_t>(),
+              weight_sugar.const_data_ptr<scalar_t>(),
+              scalar_t(pucker_temperature),
+              scalar_t(bin_blend_sdev),
+              n_poses,
+              max_n_blocks,
+              output.mutable_data_ptr<scalar_t>());
+        } else {
+          na_torsion_derivative_kernel<scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  coords.const_data_ptr<scalar_t>(),
+                  base.const_data_ptr<int64_t>(),
+                  is_na.const_data_ptr<bool>(),
+                  torsion_indices.const_data_ptr<int64_t>(),
+                  torsion_ok.const_data_ptr<bool>(),
+                  ring_indices.const_data_ptr<int64_t>(),
+                  ring_ok.const_data_ptr<bool>(),
+                  prev.const_data_ptr<int64_t>(),
+                  backbone_means.const_data_ptr<scalar_t>(),
+                  backbone_sdev.const_data_ptr<scalar_t>(),
+                  sugar_means.const_data_ptr<scalar_t>(),
+                  chi_means.const_data_ptr<scalar_t>(),
+                  sdev_sugar.const_data_ptr<scalar_t>(),
+                  sdev_chi.const_data_ptr<scalar_t>(),
+                  well_pucker.const_data_ptr<scalar_t>(),
+                  well_alpha_gamma.const_data_ptr<scalar_t>(),
+                  well_bibii_pucker.const_data_ptr<scalar_t>(),
+                  well_alphanext_bibii.const_data_ptr<scalar_t>(),
+                  well_chi_syn.const_data_ptr<scalar_t>(),
+                  is_north.const_data_ptr<bool>(),
+                  weight_bb.const_data_ptr<scalar_t>(),
+                  weight_chi.const_data_ptr<scalar_t>(),
+                  weight_sugar.const_data_ptr<scalar_t>(),
+                  scalar_t(pucker_temperature),
+                  scalar_t(bin_blend_sdev),
+                  n_poses,
+                  max_n_blocks,
+                  int(coords.size(0)),
+                  derivatives.mutable_data_ptr<scalar_t>(),
+                  output.mutable_data_ptr<scalar_t>());
+        }
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {output, derivatives};
+}
+
+template <typename Real>
+__global__ void na_torsion_backward_kernel(
+    Real const* derivatives,
+    Real const* grad_output,
+    int64_t grad_stride_score,
+    int64_t grad_stride_pose,
+    int n_poses,
+    int n_atoms,
+    Real* grad_coords) {
+  int index = blockIdx.x * blockDim.x + threadIdx.x;
+  int n_values = n_atoms * 3;
+  if (index >= n_values) return;
+  int atom = index / 3;
+  int atoms_per_pose = n_atoms / n_poses;
+  int pose = atom / atoms_per_pose;
+  Real grad_harmonic = grad_output[pose * grad_stride_pose];
+  Real grad_well = grad_output[grad_stride_score + pose * grad_stride_pose];
+  grad_coords[index] = grad_harmonic * derivatives[index]
+                       + grad_well * derivatives[n_values + index];
+}
+
+at::Tensor na_torsion_pose_score_backward_cuda(
+    at::Tensor derivatives, at::Tensor grad_output) {
+  TORCH_CHECK(derivatives.is_cuda(), "NA torsion derivatives must be CUDA");
+  TORCH_CHECK(
+      grad_output.is_cuda(), "NA torsion output gradients must be CUDA");
+  TORCH_CHECK(
+      derivatives.dim() == 3 && derivatives.size(0) == 2,
+      "expected derivatives shaped [2, n_atoms, 3]");
+  TORCH_CHECK(
+      grad_output.dim() == 2 && grad_output.size(0) == 2,
+      "expected output gradients shaped [2, n_poses]");
+  int n_poses = int(grad_output.size(1));
+  int n_atoms = int(derivatives.size(1));
+  TORCH_CHECK(n_atoms % n_poses == 0, "atoms must divide evenly among poses");
+  auto grad_coords = at::empty({n_atoms, 3}, derivatives.options());
+  c10::cuda::CUDAGuard guard(derivatives.device());
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int threads = 256;
+  int blocks = (n_atoms * 3 + threads - 1) / threads;
+  AT_DISPATCH_FLOATING_TYPES(
+      derivatives.scalar_type(), "na_torsion_pose_score_backward_cuda", [&] {
+        na_torsion_backward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+            derivatives.const_data_ptr<scalar_t>(),
+            grad_output.const_data_ptr<scalar_t>(),
+            grad_output.stride(0),
+            grad_output.stride(1),
+            n_poses,
+            n_atoms,
+            grad_coords.mutable_data_ptr<scalar_t>());
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return grad_coords;
+}
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/na_torsion/potentials/na_torsion_pose_score.hh
+++ b/tmol/score/na_torsion/potentials/na_torsion_pose_score.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace tmol {
+namespace score {
+namespace na_torsion {
+namespace potentials {
+
+std::tuple<at::Tensor, at::Tensor> na_torsion_pose_score_cuda(
+    at::Tensor coords,
+    at::Tensor base,
+    at::Tensor is_na,
+    at::Tensor torsion_indices,
+    at::Tensor torsion_ok,
+    at::Tensor ring_indices,
+    at::Tensor ring_ok,
+    at::Tensor prev,
+    at::Tensor backbone_means,
+    at::Tensor backbone_sdev,
+    at::Tensor sugar_means,
+    at::Tensor chi_means,
+    at::Tensor sdev_sugar,
+    at::Tensor sdev_chi,
+    at::Tensor well_pucker,
+    at::Tensor well_alpha_gamma,
+    at::Tensor well_bibii_pucker,
+    at::Tensor well_alphanext_bibii,
+    at::Tensor well_chi_syn,
+    at::Tensor is_north,
+    at::Tensor weight_bb,
+    at::Tensor weight_chi,
+    at::Tensor weight_sugar,
+    double pucker_temperature,
+    double bin_blend_sdev,
+    bool compute_derivs);
+
+at::Tensor na_torsion_pose_score_backward_cuda(
+    at::Tensor derivatives, at::Tensor grad_output);
+
+}  // namespace potentials
+}  // namespace na_torsion
+}  // namespace score
+}  // namespace tmol

--- a/tmol/tests/io/test_pose_stack_from_atom37_and_biotite.py
+++ b/tmol/tests/io/test_pose_stack_from_atom37_and_biotite.py
@@ -13,6 +13,7 @@ from tmol.io import (
     canonical_ordering_for_biotite,
     pose_stack_from_atom37_and_biotite,
     pose_stack_from_biotite,
+    prepare_pose_stack_from_atom37,
 )
 from tmol.tests.data import data_path
 
@@ -120,6 +121,130 @@ def test_atom37_pose_supports_protein_dna_and_rna(filename, torch_device):
     assert torch.count_nonzero(atom37.grad) > 0
 
 
+@pytest.mark.parametrize("filename", ["1ubq.pdb", "1bna.pdb", "3zp8.pdb"])
+def test_prepared_atom37_builder_matches_direct_pose(filename, torch_device):
+    structure = _first_residues(_load_structure(data_path("pdb", filename)), 2)
+    structure, atom37 = _atomized_atom37(structure, torch_device, n_poses=2)
+    context = build_context_from_biotite(structure, torch_device)
+
+    expected = pose_stack_from_atom37_and_biotite(
+        atom37, structure, context, no_optH=True
+    )
+    builder = prepare_pose_stack_from_atom37(structure, context)
+    actual = builder(atom37, opt_h=False)
+
+    torch.testing.assert_close(actual.coords, expected.coords)
+    torch.testing.assert_close(actual.block_type_ind, expected.block_type_ind)
+    torch.testing.assert_close(
+        actual.inter_residue_connections, expected.inter_residue_connections
+    )
+
+
+def test_prepared_atom37_builder_is_reusable_and_differentiable(
+    biotite_1ubq, torch_device
+):
+    structure, atom37 = _atomized_atom37(_first_residues(biotite_1ubq, 2), torch_device)
+    context = build_context_from_biotite(structure, torch_device)
+    builder = prepare_pose_stack_from_atom37(structure, context)
+
+    first_coords = atom37.detach().clone().requires_grad_(True)
+    first_pose = builder(first_coords, opt_h=False)
+    assert (
+        next(iter(builder._pose_topologies.values())).pose_stack.coords.grad_fn is None
+    )
+    first_snapshot = first_pose.coords.detach().clone()
+    first_pose.coords[first_pose.real_atoms].sum().backward()
+    assert torch.count_nonzero(first_coords.grad) > 0
+
+    second_coords = atom37.detach().clone()
+    second_coords[:, :, 1] += 1
+    second_coords.requires_grad_(True)
+    second_pose = builder(second_coords, opt_h=False)
+    expected_second = pose_stack_from_atom37_and_biotite(
+        second_coords, structure, context, no_optH=True
+    )
+    torch.testing.assert_close(first_pose.coords, first_snapshot)
+    torch.testing.assert_close(second_pose.coords, expected_second.coords)
+    second_pose.coords[second_pose.real_atoms].sum().backward()
+    assert torch.count_nonzero(second_coords.grad) > 0
+
+    batched_coords = second_coords.detach().expand(2, -1, -1, -1).clone()
+    batched_pose = builder(batched_coords, opt_h=False)
+    expected_batched = pose_stack_from_atom37_and_biotite(
+        batched_coords, structure, context, no_optH=True
+    )
+    torch.testing.assert_close(batched_pose.coords, expected_batched.coords)
+    assert set(builder._pose_topologies) == {1, 2}
+
+    nonfinite_coords = second_coords.detach().clone()
+    nonfinite_coords[:, 0, 1] = torch.nan
+    actual_nonfinite = builder(nonfinite_coords, opt_h=False)
+    expected_nonfinite = pose_stack_from_atom37_and_biotite(
+        nonfinite_coords, structure, context, no_optH=True
+    )
+    torch.testing.assert_close(actual_nonfinite.coords, expected_nonfinite.coords)
+
+    for batch_size in (3, 4, 5):
+        builder(second_coords.detach().expand(batch_size, -1, -1, -1), opt_h=False)
+    assert set(builder._pose_topologies) == {1, 3, 4, 5}
+
+
+@pytest.mark.parametrize("filename", ["1ubq.pdb", "1bna.pdb", "3zp8.pdb"])
+def test_prepared_atom37_builder_preserves_default_opth(filename, torch_device):
+    structure = _first_residues(_load_structure(data_path("pdb", filename)), 2)
+    structure, atom37 = _atomized_atom37(structure, torch_device)
+    context = build_context_from_biotite(structure, torch_device)
+
+    builder = prepare_pose_stack_from_atom37(structure, context)
+    for coords in (atom37, atom37 + torch.randn_like(atom37) * 0.01):
+        coords = coords.detach().requires_grad_(True)
+        torch.manual_seed(0)
+        expected = pose_stack_from_atom37_and_biotite(coords, structure, context)
+        torch.manual_seed(0)
+        actual = builder(coords)
+
+        torch.testing.assert_close(actual.coords, expected.coords)
+        actual.coords[actual.real_atoms].sum().backward()
+        assert torch.count_nonzero(coords.grad) > 0
+
+
+def test_prepared_atom37_builder_falls_back_for_variable_atom_presence(
+    biotite_1ubq, torch_device
+):
+    structure = _first_residues(biotite_1ubq, 2)
+    oxygen = int(np.flatnonzero(structure.atom_name == "O")[0])
+    structure.coord[oxygen] = np.nan
+    structure, atom37 = _atomized_atom37(structure, torch_device)
+    context = build_context_from_biotite(structure, torch_device)
+    builder = prepare_pose_stack_from_atom37(structure, context)
+
+    first = builder(atom37, opt_h=False)
+    second_coords = atom37.clone()
+    second_coords[0, oxygen, 1] = torch.tensor([1.0, 2.0, 3.0], device=torch_device)
+    expected_second = pose_stack_from_atom37_and_biotite(
+        second_coords, structure, context, no_optH=True
+    )
+    actual_second = builder(second_coords, opt_h=False)
+
+    assert torch.isfinite(first.coords[first.real_atoms]).all()
+    assert not builder._topology_cache_safe
+    assert not builder._pose_topologies
+    torch.testing.assert_close(actual_second.coords, expected_second.coords)
+
+
+def test_prepared_atom37_builder_falls_back_for_ambiguous_histidine_hydrogen(
+    biotite_1ubq, torch_device
+):
+    structure = biotite_1ubq[biotite_1ubq.res_name == "HIS"].copy()
+    structure.atom_name[structure.atom_name == "HE2"] = "HN"
+    structure, _ = _atomized_atom37(structure, torch_device)
+    context = build_context_from_biotite(structure, torch_device)
+
+    builder = prepare_pose_stack_from_atom37(structure, context)
+
+    assert not builder._topology_cache_safe
+
+
 def test_atom37_pose_uses_ligand_context(torch_device):
     cif_path = data_path("protein_ligand_test", "cif_inputs", "ace.ligand.cif")
     params_path = data_path("protein_ligand_test", "ace.xtal-lig.mmff94.tmol")
@@ -158,6 +283,23 @@ def test_pose_stack_from_biotite_accepts_atom37_directly(biotite_1ubq, torch_dev
 
     assert pose.n_poses == 1
     assert torch.isfinite(pose.coords[pose.real_atoms]).all()
+
+
+def test_atom37_pose_can_return_atom_mapping(biotite_1ubq, torch_device):
+    structure, atom37 = _atomized_atom37(_first_residues(biotite_1ubq, 1), torch_device)
+    context = build_context_from_biotite(structure, torch_device)
+
+    pose, details = pose_stack_from_atom37_and_biotite(
+        atom37,
+        structure,
+        context,
+        no_optH=True,
+        return_atom_mapping=True,
+    )
+
+    n_real_atoms = int(pose.real_atoms.sum())
+    assert details["can_atom_mapping"].shape[0] == n_real_atoms
+    assert details["ps_atom_mapping"].shape[0] == n_real_atoms
 
 
 def test_atom37_gradients_survive_hydrogen_optimization(biotite_1ubq, torch_device):

--- a/tmol/tests/io/test_pose_stack_from_biotite_context_reuse.py
+++ b/tmol/tests/io/test_pose_stack_from_biotite_context_reuse.py
@@ -98,8 +98,15 @@ def test_context_opth_score_function_omits_invariant_terms(biotite_1ubq, torch_d
     """The lighter OptH scorer preserves its rotamer assignment exactly."""
     context = build_context_from_biotite(biotite_1ubq, torch_device)
     score_function = context._opth_score_function
-    assert score_function.get_weight(ScoreType.rama) == 0
-    assert score_function.get_weight(ScoreType.omega) == 0
+    for score_type in (
+        ScoreType.disulfide,
+        ScoreType.omega,
+        ScoreType.rama,
+        ScoreType.ref,
+        ScoreType.na_torsion,
+        ScoreType.na_torsion_well,
+    ):
+        assert score_function.get_weight(score_type) == 0
     assert score_function.get_weight(ScoreType.hbond) != 0
 
     pose = pose_stack_from_biotite(

--- a/tmol/tests/ligand/test_fragmented_ligand_scoring.py
+++ b/tmol/tests/ligand/test_fragmented_ligand_scoring.py
@@ -296,7 +296,10 @@ def test_fragmentation_uses_ligand_already_in_parameter_database(torch_device):
 
 
 def test_fragmented_ligand_preserves_atom37_routing(torch_device):
-    from tmol.io import pose_stack_from_atom37_and_biotite
+    from tmol.io import (
+        pose_stack_from_atom37_and_biotite,
+        prepare_pose_stack_from_atom37,
+    )
 
     structure, params_path, preparation = _load_fixture()
     annotated = _annotate_at_bridge(structure, preparation)
@@ -320,6 +323,21 @@ def test_fragmented_ligand_preserves_atom37_routing(torch_device):
     assert torch.isfinite(pose.coords[pose.real_atoms]).all()
     pose.coords[pose.real_atoms].sum().backward()
     assert torch.count_nonzero(atom37.grad) > 0
+
+    prepared_coords = atom37.detach().clone().requires_grad_(True)
+    builder = prepare_pose_stack_from_atom37(annotated, context)
+    prepared_pose = builder(prepared_coords, opt_h=False)
+    assert len(prepared_pose.split_block_mapping.entries) == 2
+    prepared_pose.coords[prepared_pose.real_atoms].sum().backward()
+    assert torch.count_nonzero(prepared_coords.grad) > 0
+
+    shifted_coords = atom37.detach().clone()
+    shifted_coords[:, :, 1, 0] += 0.25
+    expected_shifted = pose_stack_from_atom37_and_biotite(
+        shifted_coords, annotated, context, no_optH=True
+    )
+    actual_shifted = builder(shifted_coords, opt_h=False)
+    torch.testing.assert_close(actual_shifted.coords, expected_shifted.coords)
 
 
 def test_fragment_interactions_validate_inputs(torch_device):

--- a/tmol/tests/ligand/test_ligand_entry_paths.py
+++ b/tmol/tests/ligand/test_ligand_entry_paths.py
@@ -119,6 +119,8 @@ def test_tmol_params_roundtrip_and_inject(tmp_path) -> None:
     loaded = load_params_file(tmol_file)
     assert len(loaded) == 1
     assert loaded[0].residue_type.name == prep.residue_type.name
+    loaded[0].partial_charges.clear()
+    assert load_params_file(tmol_file)[0].partial_charges
 
     injected = inject_params_file(ParameterDatabase.get_default(), tmol_file)
     assert any(r.name == prep.residue_type.name for r in injected.chemical.residues)
@@ -136,6 +138,7 @@ def test_tmol_loader_accepts_minor_version_difference(tmp_path) -> None:
     prep = _single_prep()
     tmol_file = tmp_path / "lig.tmol"
     write_params_file([prep], str(tmol_file), format="tmol")
+    load_params_file(tmol_file)
 
     text = tmol_file.read_text().replace('version: "1.0"', 'version: "1.9"')
     assert "1.9" in text

--- a/tmol/tests/ligand/test_ligand_pipeline.py
+++ b/tmol/tests/ligand/test_ligand_pipeline.py
@@ -42,6 +42,16 @@ class TestDetectFromCIF:
         """A pure-protein structure yields no non-standard residues."""
         assert len(detect_nonstandard_residues(biotite_1ubq, canonical_ordering)) == 0
 
+    def test_known_residues_skip_connectivity_scan(
+        self, monkeypatch, biotite_1ubq, canonical_ordering
+    ) -> None:
+        """Known structures do not need the spatial connectivity pass."""
+        monkeypatch.setattr(
+            "tmol.ligand._detect._residue_names_with_cross_residue_bonds",
+            lambda _: pytest.fail("connectivity scan should be skipped"),
+        )
+        assert detect_nonstandard_residues(biotite_1ubq, canonical_ordering) == []
+
     def test_detects_i4b_in_184l(self, cif_184l_with_i4b, canonical_ordering) -> None:
         """The I4B ligand in 184L is detected with coords and CCD type."""
         ligands = detect_nonstandard_residues(cif_184l_with_i4b, canonical_ordering)

--- a/tmol/tests/ligand/test_protein_ligand_ddg.py
+++ b/tmol/tests/ligand/test_protein_ligand_ddg.py
@@ -26,6 +26,7 @@ import torch
 
 PLI_DATA_DIR = data_path("protein_ligand_test")
 LIGAND_RES_NAME = "LG1"
+ROSETTA_DDG_ATOL = 0.11
 
 # Weighted block-pair ddG (beta2016, minimize=False, pack=False, no_optH=True)
 # captured on CPU from fixture CIF + fixture .tmol params.
@@ -58,6 +59,20 @@ _GOLDEN_DDG: dict[str, float] = {
     "tk": -29.913303,
     "vegfr2": 48.350834,
 }
+
+
+def _rosetta_ddg(target: str) -> float:
+    """Read Rosetta's weighted interface score from the checked-in scorefile."""
+    suffix = (
+        "_complex_nometals.sc" if target in {"ace", "ada", "pde5"} else "_complex.sc"
+    )
+    score_lines = [
+        line.split()
+        for line in (PLI_DATA_DIR / f"{target}{suffix}").read_text().splitlines()
+        if line.startswith("SCORE:")
+    ]
+    score_fields = dict(zip(score_lines[0][1:], score_lines[1][1:]))
+    return float(score_fields["dG_total"])
 
 
 def _load_complex_cif(target: str):
@@ -126,7 +141,10 @@ def _weighted_ddg_from_fixtures(target: str, torch_device: torch.device) -> floa
 
 @pytest.mark.parametrize("target", sorted(_GOLDEN_DDG))
 def test_protein_ligand_cif_to_ddg_golden(target: str, torch_device) -> None:
-    """CIF complex + golden .tmol params reproduces pinned weighted ddG."""
+    """CIF complex reproduces pinned tmol and checked-in Rosetta ddG."""
     actual = _weighted_ddg_from_fixtures(target, torch_device)
     expected = _GOLDEN_DDG[target]
     numpy.testing.assert_allclose(actual, expected, rtol=1e-3, atol=1e-3)
+    numpy.testing.assert_allclose(
+        actual, _rosetta_ddg(target), rtol=0, atol=ROSETTA_DDG_ATOL
+    )

--- a/tmol/tests/ops/test_score_utils.py
+++ b/tmol/tests/ops/test_score_utils.py
@@ -127,7 +127,9 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
 
     class ScoreFunction:
         @staticmethod
-        def render_block_pair_scoring_module(_pose):
+        def render_block_pair_scoring_module(_pose, *, interaction_only=False):
+            assert interaction_only
+
             class Scorer:
                 def __init__(self):
                     self.weights = weights
@@ -153,6 +155,32 @@ def test_calculate_ddg_accepts_single_block_indices(torch_device):
         score_utils.calculate_block_pair_ddg(
             Pose(), block_indices.float(), sfxn=ScoreFunction(), minimize=False
         )
+
+
+def test_calculate_ddg_retains_diagonal_terms_for_overlapping_masks(torch_device):
+    class Pose:
+        device = torch_device
+        n_poses = 1
+        block_type_ind = torch.zeros(1, 2, dtype=torch.int32, device=torch_device)
+        coords = torch.empty(1, 0, 3, device=torch_device)
+
+    scores = torch.zeros((1, 1, 2, 2), device=torch_device)
+    scores[0, 0, 0, 0] = 3
+    rendered_modes = []
+
+    class ScoreFunction:
+        @staticmethod
+        def render_block_pair_scoring_module(_pose, *, interaction_only=False):
+            rendered_modes.append(interaction_only)
+            return lambda _coords, sum_terms, apply_weights=True: scores
+
+    mask = torch.tensor([[True, False]], device=torch_device)
+    result = score_utils.calculate_block_pair_ddg(
+        Pose(), mask, mask, sfxn=ScoreFunction(), minimize=False
+    )
+
+    torch.testing.assert_close(result, torch.tensor([3.0], device=torch_device))
+    assert rendered_modes == [False]
 
 
 def test_interacting_coord_mask_matches_per_pose_reference(

--- a/tmol/tests/optimization/test_minimizers.py
+++ b/tmol/tests/optimization/test_minimizers.py
@@ -58,7 +58,11 @@ def test_run_cart_min_smoke(
     wpsm = sfxn.render_whole_pose_scoring_module(pose_stack)
 
     start_score = wpsm(pose_stack.coords)
-    minimized_pose_stack = run_cart_min(pose_stack, sfxn)
+    minimized_pose_stack = run_cart_min(
+        pose_stack,
+        sfxn,
+        cuda_graph=torch_device.type == "cuda",
+    )
     end_score = wpsm(minimized_pose_stack.coords)
 
     assert torch.all(end_score < start_score)

--- a/tmol/tests/optimization/test_scorefunction_minimization.py
+++ b/tmol/tests/optimization/test_scorefunction_minimization.py
@@ -1,5 +1,6 @@
-import torch
+import attr
 import pytest
+import torch
 
 from tmol.io import pose_stack_from_pdb
 from tmol.pose import PoseStackBuilder
@@ -47,6 +48,43 @@ def test_cart_minimize_w_pose_and_sfxn_smoke(ubq_pdb, default_database, torch_de
         cart_sfxn_network.full_coords
     ).sum()
     assert E1 < E0
+
+
+def test_cart_network_reset_reuses_topology_and_updates_weights(
+    ubq_pdb, default_database, torch_device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+    network = CartesianSfxnNetwork(
+        sfxn,
+        pose_stack,
+        cuda_graph=("forward_backward" if torch_device.type == "cuda" else False),
+    )
+
+    # A cloned pose has independent connectivity storage; FastRelax packing
+    # preserves these tensors within a ramp, so only that case is reusable.
+    assert not network._reusable_for(sfxn, pose_stack.clone())
+
+    updated_pose = attr.evolve(pose_stack, coords=pose_stack.coords + 0.01)
+    assert network._reusable_for(sfxn, updated_pose)
+
+    sfxn.set_weight(ScoreType.fa_ljatr, 0.5)
+    assert network._reset(sfxn, updated_pose)
+    actual = network()
+    expected_network = CartesianSfxnNetwork(sfxn, updated_pose)
+    expected = expected_network()
+
+    torch.testing.assert_close(network.full_coords, updated_pose.coords)
+    torch.testing.assert_close(
+        network.whole_pose_scoring_module.weights[:, 0], sfxn.weights_tensor()
+    )
+    torch.testing.assert_close(actual, expected)
+
+    # Adding or removing a term changes the rendered module layout and must
+    # force the caller to build a fresh network.
+    sfxn.set_weight(ScoreType.fa_ljatr, 0.0)
+    assert not network._reset(sfxn, updated_pose)
 
 
 def test_kin_minimize_w_pose_and_sfxn_smoke(ubq_pdb, default_database, torch_device):

--- a/tmol/tests/pack/test_build_missing_sidechains.py
+++ b/tmol/tests/pack/test_build_missing_sidechains.py
@@ -92,7 +92,7 @@ def test_build_missing_sidechains_freezes_complete_non_opth_blocks(
     ubq_pdb, torch_device, dun_sampler, monkeypatch
 ):
     """Do not send chemically immutable blocks through one-rotamer packing."""
-    from tmol.pack.rotamer import OptHSampler
+    from tmol.pack.rotamer import FixedAAChiSampler, OptHSampler
 
     pose_stack = pose_stack_from_pdb_and_resnums(ubq_pdb, torch_device)
     missing = torch.zeros(
@@ -121,5 +121,9 @@ def test_build_missing_sidechains_freezes_complete_non_opth_blocks(
         pose_stack.block_type_ind64.clamp_min(0),
     )
     task = captured["task"]
+    assert dun_sampler not in task.conformer_samplers
+    assert not any(
+        isinstance(sampler, FixedAAChiSampler) for sampler in task.conformer_samplers
+    )
     packable = task.per_block_is_block_type_allowed.any(dim=2) & real
     torch.testing.assert_close(packable, supported)

--- a/tmol/tests/relax/test_fast_relax.py
+++ b/tmol/tests/relax/test_fast_relax.py
@@ -1,9 +1,11 @@
-import torch
+import time
+
 import numpy
 import pytest
+import torch
 
-from tmol.relax import _default_cart_min_fn, fast_relax
-import time
+from tmol.relax import fast_relax
+from tmol.relax._fast_relax import _resolve_cuda_graph_mode
 
 from tmol.pose import (
     PoseStack,
@@ -53,6 +55,25 @@ def get_relax_sfxn(default_database, torch_device):
     sfxn.set_weight(ScoreType.disulfide, 1.0)
 
     return sfxn
+
+
+@pytest.mark.parametrize(
+    "pdb_fixture, expected",
+    [
+        ("ubq_pdb", False),
+        ("dna_pdb", True),
+        ("rna_pdb", True),
+        ("protein_dna_pdb", True),
+    ],
+)
+def test_fast_relax_automatic_graph_mode(request, pdb_fixture, expected, torch_device):
+    pose_stack = pose_stack_from_pdb(request.getfixturevalue(pdb_fixture), torch_device)
+
+    assert _resolve_cuda_graph_mode(pose_stack, None) == (
+        expected and torch_device.type == "cuda"
+    )
+    assert _resolve_cuda_graph_mode(pose_stack, True)
+    assert not _resolve_cuda_graph_mode(pose_stack, False)
 
 
 @pytest.mark.parametrize("n_poses", [1])
@@ -111,8 +132,7 @@ def test_fast_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_
 def test_cart_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_poses):
     """Cartesian fast-relax on ubiquitin using CartesianSfxnNetwork.
 
-    Mirrors test_fast_relax_ubq but swaps the kinematic min_fn for the
-    Cartesian one via _default_cart_min_fn + CartesianMoveMap.
+    Exercise the default Cartesian minimizer with CUDA graph capture.
     """
     if torch_device == torch.device("cpu"):
         pytest.skip("CUDA only test")
@@ -146,7 +166,7 @@ def test_cart_relax_ubq(default_database, ubq_pdb, dun_sampler, torch_device, n_
         cart_mm,
         fold_forest,
         task_operations=[task_op],
-        min_fn=_default_cart_min_fn,
+        cuda_graph=True,
         num_repeats=1,
         verbose=verbose,
     )

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -2,6 +2,7 @@ import numpy
 import torch
 
 from tmol.io import pose_stack_from_pdb
+from tmol.pose import PoseStackBuilder
 from tmol.score.lk_ball import LKBallEnergyTerm
 
 from tmol.tests.score.common import EnergyTermTestBase
@@ -54,6 +55,8 @@ def test_whole_pose_scoring_module_smoke(ubq_pdb, default_database, torch_device
     )
     lk_ball_energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
     p1 = pose_stack_from_pdb(ubq_pdb, torch_device)
+    if torch_device.type == "cuda":
+        p1 = PoseStackBuilder.from_poses([p1] * 30, torch_device)
     for bt in p1.packed_block_types.active_block_types:
         lk_ball_energy.setup_block_type(bt)
     lk_ball_energy.setup_packed_block_types(p1.packed_block_types)
@@ -66,8 +69,9 @@ def test_whole_pose_scoring_module_smoke(ubq_pdb, default_database, torch_device
 
     # make sure we're still good
     torch.arange(100, device=torch_device)
+    expected = numpy.repeat(gold_vals, scores.shape[1], axis=1)
     numpy.testing.assert_allclose(
-        gold_vals, scores.cpu().detach().numpy(), atol=1e-3, rtol=1e-3
+        expected, scores.cpu().detach().numpy(), atol=1e-3, rtol=1e-3
     )
 
 

--- a/tmol/tests/score/na_torsion/test_na_torsion_energy_term.py
+++ b/tmol/tests/score/na_torsion/test_na_torsion_energy_term.py
@@ -10,6 +10,8 @@ from tmol.score.na_torsion import (
     polymer_index,
     wrap_degrees,
 )
+from tmol.score.na_torsion._na_torsion_energy_term import _pose_subterms
+from tmol.score.common import ZeroTermPoseScoringModule
 
 
 def _term_and_pose(pdb, torch_device):
@@ -25,6 +27,20 @@ def _term_and_pose(pdb, torch_device):
 def test_smoke(default_database, torch_device):
     term = NaTorsionEnergyTerm(param_db=default_database, device=torch_device)
     assert term.device == torch_device
+
+
+def test_interaction_only_omits_diagonal_na_torsions(dna_pdb, torch_device):
+    term, pose_stack = _term_and_pose(dna_pdb, torch_device)
+
+    scorer = term.render_block_pair_scoring_module(pose_stack, interaction_only=True)
+
+    assert isinstance(scorer, ZeroTermPoseScoringModule)
+    assert scorer(pose_stack.coords).shape == (
+        2,
+        pose_stack.n_poses,
+        pose_stack.max_n_blocks,
+        pose_stack.max_n_blocks,
+    )
 
 
 @pytest.mark.parametrize(
@@ -101,6 +117,151 @@ def _subterms(term, ps):
     )
 
 
+def _native_pose_scores(term, ps, coords):
+    from tmol.score.na_torsion.potentials import na_torsion_pose_score
+
+    p = term.params
+    return na_torsion_pose_score(
+        coords.flatten(0, -2),
+        *ps.na_torsion_pose_params,
+        p.backbone_means,
+        p.backbone_sdev,
+        p.sugar_means,
+        p.chi_means,
+        p.sdev_sugar,
+        p.sdev_chi,
+        p.well_pucker,
+        p.well_alpha_gamma,
+        p.well_bibii_pucker,
+        p.well_alphanext_bibii,
+        p.well_chi_syn,
+        p.is_north,
+        p.weight_bb,
+        p.weight_chi,
+        p.weight_sugar,
+        p.pucker_temperature,
+        p.bin_blend_sdev,
+    )[0]
+
+
+def _reference_pose_scores(term, ps, coords):
+    p = term.params
+    bb, chi, sugar, well = _pose_subterms(
+        coords.flatten(0, -2),
+        *ps.na_torsion_pose_params,
+        p.backbone_means,
+        p.backbone_sdev,
+        p.sugar_means,
+        p.chi_means,
+        p.sdev_sugar,
+        p.sdev_chi,
+        p.well_pucker,
+        p.well_alpha_gamma,
+        p.well_bibii_pucker,
+        p.well_alphanext_bibii,
+        p.well_chi_syn,
+        p.is_north,
+        p.pucker_temperature,
+        p.bin_blend_sdev,
+    )
+    poly = polymer_index(ps.na_torsion_pose_params[0])
+    harmonic = p.weight_bb[poly] * bb + p.weight_chi[poly] * chi
+    harmonic = harmonic + p.weight_sugar[poly] * sugar
+    mask = ps.na_torsion_pose_params[1]
+    zero = torch.zeros_like(harmonic)
+    return torch.stack(
+        [
+            torch.where(mask, harmonic, zero).sum(dim=1),
+            torch.where(mask, well, zero).sum(dim=1),
+        ]
+    )
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+@pytest.mark.parametrize("n_poses", [1, 3])
+def test_native_cuda_pose_scores_match_reference(
+    n_poses, fixture, request, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("native NA torsion scoring is CUDA-only")
+
+    from tmol.pose import PoseStackBuilder
+
+    term, ps1 = _term_and_pose(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * n_poses, torch_device)
+    term.setup_packed_block_types(ps.packed_block_types)
+    term.setup_poses(ps)
+
+    expected = _reference_pose_scores(term, ps, ps.coords)
+    actual = _native_pose_scores(term, ps, ps.coords)
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-3)
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+@pytest.mark.parametrize("n_poses", [1, 3])
+def test_native_cuda_pose_gradients_match_reference(
+    n_poses, fixture, request, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("native NA torsion scoring is CUDA-only")
+
+    from tmol.pose import PoseStackBuilder
+
+    term, ps1 = _term_and_pose(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * n_poses, torch_device)
+    term.setup_packed_block_types(ps.packed_block_types)
+    term.setup_poses(ps)
+    reference_coords = ps.coords.detach().clone().requires_grad_(True)
+    native_coords = ps.coords.detach().clone().requires_grad_(True)
+    reference = _reference_pose_scores(term, ps, reference_coords)
+    native = _native_pose_scores(term, ps, native_coords)
+    output_weights = torch.linspace(
+        -1.2,
+        0.7,
+        2 * n_poses,
+        dtype=ps.coords.dtype,
+        device=torch_device,
+    ).reshape(2, n_poses)
+    (reference_grad,) = torch.autograd.grad(
+        torch.sum(reference * output_weights), reference_coords
+    )
+    (native_grad,) = torch.autograd.grad(
+        torch.sum(native * output_weights), native_coords
+    )
+
+    torch.testing.assert_close(native, reference, rtol=2e-5, atol=2e-3)
+    torch.testing.assert_close(native_grad, reference_grad, rtol=5e-4, atol=5e-2)
+
+
+@pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb", "protein_dna_pdb"])
+def test_native_cuda_pose_scoring_is_graph_capture_safe(
+    fixture, request, default_database, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA graph capture requires CUDA")
+
+    from tmol.pose import PoseStackBuilder
+    from tmol.score import ScoreFunction
+
+    ps1 = pose_stack_from_pdb(request.getfixturevalue(fixture), torch_device)
+    ps = PoseStackBuilder.from_poses([ps1] * 3, torch_device)
+    sfxn = ScoreFunction(default_database, torch_device)
+    for score_type in NaTorsionEnergyTerm.score_types():
+        sfxn.set_weight(score_type, 1.0)
+
+    eager = sfxn.render_whole_pose_scoring_module(ps)
+    graphed = sfxn.render_whole_pose_scoring_module(ps, cuda_graph="both")
+    eager_coords = ps.coords.detach().clone().requires_grad_(True)
+    graph_coords = ps.coords.detach().clone().requires_grad_(True)
+    eager_score = eager(eager_coords)
+    graph_score = graphed(graph_coords)
+    (eager_grad,) = torch.autograd.grad(eager_score.sum(), eager_coords)
+    (graph_grad,) = torch.autograd.grad(graph_score.sum(), graph_coords)
+
+    torch.testing.assert_close(graph_score, eager_score)
+    torch.testing.assert_close(graph_grad, eager_grad)
+
+
 @pytest.mark.parametrize("fixture", ["dna_pdb", "rna_pdb"])
 def test_subterms_sum_to_the_totals(fixture, request, torch_device):
     term, ps = _term_and_pose(request.getfixturevalue(fixture), torch_device)
@@ -144,11 +305,19 @@ def test_rotamer_energies_match_the_pose_energies(protein_dna_pdb, torch_device)
         ps, SetPackerTask.from_packer_task(task), ps.packed_block_types.chem_db
     )
 
-    per_rot = (
-        sfxn.render_rotamer_scoring_module(ps, rotamer_set)(rotamer_set.coords)
-        .coalesce()
-        .to_dense()
-    )
+    rotamer_scorer = sfxn.render_rotamer_scoring_module(ps, rotamer_set)
+    per_rot_sparse = rotamer_scorer(rotamer_set.coords).coalesce()
+    if torch_device.type == "cuda":
+        # Requiring coordinate gradients selects the eager reference path;
+        # ordinary search/packing inference uses the native CUDA row kernel.
+        eager = rotamer_scorer(
+            rotamer_set.coords.detach().clone().requires_grad_(True)
+        ).coalesce()
+        torch.testing.assert_close(per_rot_sparse.indices(), eager.indices())
+        torch.testing.assert_close(
+            per_rot_sparse.values(), eager.values(), rtol=2e-5, atol=2e-3
+        )
+    per_rot = per_rot_sparse.to_dense()
     per_block = sfxn.render_block_pair_scoring_module(ps)(ps.coords)
 
     pose = rotamer_set.pose_for_rot.to(torch.int64)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -576,6 +576,52 @@ def test_block_pair_scoring_matches_whole_pose(ubq_pdb, default_database, torch_
         assert torch.equal(parallel_score, serial_score)
 
 
+def test_interaction_only_block_pair_scoring_skips_diagonal_terms(
+    ubq_pdb, default_database, torch_device
+):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    sfxn = beta2016_score_function(torch_device, default_database)
+    full_scorer = sfxn.render_block_pair_scoring_module(pose_stack)
+    interaction_scorer = sfxn.render_block_pair_scoring_module(
+        pose_stack, interaction_only=True
+    )
+
+    full = full_scorer(pose_stack.coords, sum_terms=False)
+    interaction = interaction_scorer(pose_stack.coords, sum_terms=False)
+    off_diagonal = ~torch.eye(
+        pose_stack.max_n_blocks, dtype=torch.bool, device=torch_device
+    )
+    torch.testing.assert_close(interaction[..., off_diagonal], full[..., off_diagonal])
+    block_pairs = torch.nonzero(off_diagonal, as_tuple=False)
+    torch.testing.assert_close(
+        interaction_scorer.score_interactions(
+            pose_stack.coords, block_pairs, sum_terms=False
+        ),
+        full[..., off_diagonal].sum(dim=2),
+    )
+    assert len(interaction_scorer._active_term_modules) < len(
+        full_scorer._active_term_modules
+    )
+
+
+def test_score_interactions_validates_block_pairs(ubq_pdb, torch_device):
+    pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=2)
+    scorer = beta2016_score_function(torch_device).render_block_pair_scoring_module(
+        pose_stack, interaction_only=True
+    )
+
+    with pytest.raises(ValueError, match="shape"):
+        scorer.score_interactions(
+            pose_stack.coords,
+            torch.zeros((2,), dtype=torch.int64, device=torch_device),
+        )
+    with pytest.raises(TypeError, match="integer"):
+        scorer.score_interactions(
+            pose_stack.coords,
+            torch.zeros((1, 2), dtype=torch.float32, device=torch_device),
+        )
+
+
 def test_block_pair_gradients_respect_sparse_upstream_weights(
     ubq_pdb, default_database, torch_device
 ):

--- a/tmol/tests/utility/test_cpp_extension.py
+++ b/tmol/tests/utility/test_cpp_extension.py
@@ -1,0 +1,39 @@
+from tmol.utility import _cpp_extension
+
+
+def test_required_cxx_standard():
+    assert _cpp_extension._required_cxx_standard("2", "12") == 17
+    assert _cpp_extension._required_cxx_standard("2", "13") == 20
+    assert _cpp_extension._required_cxx_standard("3", "0") == 20
+
+
+def test_active_torch_cxx_standard_flags_match():
+    expected = _cpp_extension._required_cxx_standard(
+        *_cpp_extension.get_torch_version()
+    )
+
+    assert f"--std=c++{expected}" in _cpp_extension._required_flags
+    assert f"-std=c++{expected}" in _cpp_extension._required_cuda_flags
+
+
+def test_select_cuda_architecture_prefers_active_device():
+    select = _cpp_extension._select_cuda_architecture
+    assert select(None, (9, 0)) == "9.0"
+    assert select("   ", (9, 0)) == "9.0"
+    assert select("8.0;9.0;12.0+PTX", (12, 0)) == "12.0"
+    assert select("7.5;8.0;8.6;9.0", (8, 9)) == "8.9"
+    assert select("8.6 9.0", (9, 0)) == "9.0"
+    assert select("8.6", (9, 0)) == "8.6"
+
+
+def test_custom_extension_flags_preserve_release_optimization():
+    kwargs = _cpp_extension._augment_kwargs(
+        "test_extension",
+        ["test.cpp"],
+        extra_cflags=["-DCUSTOM_CXX"],
+        extra_cuda_cflags=["-DCUSTOM_CUDA"],
+        with_cuda=False,
+    )
+
+    assert kwargs["extra_cflags"][:2] == ["-O3", "-DCUSTOM_CXX"]
+    assert kwargs["extra_cuda_cflags"][:2] == ["-O3", "-DCUSTOM_CUDA"]

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -45,8 +45,6 @@ _cccl_include = _get_cccl_include()
 if _cccl_include:
     _default_include_paths.append(_cccl_include)
 
-_required_flags = ["--std=c++17", "-DWITH_NVTX", "-w"]
-
 if os.environ.get("DEBUG"):
     _default_flags = ["-O3", "-DDEBUG"]
     # _default_flags = ["-g", "-Og", "-DDEBUG"]
@@ -65,8 +63,18 @@ def get_torch_version():
 
 torch_major, torch_minor = get_torch_version()
 
+
+def _required_cxx_standard(torch_major, torch_minor):
+    """Return the language standard required by this PyTorch release."""
+    version = int(torch_major), int(torch_minor)
+    return 20 if version >= (2, 13) else 17
+
+
+_cxx_standard = _required_cxx_standard(torch_major, torch_minor)
+_required_flags = [f"--std=c++{_cxx_standard}", "-DWITH_NVTX", "-w"]
+
 _required_cuda_flags = [
-    "-std=c++17",
+    f"-std=c++{_cxx_standard}",
     "--expt-extended-lambda",
     "-DWITH_NVTX",
     "-w",
@@ -74,6 +82,23 @@ _required_cuda_flags = [
     f"-DTORCH_VERSION_MAJOR={torch_major}",
     f"-DTORCH_VERSION_MINOR={torch_minor}",
 ]
+
+
+def _select_cuda_architecture(arch_list, device_capability):
+    """Choose the active device from a possibly multi-architecture setting."""
+    current = ".".join(str(part) for part in device_capability)
+    if not arch_list:
+        return current
+    requested = arch_list.replace(" ", ";").split(";")
+    requested = [arch.removesuffix("+PTX") for arch in requested if arch]
+    if not requested:
+        return current
+    # A multi-architecture value commonly comes from a wheel/container build
+    # environment and can lag newly installed hardware. A local JIT build is
+    # for the active device, so do not silently compile its first (often
+    # oldest) entry when the device is absent. Preserve a single explicit
+    # architecture as the user's deliberate cross-compilation request.
+    return current if len(requested) > 1 else requested[0]
 
 
 # Add an additional --gpu-architecture flag to the nvcc command:
@@ -86,12 +111,9 @@ if torch.cuda.is_available():
 
     arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
     # If not given, determine what's needed for the GPU that can be found
-    if not arch_list:
-        _major, _minor = torch.cuda.get_device_capability(0)
-    else:
-        # Take the first architecture listed.
-        # Deal with lists that are ' ' or ';' separated
-        _major, _minor = arch_list.replace(" ", ";").split(";")[0].split(".")
+    _major, _minor = _select_cuda_architecture(
+        arch_list, torch.cuda.get_device_capability()
+    ).split(".")
     _required_cuda_flags.append(f"--gpu-architecture=sm_{_major}{_minor}")
 
     # we need to add the search path for nvtx3
@@ -128,10 +150,11 @@ _default_cuda_flags = ["-O3"]
 # commands to the terminal
 def _augment_kwargs(name, sources, **kwargs):
     kwargs["extra_cflags"] = (
-        list(kwargs.get("extra_cflags", _default_flags)) + _required_flags
+        _default_flags + list(kwargs.get("extra_cflags", [])) + _required_flags
     )
     kwargs["extra_cuda_cflags"] = (
-        list(kwargs.get("extra_cuda_cflags", _default_cuda_flags))
+        _default_cuda_flags
+        + list(kwargs.get("extra_cuda_cflags", []))
         + _required_cuda_flags
     )
     kwargs["extra_include_paths"] = (


### PR DESCRIPTION
## Summary

This is the combined, reviewable head for the compatible work from #464 and #465; it supersedes #464.

- fuse CUDA nucleic-acid whole-pose and rotamer torsion scoring
- reduce LKBall launch overhead without changing score or gradient contracts
- expose a small interaction-only block-pair API for guidance and ddG workloads
- bind immutable Atom37 chemistry and routing once for repeated diffusion/search poses
- select fixed-shape CUDA graph replay automatically for DNA/RNA Cartesian relaxation, with one boolean override
- reuse expensive pose-build, packing, and scoring setup across repeated structures
- cache fixed Atom37 pose layouts for the four most recently used batch sizes,
  with automatic fallback when atom presence can change topology
- skip ligand fragmentation/connectivity scans when the input cannot need them
- make native, CPU-only, JIT, CI, and release builds select the PyTorch-required C++ standard and valid CUDA architectures
- cover PyTorch 2.14 and make hosted high-memory CUDA wheel builds reliable
- keep benchmark/profiling harnesses out of the production diff and trim recurring PR CI to representative lanes

## Measured performance

- native nucleic-acid rotamer scoring: **31–37x** faster across representative batches
- DNA/RNA CUDA graph forward+backward replay: **4.86–9.95x**; protein–DNA is **1.33–4.54x**
- interaction-only selected scoring: **2.42–3.73x** forward and **2.77–5.53x** forward+backward
- representative batch-100 protein–DNA LKBall forward+backward: **13.60 ms → 11.94 ms**
- same-model L40 LKBall backward: **1.552 ms → 1.226 ms** at batch 100 (**1.27x**) and **0.855 ms → 0.710 ms** at batch 30 (**1.20x**)
- OptH score setup omits six candidate-invariant terms; fixed-seed protein, DNA, RNA, ligand, and mixed outputs remain identical, while the measured HSP90 repeated build improved by about **4.4%**
- default packed-block tensor construction: **28.44 ms → 2.24 ms** (**12.7x**), replacing hundreds of tiny host tensors/device transfers with three packed transfers
- warmed, pre-parameterized HSP90 ligand context construction: **78.9 ms → 8.77 ms** (**9.0x**), including a **31x** cache hit for the structured `.tmol` parameter file
- cold ligand conformer refinement avoids importing TorchDynamo and starts in **3.50 s → 0.58 s** (**6.0x**); vectorized distance refinement is **1.02–1.12x** faster on larger stress cases
- bounded LBFGS refinement history improves the representative 40-ligand set by **1.17x** while retaining chirality and essentially unchanged objectives (median ratio **1.001**, 95th percentile **1.024**)
- prepared HSP90 Atom37 pose construction at batch 1: **16.28 ms → 0.526 ms** without OptH (**31.0x**, 2,533 profiler events → 111); with default OptH, **124.49 ms → 105.57 ms** (**1.18x**), after which rotamer packing/scoring dominates
- packing four independent CUDA annealing warps per CTA preserves every trajectory and random stream while reducing prepared HSP90 batch-100 OptH from **2.274 s → 2.024 s** (**1.12x**) with bit-for-bit identical output coordinates
- initializing Philox state only in the lane that consumes it reduces the hot low-temperature annealer from 126 to 80 registers/thread; an 11-round ABBA benchmark on RTX 4000 Ada reduced prepared HSP90 batch-100 OptH from **2.162 s → 1.958 s** (**1.104x**, 9.44% lower latency), with bit-for-bit identical coordinates and energies across every leg
- bounding annealing iterations per pose removes jagged-batch overwork: a 90-short/10-full mixed batch improved from **458.01 ms → 275.03 ms** (**1.665x**, 39.95% lower latency), while homogeneous HSP90 remained neutral (**1965.55 ms vs 1965.64 ms**) and bit-for-bit identical
- a workload- and architecture-aware hitemp launch selects six-CTA occupancy for 128+ rotamers on Ampere/newer targets while retaining the unconstrained kernel for short poses and sm75; native-sm89 HSP90 batch-100 improved from **1962.88 ms → 1917.68 ms** (**1.024x**, 2.30% lower latency), with the profiled hitemp kernel falling from **793.4 ms → 743.3 ms**; the 72-rotamer DNA case remained neutral (**83.34 ms vs 83.18 ms**), with bit-for-bit coordinates and energies

Pure protein/protein–ligand graph replay, global fast math, unconditional occupancy settings, split annealing phases, float pair mapping, direct per-term interaction reductions, more aggressive LKBall fusion, and persistent H-bond candidate grids were benchmarked and not retained because their gains were absent or unstable, runtime regressed, or numerical change was too large. The H-bond cap sweep improved representative batch-100 forward scoring by at most 1.4% and forward+backward by 0.5%, while small workloads regressed by up to 2.4x. A 64/128-trajectory search sweep was 1.7–2.5x faster and bit-identical on the five-system fixed-seed matrix, but the default 500-trajectory search breadth is intentionally retained until harder design-quality evidence supports changing it.

On the current batch-100 protein–DNA profile, native nucleic-acid scoring is one forward kernel (two total with gradients). LJ/LK, electrostatics, Cartesian bonded, and the H-bond score are likewise one large score kernel each; LKBall is three forward/five total launches and H-bond adds one derived-base prepass. At this scale the remaining time is dominated by useful pairwise work (LKBall 36.8% and LJ/LK, electrostatics, H-bond, and Cartesian bonded 10.8–17.3% each), rather than a long tail of tiny launches.

## Public interfaces and RFD4 co-design

Selected interactions stay two lines:

```python
scorer = sfxn.render_block_pair_scoring_module(pose_stack, interaction_only=True)
energy = scorer.score_interactions(pose_stack.coords, block_pair_indices)
```

`interaction_only=True` is for strictly off-diagonal interactions; diagonal entries are documented as incomplete. A direct per-term reduction implementation was 4–6% slower, so `score_interactions()` deliberately preserves the scorer's fast operation ordering and adds one indexed reduction.

The differentiable Atom37 entry point is chemistry-generic. One-off conversion remains one call:

```python
pose = pose_stack_from_atom37_and_biotite(atom37_coords, atom_array, context)
```

Repeated campaigns bind the immutable work once and keep the per-step call minimal:

```python
pose_builder = prepare_pose_stack_from_atom37(atom_array, context)
pose = pose_builder(atom37_coords)  # opt_h=True by default
```

The builder caches the fixed pose layout per batch size in a bounded four-entry
LRU. A non-finite per-step coordinate falls back to the stable AtomArray
template. Reference structures with variable atom presence, ambiguous histidine
hydrogens, or missing heavy atoms automatically use the general construction
path instead of reusing an unsafe layout.

The AtomArray supplies chemical identity, bonds, charges, fragments, and the `token_id` / `atom37_slot` mapping; coordinates remain on the autograd tape. There is no RFD4-side residue or element allowlist, so future PTM/ion/metal support flows through the same call once the supplied TMol context supports that chemistry.

The co-designed RFD4 branch:

- keeps `opt_h=True` as the intuitive default
- uses the prepared builder and interaction-only scorer from this release
- batches equal topologies for full, partial, and beam-search guidance
- transfers only a compact discrete topology signature on cache hits and builds an AtomArray only on a new topology
- accepts either matrix orientation while normalizing each unordered selected block pair once
- keys cache entries by residue/atom identity, element, charge, bonds, AtomWorks fragmentation fields, and `tmol_fragment_id`
- uses the 0.1.54 interaction-only scorer without a compatibility fallback

For a 150-residue decoded sample, eager AtomArray rebuilding measured **34.3 ms per sample** before TMol scoring. Cache-hit bookkeeping is **0.08 ms at batch 1** and **0.82 ms at batch 100**, avoiding up to roughly 3.4 seconds of serial host work per guided batch-100 step when topology repeats.

## CUDA graph policy

The native nucleic-acid rewrite reduced one representative mixed protein–DNA profile from 1,540 CUDA operations / 2.345 ms to 15 operations / 0.191 ms. Whole-score replay still materially accelerates repeated DNA/RNA gradient evaluations. Pure protein and protein–ligand scoring measured only 1–7% replay improvement and end-to-end relaxation is packing-dominated, so those workloads remain eager by default to avoid capture/storage cost. `fast_relax(..., cuda_graph=True|False)` overrides automatic selection.

## Build compatibility

Torch 2.13+ builds use C++20 as required by those releases; older supported Torch versions remain on C++17. CPU-only and CUDA JIT branches are exercised. Normal local/self-hosted CUDA builds stay native; release wheels deliberately compile the supported architecture set. Hosted CUDA wheels serialize high-memory compilation and add swap to prevent runner loss.

## Validation

- pre-ligand-fast-path combined head: lint, docs, and every CPU/CUDA CI lane passed
- current integrated Linux x86_64 CPU suite: **1,626 passed, 1,081 skipped, 5 expected failures, 1 XPASS** (CUDA/device parameterizations were collected and skipped)
- CUDA: 1,004 passed, 20 skipped, 1 XPASS; the secondary full-suite pass reported 603 passed, 2,100 skipped, 1 expected failure
- pre-ligand-fast-path combined head: the complete CPU and clean-install CUDA wheel smoke matrix passed
- latest ligand fast paths: the complete ligand suite passed (**345 passed, 67 environment-dependent skips**), including 67 ligand/context, 37 fragmentation, and 44 params/serialization tests
- latest annealer refinements: **87 passed, 74 CUDA-skipped** in the full CPU pack suite; **35/35** focused CPU/CUDA pack and OptH tests passed against the final native-sm89 artifact; direct CUDA ABBA output was bit-for-bit identical across two baseline and two candidate runs
- prepared Atom37 builder: 64 focused protein/DNA/RNA/fragmented-ligand/OptH tests passed (45 device-dependent skips); first- and cached-call differentiability, batch-size LRU reuse, unsafe-topology fallback, direct-path parity, and default OptH parity are covered
- final local 0.1.54 head: Black/Flake8/ClangFormat and release-manifest checks passed; 1,569 CPU tests passed on PyTorch 2.14 after resolving the sole validator annotation mismatch; focused RFD4 guidance/metric integration passed on CPU and CUDA, including analytic/numerical gradient parity
- prior pushed release head: full CPU/macOS/CUDA, docs, and every clean-install CPU/CUDA wheel smoke passed: https://github.com/uw-ipd/tmol/actions/runs/33822390895
- direct CPU and CUDA translation-unit compilation passed for the resolved LKBall dispatch
- local Atom37 return-mapping regression and fixed-seed OptH equivalence checks passed
- prior co-designed RFD4 full/partial/beam-search suite: 60 passed, 6 GPU-skipped
- definitive pre-integration release audit: 65/65 wheel builds plus 50/50 clean install/runtime checks passed (115 successful jobs; 4 intentional skips): https://github.com/uw-ipd/tmol/actions/runs/33792926365
- exact pushed-head audit at `d1ab2132`: all 119 wheel build, install, and native-extension jobs passed: https://github.com/uw-ipd/tmol/actions/runs/33840360735

Fresh Nsight profiling of the pushed chemistry matrix and same-device cap sweeps were run on DIGS after integration; the retained optimizations and rejected alternatives above reflect those final-head measurements.


