### PR TITLE
Fix cross-filesystem release-wheel downloads

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,7 +58,12 @@ pip install tmol
 
 During a PyPI source-distribution build, TMol tries to fetch a matching
 pre-built wheel from GitHub Releases. If no compatible wheel exists, it builds
-locally.
+locally. Because an isolated build may see a different PyTorch variant than
+the runtime environment, pin the wheel lane when PyTorch is already installed:
+
+```bash
+TMOL_WHEEL_LOCAL_TAG=cputorch2.14 pip install tmol
+```
 
 Useful environment variables:
 
@@ -134,11 +139,11 @@ python -c "import sys, torch; print(f'Python {sys.version_info.major}.{sys.versi
 ## Google Colab
 
 Colab GPU runtimes currently use PyTorch 2.11.0 with CUDA 12.8 and may provide
-Python 3.12 or 3.13. TMol v0.1.55 provides separate Python-ABI wheels compiled
+Python 3.12 or 3.13. TMol v0.1.56 provides separate Python-ABI wheels compiled
 for T4 (`sm_75`), A100 (`sm_80`), and L4 (`sm_89`) GPUs. For Python 3.13:
 
 ```bash
-pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.55/tmol-0.1.55+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
+pip install "tmol @ https://github.com/uw-ipd/tmol/releases/download/v0.1.56/tmol-0.1.56+cu128torch2.11-cp313-cp313-manylinux_2_28_x86_64.whl"
 ```
 
 The tutorial bootstrap selects the wheel matching the runtime's Python ABI and

--- a/docs/tutorial/colab_setup.py
+++ b/docs/tutorial/colab_setup.py
@@ -10,7 +10,7 @@ from urllib.request import urlretrieve
 
 TUTORIAL_REF = "master"
 RAW_BASE = f"https://raw.githubusercontent.com/uw-ipd/tmol/{TUTORIAL_REF}"
-TMOL_RELEASE = "0.1.55"
+TMOL_RELEASE = "0.1.56"
 RELEASE_WHEEL_TORCH_MINOR = "2.11"
 RELEASE_WHEEL_CUDA = "12.8"
 RELEASE_WHEEL_PYTHONS = frozenset({(3, 12), (3, 13)})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-version = "0.1.55"
+version = "0.1.56"
 
 dependencies = [
     # Core ML framework

--- a/tmol/tests/test_build_backend.py
+++ b/tmol/tests/test_build_backend.py
@@ -225,7 +225,14 @@ def test_download_retries_then_succeeds(monkeypatch, tmp_path):
             raise URLError("temporary network error")
         return _Response(b"wheel-bytes")
 
+    real_named_temporary_file = backend.tempfile.NamedTemporaryFile
+
+    def named_temporary_file(**kwargs):
+        assert Path(kwargs["dir"]) == tmp_path
+        return real_named_temporary_file(**kwargs)
+
     monkeypatch.setattr(backend, "urlopen", fake_urlopen)
+    monkeypatch.setattr(backend.tempfile, "NamedTemporaryFile", named_temporary_file)
 
     assert (
         backend._download_to_path("https://example.invalid/wheel.whl", out_path) is True

--- a/tmol_build_backend.py
+++ b/tmol_build_backend.py
@@ -261,7 +261,11 @@ def _download_to_path(url: str, out_path: Path) -> bool:
                 if getattr(response, "status", 200) != 200:
                     _log(f"Wheel probe returned HTTP {response.status}: {url}")
                     return False
-                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                # Keep the staging file on the destination filesystem so the
+                # final atomic rename also works when /tmp is a separate mount.
+                with tempfile.NamedTemporaryFile(
+                    dir=out_path.parent, delete=False
+                ) as tmp:
                     shutil.copyfileobj(response, tmp)
                     tmp_path = Path(tmp.name)
             tmp_path.replace(out_path)


### PR DESCRIPTION
Fixes the PyPI sdist wheel-fetch path when the frontend build cache and /tmp are on different filesystems.

The backend now creates its staging file beside the destination, preserving the final atomic rename without EXDEV. The existing download/retry test asserts that invariant. Install guidance now shows how to pin the runtime wheel lane under PEP 517 isolation, and the patch version is 0.1.56.

Validated locally:
- focused backend tests: 11 passed
- pre-commit hooks: passed
- real 58,475,642-byte GitHub Release wheel download across /tmp and /mnt: passed with matching SHA-256
- sdist build and twine check: passed