### PR TITLE
Accelerate and harden scoring, packing, and minimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,7 @@ set(_C_SOURCES
   # score/ljlk
   tmol/score/ljlk/potentials/compiled.ops.cpp
   tmol/score/ljlk/potentials/ljlk_pose_score.cpu.cpp
+  tmol/score/ljlk/potentials/ljlk_elec_pose_score.cpu.cpp
   # score/lk_ball
   tmol/score/lk_ball/potentials/compiled.ops.cpp
   tmol/score/lk_ball/potentials/lk_ball_pose_score.cpu.cpp
@@ -474,6 +475,7 @@ if(TMOL_HAS_CUDA)
     tmol/score/hbond/potentials/hbond_pose_score.cuda.cu
     tmol/score/hbond/potentials/gen_hbond_bases.cuda.cu
     tmol/score/ljlk/potentials/ljlk_pose_score.cuda.cu
+    tmol/score/ljlk/potentials/ljlk_elec_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/gen_pose_waters.cuda.cu
     tmol/score/na_torsion/potentials/na_torsion_pose_score.cuda.cu
@@ -485,6 +487,7 @@ if(TMOL_HAS_CUDA)
     tmol/score/elec/potentials/elec_pose_score.cuda.cu
     tmol/score/hbond/potentials/hbond_pose_score.cuda.cu
     tmol/score/ljlk/potentials/ljlk_pose_score.cuda.cu
+    tmol/score/ljlk/potentials/ljlk_elec_pose_score.cuda.cu
     tmol/score/lk_ball/potentials/lk_ball_pose_score.cuda.cu
     PROPERTIES COMPILE_OPTIONS "--use_fast_math"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,9 @@ endfunction()
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set(_C_SOURCES
+  # optimization
+  tmol/optimization/armijo_compiled.ops.cpp
+  tmol/optimization/armijo_compiled.cpu.cpp
   # io/details/compiled
   tmol/io/details/compiled/compiled.ops.cpp
   tmol/io/details/compiled/gen_pose_leaf_atoms.cpu.cpp
@@ -454,6 +457,7 @@ set(_C_SOURCES
 
 if(TMOL_HAS_CUDA)
   list(APPEND _C_SOURCES
+    tmol/optimization/armijo_compiled.cuda.cu
     tmol/io/details/compiled/gen_pose_leaf_atoms.cuda.cu
     tmol/io/details/compiled/resolve_his_taut.cuda.cu
     tmol/kinematics/compiled/compiled.cuda.cu

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Explore the **[TMol documentation](https://uw-ipd.github.io/tmol/)** for
 complete installation guidance, executable tutorials, workflows, and the API
 reference.
 
-Three ways in:
+Four ways in:
 
 - 🚀 **Start scoring** → [quick start](#quick-start), then the full **[Quickstart](https://uw-ipd.github.io/tmol/latest/quickstart.html)**.
 - 🧬 **Build a workflow** → **[scoring, packing, minimization, FastRelax, and ligand recipes](https://uw-ipd.github.io/tmol/latest/workflows/index.html)**.
+- 🤖 **Guide an agent** → **[portable TMol skills](skills/README.md)** for setup, scoring, packing/relax, and development.
 - 🛠️ **Develop TMol** → **[contributor guide](https://uw-ipd.github.io/tmol/latest/contributor_guide.html)**.
 
 ## Install

--- a/docs/agent_skills.md
+++ b/docs/agent_skills.md
@@ -1,0 +1,25 @@
+# Agent skills
+
+TMol includes portable agent skills for recurring user and contributor
+workflows. Each skill is a directory under `skills/` with a `SKILL.md` that an
+agent reads only when the request matches that workflow. The skills point to
+the maintained documentation and public APIs rather than duplicating them.
+
+| Skill | Use it for |
+| --- | --- |
+| `tmol-setup` | Select a wheel or source/JIT install, verify CPU/CUDA support, and diagnose extension loading. |
+| `tmol-score` | Load a structure, render a scorer, inspect terms, compute coordinate gradients, and choose CPU or CUDA execution. |
+| `tmol-pack-relax` | Configure repacking or design, minimize coordinates, and run FastRelax with bounded CPU/GPU memory. |
+| `tmol-develop` | Build extensions, run focused CPU/CUDA tests, profile kernels, and prepare a reviewable performance change. |
+
+## Install or vendor a skill
+
+The repository directories are self-contained. An agent environment that
+supports repository skills can install one from the GitHub repository or vendor
+the corresponding `skills/<name>/` directory into its skill search path. Read
+[`skills/README.md`](https://github.com/uw-ipd/tmol/tree/master/skills) for the
+catalog and artifact conventions.
+
+Skills do not grant permission to submit jobs, spend external compute, push
+branches, or merge pull requests. Those actions still require the authority
+provided by the user's request and the active environment.

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -57,3 +57,12 @@ useful module, class, and function docstrings because those docstrings become
 the reference documentation.
 
 Use Google or NumPy-style docstrings.
+
+## Agent skills
+
+Repository skills under `skills/` encode recurring workflows for coding agents.
+Keep each `SKILL.md` narrow and grounded in current public commands and APIs.
+Link substantial explanations to the maintained docs instead of copying them
+into several skills. When behavior changes, update the relevant skill, its
+human-readable skill card, and its bounded eval case together. See
+{doc}`Agent skills </agent_skills>` for the catalog.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ Choose a path
 
 Start with :doc:`quickstart` for a first score calculation. Continue with the
 interactive :doc:`examples <examples_index>`, use a concise
-:doc:`workflow <workflows/index>`, or look up a specific operation in the
+:doc:`workflow <workflows/index>`, ask an agent to follow a repository
+:doc:`skill <agent_skills>`, or look up a specific operation in the
 :doc:`task index <tutorial/recipe_index>`.
 
 .. raw:: html
@@ -45,5 +46,6 @@ interactive :doc:`examples <examples_index>`, use a concise
    Quickstart <quickstart>
    Workflows <workflows/index>
    Examples <examples_index>
+   Agent skills <agent_skills>
    API <api_reference>
    Contributing <contributor_guide>

--- a/docs/user_guide/cpu_threading.md
+++ b/docs/user_guide/cpu_threading.md
@@ -1,0 +1,97 @@
+# CPU threading
+
+TMol uses PyTorch's process-wide CPU thread budget. In a normal environment,
+PyTorch initializes that budget from the CPUs visible to the process and its
+OpenMP settings. TMol does not require a separate thread-count API: inspect and
+change the same setting used by the rest of a PyTorch application.
+
+> - **Related workflows:** {doc}`Scoring </user_guide/scoring>`,
+>   {doc}`Packing </workflows/packing>`, and
+>   {doc}`Minimization and FastRelax </user_guide/optimization>`.
+> - **Performance measurement:** {doc}`Benchmarking
+>   </user_guide/benchmarking>`.
+> - **PyTorch API:** [`torch.set_num_threads()`](https://docs.pytorch.org/docs/stable/generated/torch.set_num_threads.html).
+
+## Inspect the allocation and active budget
+
+On Linux, process affinity is the most useful answer to “how many CPUs may this
+process use?” It respects scheduler and container restrictions:
+
+```python
+import os
+import torch
+
+available_cpus = (
+    len(os.sched_getaffinity(0))
+    if hasattr(os, "sched_getaffinity")
+    else (os.cpu_count() or 1)
+)
+print(f"CPUs available to this process: {available_cpus}")
+print(f"PyTorch intra-op threads: {torch.get_num_threads()}")
+```
+
+When no thread environment variable or application setting overrides it,
+PyTorch normally uses the CPUs available to the process. Always print both
+values in performance logs: a scheduler can grant many host CPUs while exposing
+only the allocated affinity mask, and an inherited `OMP_NUM_THREADS` can choose
+a smaller active budget.
+
+## Override the budget
+
+Set the budget before rendering TMol scorers or starting autograd work:
+
+```python
+torch.set_num_threads(8)
+```
+
+For a command-line job, set the equivalent launch-time controls:
+
+```bash
+OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 python workflow.py
+```
+
+`MKL_NUM_THREADS` controls MKL independently and takes precedence for MKL
+operations. `torch.get_num_threads()` is the authoritative value for PyTorch
+intra-op work after startup. `torch.set_num_interop_threads()` controls a
+different, process-wide pool and generally does not need changing for TMol; if
+an application changes it, PyTorch requires doing so before inter-op work starts.
+
+For Slurm, request CPUs and either rely on the launcher's affinity or set the
+same number explicitly:
+
+```bash
+srun --cpus-per-task=8 \
+  env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 python workflow.py
+```
+
+## How TMol uses the budget
+
+When a CPU scoring module is rendered, TMol derives bounded worker and pair-
+traversal shard counts from `torch.get_num_threads()`. It can parallelize
+independent score terms, poses, and the dominant pair traversal, but deliberately
+uses fewer workers for small workloads where coordination would cost more than
+it saves. The requested PyTorch budget is therefore a ceiling, not a promise
+that every score call will keep every logical CPU busy.
+
+Changes to the thread budget should happen before rendering a scorer because
+the scorer's internal execution plan is selected at construction time. Render
+a new scorer after changing the budget.
+
+Packing, minimization, and FastRelax call the same scoring machinery and inherit
+the same process budget. CUDA kernels do not use this CPU thread count, although
+structure preparation and other host-side work still can.
+
+## Choose a practical value
+
+Start with all CPUs in the process affinity mask for one TMol process. Then
+measure representative structures at smaller values; memory bandwidth,
+workload size, and the mix of score terms can produce a plateau before every
+logical CPU is useful. Prefer physical cores before adding sibling hardware
+threads when topology is known.
+
+For multiple processes or data-loader workers, divide the allocation between
+them instead of giving every process the full count. For example, four worker
+processes in a 32-CPU allocation should normally start near eight intra-op
+threads each. Record the affinity, `torch.get_num_threads()`, pose sizes, batch
+size, and process count with benchmark results so comparisons remain
+reproducible.

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -10,7 +10,8 @@ depth.
 >   </tutorial/05_minimization_constraints_kinematics>` and
 >   {doc}`06 — FastRelax </tutorial/06_fast_relax>`.
 > - **Related workflows:** {doc}`Ligand preparation </user_guide/ligands>` and
->   {doc}`Nucleic acids </workflows/nucleic_acids>`.
+>   {doc}`Nucleic acids </workflows/nucleic_acids>`; for CPU execution, see
+>   {doc}`CPU threading </user_guide/cpu_threading>`.
 > - **API reference:** {doc}`Optimization </api/optimization>`,
 >   {doc}`Kinematics </api/kinematics>`, and {doc}`Relax </api/relax>`.
 > - **Rosetta mapping:** {doc}`Minimization, constraints, kinematics, and

--- a/docs/user_guide/scoring.md
+++ b/docs/user_guide/scoring.md
@@ -51,17 +51,22 @@ score.backward()
 
 ## CPU batch throughput
 
-Whole-pose CPU scoring parallelizes independent poses through PyTorch's
-intra-op thread pool. Set the pool from the cores actually allocated to the
-process, and normally do not assign more scoring threads than poses:
+Whole-pose CPU scoring uses PyTorch's process-wide intra-op thread budget.
+PyTorch defaults to the CPUs available to the process, including an affinity-
+restricted scheduler allocation. Inspect or override that budget before
+rendering a scorer:
 
 ```python
-torch.set_num_threads(min(n_poses, allocated_physical_cores))
+print(torch.get_num_threads())
+torch.set_num_threads(8)
 ```
 
-The pose boundary keeps gradients race-free, so a one-pose batch does not gain
-intra-pose parallelism. When several processes or data-loader workers score at
-once, divide the available cores between them to avoid oversubscription.
+TMol parallelizes independent poses and score terms and can shard the dominant
+pair traversal for a single pose. Small workloads may use fewer threads when
+additional shards would cost more than they save. When several processes or
+data-loader workers score at once, divide the available cores between them to
+avoid oversubscription. `OMP_NUM_THREADS` is the equivalent launch-time
+override.
 
 ## Ligand-aware Scoring
 

--- a/docs/user_guide/scoring.md
+++ b/docs/user_guide/scoring.md
@@ -51,10 +51,9 @@ score.backward()
 
 ## CPU batch throughput
 
-Whole-pose CPU scoring uses PyTorch's process-wide intra-op thread budget.
-PyTorch defaults to the CPUs available to the process, including an affinity-
-restricted scheduler allocation. Inspect or override that budget before
-rendering a scorer:
+Whole-pose CPU scoring follows PyTorch's process-wide intra-op thread budget.
+Inspect the active value and, when needed, override it before rendering a
+scorer:
 
 ```python
 print(torch.get_num_threads())
@@ -65,8 +64,9 @@ TMol parallelizes independent poses and score terms and can shard the dominant
 pair traversal for a single pose. Small workloads may use fewer threads when
 additional shards would cost more than they save. When several processes or
 data-loader workers score at once, divide the available cores between them to
-avoid oversubscription. `OMP_NUM_THREADS` is the equivalent launch-time
-override.
+avoid oversubscription. See {doc}`CPU threading </user_guide/cpu_threading>`
+for affinity-aware discovery, scheduler examples, launch-time overrides, and
+benchmarking guidance.
 
 ## Ligand-aware Scoring
 

--- a/docs/workflows/gpu_batching.md
+++ b/docs/workflows/gpu_batching.md
@@ -9,7 +9,8 @@ and interpretation.
 > - **Deep tutorial:** {doc}`02 — GPU Batching with TMol
 >   </tutorial/02_gpu_batching>`.
 > - **Related workflows:** {doc}`Packing </workflows/packing>` and
->   {doc}`developer benchmarking </user_guide/benchmarking>`.
+>   {doc}`developer benchmarking </user_guide/benchmarking>`; for CPU
+>   execution, see {doc}`CPU threading </user_guide/cpu_threading>`.
 > - **API reference:** {doc}`Pose </api/pose>` and {doc}`Scoring </api/score>`.
 > - **Rosetta mapping:** {doc}`GPU batching and external orchestration
 >   </tutorial/rosetta_crosswalk>`.

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -22,6 +22,11 @@ corresponding Tutorials for deeper analysis.
     <span class="docs-card-title">GPU batching</span>
     <span class="docs-card-description">Batch compatible structures, measure CUDA work correctly, and chunk larger application workloads.</span>
   </a>
+  <a class="docs-card" href="../user_guide/cpu_threading.html">
+    <span class="docs-card-kicker">Parallelize</span>
+    <span class="docs-card-title">CPU threading</span>
+    <span class="docs-card-description">Inspect affinity and PyTorch's active budget, select a thread count, and avoid multi-process oversubscription.</span>
+  </a>
   <a class="docs-card" href="../user_guide/scoring.html">
     <span class="docs-card-kicker">Evaluate</span>
     <span class="docs-card-title">Scoring and analysis</span>
@@ -62,6 +67,7 @@ corresponding Tutorials for deeper analysis.
 structure_io
 ../user_guide/integrations
 gpu_batching
+../user_guide/cpu_threading
 ```
 
 ```{toctree}

--- a/docs/workflows/packing.md
+++ b/docs/workflows/packing.md
@@ -8,7 +8,8 @@ develops local repacking and explicitly scoped mutation or design experiments.
 > - **Deep tutorial:** {doc}`04 — Packing and Mutation Scan
 >   </tutorial/04_packing_and_mutation_scan>`.
 > - **Related workflows:** {doc}`Optimization </user_guide/optimization>` and
->   {doc}`Nucleic acids </workflows/nucleic_acids>`.
+>   {doc}`Nucleic acids </workflows/nucleic_acids>`; for CPU execution, see
+>   {doc}`CPU threading </user_guide/cpu_threading>`.
 > - **API reference:** {doc}`Packing </api/pack>` and
 >   {doc}`Relax </api/relax>`.
 > - **Rosetta mapping:** {doc}`Packing, design, and mutation scans

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,30 @@
+# TMol Agent Skills
+
+Portable agent skills for common TMol user and contributor workflows. Each
+skill is a self-contained directory with an agent-facing `SKILL.md`, a
+human-readable `skill-card.md`, and a bounded case under `evals/`. They encode
+TMol's real public APIs, build commands, and execution constraints so an agent
+does not have to rediscover them from implementation details.
+
+## Catalog
+
+| Skill | What it does | Typical order |
+| --- | --- | --- |
+| [`tmol-setup`](tmol-setup/) | Choose a compatible wheel or source/JIT installation and verify CPU/CUDA extension loading. | 1 |
+| [`tmol-score`](tmol-score/) | Load and score structures, inspect terms, compute gradients, and configure CPU threads or CUDA graph replay. | 2 |
+| [`tmol-pack-relax`](tmol-pack-relax/) | Repack or design side chains, minimize coordinates, and run FastRelax with bounded memory. | 3 |
+| [`tmol-develop`](tmol-develop/) | Build, test, benchmark, profile, and review TMol implementation changes. | Contributor workflow |
+
+Typical modeling order is **setup → score → pack/relax**. The development skill
+is independent and applies to repository changes rather than ordinary library
+use.
+
+## Use
+
+Each skill can be vendored by copying its directory into an agent environment's
+skill search path. Environments that discover skills directly from a repository
+can point at `skills/<name>/SKILL.md`.
+
+The skill text and helper artifacts use TMol's top-level Apache-2.0 license.
+Generated signatures or benchmark reports, if required by a downstream skill
+catalog, are onboarding artifacts and are not maintained in this repository.

--- a/skills/tmol-develop/SKILL.md
+++ b/skills/tmol-develop/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: tmol-develop
+description: >
+  Develop, test, benchmark, and profile TMol Python/C++/CUDA changes. Use for
+  editable builds, focused and full CPU/CUDA validation, performance or memory
+  regressions, launch profiling, code quality, and preparing a reviewable PR.
+  Do not use for ordinary installed-library modeling workflows.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+license: Apache-2.0
+---
+
+# TMol development
+
+Make the smallest production change supported by correctness tests and matched
+measurements. Preserve unrelated work in a dirty checkout; use a clean worktree
+from the target base for integration or final A/B validation.
+
+This workflow requires a TMol source checkout, Python 3.11+, CMake, Ninja, and a
+C++ compiler. CUDA development additionally requires `nvcc` and a supported GPU.
+
+## Build for the task
+
+Use an editable source build and include test-only native extensions when the
+affected tests need them:
+
+```bash
+TMOL_DISABLE_WHEEL_FETCH=1 python -m pip install --no-build-isolation -e ".[dev]" \
+  -Ccmake.define.TMOL_BUILD_TESTS=ON
+```
+
+For kernel iteration, `TMOL_USE_JIT=1` is faster to turn around. Use a distinct
+`TORCH_EXTENSIONS_DIR` per compared source revision so one candidate cannot
+reuse another revision's binary. Record compiler, PyTorch, CUDA, architecture,
+and source commit.
+
+## Test from narrow to broad
+
+1. Run the smallest unit/regression test that exercises the changed invariant.
+2. Run the affected subsystem, on CPU and CUDA when templates or dispatch code
+   are shared.
+3. Run `tmol/tests/optimization`, `tmol/tests/pack`, and `tmol/tests/score` for
+   changes crossing those boundaries.
+4. Run the repository's complete CI-equivalent lanes before merge when risk
+   warrants it.
+
+```bash
+pytest -q tmol/tests/score/test_score_function.py
+pytest -q tmol/tests/optimization tmol/tests/pack tmol/tests/score
+pre-commit run --all-files --show-diff-on-failure
+```
+
+If a format command changes files, inspect the diff rather than committing a
+mechanical rewrite blindly. Build docs when public behavior, APIs, or examples
+change.
+
+## Benchmark correctly
+
+Read `docs/user_guide/benchmarking.md` before collecting evidence. Use
+`dev/bin/compare_benchmark` for matched revisions and `TREE` for the current
+worktree. For CUDA, warm up and synchronize around timed work. For CPU, record
+affinity, `torch.get_num_threads()`, process count, and the one-thread baseline.
+
+Keep the input, device, dtype, warmup, sample count, process order, and JIT/AOT
+mode identical across variants. Reverse process order or alternate variants
+when system drift could rival the claimed effect. Report distributions and
+correctness checks, not only the best sample.
+
+Measure peak allocated memory around the operation separately from import and
+pose setup. CUDA Graph capture and compact data representation are independent:
+attribute improvements to the mechanism actually changed.
+
+## Profile before optimizing
+
+Use `dev/bin/profile_benchmark` with a narrow pytest selector. Nsight Systems
+answers orchestration and launch-count questions; Nsight Compute answers
+kernel occupancy, instruction, and memory-traffic questions. On CPU, use an
+operator profile plus native sampling where Python/Torch attribution is
+insufficient.
+
+Do not optimize launch count as a proxy for latency. Accept an optimization only
+when a representative matched A/B is favorable or neutral in the important
+regimes and the implementation remains understandable.
+
+## Integration and handoff
+
+- Keep one-off harnesses, raw traces, plots, build caches, and benchmark results
+  outside the production branch unless they are established repository tools.
+- Commit production code, focused regression tests, and user-facing docs.
+- Preserve public fallbacks such as unweighted/decomposed scoring, term removal,
+  custom weights, device choice, and changing input layouts.
+- Run `git diff --check`, inspect the final file list, and confirm the branch is
+  based on the intended upstream commit.
+- Push or merge only when the user authorized the external action and required
+  checks/reviews permit it.
+
+Primary references: `docs/user_guide/development.md`,
+`docs/user_guide/benchmarking.md`, `docs/contributor_guide.md`, and
+`.github/workflows/ci.yml`.

--- a/skills/tmol-develop/evals/evals.json
+++ b/skills/tmol-develop/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "skill": "tmol-develop",
+  "cases": [
+    {
+      "id": "review-cuda-performance-change",
+      "prompt": "Review a TMol CUDA scoring optimization against origin/master. Confirm correctness and flexibility, measure latency, peak memory, and physical launches on representative B1 and B32 inputs, and prepare only the production change and focused regression tests for review.",
+      "setup": {
+        "cwd": "clean TMol worktree on the candidate branch",
+        "requires": ["supported NVIDIA GPU", "CUDA development environment", "origin/master available"]
+      },
+      "expected_behavior": [
+        "Uses isolated build/JIT caches for baseline and candidate",
+        "Synchronizes CUDA timing and uses matched representative inputs",
+        "Tests decomposed and unweighted scores, custom or zero weights, and gradients when affected",
+        "Reports latency, peak allocated memory, launch counts, and correctness together",
+        "Keeps raw profiles, plots, and one-off benchmark harnesses outside the production diff",
+        "Runs focused, subsystem, and code-quality gates before recommending merge"
+      ],
+      "success_criteria": {
+        "correctness_gate_passes": true,
+        "reports_b1_and_b32": true,
+        "reports_speed_memory_and_launches": true,
+        "production_diff_excludes_raw_benchmark_artifacts": true
+      }
+    }
+  ]
+}

--- a/skills/tmol-develop/skill-card.md
+++ b/skills/tmol-develop/skill-card.md
@@ -1,0 +1,42 @@
+# Skill Card
+
+## Description
+
+`tmol-develop` guides focused TMol Python/C++/CUDA changes from a clean worktree
+through correctness tests, matched speed/memory measurements, profiling, code
+quality, and a reviewable integration handoff.
+
+## Owner and license
+
+TMol maintainers. Apache-2.0; see the repository `LICENSE`.
+
+## Requirements
+
+A TMol source checkout and its development toolchain. CUDA work additionally
+requires a compatible toolkit and GPU. Cluster submission, remote pushes, and
+merges require explicit user authority.
+
+## Risks and mitigations
+
+- Stale JIT binaries can invalidate A/B conclusions; the skill isolates caches
+  by revision.
+- Asynchronous CUDA execution and CPU oversubscription can bias timing; the
+  skill records execution settings and synchronizes measured CUDA regions.
+- Narrow microbenchmarks can hide end-to-end regressions; the skill expands from
+  focused tests to representative workflows and subsystem gates.
+- Profiling artifacts can bloat PRs; the skill keeps one-off evidence outside
+  the production branch.
+
+## References and output
+
+References: `docs/user_guide/development.md`,
+`docs/user_guide/benchmarking.md`, `docs/contributor_guide.md`, and CI workflow
+files.
+
+Output: a focused source/test/docs diff, reproducible validation commands,
+matched benchmark evidence when relevant, and a clean branch suitable for
+review. External mutations remain subject to explicit authorization.
+
+## Skill version
+
+0.1.0 (2026-09)

--- a/skills/tmol-pack-relax/SKILL.md
+++ b/skills/tmol-pack-relax/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: tmol-pack-relax
+description: >
+  Repack or design side chains, minimize coordinates, and run TMol FastRelax on
+  CPU or CUDA. Use for PackerTask masks and samplers, Cartesian or kinematic
+  movement, constraints, large-batch packing memory, and CUDA graph selection.
+  Do not use for score-only analysis.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+license: Apache-2.0
+---
+
+# TMol packing and relax
+
+Keep chemistry, task masks, movement controls, and score-function parameters
+explicit. Packing can change block identities and atom layout; render a new
+scorer for the returned pose.
+
+This workflow requires a working TMol installation, a prepared `PoseStack`,
+and a score function built from the same `ParameterDatabase`.
+
+## Fixed-sequence repacking
+
+```python
+from tmol.pack import PackerPalette, PackerTask, pack_rotamers
+from tmol.pack.rotamer import FixedAAChiSampler, IncludeCurrentSampler
+from tmol.pack.rotamer.dunbrack import create_dunbrack_sampler_from_database
+
+task = PackerTask(pose, PackerPalette())
+task.restrict_to_repacking()
+task.add_conformer_sampler(
+    create_dunbrack_sampler_from_database(database, pose.device)
+)
+task.add_conformer_sampler(FixedAAChiSampler())
+task.add_conformer_sampler(IncludeCurrentSampler())
+packed = pack_rotamers(pose, sfxn, task)
+```
+
+Use `disable_packing_by_block_mask()` to freeze selected blocks.
+`restrict_to_repacking()` preserves the original identities; mutation or design
+requires an explicit allowed-identity task rather than silently relaxing this
+restriction. Protein, nucleic-acid, and ligand cases may need different
+samplers; follow `docs/workflows/packing.md` and the chemistry-specific guide.
+
+## Minimization
+
+Use `run_cart_min()` for coordinate optimization and pass a boolean coordinate
+mask when only selected atoms may move. Use `run_kin_min()` with a configured
+`FoldForest` and `MoveMap` when torsions or rigid-body jumps are the actual
+degrees of freedom. A `MoveMap` does not enable movement merely by existing;
+set the intended flags or masks.
+
+Constraints must be attached to the pose and have a nonzero score-function
+weight. Preserve that pair of requirements when diagnosing a constraint that
+appears inactive.
+
+## FastRelax
+
+```python
+from tmol.kinematics import CartesianMoveMap, FoldForest
+from tmol.pack import PackerPalette
+from tmol.relax import fast_relax
+
+relaxed = fast_relax(
+    pose,
+    sfxn,
+    PackerPalette(),
+    CartesianMoveMap(),
+    FoldForest.reasonable_fold_forest(pose),
+)
+```
+
+On CUDA, the default uses graph replay for DNA/RNA poses and eager execution for
+protein and protein-ligand poses. Override with `cuda_graph=True` or `False`
+only when the fixed-shape/repetition tradeoff is known. Custom minimizers manage
+their own execution mode.
+
+## Large batches and memory
+
+TMol automatically chunks large pose stacks before native packing, using a
+conservative topology and free-memory policy. The compact interaction-graph path
+does not require CUDA graph capture. Let the default select a chunk size first.
+
+For diagnosis or an application-specific memory ceiling, lower the bound with:
+
+```bash
+TMOL_PACK_MAX_POSES_PER_CHUNK=10 python workflow.py
+```
+
+Smaller chunks reduce peak memory but can reduce throughput. A larger override
+does not bypass native signed-32-bit safety checks and may fail cleanly if the
+work unit is unrepresentable. Record the pose count, largest residue count,
+device, chunk override, runtime, and peak allocation when tuning.
+
+## Validate
+
+Confirm that output poses are finite, the expected blocks were allowed to
+change, fixed blocks remained fixed, and constraints/movement masks were
+honored. FastRelax is stochastic: seed reproducibly for regression tests and
+compare outcomes as well as elapsed time.
+
+Primary references: `docs/workflows/packing.md`,
+`docs/user_guide/optimization.md`, `docs/user_guide/cpu_threading.md`, and
+`docs/api/pack.rst`.

--- a/skills/tmol-pack-relax/evals/evals.json
+++ b/skills/tmol-pack-relax/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "skill": "tmol-pack-relax",
+  "cases": [
+    {
+      "id": "bounded-fixed-sequence-repack",
+      "prompt": "Repack a batch of canonical protein poses on the available device without changing sequence identities. Keep a supplied block mask fixed, use a conservative packing chunk size of 10, and verify the output before reporting runtime and peak memory.",
+      "setup": {
+        "cwd": "TMol repository root",
+        "requires": ["working TMol installation", "prepared canonical PoseStack", "fixed-block mask"]
+      },
+      "expected_behavior": [
+        "Uses PackerTask.restrict_to_repacking() and the standard conformer samplers",
+        "Applies disable_packing_by_block_mask() to the supplied mask",
+        "Sets TMOL_PACK_MAX_POSES_PER_CHUNK=10 for this run",
+        "Does not require CUDA graph capture for compact packing memory",
+        "Verifies finite output and unchanged fixed blocks and identities"
+      ],
+      "success_criteria": {
+        "finite_output": true,
+        "sequence_identities_unchanged": true,
+        "fixed_blocks_unchanged": true,
+        "reports_runtime": true,
+        "reports_peak_memory": true
+      }
+    }
+  ]
+}

--- a/skills/tmol-pack-relax/skill-card.md
+++ b/skills/tmol-pack-relax/skill-card.md
@@ -1,0 +1,40 @@
+# Skill Card
+
+## Description
+
+`tmol-pack-relax` configures side-chain/nucleic conformer sampling, coordinate
+or kinematic minimization, constraints, and FastRelax while keeping large CPU or
+CUDA packing workloads within bounded native work units.
+
+## Owner and license
+
+TMol maintainers. Apache-2.0; see the repository `LICENSE`.
+
+## Requirements
+
+A working TMol installation, a prepared `PoseStack`, and a score function made
+from the same parameter database. CUDA is optional.
+
+## Risks and mitigations
+
+- Repacking and design have different identity semantics. The skill never treats
+  `restrict_to_repacking()` as a design task.
+- Packing can change topology, invalidating a rendered scorer. The skill requires
+  rerendering after layout changes.
+- Large batches can exceed memory or native dispatch limits. The skill relies on
+  automatic chunking, permits a lower explicit bound, and retains checked native
+  failures.
+- Relax is stochastic and scores are modeling objectives, not experimental
+  validation. The skill seeds regression runs and reports that limitation.
+
+## References and output
+
+References: `docs/workflows/packing.md`, `docs/user_guide/optimization.md`,
+`docs/workflows/nucleic_acids.md`, and `docs/api/relax.rst`.
+
+Output: a new packed, minimized, or relaxed `PoseStack`, plus validation of task
+masks, finite coordinates/scores, and relevant memory/timing metadata.
+
+## Skill version
+
+0.1.0 (2026-09)

--- a/skills/tmol-score/SKILL.md
+++ b/skills/tmol-score/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: tmol-score
+description: >
+  Score structures with TMol on CPU or CUDA, including PoseStack construction,
+  score-term weights, unweighted decomposition, block-pair analysis, coordinate
+  gradients, CPU thread control, batching, and fixed-shape CUDA graph replay.
+  Do not use for side-chain packing or full FastRelax protocols.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+license: Apache-2.0
+---
+
+# TMol scoring
+
+Build a scorer whose device, chemical database, and pose layout agree, then
+choose summed, decomposed, differentiable, or captured execution based on the
+requested output. TMol scores are TMol score units, not kcal/mol and not
+numerically interchangeable with Rosetta scores.
+
+This workflow requires a working TMol installation. Prepared ligand chemistry
+also requires Biotite and the extended `ParameterDatabase` returned by pose
+construction.
+
+## Minimal workflow
+
+```python
+import torch
+from tmol.io import pose_stack_from_pdb
+from tmol.score import beta2016_score_function
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+pose = pose_stack_from_pdb("input.pdb", device)
+sfxn = beta2016_score_function(device)
+scorer = sfxn.render_whole_pose_scoring_module(pose)
+scores = scorer(pose.coords)
+```
+
+Render the scorer again after changing the pose's block or atom layout. A
+coordinate-only update with the same layout can reuse it.
+
+For ligands prepared through `pose_stack_from_biotite(...,
+return_context=True)`, construct the score function with
+`context.parameter_database`. Read `docs/workflows/structure_io.md` and
+`docs/user_guide/ligands.md` before substituting a direct PDB path for
+noncanonical chemistry.
+
+## Gradients and score terms
+
+```python
+coords = pose.coords.detach().clone().requires_grad_(True)
+total = scorer(coords).sum()
+total.backward()
+gradient = coords.grad
+
+unweighted = scorer(coords.detach(), sum_terms=False, apply_weights=False)
+weighted = scorer(coords.detach(), sum_terms=False, apply_weights=True)
+```
+
+Changing or zeroing individual score-function weights remains supported. Do not
+replace decomposed requests with a summed fused result: callers asking for
+`sum_terms=False` or `apply_weights=False` require canonical term lanes.
+
+Use `render_block_pair_scoring_module()` for block-by-block attribution. Treat
+historically named `ddg` helpers as interaction-score conventions unless the
+workflow explicitly constructs the required physical reference states.
+
+## CPU execution
+
+Inspect both process affinity and the active PyTorch budget. Set the budget
+before rendering the scorer:
+
+```python
+import os
+import torch
+
+available = (
+    len(os.sched_getaffinity(0))
+    if hasattr(os, "sched_getaffinity")
+    else (os.cpu_count() or 1)
+)
+print(available, torch.get_num_threads())
+torch.set_num_threads(8)
+```
+
+TMol uses the PyTorch value as a ceiling and may use fewer workers on small
+inputs. Divide cores between concurrent processes. Read
+`docs/user_guide/cpu_threading.md` for scheduler and environment examples.
+
+## CUDA execution
+
+Batch similarly sized poses to limit padding. Synchronize before and after
+timed CUDA regions. For repeated default weighted scoring with a fixed shape,
+dtype, device, and scorer, capture replay with:
+
+```python
+graphed = sfxn.render_whole_pose_scoring_module(pose, cuda_graph="forward")
+with torch.no_grad():
+    scores = graphed(pose.coords)
+```
+
+Use `cuda_graph="forward_backward"` when the repeated workload includes
+coordinate gradients. Graph replay reduces launch overhead but is not required
+for compact scoring or packing memory. Its output buffers are reused; clone an
+output that must survive the next replay. Keep eager execution for changing
+shapes or unsupported dynamic behavior.
+
+## Validate
+
+Check finite totals and, when requested, finite coordinate gradients. For an
+optimization or implementation comparison, also compare decomposed weighted
+terms, not only a final total that could hide compensating errors.
+
+Primary references: `docs/user_guide/scoring.md`,
+`docs/user_guide/cpu_threading.md`, `docs/workflows/gpu_batching.md`, and
+`docs/api/score.rst`.

--- a/skills/tmol-score/evals/evals.json
+++ b/skills/tmol-score/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "skill": "tmol-score",
+  "cases": [
+    {
+      "id": "cpu-score-gradient-and-terms",
+      "prompt": "Score a canonical PDB on CPU using four threads. Report the weighted total, all unweighted score-term lanes, and the Cartesian gradient norm without changing the pose topology.",
+      "setup": {
+        "cwd": "TMol repository root",
+        "requires": ["working TMol installation", "one canonical test PDB"]
+      },
+      "expected_behavior": [
+        "Calls torch.set_num_threads(4) before rendering the scorer",
+        "Builds the pose and beta2016 score function on CPU",
+        "Uses sum_terms=False and apply_weights=False for canonical unweighted lanes",
+        "Computes a coordinate gradient through the rendered scorer",
+        "Labels scores as TMol score units rather than kcal/mol"
+      ],
+      "success_criteria": {
+        "finite_total": true,
+        "finite_gradient": true,
+        "reports_thread_count": 4,
+        "reports_term_lanes": true
+      }
+    }
+  ]
+}

--- a/skills/tmol-score/skill-card.md
+++ b/skills/tmol-score/skill-card.md
@@ -1,0 +1,41 @@
+# Skill Card
+
+## Description
+
+`tmol-score` constructs compatible poses and score functions, evaluates totals
+or term decompositions, computes coordinate gradients, and selects CPU
+threading, CUDA batching, or fixed-shape graph replay.
+
+## Owner and license
+
+TMol maintainers. Apache-2.0; see the repository `LICENSE`.
+
+## Requirements
+
+A working TMol installation and an input whose chemistry can be represented by
+the selected parameter database. CUDA is optional.
+
+## Risks and mitigations
+
+- TMol and Rosetta score values are not numerically interchangeable; the skill
+  labels units and comparisons accordingly.
+- A ligand pose paired with the default database can omit prepared parameters;
+  the skill preserves and reuses the build context's database.
+- Asynchronous CUDA timing and CPU oversubscription can produce misleading
+  results; the skill requires synchronization and records the active thread
+  budget.
+- CUDA graph outputs are reused. The skill calls this out before downstream code
+  retains a result across replays.
+
+## References and output
+
+References: `docs/user_guide/scoring.md`, `docs/user_guide/cpu_threading.md`,
+`docs/workflows/gpu_batching.md`, and `docs/api/score.rst`.
+
+Output: finite per-pose scores, optional canonical score-term lanes, and optional
+coordinate gradients. The workflow reads structures and does not modify them
+unless the user separately requests output files.
+
+## Skill version
+
+0.1.0 (2026-09)

--- a/skills/tmol-setup/SKILL.md
+++ b/skills/tmol-setup/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: tmol-setup
+description: >
+  Install and verify TMol on CPU or CUDA. Use for wheel selection, source or
+  editable builds, AOT versus JIT extension loading, PyTorch/CUDA compatibility,
+  and import or compiler failures. Do not use for scoring or modeling once an
+  installation already works.
+allowed-tools: Bash, Read, Write, AskUserQuestion
+license: Apache-2.0
+---
+
+# TMol setup
+
+Produce a verified TMol installation using the least expensive path compatible
+with the user's Python, PyTorch, platform, and device. Run commands from the TMol
+repository root only when building a checkout.
+
+This workflow requires Python 3.11+ and PyTorch 2.5+. Source or JIT builds need
+a C++ compiler; only CUDA source or JIT builds need `nvcc`.
+
+## Select the installation path
+
+1. Inspect `python`, `torch.__version__`, `torch.version.cuda`, the platform,
+   and GPU availability before choosing a wheel.
+2. Prefer a matching wheel from the current GitHub release. Wheel tags must
+   match the Python ABI and PyTorch minor; CUDA wheels must also match the CUDA
+   lane.
+3. Use `pip install tmol` when source-distribution fallback behavior is
+   acceptable.
+4. Use an editable source build for development or an unsupported wheel lane.
+   Request CPU-only explicitly when CUDA is not wanted.
+
+Read `docs/installation.md` for current supported lanes and runtime notes before
+constructing a versioned wheel URL.
+
+## Source builds
+
+```bash
+git clone https://github.com/uw-ipd/tmol.git
+cd tmol
+TMOL_DISABLE_WHEEL_FETCH=1 python -m pip install -e ".[dev]"
+```
+
+CPU-only:
+
+```bash
+TMOL_DISABLE_WHEEL_FETCH=1 python -m pip install -e . \
+  -Ccmake.define.TMOL_ENABLE_CUDA=OFF
+```
+
+For an existing PyTorch environment, install the small build dependencies and
+use `--no-build-isolation`; see `docs/user_guide/development.md`. Control build
+parallelism with `MAX_JOBS` and CUDA compiler parallelism with
+`TMOL_NVCC_THREADS` instead of oversubscribing a scheduler allocation.
+
+## AOT and JIT loading
+
+Normal wheel installs use ahead-of-time compiled extensions. During kernel
+development, force source compilation with:
+
+```bash
+TMOL_USE_JIT=1 python -c "import tmol; print(tmol.__version__)"
+```
+
+Use `TMOL_JIT_FALLBACK=1` only when the desired behavior is AOT first and JIT
+after an AOT load failure. CPU JIT needs a C++ compiler and Ninja; CUDA JIT also
+needs a compatible `nvcc`.
+
+## Verify
+
+```bash
+python - <<'PY'
+import torch
+import tmol
+
+print("tmol", tmol.__version__)
+print("torch", torch.__version__)
+print("torch CUDA", torch.version.cuda)
+print("CUDA available", torch.cuda.is_available())
+print("CPU threads", torch.get_num_threads())
+PY
+```
+
+For a source checkout, finish with a narrow CPU test before attempting the full
+suite:
+
+```bash
+pytest -q tmol/tests/score/test_score_function.py -k "not cuda"
+```
+
+## Failure routing
+
+- ABI, PyTorch-minor, or CUDA-lane mismatch: install a matching wheel rather
+  than debugging symbols in an incompatible binary.
+- `GLIBCXX_* not found`: use a newer runtime/compiler or build against the host;
+  do not copy arbitrary C++ runtime libraries into the package.
+- no CUDA compiler: choose CPU-only or install a toolkit whose `nvcc` is
+  compatible with the active PyTorch build.
+- extension changes not appearing: use a fresh `TORCH_EXTENSIONS_DIR` or rebuild
+  the editable install, then record which mode was tested.
+
+Do not modify shell startup files, install system packages, or download large
+toolchains unless the user authorized those environment changes.

--- a/skills/tmol-setup/evals/evals.json
+++ b/skills/tmol-setup/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0",
+  "skill": "tmol-setup",
+  "cases": [
+    {
+      "id": "verify-existing-cpu-install",
+      "prompt": "Verify this existing CPU-only TMol checkout without installing system packages. Report the TMol and PyTorch versions, CUDA availability, active CPU thread count, and run one focused CPU scoring test.",
+      "setup": {
+        "cwd": "TMol repository root with its Python environment available",
+        "requires": ["Python 3.11+", "PyTorch 2.5+"]
+      },
+      "expected_behavior": [
+        "Inspects the active Python, TMol, PyTorch, and CUDA state before changing the environment",
+        "Does not require nvcc for the requested CPU-only verification",
+        "Reports torch.get_num_threads()",
+        "Runs a focused non-CUDA scoring test and reports its exit status"
+      ],
+      "success_criteria": {
+        "focused_test_exit_code": 0,
+        "reports_versions": true,
+        "reports_cpu_threads": true
+      }
+    }
+  ]
+}

--- a/skills/tmol-setup/skill-card.md
+++ b/skills/tmol-setup/skill-card.md
@@ -1,0 +1,37 @@
+# Skill Card
+
+## Description
+
+`tmol-setup` selects and verifies a compatible TMol CPU or CUDA installation,
+including release wheels, editable source builds, and JIT extension loading.
+
+## Owner and license
+
+TMol maintainers. Apache-2.0; see the repository `LICENSE`.
+
+## Requirements
+
+Python 3.11+, PyTorch 2.5+, and a matching supported platform. Source/JIT builds
+need CMake, Ninja, and a C++ compiler; CUDA source/JIT builds additionally need
+`nvcc`. No credentials are required for public releases.
+
+## Risks and mitigations
+
+- Binary tags are coupled to the Python ABI, PyTorch minor, and CUDA lane. The
+  skill inspects these before selecting a wheel.
+- Source builds can consume substantial CPU, memory, and time. The skill exposes
+  `MAX_JOBS` and does not install system toolchains without authorization.
+- JIT caches can hide stale builds. The skill records the loading mode and uses
+  a fresh cache when validating changed native sources.
+
+## References and output
+
+References: `docs/installation.md` and `docs/user_guide/development.md`.
+
+Output: a working import, reported TMol/PyTorch/CUDA versions, device
+availability, and a bounded test result. Installation may modify only the
+selected Python environment and explicitly chosen build/cache directories.
+
+## Skill version
+
+0.1.0 (2026-09)

--- a/tmol/__init__.py
+++ b/tmol/__init__.py
@@ -36,6 +36,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "CanonicalOrdering",
+    "CartesianMinimizer",
     "CartesianMoveMap",
     "ConstraintEnergyTerm",
     "ConstraintSet",
@@ -127,7 +128,13 @@ for _module, _names in (
     ),
     (
         "tmol.optimization",
-        ("build_kinforest_network", "run_cart_min", "run_kin_min", "run_min"),
+        (
+            "CartesianMinimizer",
+            "build_kinforest_network",
+            "run_cart_min",
+            "run_kin_min",
+            "run_min",
+        ),
     ),
     (
         "tmol.pose",

--- a/tmol/extern/moderngpu/meta.hxx
+++ b/tmol/extern/moderngpu/meta.hxx
@@ -76,13 +76,13 @@ MGPU_HOST_DEVICE constexpr bool is_pow2(int x) {
   return 0 == (x & (x - 1));
 }
 MGPU_HOST_DEVICE constexpr int div_up(int x, int y) {
-  return (x + y - 1) / y;
+  return x / y + (x % y != 0);
 }
 MGPU_HOST_DEVICE constexpr int64_t div_up(int64_t x, int64_t y) {
-  return (x + y - 1) / y;
+  return x / y + (x % y != 0);
 }
 MGPU_HOST_DEVICE constexpr size_t div_up(size_t x, size_t y) {
-  return (x + y - 1) / y;
+  return x / y + (x % y != 0);
 }
 MGPU_HOST_DEVICE constexpr int s_log2(int x, int p = 0) {
   return x > 1 ? s_log2(x / 2) + 1 : p;

--- a/tmol/optimization/__init__.py
+++ b/tmol/optimization/__init__.py
@@ -6,6 +6,7 @@ from ._lbfgs_armijo import (  # noqa: F401
     lbfgs_two_loop,
 )  # noqa: F401
 from ._minimizers import (  # noqa: F401
+    CartesianMinimizer,
     build_kinforest_network,
     run_cart_min,
     run_kin_min,
@@ -14,6 +15,7 @@ from ._minimizers import (  # noqa: F401
 from ._sfxn_modules import CartesianSfxnNetwork, KinForestSfxnNetwork  # noqa: F401
 
 __all__ = [
+    "CartesianMinimizer",
     "CartesianSfxnNetwork",
     "KinForestSfxnNetwork",
     "build_kinforest_network",

--- a/tmol/optimization/_armijo_compiled.py
+++ b/tmol/optimization/_armijo_compiled.py
@@ -1,0 +1,27 @@
+"""Compiled state transitions for the segmented Armijo line search.
+
+Scoring remains a separate call because it is the expensive, differentiable
+part of the search and may be captured in a CUDA graph.  These operations fuse
+the small comparisons, masks, and selections around each score evaluation.
+They are deliberately functional: returning fresh tensors keeps the optimizer
+compatible with both eager execution and a graph-captured scorer.
+"""
+
+from tmol._load_ext import load_ops
+
+_ops = load_ops(
+    __name__,
+    __file__,
+    [
+        "armijo_compiled.ops.cpp",
+        "armijo_compiled.cpu.cpp",
+        "armijo_compiled.cuda.cu",
+    ],
+    "tmol_optimization",
+)
+
+armijo_start = _ops.armijo_start
+armijo_classify = _ops.armijo_classify
+armijo_trial = _ops.armijo_trial
+armijo_update = _ops.armijo_update
+armijo_finalize = _ops.armijo_finalize

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -4,6 +4,14 @@ from typing import Any
 import torch
 from torch.optim import Optimizer
 
+from tmol.optimization._armijo_compiled import (
+    armijo_classify,
+    armijo_finalize,
+    armijo_start,
+    armijo_trial,
+    armijo_update,
+)
+
 
 def lbfgs_two_loop(grad, dirs, stps):
     """L-BFGS search direction H_k @ grad via the compact
@@ -86,6 +94,11 @@ _LS_BACKTRACK = 2
 _LS_FAILED = 3
 
 
+def _any_true(mask):
+    """Synchronize a predicate without launching a reduction for one segment."""
+    return bool(mask) if mask.numel() == 1 else bool(mask.any())
+
+
 def armijo_linesearch_segmented(
     func,
     derphi0,
@@ -139,75 +152,61 @@ def armijo_linesearch_segmented(
               * 'factor' corresponds roughly to 'beta' in the text (see point 1)
     """
     phi0 = old_fval
-    zeros = torch.zeros_like(alpha0)
-    alpha = torch.where(searching, alpha0, zeros)
-    # no step until one is accepted, so a rejected trial is never applied
-    accepted = zeros.clone()
-    phi_accepted = phi0.clone()
-    status = torch.full(alpha0.shape, _LS_DONE, dtype=torch.int64, device=alpha0.device)
+    alpha = armijo_start(searching, alpha0)
 
     phi = func(alpha)
     n_evals = 1
 
     # sigma_increase > sigma_decrease, so a linear-looking step also has
     # sufficient decrease; it is the one case where a longer step is tried
-    linear = phi <= phi0 + alpha * sigma_increase * derphi0
-    sufficient = phi <= phi0 + alpha * sigma_decrease * derphi0
-    status = torch.where(searching & linear, _LS_INCREASE, status)
-    status = torch.where(searching & ~linear & ~sufficient, _LS_BACKTRACK, status)
-    took = searching & (linear | sufficient)
-    accepted = torch.where(took, alpha, accepted)
-    phi_accepted = torch.where(took, phi, phi_accepted)
+    accepted, phi_accepted, status, active = armijo_classify(
+        searching,
+        alpha,
+        phi,
+        phi0,
+        derphi0,
+        sigma_increase,
+        sigma_decrease,
+    )
 
     while True:
-        active = (status == _LS_INCREASE) | (status == _LS_BACKTRACK)
-        if not bool(active.any()):
+        if not _any_true(active):
             break
 
-        trial = torch.where(status == _LS_INCREASE, alpha / factor, accepted)
-        # see note above, decrease by factor^2
-        trial = torch.where(status == _LS_BACKTRACK, alpha * factor * factor, trial)
+        trial = armijo_trial(status, alpha, accepted, factor)
         phi_trial = func(trial)
         n_evals += 1
 
-        # longer step: keep it only if it beats the step we already have
-        increasing = status == _LS_INCREASE
-        better = increasing & (phi_trial < phi)
-        accepted = torch.where(better, trial, accepted)
-        phi_accepted = torch.where(better, phi_trial, phi_accepted)
-        status = torch.where(increasing, _LS_DONE, status)
-
-        backtracking = status == _LS_BACKTRACK
-        armijo = backtracking & (phi_trial <= phi0 + trial * sigma_decrease * derphi0)
-        accepted = torch.where(armijo, trial, accepted)
-        phi_accepted = torch.where(armijo, phi_trial, phi_accepted)
-        status = torch.where(armijo, _LS_DONE, status)
-
-        # under the floor: accept anything that still went downhill, else fail
-        floored = backtracking & ~armijo & (trial < minstep)
-        downhill = floored & (phi_trial < phi0)
-        accepted = torch.where(downhill, trial, accepted)
-        phi_accepted = torch.where(downhill, phi_trial, phi_accepted)
-        status = torch.where(downhill, _LS_DONE, status)
-        failed = floored & ~downhill
-        accepted = torch.where(failed, zeros, accepted)
-        phi_accepted = torch.where(failed, phi0, phi_accepted)
-        status = torch.where(failed, _LS_FAILED, status)
-        for p in failed.nonzero(as_tuple=False).flatten().tolist():
-            step = float(trial[p])
-            finite = (
-                (float(phi_trial[p]) - float(phi0[p])) / step if step else float("inf")
-            )
-            print(
-                "Inaccurate G! Segment=",
-                p,
-                " Step=",
-                step,
-                " Deriv=",
-                float(derphi0[p]),
-                " Finite=",
-                finite,
-            )
+        accepted, phi_accepted, status, failed, active = armijo_update(
+            status,
+            trial,
+            accepted,
+            phi_accepted,
+            phi,
+            phi_trial,
+            phi0,
+            derphi0,
+            sigma_decrease,
+            minstep,
+        )
+        if _any_true(failed):
+            for p in failed.nonzero(as_tuple=False).flatten().tolist():
+                step = float(trial[p])
+                finite = (
+                    (float(phi_trial[p]) - float(phi0[p])) / step
+                    if step
+                    else float("inf")
+                )
+                print(
+                    "Inaccurate G! Segment=",
+                    p,
+                    " Step=",
+                    step,
+                    " Deriv=",
+                    float(derphi0[p]),
+                    " Finite=",
+                    finite,
+                )
 
         alpha = trial
         phi = phi_trial
@@ -229,6 +228,8 @@ class LBFGS_Armijo(Optimizer):
         history_size (int): update history size (default: 128).
         segment_ids (Tensor): the segment (e.g. pose) each parameter element
             belongs to; each segment is minimized independently (default: one)
+        fixed_iterations (bool): run exactly ``max_iter`` iterations instead of
+            evaluating convergence criteria (default: False).
     """
 
     supports_segments = True
@@ -303,6 +304,7 @@ class LBFGS_Armijo(Optimizer):
         minstep=1e-12,
         verbose=False,
         segment_ids=None,
+        fixed_iterations=False,
     ):
         defaults = dict(
             lr=lr,
@@ -311,6 +313,7 @@ class LBFGS_Armijo(Optimizer):
             rtol=rtol,
             gradtol=gradtol,
             history_size=history_size,
+            fixed_iterations=fixed_iterations,
         )
         super(LBFGS_Armijo, self).__init__(params, defaults)
 
@@ -333,6 +336,35 @@ class LBFGS_Armijo(Optimizer):
                 device=self._params[0].device,
             )
         self._init_segments(segment_ids)
+
+    def reset(self) -> None:
+        """Reset trajectory state while retaining shape-compatible scratch.
+
+        This is useful when repeatedly minimizing new coordinates with the
+        same parameter tensor and optimizer configuration. History contents
+        are ignored until overwritten, so large buffers do not need clearing.
+        """
+        param = self._params[0]
+        param.grad = None
+        state = self.state.get(param)
+        if not state:
+            return
+
+        state["func_evals"] = 0
+        state["n_iter"] = 0
+        state["history_start"] = 0
+        state["history_count"] = 0
+        for name in ("t", "prev_flat_grad", "prev_loss_vec"):
+            state.pop(name, None)
+        if state.get("x_ref") is not None:
+            state["x_ref"].copy_(param.data.view(-1))
+        for name in ("converged", "stalled", "needs_reset", "was_reset"):
+            if state.get(name) is not None:
+                state[name].zero_()
+        state["any_needs_reset"] = False
+        state["any_inactive"] = False
+        self._last_loss_vec = None
+        self._closure_fn = None
 
     def _init_segments(self, segment_ids):
         """Set up the mapping from parameter elements to independent blocks.
@@ -479,6 +511,10 @@ class LBFGS_Armijo(Optimizer):
         atol = group["atol"]
         gradtol = group["gradtol"]
         history_size = group["history_size"]
+        fixed_iterations = group["fixed_iterations"]
+        # At most one curvature pair is created after each iteration beyond
+        # the first. Short protocols should not allocate the default 128 slots.
+        history_size = min(history_size, max(1, max_iter - 1))
 
         # dtype-based default
         #   float32 : eps~3.45e-4
@@ -527,11 +563,12 @@ class LBFGS_Armijo(Optimizer):
                 state["grad_pad"] = torch.zeros(
                     hist_shape[1:], device=x.device, dtype=x.dtype
                 )
-            # zero-filled: unwritten slots and padding must not contribute
-            state["old_dirs_mat"] = torch.zeros(
+            # Only ``history_count`` written slots are consumed. Non-dense
+            # segmented writes explicitly zero their own padding.
+            state["old_dirs_mat"] = torch.empty(
                 hist_shape, device=x.device, dtype=x.dtype
             )
-            state["old_stps_mat"] = torch.zeros(
+            state["old_stps_mat"] = torch.empty(
                 hist_shape, device=x.device, dtype=x.dtype
             )
             state["history_start"] = 0  # Circular buffer start index
@@ -553,6 +590,7 @@ class LBFGS_Armijo(Optimizer):
             atol=atol,
             gradtol=gradtol,
             history_size=history_size,
+            fixed_iterations=fixed_iterations,
             # torch / state
             state=state,
             param=param,
@@ -606,7 +644,7 @@ class LBFGS_Armijo(Optimizer):
             # a segment with no curvature of its own contributes no history
             keep = self._seg_sum(y * s) > 1e-6
 
-            if bool(keep.any()):
+            if _any_true(keep):
                 # updating memory - write directly into circular buffer
                 if ctx.history_count < ctx.history_size:
                     # Still filling up the buffer
@@ -700,7 +738,7 @@ class LBFGS_Armijo(Optimizer):
         if correct:
             for check in (1, 2):
                 bad = (gtd_seg > -1e-5) & ~self._inactive(ctx)
-                if not bool(bad.any()):
+                if not _any_true(bad):
                     break
                 bad_elem = self._per_element(bad)
                 if check == 1:
@@ -743,12 +781,15 @@ class LBFGS_Armijo(Optimizer):
 
         # a failed search gets one steepest-descent restart, applied on the next
         # iteration so the other segments are not held up; then it is retired
-        failed = status == _LS_FAILED
-        # restart step length, as in the unsegmented rescue: 1/sqrt(|g.d|)
-        retry_t = torch.clamp((-ctx.gtd_seg).clamp(min=self._minstep).rsqrt(), max=1.0)
-        ctx.t = torch.where(failed, retry_t, accepted)
-        ctx.t = torch.where(searching, ctx.t, start_t)
-        any_failed = bool(failed.any())
+        ctx.t, failed = armijo_finalize(
+            status,
+            ctx.gtd_seg,
+            accepted,
+            start_t,
+            searching,
+            self._minstep,
+        )
+        any_failed = _any_true(failed)
         if any_failed:
             ctx.stalled |= failed & ctx.was_reset
             ctx.needs_reset |= failed & ~ctx.was_reset
@@ -765,6 +806,12 @@ class LBFGS_Armijo(Optimizer):
         keeps moving while another pose finishes, making batch minimization
         depend on which other structures happen to share the stack.
         """
+        if ctx.fixed_iterations:
+            # Benchmarking and truncated inference protocols often require an
+            # exact iteration count. Skip convergence reductions and their
+            # device-to-host synchronization while preserving failure resets.
+            return False
+
         newly_converged = self._seg_amax(ctx.flat_grad.abs()) <= ctx.gradtol
         if ctx.prev_loss_vec is not None:
             dE = (ctx.loss_vec - ctx.prev_loss_vec).abs()

--- a/tmol/optimization/_minimizers.py
+++ b/tmol/optimization/_minimizers.py
@@ -192,6 +192,115 @@ def run_kin_min(
     )
 
 
+class _ReusableLBFGSFactory:
+    """Construct once, then reset LBFGS when parameters and options match."""
+
+    supports_segments = True
+
+    def __init__(self):
+        self.optimizer: LBFGS_Armijo | None = None
+        self.parameter: torch.Tensor | None = None
+        self.options: dict[str, object] | None = None
+        self.last_reused = False
+
+    @staticmethod
+    def _same_options(left: dict[str, object], right: dict[str, object]) -> bool:
+        if left.keys() != right.keys():
+            return False
+        for name, left_value in left.items():
+            right_value = right[name]
+            if isinstance(left_value, torch.Tensor) or isinstance(
+                right_value, torch.Tensor
+            ):
+                if left_value is not right_value:
+                    return False
+            elif left_value != right_value:
+                return False
+        return True
+
+    def __call__(self, params, **options) -> LBFGS_Armijo:
+        parameters = list(params)
+        if len(parameters) != 1:
+            return LBFGS_Armijo(parameters, **options)
+        parameter = parameters[0]
+        reusable = (
+            self.optimizer is not None
+            and parameter is self.parameter
+            and self.options is not None
+            and self._same_options(self.options, options)
+        )
+        self.last_reused = reusable
+        if reusable:
+            assert self.optimizer is not None
+            self.optimizer.reset()
+            return self.optimizer
+
+        self.optimizer = LBFGS_Armijo(parameters, **options)
+        self.parameter = parameter
+        self.options = dict(options)
+        return self.optimizer
+
+
+class CartesianMinimizer:
+    """Reusable Cartesian minimizer for pose stacks with stable topology.
+
+    Rendering a score function builds topology-dependent tensors and, when
+    requested, captures a CUDA graph.  Those are setup costs rather than part
+    of the numerical minimization.  This class retains that rendered network
+    across calls and resets only its coordinates when the score function,
+    topology, shape, and coordinate mask remain compatible.
+
+    Create one instance per reusable workflow.  A topology or score-function
+    change is detected automatically and safely rebuilds the network.
+
+    Args:
+        cuda_graph: Capture and replay the fixed-shape CUDA forward/backward
+            score path.  This has a one-time setup and memory cost and requires
+            CUDA, so it is most useful when the instance will be reused.
+    """
+
+    def __init__(self, cuda_graph: bool = False):
+        self.cuda_graph = cuda_graph
+        self.network: CartesianSfxnNetwork | None = None
+        self.optimizer: LBFGS_Armijo | None = None
+        self.last_optimizer_reused = False
+        self._lbfgs_factory = _ReusableLBFGSFactory()
+
+    def __call__(
+        self,
+        pose_stack: PoseStack,
+        sfxn: ScoreFunction,
+        coord_mask: Tensor[torch.bool][:, :] | None = None,
+        optimizer_cls: type[torch.optim.Optimizer] = LBFGS_Armijo,
+        optimizer_kwargs: dict[str, object] | None = None,
+        verbose: bool = False,
+    ) -> PoseStack:
+        """Minimize one pose stack, reusing compatible rendered state."""
+        from tmol.optimization import CartesianSfxnNetwork
+
+        if self.network is None or not self.network._reset(
+            sfxn, pose_stack, coord_mask
+        ):
+            self.network = CartesianSfxnNetwork(
+                sfxn,
+                pose_stack,
+                coord_mask,
+                cuda_graph="forward_backward" if self.cuda_graph else False,
+            )
+        selected_optimizer = (
+            self._lbfgs_factory if optimizer_cls is LBFGS_Armijo else optimizer_cls
+        )
+        result = run_min(
+            self.network,
+            optimizer_cls=selected_optimizer,
+            optimizer_kwargs=optimizer_kwargs,
+            verbose=verbose,
+        )
+        self.optimizer = self._lbfgs_factory.optimizer
+        self.last_optimizer_reused = self._lbfgs_factory.last_reused
+        return result
+
+
 def run_cart_min(
     pose_stack: PoseStack,
     sfxn: ScoreFunction,
@@ -217,17 +326,10 @@ def run_cart_min(
     Returns:
         A new pose stack containing the minimized coordinates.
     """
-    from tmol.optimization import CartesianSfxnNetwork
-
-    cart_network = CartesianSfxnNetwork(
-        sfxn,
+    return CartesianMinimizer(cuda_graph=cuda_graph)(
         pose_stack,
-        coord_mask,
-        cuda_graph="forward_backward" if cuda_graph else False,
-    )
-
-    return run_min(
-        cart_network,
+        sfxn,
+        coord_mask=coord_mask,
         optimizer_cls=optimizer_cls,
         optimizer_kwargs=optimizer_kwargs,
         verbose=verbose,

--- a/tmol/optimization/_sfxn_modules.py
+++ b/tmol/optimization/_sfxn_modules.py
@@ -38,6 +38,7 @@ class CartesianSfxnNetwork(torch.nn.Module):
         # clone: forward() writes into full_coords in place, which would
         # otherwise overwrite the caller's coordinates
         self.full_coords = pose_stack.coords.clone().detach()
+        self._uses_default_coord_mask = coord_mask is None
         if coord_mask is None:
             # Padding coordinates never contribute to a pose's score. Excluding
             # them keeps heterogeneous batches from allocating and updating
@@ -76,9 +77,10 @@ class CartesianSfxnNetwork(torch.nn.Module):
         coord_mask=None,
     ) -> bool:
         """Return whether this network can score another pose without rendering."""
-        if coord_mask is None:
-            coord_mask = pose_stack.real_atoms
-        return (
+        # Check cheap Python identity and shape predicates before any tensor
+        # comparison. The normal repeated-topology path shares these tensors,
+        # so it avoids both rebuilding ``real_atoms`` and synchronizing CUDA.
+        if not (
             score_function is self._score_function
             and self._score_function_versions
             == (
@@ -88,14 +90,28 @@ class CartesianSfxnNetwork(torch.nn.Module):
             and pose_stack.packed_block_types is self.pose_stack.packed_block_types
             and pose_stack.constraint_set is self.pose_stack.constraint_set
             and pose_stack.coords.shape == self.pose_stack.coords.shape
-            and torch.equal(coord_mask, self.coord_mask)
-            and torch.equal(pose_stack.block_type_ind, self.pose_stack.block_type_ind)
-            and torch.equal(
-                pose_stack.block_coord_offset, self.pose_stack.block_coord_offset
-            )
             and pose_stack.inter_residue_connections
             is self.pose_stack.inter_residue_connections
             and pose_stack.inter_block_bondsep is self.pose_stack.inter_block_bondsep
+        ):
+            return False
+
+        if coord_mask is None:
+            if not self._uses_default_coord_mask:
+                return False
+        elif coord_mask is not self.coord_mask and not torch.equal(
+            coord_mask, self.coord_mask
+        ):
+            return False
+
+        return (
+            pose_stack.block_type_ind is self.pose_stack.block_type_ind
+            or torch.equal(pose_stack.block_type_ind, self.pose_stack.block_type_ind)
+        ) and (
+            pose_stack.block_coord_offset is self.pose_stack.block_coord_offset
+            or torch.equal(
+                pose_stack.block_coord_offset, self.pose_stack.block_coord_offset
+            )
         )
 
     def _reset(
@@ -150,7 +166,6 @@ class KinForestSfxnNetwork(torch.nn.Module):
         dof_mask=None,
         kin_dtype=torch.float32,
     ):
-
         super(KinForestSfxnNetwork, self).__init__()
 
         torch_device = pose_stack.device
@@ -230,7 +245,6 @@ class KinForestSfxnNetwork(torch.nn.Module):
         return self.whole_pose_scoring_module(self.full_coords)
 
     def pose_stack_from_dofs(self) -> PoseStack:
-
         full_dofs = self.full_dofs.clone()
         flat_coords = self.flat_coords.detach()
         full_dofs.view(-1)[self._dof_flat_idx] = self.masked_dofs

--- a/tmol/optimization/armijo_compiled.cpu.cpp
+++ b/tmol/optimization/armijo_compiled.cpu.cpp
@@ -1,0 +1,17 @@
+#include <tmol/score/common/device_operations.cpu.impl.hh>
+#include <tmol/optimization/armijo_compiled.impl.hh>
+
+namespace tmol {
+namespace optimization {
+
+template struct ArmijoCompiledDispatch<
+    score::common::DeviceOperations,
+    tmol::Device::CPU,
+    float>;
+template struct ArmijoCompiledDispatch<
+    score::common::DeviceOperations,
+    tmol::Device::CPU,
+    double>;
+
+}  // namespace optimization
+}  // namespace tmol

--- a/tmol/optimization/armijo_compiled.cuda.cu
+++ b/tmol/optimization/armijo_compiled.cuda.cu
@@ -1,0 +1,17 @@
+#include <tmol/score/common/device_operations.cuda.impl.cuh>
+#include <tmol/optimization/armijo_compiled.impl.hh>
+
+namespace tmol {
+namespace optimization {
+
+template struct ArmijoCompiledDispatch<
+    score::common::DeviceOperations,
+    tmol::Device::CUDA,
+    float>;
+template struct ArmijoCompiledDispatch<
+    score::common::DeviceOperations,
+    tmol::Device::CUDA,
+    double>;
+
+}  // namespace optimization
+}  // namespace tmol

--- a/tmol/optimization/armijo_compiled.hh
+++ b/tmol/optimization/armijo_compiled.hh
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <tuple>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/context_manager.hh>
+
+namespace tmol {
+namespace optimization {
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+struct ArmijoCompiledDispatch {
+  static TPack<Real, 1, D> start(
+      ContextManager& mgr,
+      TView<bool, 1, D> searching,
+      TView<Real, 1, D> alpha0);
+
+  static std::tuple<
+      TPack<Real, 1, D>,
+      TPack<Real, 1, D>,
+      TPack<int64_t, 1, D>,
+      TPack<bool, 1, D>>
+  classify(
+      ContextManager& mgr,
+      TView<bool, 1, D> searching,
+      TView<Real, 1, D> alpha,
+      TView<Real, 1, D> phi,
+      TView<Real, 1, D> phi0,
+      TView<Real, 1, D> derphi0,
+      Real sigma_increase,
+      Real sigma_decrease);
+
+  static TPack<Real, 1, D> trial(
+      ContextManager& mgr,
+      TView<int64_t, 1, D> status,
+      TView<Real, 1, D> alpha,
+      TView<Real, 1, D> accepted,
+      Real factor);
+
+  static std::tuple<
+      TPack<Real, 1, D>,
+      TPack<Real, 1, D>,
+      TPack<int64_t, 1, D>,
+      TPack<bool, 1, D>,
+      TPack<bool, 1, D>>
+  update(
+      ContextManager& mgr,
+      TView<int64_t, 1, D> status,
+      TView<Real, 1, D> trial,
+      TView<Real, 1, D> accepted,
+      TView<Real, 1, D> phi_accepted,
+      TView<Real, 1, D> phi,
+      TView<Real, 1, D> phi_trial,
+      TView<Real, 1, D> phi0,
+      TView<Real, 1, D> derphi0,
+      Real sigma_decrease,
+      Real minstep);
+
+  static std::tuple<TPack<Real, 1, D>, TPack<bool, 1, D>> finalize(
+      ContextManager& mgr,
+      TView<int64_t, 1, D> status,
+      TView<Real, 1, D> derphi0,
+      TView<Real, 1, D> accepted,
+      TView<Real, 1, D> start,
+      TView<bool, 1, D> searching,
+      Real minstep);
+};
+
+}  // namespace optimization
+}  // namespace tmol

--- a/tmol/optimization/armijo_compiled.impl.hh
+++ b/tmol/optimization/armijo_compiled.impl.hh
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <cmath>
+
+#include <tmol/optimization/armijo_compiled.hh>
+#include <tmol/score/common/diamond_macros.hh>
+#include <tmol/score/common/launch_box_macros.hh>
+
+namespace tmol {
+namespace optimization {
+
+// Keep these values synchronized with _lbfgs_armijo.py.  The kernels preserve
+// the Python implementation's sequential state transitions while replacing
+// each group of elementwise tensor expressions with one launch.
+constexpr int64_t LS_DONE = 0;
+constexpr int64_t LS_INCREASE = 1;
+constexpr int64_t LS_BACKTRACK = 2;
+constexpr int64_t LS_FAILED = 3;
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+TPack<Real, 1, D> ArmijoCompiledDispatch<DeviceDispatch, D, Real>::start(
+    ContextManager& mgr,
+    TView<bool, 1, D> searching,
+    TView<Real, 1, D> alpha0) {
+  int const n_segments = alpha0.size(0);
+  auto alpha_t = TPack<Real, 1, D>::empty({n_segments});
+  auto alpha = alpha_t.view;
+
+  LAUNCH_BOX_128;
+  DeviceDispatch<D>::template forall<launch_t>(
+      mgr, n_segments, [=] TMOL_DEVICE_FUNC(int i) {
+        alpha[i] = searching[i] ? alpha0[i] : Real(0);
+      });
+  return alpha_t;
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+std::tuple<
+    TPack<Real, 1, D>,
+    TPack<Real, 1, D>,
+    TPack<int64_t, 1, D>,
+    TPack<bool, 1, D>>
+ArmijoCompiledDispatch<DeviceDispatch, D, Real>::classify(
+    ContextManager& mgr,
+    TView<bool, 1, D> searching,
+    TView<Real, 1, D> alpha,
+    TView<Real, 1, D> phi,
+    TView<Real, 1, D> phi0,
+    TView<Real, 1, D> derphi0,
+    Real sigma_increase,
+    Real sigma_decrease) {
+  int const n_segments = alpha.size(0);
+  auto accepted_t = TPack<Real, 1, D>::empty({n_segments});
+  auto phi_accepted_t = TPack<Real, 1, D>::empty({n_segments});
+  auto status_t = TPack<int64_t, 1, D>::empty({n_segments});
+  auto active_t = TPack<bool, 1, D>::empty({n_segments});
+  auto accepted = accepted_t.view;
+  auto phi_accepted = phi_accepted_t.view;
+  auto status = status_t.view;
+  auto active = active_t.view;
+
+  LAUNCH_BOX_128;
+  DeviceDispatch<D>::template forall<launch_t>(
+      mgr, n_segments, [=] TMOL_DEVICE_FUNC(int i) {
+        bool const linear =
+            phi[i] <= phi0[i] + alpha[i] * sigma_increase * derphi0[i];
+        bool const sufficient =
+            phi[i] <= phi0[i] + alpha[i] * sigma_decrease * derphi0[i];
+        bool const took = searching[i] && (linear || sufficient);
+
+        accepted[i] = took ? alpha[i] : Real(0);
+        phi_accepted[i] = took ? phi[i] : phi0[i];
+        int64_t const status_i = !searching[i] ? LS_DONE
+                                 : linear      ? LS_INCREASE
+                                 : !sufficient ? LS_BACKTRACK
+                                               : LS_DONE;
+        status[i] = status_i;
+        active[i] = status_i == LS_INCREASE || status_i == LS_BACKTRACK;
+      });
+  return {accepted_t, phi_accepted_t, status_t, active_t};
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+TPack<Real, 1, D> ArmijoCompiledDispatch<DeviceDispatch, D, Real>::trial(
+    ContextManager& mgr,
+    TView<int64_t, 1, D> status,
+    TView<Real, 1, D> alpha,
+    TView<Real, 1, D> accepted,
+    Real factor) {
+  int const n_segments = alpha.size(0);
+  auto result_t = TPack<Real, 1, D>::empty({n_segments});
+  auto result = result_t.view;
+
+  LAUNCH_BOX_128;
+  DeviceDispatch<D>::template forall<launch_t>(
+      mgr, n_segments, [=] TMOL_DEVICE_FUNC(int i) {
+        result[i] = status[i] == LS_INCREASE    ? alpha[i] / factor
+                    : status[i] == LS_BACKTRACK ? alpha[i] * factor * factor
+                                                : accepted[i];
+      });
+  return result_t;
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+std::tuple<
+    TPack<Real, 1, D>,
+    TPack<Real, 1, D>,
+    TPack<int64_t, 1, D>,
+    TPack<bool, 1, D>,
+    TPack<bool, 1, D>>
+ArmijoCompiledDispatch<DeviceDispatch, D, Real>::update(
+    ContextManager& mgr,
+    TView<int64_t, 1, D> status,
+    TView<Real, 1, D> trial,
+    TView<Real, 1, D> accepted,
+    TView<Real, 1, D> phi_accepted,
+    TView<Real, 1, D> phi,
+    TView<Real, 1, D> phi_trial,
+    TView<Real, 1, D> phi0,
+    TView<Real, 1, D> derphi0,
+    Real sigma_decrease,
+    Real minstep) {
+  int const n_segments = trial.size(0);
+  auto next_accepted_t = TPack<Real, 1, D>::empty({n_segments});
+  auto next_phi_accepted_t = TPack<Real, 1, D>::empty({n_segments});
+  auto next_status_t = TPack<int64_t, 1, D>::empty({n_segments});
+  auto failed_t = TPack<bool, 1, D>::empty({n_segments});
+  auto active_t = TPack<bool, 1, D>::empty({n_segments});
+  auto next_accepted = next_accepted_t.view;
+  auto next_phi_accepted = next_phi_accepted_t.view;
+  auto next_status = next_status_t.view;
+  auto failed = failed_t.view;
+  auto active = active_t.view;
+
+  LAUNCH_BOX_128;
+  DeviceDispatch<D>::template forall<launch_t>(
+      mgr, n_segments, [=] TMOL_DEVICE_FUNC(int i) {
+        Real accepted_i = accepted[i];
+        Real phi_accepted_i = phi_accepted[i];
+        int64_t status_i = status[i];
+        bool failed_i = false;
+
+        if (status_i == LS_INCREASE) {
+          if (phi_trial[i] < phi[i]) {
+            accepted_i = trial[i];
+            phi_accepted_i = phi_trial[i];
+          }
+          status_i = LS_DONE;
+        } else if (status_i == LS_BACKTRACK) {
+          bool const armijo =
+              phi_trial[i] <= phi0[i] + trial[i] * sigma_decrease * derphi0[i];
+          if (armijo) {
+            accepted_i = trial[i];
+            phi_accepted_i = phi_trial[i];
+            status_i = LS_DONE;
+          } else if (trial[i] < minstep) {
+            if (phi_trial[i] < phi0[i]) {
+              accepted_i = trial[i];
+              phi_accepted_i = phi_trial[i];
+              status_i = LS_DONE;
+            } else {
+              accepted_i = Real(0);
+              phi_accepted_i = phi0[i];
+              status_i = LS_FAILED;
+              failed_i = true;
+            }
+          }
+        }
+
+        next_accepted[i] = accepted_i;
+        next_phi_accepted[i] = phi_accepted_i;
+        next_status[i] = status_i;
+        failed[i] = failed_i;
+        active[i] = status_i == LS_INCREASE || status_i == LS_BACKTRACK;
+      });
+  return {
+      next_accepted_t, next_phi_accepted_t, next_status_t, failed_t, active_t};
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real>
+std::tuple<TPack<Real, 1, D>, TPack<bool, 1, D>>
+ArmijoCompiledDispatch<DeviceDispatch, D, Real>::finalize(
+    ContextManager& mgr,
+    TView<int64_t, 1, D> status,
+    TView<Real, 1, D> derphi0,
+    TView<Real, 1, D> accepted,
+    TView<Real, 1, D> start,
+    TView<bool, 1, D> searching,
+    Real minstep) {
+  int const n_segments = accepted.size(0);
+  auto step_t = TPack<Real, 1, D>::empty({n_segments});
+  auto failed_t = TPack<bool, 1, D>::empty({n_segments});
+  auto step = step_t.view;
+  auto failed = failed_t.view;
+
+  LAUNCH_BOX_128;
+  DeviceDispatch<D>::template forall<launch_t>(
+      mgr, n_segments, [=] TMOL_DEVICE_FUNC(int i) {
+        bool const failed_i = status[i] == LS_FAILED;
+        Real selected = accepted[i];
+        if (failed_i) {
+          Real magnitude = -derphi0[i];
+          magnitude = magnitude < minstep ? minstep : magnitude;
+          Real retry = Real(1) / sqrt(magnitude);
+          selected = retry < Real(1) ? retry : Real(1);
+        }
+        step[i] = searching[i] ? selected : start[i];
+        failed[i] = failed_i;
+      });
+  return {step_t, failed_t};
+}
+
+}  // namespace optimization
+}  // namespace tmol

--- a/tmol/optimization/armijo_compiled.ops.cpp
+++ b/tmol/optimization/armijo_compiled.ops.cpp
@@ -1,0 +1,157 @@
+#include <torch/script.h>
+#include <torch/torch.h>
+
+#include <tmol/optimization/armijo_compiled.hh>
+#include <tmol/score/common/device_operations.hh>
+#include <tmol/utility/function_dispatch/aten.hh>
+#include <tmol/utility/tensor/TensorCast.h>
+
+namespace tmol {
+namespace optimization {
+
+using torch::Tensor;
+ContextManager mgr;
+
+Tensor armijo_start(Tensor searching, Tensor alpha0) {
+  Tensor alpha;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      alpha0.options(), "armijo_start", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        alpha =
+            ArmijoCompiledDispatch<score::common::DeviceOperations, Dev, Real>::
+                start(mgr, TCAST(searching), TCAST(alpha0))
+                    .tensor;
+      }));
+  return alpha;
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor> armijo_classify(
+    Tensor searching,
+    Tensor alpha,
+    Tensor phi,
+    Tensor phi0,
+    Tensor derphi0,
+    double sigma_increase,
+    double sigma_decrease) {
+  Tensor accepted, phi_accepted, status, active;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      alpha.options(), "armijo_classify", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        auto result =
+            ArmijoCompiledDispatch<score::common::DeviceOperations, Dev, Real>::
+                classify(
+                    mgr,
+                    TCAST(searching),
+                    TCAST(alpha),
+                    TCAST(phi),
+                    TCAST(phi0),
+                    TCAST(derphi0),
+                    Real(sigma_increase),
+                    Real(sigma_decrease));
+        accepted = std::get<0>(result).tensor;
+        phi_accepted = std::get<1>(result).tensor;
+        status = std::get<2>(result).tensor;
+        active = std::get<3>(result).tensor;
+      }));
+  return {accepted, phi_accepted, status, active};
+}
+
+Tensor armijo_trial(
+    Tensor status, Tensor alpha, Tensor accepted, double factor) {
+  Tensor trial;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      alpha.options(), "armijo_trial", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        trial =
+            ArmijoCompiledDispatch<score::common::DeviceOperations, Dev, Real>::
+                trial(
+                    mgr,
+                    TCAST(status),
+                    TCAST(alpha),
+                    TCAST(accepted),
+                    Real(factor))
+                    .tensor;
+      }));
+  return trial;
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> armijo_update(
+    Tensor status,
+    Tensor trial,
+    Tensor accepted,
+    Tensor phi_accepted,
+    Tensor phi,
+    Tensor phi_trial,
+    Tensor phi0,
+    Tensor derphi0,
+    double sigma_decrease,
+    double minstep) {
+  Tensor next_accepted, next_phi_accepted, next_status, failed, active;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      trial.options(), "armijo_update", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        auto result =
+            ArmijoCompiledDispatch<score::common::DeviceOperations, Dev, Real>::
+                update(
+                    mgr,
+                    TCAST(status),
+                    TCAST(trial),
+                    TCAST(accepted),
+                    TCAST(phi_accepted),
+                    TCAST(phi),
+                    TCAST(phi_trial),
+                    TCAST(phi0),
+                    TCAST(derphi0),
+                    Real(sigma_decrease),
+                    Real(minstep));
+        next_accepted = std::get<0>(result).tensor;
+        next_phi_accepted = std::get<1>(result).tensor;
+        next_status = std::get<2>(result).tensor;
+        failed = std::get<3>(result).tensor;
+        active = std::get<4>(result).tensor;
+      }));
+  return {next_accepted, next_phi_accepted, next_status, failed, active};
+}
+
+std::tuple<Tensor, Tensor> armijo_finalize(
+    Tensor status,
+    Tensor derphi0,
+    Tensor accepted,
+    Tensor start,
+    Tensor searching,
+    double minstep) {
+  Tensor step, failed;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      accepted.options(), "armijo_finalize", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        auto result =
+            ArmijoCompiledDispatch<score::common::DeviceOperations, Dev, Real>::
+                finalize(
+                    mgr,
+                    TCAST(status),
+                    TCAST(derphi0),
+                    TCAST(accepted),
+                    TCAST(start),
+                    TCAST(searching),
+                    Real(minstep));
+        step = std::get<0>(result).tensor;
+        failed = std::get<1>(result).tensor;
+      }));
+  return {step, failed};
+}
+
+TORCH_LIBRARY(tmol_optimization, m) {
+  m.def("armijo_start", &armijo_start);
+  m.def("armijo_classify", &armijo_classify);
+  m.def("armijo_trial", &armijo_trial);
+  m.def("armijo_update", &armijo_update);
+  m.def("armijo_finalize", &armijo_finalize);
+}
+
+}  // namespace optimization
+}  // namespace tmol

--- a/tmol/pack/_pack_rotamers.py
+++ b/tmol/pack/_pack_rotamers.py
@@ -1,8 +1,11 @@
+import copy
+import os
 import time
 
+import attr
 import torch
 
-from tmol.pose import PoseStack
+from tmol.pose import PDBInfo, PoseStack, PoseStackBuilder
 from tmol.score import ScoreFunction
 
 from tmol.pack import (
@@ -33,6 +36,24 @@ def pack_rotamers(
     Returns:
         A new pose stack containing the lowest-ranked assignment per pose.
     """
+
+    max_poses_per_chunk = _max_poses_per_packing_chunk(pose_stack)
+    if pose_stack.n_poses > max_poses_per_chunk:
+        packed_chunks = []
+        for first_pose in range(0, pose_stack.n_poses, max_poses_per_chunk):
+            last_pose = min(first_pose + max_poses_per_chunk, pose_stack.n_poses)
+            chunk_pose_stack = _slice_pose_stack_for_packing(
+                pose_stack, first_pose, last_pose
+            )
+            chunk_task = _slice_packer_task(task, first_pose, last_pose)
+            packed_chunk = pack_rotamers(
+                chunk_pose_stack, sfxn, chunk_task, verbose=verbose
+            )
+            packed_chunks.append(packed_chunk)
+        combined_pose_stack = PoseStackBuilder.from_poses(
+            packed_chunks, pose_stack.device
+        )
+        return combined_pose_stack
 
     if verbose:
         synchronize_device(pose_stack.device)
@@ -89,14 +110,179 @@ def pack_rotamers(
     return new_pose_stack
 
 
+_SMALL_PACKING_POSE_CHUNK = 25
+_DEFAULT_PACKING_POSE_CHUNK = 10
+_ESTIMATED_PACKING_BYTES_PER_BLOCK = 2 * 1024 * 1024
+_PACKING_FREE_MEMORY_FRACTION = 0.25
+
+
+def _max_poses_per_packing_chunk(pose_stack: PoseStack) -> int:
+    """Return a bounded, memory-aware native-packer batch size.
+
+    Native score dispatches use signed 32-bit per-chunk indices. Keeping the
+    batch bounded prevents a wide pose stack from overflowing those indices
+    and also limits transient score/index storage. The size cutoff and memory
+    estimate are deliberately conservative: packing scratch grows with both
+    residue count and rotamer density. The environment override is primarily
+    for deterministic tests and performance tuning.
+    """
+    configured = os.environ.get("TMOL_PACK_MAX_POSES_PER_CHUNK")
+    if configured is not None:
+        try:
+            chunk_size = int(configured)
+        except ValueError as error:
+            raise ValueError(
+                "TMOL_PACK_MAX_POSES_PER_CHUNK must be a positive integer; "
+                f"got {configured!r}"
+            ) from error
+        if chunk_size <= 0:
+            raise ValueError(
+                "TMOL_PACK_MAX_POSES_PER_CHUNK must be a positive integer; "
+                f"got {configured!r}"
+            )
+        return chunk_size
+
+    max_n_blocks = pose_stack.max_n_blocks
+    chunk_size = (
+        _SMALL_PACKING_POSE_CHUNK
+        if max_n_blocks <= 256
+        else _DEFAULT_PACKING_POSE_CHUNK
+    )
+
+    if pose_stack.device.type == "cuda":
+        free_bytes, _ = torch.cuda.mem_get_info(pose_stack.device)
+        memory_budget = int(free_bytes * _PACKING_FREE_MEMORY_FRACTION)
+        estimated_bytes_per_pose = (
+            max(1, max_n_blocks) * _ESTIMATED_PACKING_BYTES_PER_BLOCK
+        )
+        memory_limited_chunk = max(1, memory_budget // estimated_bytes_per_pose)
+        chunk_size = min(chunk_size, memory_limited_chunk)
+    return chunk_size
+
+
+_PACKER_TASK_POSE_TENSORS = (
+    "is_real_block",
+    "per_block_orig_block_type",
+    "per_block_n_considered_block_types",
+    "per_block_considered_block_types",
+    "per_block_considered_block_types_is_orig",
+    "restrict_to_repacking_masks",
+    "per_block_is_block_type_allowed",
+    "per_block_conformer_sampler_allowed",
+    "per_block_chi_expansion",
+)
+
+
+def _slice_pose_stack_for_packing(
+    pose_stack: PoseStack, first_pose: int, last_pose: int
+) -> PoseStack:
+    """Make a cheap contiguous view for an unconstrained packing chunk.
+
+    The packer reads the input topology and coordinates but returns a new pose
+    stack, so ordinary FastRelax chunks can share input storage safely. Fall
+    back to the general builder for the uncommon metadata types whose pose
+    indices need remapping.
+    """
+    if pose_stack.split_block_mapping:
+        return PoseStackBuilder.from_poses(
+            [pose_stack.split(i) for i in range(first_pose, last_pose)],
+            pose_stack.device,
+        )
+
+    chunk_constraint_set = None
+    if pose_stack.constraint_set is not None:
+        constraints = pose_stack.constraint_set
+        constraint_poses = constraints.constraint_atoms[:, :, 0]
+        selected = torch.where(
+            ((constraint_poses >= first_pose) & (constraint_poses < last_pose)).any(
+                dim=1
+            )
+        )[0]
+        chunk_atoms = constraints.constraint_atoms[selected].clone()
+        chunk_atom_poses = chunk_atoms[:, :, 0]
+        real_atoms = chunk_atom_poses != -1
+        chunk_atom_poses[real_atoms] -= first_pose
+        chunk_atoms[:, :, 0] = chunk_atom_poses
+        chunk_unique_blocks = constraints.constraint_unique_blocks[selected].clone()
+        chunk_unique_blocks[:, 0] -= first_pose
+        chunk_constraint_set = attr.evolve(
+            constraints,
+            n_poses=last_pose - first_pose,
+            constraint_function_inds=constraints.constraint_function_inds[selected],
+            constraint_atoms=chunk_atoms,
+            constraint_params=constraints.constraint_params[selected],
+            constraint_num_unique_blocks=constraints.constraint_num_unique_blocks[
+                selected
+            ],
+            constraint_unique_blocks=chunk_unique_blocks,
+        )
+
+    pdb_info = pose_stack.pdb_info
+    chunk_pdb_info = PDBInfo(
+        residue_labels=pdb_info.residue_labels[first_pose:last_pose].copy(),
+        residue_insertion_codes=pdb_info.residue_insertion_codes[
+            first_pose:last_pose
+        ].copy(),
+        chain_labels=pdb_info.chain_labels[first_pose:last_pose].copy(),
+        atom_occupancy=pdb_info.atom_occupancy[first_pose:last_pose].copy(),
+        atom_b_factor=pdb_info.atom_b_factor[first_pose:last_pose].copy(),
+    )
+
+    def view(tensor):
+        return tensor[first_pose:last_pose].detach()
+
+    return PoseStack(
+        packed_block_types=pose_stack.packed_block_types,
+        coords=view(pose_stack.coords),
+        block_coord_offset=view(pose_stack.block_coord_offset),
+        block_coord_offset64=view(pose_stack.block_coord_offset64),
+        inter_residue_connections=view(pose_stack.inter_residue_connections),
+        inter_residue_connections64=view(pose_stack.inter_residue_connections64),
+        inter_block_bondsep=view(pose_stack.inter_block_bondsep),
+        inter_block_bondsep64=view(pose_stack.inter_block_bondsep64),
+        block_type_ind=view(pose_stack.block_type_ind),
+        block_type_ind64=view(pose_stack.block_type_ind64),
+        chain_id=view(pose_stack.chain_id),
+        chain_id64=view(pose_stack.chain_id64),
+        pdb_info=chunk_pdb_info,
+        constraint_set=chunk_constraint_set,
+        device=pose_stack.device,
+        split_block_mapping=None,
+    )
+
+
+def _slice_packer_task(task: PackerTask, first_pose: int, last_pose: int) -> PackerTask:
+    """Shallow-copy a configured task and slice all pose-major tensors."""
+    chunk_task = copy.copy(task)
+    for attribute in _PACKER_TASK_POSE_TENSORS:
+        value = getattr(task, attribute)
+        setattr(chunk_task, attribute, value[first_pose:last_pose])
+    chunk_task.real_block_pose, chunk_task.real_block_block = torch.nonzero(
+        chunk_task.is_real_block, as_tuple=True
+    )
+    return chunk_task
+
+
 def _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=False):
     from tmol.pack.compiled import build_interaction_graph
 
     pbt = pose_stack.packed_block_types
     rotamer_scoring_module = sfxn.render_rotamer_scoring_module(pose_stack, rotamer_set)
 
-    energies = rotamer_scoring_module(rotamer_set.coords)
-    energies = energies.coalesce()
+    if pose_stack.device.type == "cuda":
+        # CUDA graph construction atomically accumulates duplicate coordinates,
+        # so it can consume raw int32 entries. Avoid constructing/coalescing a
+        # PyTorch COO tensor: COO promotes coordinates to int64 and sorting can
+        # briefly require another full-size copy.
+        energy_indices, energy_values = rotamer_scoring_module.forward_sparse_entries(
+            rotamer_set.coords
+        )
+    else:
+        # The CPU interaction-graph accumulator is deliberately non-atomic.
+        # Coalesce cross-layout duplicates before its parallel native loops.
+        energies = rotamer_scoring_module(rotamer_set.coords).coalesce()
+        energy_indices = energies.indices().to(torch.int32)
+        energy_values = energies.values()
 
     if verbose:
         synchronize_device(pose_stack.device)
@@ -130,8 +316,8 @@ def _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=Fals
         rotamer_set.pose_for_rot,
         rotamer_set.block_type_ind_for_rot,
         rotamer_set.block_ind_for_rot,
-        energies.indices().to(torch.int32),
-        energies.values(),
+        energy_indices,
+        energy_values,
         verbose,
     )
     if verbose:

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -366,9 +366,14 @@ MGPU_DEVICE float warp_wide_sim_annealing(
                              + new_in_chunk];
         }
 
+        // The proposed and current rotamers commonly occupy the same chunk.
+        // In that case both table entries share one sparse chunk offset; avoid
+        // repeating this irregular global-memory lookup for every neighbor.
         int64_t const k_prev_chunk_offset =
-            ig.chunk_offsets_
-                [k_offset_offset + k_chunk * ran_res_n_chunks + prev_chunk];
+            prev_chunk == new_chunk
+                ? k_new_chunk_offset
+                : ig.chunk_offsets_[k_offset_offset
+                                    + k_chunk * ran_res_n_chunks + prev_chunk];
         float prev_contrib = 0.0f;
         if (k_prev_chunk_offset >= 0) {
           prev_contrib = ig.energy2b_

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -372,8 +372,9 @@ MGPU_DEVICE float warp_wide_sim_annealing(
         int64_t const k_prev_chunk_offset =
             prev_chunk == new_chunk
                 ? k_new_chunk_offset
-                : ig.chunk_offsets_[k_offset_offset
-                                    + k_chunk * ran_res_n_chunks + prev_chunk];
+                : ig.chunk_offsets_
+                      [k_offset_offset + k_chunk * ran_res_n_chunks
+                       + prev_chunk];
         float prev_contrib = 0.0f;
         if (k_prev_chunk_offset >= 0) {
           prev_contrib = ig.energy2b_

--- a/tmol/pack/compiled/compiled.impl.hh
+++ b/tmol/pack/compiled/compiled.impl.hh
@@ -8,6 +8,7 @@
 #include <tmol/score/common/tuple.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/counting.hh>
 
 #include <moderngpu/operators.hxx>
 
@@ -64,6 +65,17 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
   int const max_n_blocks = n_rots_for_block.size(1);
   int64_t const n_sparse_entries = sparse_inds.size(1);
 
+  int const n_sparse_entries_dispatch = score::common::checked_dispatch_size(
+      n_sparse_entries, "interaction-graph construction");
+  int const n_pose_block_cells = score::common::checked_dispatch_product(
+      n_poses, max_n_blocks, "interaction-graph block dispatch");
+  int const n_block_pair_cells = score::common::checked_dispatch_product(
+      max_n_blocks,
+      max_n_blocks,
+      "interaction-graph block-pair dispatch per pose");
+  int const n_pose_block_pair_cells = score::common::checked_dispatch_product(
+      n_poses, n_block_pair_cells, "interaction-graph block-pair dispatch");
+
   assert(rot_offset_for_pose.size(0) == n_poses);
   assert(n_rots_for_block.size(0) == n_poses);
   assert(block_type_ind_for_rot.size(0) == n_rotamers);
@@ -111,7 +123,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       }
     });
     DeviceDispatch<D>::template forall<launch_t>(
-        mgr, n_poses * max_n_blocks, count_n_chunks_for_block);
+        mgr, n_pose_block_cells, count_n_chunks_for_block);
 
     auto respair_is_adjacent_tp =
         TPack<int32_t, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
@@ -132,11 +144,11 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       // Code below relies on this.
       if (block1 > block2) {
         printf(
-            "Assumption violated! block1 %d < block2 %d for index %d (pose "
+            "Assumption violated! block1 %d < block2 %d for index %lld (pose "
             "%d)\n",
             block1,
             block2,
-            index,
+            static_cast<long long>(index),
             pose);
       } else {
         DeviceDispatch<D>::store_idempotent(
@@ -144,15 +156,15 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       }
     });
     DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_sparse_entries, note_adjacent_respairs);
+        mgr, n_sparse_entries_dispatch, note_adjacent_respairs);
 
     auto n_chunks_for_block_pair_tp =
         TPack<int64_t, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
     auto n_chunks_for_block_pair = n_chunks_for_block_pair_tp.view;
 
     auto note_n_chunks_for_block_pair = ([=] TMOL_DEVICE_FUNC(int index) {
-      int const pose = index / (max_n_blocks * max_n_blocks);
-      index = index - pose * max_n_blocks * max_n_blocks;
+      int const pose = index / n_block_pair_cells;
+      index = index - pose * n_block_pair_cells;
       int const block1 = index / max_n_blocks;
       int const block2 = index % max_n_blocks;
 
@@ -162,28 +174,30 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       if (respair_is_adjacent[pose][block1][block2]) {
         int const n_chunks1 = n_chunks_for_block[pose][block1];
         int const n_chunks2 = n_chunks_for_block[pose][block2];
-        int const n_chunk_pairs = n_chunks1 * n_chunks2;
+        int64_t const n_chunk_pairs = int64_t(n_chunks1) * n_chunks2;
         n_chunks_for_block_pair[pose][block1][block2] = n_chunk_pairs;
         n_chunks_for_block_pair[pose][block2][block1] = n_chunk_pairs;
       }
     });
     DeviceDispatch<D>::template forall<launch_t>(
-        mgr,
-        n_poses * max_n_blocks * max_n_blocks,
-        note_n_chunks_for_block_pair);
+        mgr, n_pose_block_pair_cells, note_n_chunks_for_block_pair);
 
     auto chunk_pair_offset_for_block_pair_tp =
         TPack<int64_t, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
     auto chunk_pair_offset_for_block_pair =
         chunk_pair_offset_for_block_pair_tp.view;
 
-    int const n_adjacent_chunk_pairs_total =
+    int64_t const n_adjacent_chunk_pairs_total_64 =
         DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
             mgr,
             n_chunks_for_block_pair.data(),
             chunk_pair_offset_for_block_pair.data(),
-            n_poses * max_n_blocks * max_n_blocks,
+            n_pose_block_pair_cells,
             mgpu::plus_t<int64_t>());
+    int const n_adjacent_chunk_pairs_total =
+        score::common::checked_dispatch_size(
+            n_adjacent_chunk_pairs_total_64,
+            "interaction-graph chunk-pair dispatch");
 
     auto chunk_pair_adjacency_tp =
         TPack<int64_t, 1, D>::zeros({n_adjacent_chunk_pairs_total});
@@ -222,7 +236,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
 
       // multiple threads will write exactly these values to these entries in
       // the chunk_pair_adjacency table
-      int64_t const n_pairs = chunk1_size * chunk2_size;
+      int64_t const n_pairs = int64_t(chunk1_size) * chunk2_size;
       DeviceDispatch<D>::store_idempotent(
           chunk_pair_adjacency
               [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2],
@@ -233,7 +247,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
           n_pairs);
     });
     DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_sparse_entries, note_adjacent_chunk_pairs);
+        mgr, n_sparse_entries_dispatch, note_adjacent_chunk_pairs);
 
     auto chunk_pair_offsets_tp =
         TPack<int64_t, 1, D>::zeros({n_adjacent_chunk_pairs_total});
@@ -259,7 +273,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
           int const block1 = block_ind_for_rot[rot1];
           int const block2 = block_ind_for_rot[rot2];
           if (block1 == block2) {
-            energy1b[rot1] = energy;
+            score::common::accumulate<D, Real>::add(energy1b[rot1], energy);
           } else {
             int const block1_rot_offset = rot_offset_for_block[pose][block1];
             int const block2_rot_offset = rot_offset_for_block[pose][block2];
@@ -292,24 +306,30 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
             int64_t const chunk_offset_ji = chunk_pair_offsets
                 [block_pair_chunk_offset_ji + chunk2 * n_chunks1 + chunk1];
 
-            energy2b
-                [chunk_offset_ij + rot_ind_wi_chunk1 * chunk2_size
-                 + rot_ind_wi_chunk2] = energy;
-            energy2b
-                [chunk_offset_ji + rot_ind_wi_chunk2 * chunk1_size
-                 + rot_ind_wi_chunk1] = energy;
+            score::common::accumulate<D, Real>::add(
+                energy2b
+                    [chunk_offset_ij + rot_ind_wi_chunk1 * chunk2_size
+                     + rot_ind_wi_chunk2],
+                energy);
+            score::common::accumulate<D, Real>::add(
+                energy2b
+                    [chunk_offset_ji + rot_ind_wi_chunk2 * chunk1_size
+                     + rot_ind_wi_chunk1],
+                energy);
           }
         });
     DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_sparse_entries, record_energies_in_energy1b_and_energy2b);
+        mgr,
+        n_sparse_entries_dispatch,
+        record_energies_in_energy1b_and_energy2b);
 
     // Mark the chunk_pair_offset_for_block_pair that are not adjacent w/ -1s
     // Mark the chunk_pair_offsets that are not adjacent w/ -1s
 
     auto sentinel_out_non_adjacent_block_pairs =
         ([=] TMOL_DEVICE_FUNC(int index) {
-          int const pose = index / (max_n_blocks * max_n_blocks);
-          index = index - pose * max_n_blocks * max_n_blocks;
+          int const pose = index / n_block_pair_cells;
+          index = index - pose * n_block_pair_cells;
           int const block1 = index / max_n_blocks;
           int const block2 = index % max_n_blocks;
 
@@ -321,9 +341,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
           }
         });
     DeviceDispatch<D>::template forall<launch_t>(
-        mgr,
-        n_poses * max_n_blocks * max_n_blocks,
-        sentinel_out_non_adjacent_block_pairs);
+        mgr, n_pose_block_pair_cells, sentinel_out_non_adjacent_block_pairs);
 
     auto sentinel_out_non_adjacent_chunk_pairs =
         ([=] TMOL_DEVICE_FUNC(int index) {
@@ -473,7 +491,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
             find_min_energy_for_block);
       });
       DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-          mgr, n_poses * max_n_blocks, compute_best_energy_per_block);
+          mgr, n_pose_block_cells, compute_best_energy_per_block);
 
       // Now we ask for every rotamer: should we keep it?
       // We will reject a rotamer if there is at least one rotamer for
@@ -548,7 +566,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
           count_n_rots_for_block);
     });
     DeviceDispatch<D>::template foreach_workgroup<launch_t>(
-        mgr, n_poses * max_n_blocks, decide_keep_blocks);
+        mgr, n_pose_block_cells, decide_keep_blocks);
 
   }  // end scope of first-pass interaction graph construction
   // This will deallocate the energy1b and energy2b tables
@@ -592,16 +610,18 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
 
   // scan the number of molten blocks
   auto block_to_molten_block_inds_tp =
-      TPack<int64_t, 1, D>::zeros({n_poses * max_n_blocks});
+      TPack<int64_t, 1, D>::zeros({n_pose_block_cells});
   auto block_to_molten_block_inds = block_to_molten_block_inds_tp.view;
 
-  int const n_molten_blocks =
+  int64_t const n_molten_blocks_64 =
       DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           keep_block.data(),
           block_to_molten_block_inds.data(),
-          n_poses * max_n_blocks,
+          n_pose_block_cells,
           mgpu::plus_t<int64_t>());
+  int const n_molten_blocks = score::common::checked_dispatch_size(
+      n_molten_blocks_64, "interaction-graph molten-block dispatch");
   auto molten_block_to_block_inds_tp =
       TPack<int64_t, 1, D>::zeros({n_molten_blocks});
   auto molten_block_to_block_inds = molten_block_to_block_inds_tp.view;
@@ -614,7 +634,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     }
   });
   DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, record_molten_block_indices);
+      mgr, n_pose_block_cells, record_molten_block_indices);
 
   // Figure out for each pose what its number of molten blocks is
   auto molten_block_offset_for_pose_tp = TPack<Int, 1, D>::zeros({n_poses});
@@ -649,6 +669,17 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
   // get maximum number of molten blocks per pose.
   int const max_n_molten_blocks = DeviceDispatch<D>::reduce(
       mgr, n_molten_blocks_per_pose.data(), n_poses, mgpu::maximum_t<Int>());
+  int const n_pose_molten_block_cells = score::common::checked_dispatch_product(
+      n_poses, max_n_molten_blocks, "interaction-graph molten-block dispatch");
+  int const n_molten_block_pair_cells = score::common::checked_dispatch_product(
+      max_n_molten_blocks,
+      max_n_molten_blocks,
+      "interaction-graph molten block-pair dispatch per pose");
+  int const n_pose_molten_block_pair_cells =
+      score::common::checked_dispatch_product(
+          n_poses,
+          n_molten_block_pair_cells,
+          "interaction-graph molten block-pair dispatch");
 
   auto n_bc_rots_per_pose_tp = TPack<Int, 1, D>::zeros({n_poses});
   auto bc_rot_offset_for_pose_tp = TPack<Int, 1, D>::zeros({n_poses});
@@ -771,7 +802,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     }
   });
   DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_poses * max_n_molten_blocks, count_n_chunks_for_block);
+      mgr, n_pose_molten_block_cells, count_n_chunks_for_block);
 
   auto respair_is_adjacent_tp = TPack<int32_t, 3, D>::zeros(
       {n_poses, max_n_molten_blocks, max_n_molten_blocks});
@@ -798,15 +829,15 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
         respair_is_adjacent[pose][molten_block1][molten_block2], int32_t(1));
   });
   DeviceDispatch<D>::template forall_independent<launch_t>(
-      mgr, n_sparse_entries, note_adjacent_respairs);
+      mgr, n_sparse_entries_dispatch, note_adjacent_respairs);
 
   auto n_chunks_for_block_pair_tp = TPack<int64_t, 3, D>::zeros(
       {n_poses, max_n_molten_blocks, max_n_molten_blocks});
   auto n_chunks_for_block_pair = n_chunks_for_block_pair_tp.view;
 
   auto note_n_chunks_for_block_pair = ([=] TMOL_DEVICE_FUNC(int index) {
-    int const pose = index / (max_n_molten_blocks * max_n_molten_blocks);
-    index = index - pose * max_n_molten_blocks * max_n_molten_blocks;
+    int const pose = index / n_molten_block_pair_cells;
+    index = index - pose * n_molten_block_pair_cells;
     int const molten_block1 = index / max_n_molten_blocks;
     int const molten_block2 = index % max_n_molten_blocks;
 
@@ -816,7 +847,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     if (respair_is_adjacent[pose][molten_block1][molten_block2]) {
       int const n_chunks1 = n_chunks_for_block[pose][molten_block1];
       int const n_chunks2 = n_chunks_for_block[pose][molten_block2];
-      int const n_chunk_pairs = n_chunks1 * n_chunks2;
+      int64_t const n_chunk_pairs = int64_t(n_chunks1) * n_chunks2;
       n_chunks_for_block_pair[pose][molten_block1][molten_block2] =
           n_chunk_pairs;
       n_chunks_for_block_pair[pose][molten_block2][molten_block1] =
@@ -824,22 +855,23 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     }
   });
   DeviceDispatch<D>::template forall<launch_t>(
-      mgr,
-      n_poses * max_n_molten_blocks * max_n_molten_blocks,
-      note_n_chunks_for_block_pair);
+      mgr, n_pose_molten_block_pair_cells, note_n_chunks_for_block_pair);
 
   auto chunk_pair_offset_for_block_pair_tp = TPack<int64_t, 3, D>::zeros(
       {n_poses, max_n_molten_blocks, max_n_molten_blocks});
   auto chunk_pair_offset_for_block_pair =
       chunk_pair_offset_for_block_pair_tp.view;
 
-  int const n_adjacent_chunk_pairs_total =
+  int64_t const n_adjacent_chunk_pairs_total_64 =
       DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           n_chunks_for_block_pair.data(),
           chunk_pair_offset_for_block_pair.data(),
-          n_poses * max_n_molten_blocks * max_n_molten_blocks,
+          n_pose_molten_block_pair_cells,
           mgpu::plus_t<int64_t>());
+  int const n_adjacent_chunk_pairs_total = score::common::checked_dispatch_size(
+      n_adjacent_chunk_pairs_total_64,
+      "interaction-graph retained chunk-pair dispatch");
 
   auto chunk_pair_adjacency_tp =
       TPack<int64_t, 1, D>::zeros({n_adjacent_chunk_pairs_total});
@@ -889,7 +921,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
     // multiple threads will write exactly these values to these entries in the
     // chunk_pair_adjacency table
 
-    int64_t const n_pairs = chunk1_size * chunk2_size;
+    int64_t const n_pairs = int64_t(chunk1_size) * chunk2_size;
     DeviceDispatch<D>::store_idempotent(
         chunk_pair_adjacency
             [block_pair_chunk_offset_ij + chunk1 * n_chunks2 + chunk2],
@@ -900,7 +932,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
         n_pairs);
   });
   DeviceDispatch<D>::template forall_independent<launch_t>(
-      mgr, n_sparse_entries, note_adjacent_chunk_pairs);
+      mgr, n_sparse_entries_dispatch, note_adjacent_chunk_pairs);
 
   auto chunk_pair_offsets_tp =
       TPack<int64_t, 1, D>::zeros({n_adjacent_chunk_pairs_total});
@@ -1044,23 +1076,27 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       int64_t e2b_ind_ji =
           chunk_offset_ji + rot_ind_wi_chunk2 * chunk1_size + rot_ind_wi_chunk1;
 
-      energy2b
-          [chunk_offset_ij + rot_ind_wi_chunk1 * chunk2_size
-           + rot_ind_wi_chunk2] = energy;
-      energy2b
-          [chunk_offset_ji + rot_ind_wi_chunk2 * chunk1_size
-           + rot_ind_wi_chunk1] = energy;
+      score::common::accumulate<D, Real>::add(
+          energy2b
+              [chunk_offset_ij + rot_ind_wi_chunk1 * chunk2_size
+               + rot_ind_wi_chunk2],
+          energy);
+      score::common::accumulate<D, Real>::add(
+          energy2b
+              [chunk_offset_ji + rot_ind_wi_chunk2 * chunk1_size
+               + rot_ind_wi_chunk1],
+          energy);
     }
   });
   DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_sparse_entries, record_energies_in_energy1b_and_energy2b);
+      mgr, n_sparse_entries_dispatch, record_energies_in_energy1b_and_energy2b);
 
   // Mark the chunk_pair_offset_for_block_pair that are not adjacent w/ -1s
   // Mark the chunk_pair_offsets that are not adjacent w/ -1s
   auto sentinel_out_non_adjacent_block_pairs =
       ([=] TMOL_DEVICE_FUNC(int index) {
-        int const pose = index / (max_n_molten_blocks * max_n_molten_blocks);
-        index = index - pose * max_n_molten_blocks * max_n_molten_blocks;
+        int const pose = index / n_molten_block_pair_cells;
+        index = index - pose * n_molten_block_pair_cells;
         int const block1 = index / max_n_molten_blocks;
         int const block2 = index % max_n_molten_blocks;
 
@@ -1073,7 +1109,7 @@ auto InteractionGraphBuilder<DeviceDispatch, D, Real, Int>::f(
       });
   DeviceDispatch<D>::template forall<launch_t>(
       mgr,
-      n_poses * max_n_molten_blocks * max_n_molten_blocks,
+      n_pose_molten_block_pair_cells,
       sentinel_out_non_adjacent_block_pairs);
 
   auto sentinel_out_non_adjacent_chunk_pairs =

--- a/tmol/pack/rotamer/dunbrack/dispatch.impl.hh
+++ b/tmol/pack/rotamer/dunbrack/dispatch.impl.hh
@@ -445,7 +445,9 @@ struct DunbrackChiSampler {
           wrap_iidihe += 2 * M_PI;
         }
         Real ii_period = rotameric_bb_periodicity[table_set][ii];
-        while (wrap_iidihe > ii_period) {
+        // The upper endpoint is periodic with zero. Keeping an exact endpoint
+        // would produce bin_index == table_size and index one past the table.
+        while (wrap_iidihe >= ii_period) {
           wrap_iidihe -= ii_period;
         }
 
@@ -711,7 +713,9 @@ struct DunbrackChiSampler {
           wrap_iidihe += 2 * M_PI;
         }
         Real ii_period = rotameric_bb_periodicity[table_set][ii];
-        while (wrap_iidihe > ii_period) {
+        // The upper endpoint is periodic with zero. Keeping an exact endpoint
+        // would produce bin_index == table_size and index one past the table.
+        while (wrap_iidihe >= ii_period) {
           wrap_iidihe -= ii_period;
         }
 

--- a/tmol/pose/_constraint_set.py
+++ b/tmol/pose/_constraint_set.py
@@ -164,6 +164,12 @@ class ConstraintSet:
         for i, cs in enumerate(constraint_sets):
             if cs is not None:
                 n_cs_constraints = cs.constraint_function_inds.size(0)
+                if n_cs_constraints == 0:
+                    # Split batched sets retain their parameter-column width
+                    # even when a particular pose has no constraints. An
+                    # all-empty concatenation has a zero-width destination;
+                    # avoid assigning a [0, N] source into that [0, 0] slice.
+                    continue
                 constraint_atoms_shifted = cs.constraint_atoms.detach().clone()
                 constraint_atoms_pose = constraint_atoms_shifted[:, :, 0]
                 is_real_pose = constraint_atoms_pose[:, :] != -1

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -26,10 +26,9 @@ from tmol.pack.rotamer import (
     IncludeCurrentSampler,
 )
 from tmol.optimization import (
-    CartesianSfxnNetwork,
+    CartesianMinimizer,
     run_cart_min,
     run_kin_min,
-    run_min,
 )
 from tmol.types import Tensor
 from tmol.utility._device import synchronize_device
@@ -165,8 +164,7 @@ class _DefaultCartesianMinimizer:
     """Cartesian minimizer that reuses rendering for unchanged pose topology."""
 
     def __init__(self, cuda_graph: bool):
-        self.cuda_graph = cuda_graph
-        self.network: CartesianSfxnNetwork | None = None
+        self.minimizer = CartesianMinimizer(cuda_graph=cuda_graph)
 
     def __call__(
         self,
@@ -181,17 +179,10 @@ class _DefaultCartesianMinimizer:
         coord_mask = (
             move_map.coord_mask if isinstance(move_map, CartesianMoveMap) else None
         )
-        if self.network is None or not self.network._reset(
-            sfxn, pose_stack, coord_mask
-        ):
-            self.network = CartesianSfxnNetwork(
-                sfxn,
-                pose_stack,
-                coord_mask,
-                cuda_graph="forward_backward" if self.cuda_graph else False,
-            )
-        return run_min(
-            self.network,
+        return self.minimizer(
+            pose_stack,
+            sfxn,
+            coord_mask=coord_mask,
             verbose=verbose,
             optimizer_kwargs={"verbose": verbose},
         )

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -48,6 +48,14 @@ class EnergyTerm:
         """
         raise NotImplementedError()
 
+    def accepts_shared_rotamer_dispatch(self):
+        """Whether this term accepts a compatible rotamer-pair index list."""
+        return False
+
+    def rotamer_dispatch_key(self):
+        """Compatibility key for reusable rotamer-pair dispatch layouts."""
+        return None
+
     def setup_block_type(self, block_type: RefinedResidueType):
         """Make a one-time CPU annotation on a block type.
 
@@ -112,6 +120,10 @@ class EnergyTerm:
     def get_rotamer_score_term_function(self):
         raise NotImplementedError()
 
+    def get_block_neighbor_cutoff(self):
+        """Maximum whole-pose block-neighbor reach, or ``None`` if unused."""
+        return None
+
     def get_rotamer_score_term_attributes(
         self, pose_stack: PoseStack, rotamer_set: RotamerSet
     ):
@@ -147,12 +159,14 @@ class EnergyTerm:
                 pose_stack.device,
             )
         f = self.get_pose_score_term_function()
+        term_attributes = self.get_score_term_attributes(pose_stack)
 
         return TermWholePoseScoringModule(
             self.class_name(),
             pose_stack,
-            self.get_score_term_attributes(pose_stack),
+            term_attributes,
             f,
+            self.get_block_neighbor_cutoff(),
         )
 
     def render_block_pair_scoring_module(
@@ -175,6 +189,7 @@ class EnergyTerm:
             pose_stack,
             self.get_score_term_attributes(pose_stack),
             f,
+            self.get_block_neighbor_cutoff(),
         )
 
     def render_rotamer_scoring_module(
@@ -190,4 +205,7 @@ class EnergyTerm:
             rotamer_set,
             self.get_rotamer_score_term_attributes(pose_stack, rotamer_set),
             f,
+            self.get_block_neighbor_cutoff(),
+            self.accepts_shared_rotamer_dispatch(),
+            self.rotamer_dispatch_key(),
         )

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -80,6 +80,17 @@ def _use_weighted_fused_score(
     return atoms_per_pose >= _CUDA_WEIGHTED_FUSED_MIN_BATCH_ATOMS_PER_POSE
 
 
+def _rotamer_dispatch_cutoff_compatible(
+    device_type: str,
+    producer_cutoff: float,
+    consumer_cutoff: float,
+) -> bool:
+    """Select exact layouts everywhere and larger-cutoff supersets on CUDA."""
+    return producer_cutoff == consumer_cutoff or (
+        device_type == "cuda" and producer_cutoff > consumer_cutoff
+    )
+
+
 def _cpu_score_term_executor(n_workers: int) -> ThreadPoolExecutor:
     """Return a process-local executor shared by rendered CPU scorers."""
     with _CPU_SCORE_TERM_EXECUTOR_LOCK:
@@ -1677,29 +1688,45 @@ class RotamerScoringModule:
         else:
             # Do not retain every term's complete score/index tensors. CUDA
             # packing layouts can be many GiB apiece, so consume each result
-            # before evaluating the next term. Neighbor-sphere dispatch is
-            # determined only by the rotamer set and cutoff; exact-compatible
-            # consumers may reuse the preceding layout without retaining the
-            # score tensors for every term.
+            # before evaluating the next term.
             def sequential_term_results():
-                dispatch_by_compatibility = {}
+                # A larger-cutoff sphere-overlap layout is a safe superset for
+                # a smaller consumer, whose native potential still applies its
+                # own cutoff. Measurements favor this on CUDA; exact layouts
+                # remain reusable on every device.
+                dispatch_by_key = {}
                 for term in self.term_modules:
                     cutoff = getattr(term, "block_neighbor_cutoff", None)
                     dispatch_key = getattr(term, "rotamer_dispatch_key", None)
-                    compatibility = (dispatch_key, cutoff)
                     accepts_shared = getattr(term, "accepts_shared_dispatch", False)
-                    if accepts_shared:
-                        result = term.forward(
-                            coords, dispatch_by_compatibility.get(compatibility)
-                        )
+                    compatible_dispatch = None
+                    if (
+                        accepts_shared
+                        and dispatch_key is not None
+                        and cutoff is not None
+                    ):
+                        producers = dispatch_by_key.get(dispatch_key, ())
+                        compatible = [
+                            (producer_cutoff, indices)
+                            for producer_cutoff, indices in producers
+                            if _rotamer_dispatch_cutoff_compatible(
+                                coords.device.type,
+                                producer_cutoff,
+                                cutoff,
+                            )
+                        ]
+                        if compatible:
+                            _, compatible_dispatch = min(
+                                compatible, key=lambda item: item[0]
+                            )
+                    if compatible_dispatch is not None:
+                        result = term.forward(coords, compatible_dispatch)
                     else:
                         result = term.forward(coords)
-                    if (
-                        dispatch_key is not None
-                        and cutoff is not None
-                        and compatibility not in dispatch_by_compatibility
-                    ):
-                        dispatch_by_compatibility[compatibility] = result[1]
+                    if dispatch_key is not None and cutoff is not None:
+                        dispatch_by_key.setdefault(dispatch_key, []).append(
+                            (cutoff, result[1])
+                        )
                     yield result
 
             term_results = sequential_term_results()

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -34,6 +34,7 @@ SFXN_FORMAT_VERSION: str = "1.0"
 _CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES = 16 * 1024 * 1024
 _CPU_ROTAMER_SORTED_LAYOUT_MIN_NNZ = 4096
 _MAX_CPU_SCORE_TERM_WORKERS = 4
+_MAX_CPU_FUSED_SCORE_WORKERS = 16
 _CPU_PARALLEL_SCORE_BACKWARD_MIN_COORD_ELEMENTS = 8192
 # Independent CUDA terms overlap profitably for one large pose or a wide batch,
 # but stream setup and coordination cost more than they save for small poses.
@@ -41,9 +42,42 @@ _CUDA_PARALLEL_SCORE_MIN_COORD_ELEMENTS = 20 * 1024
 # Backward has more stream-coordination overhead than inference. Keep eager
 # gradient scoring serial until the batch is large enough to amortize it.
 _CUDA_PARALLEL_GRAD_SCORE_MIN_COORD_ELEMENTS = 100 * 1024
+# Reducing LJ/LK and electrostatics to one weighted lane saves device work for
+# wide CUDA workloads, but the extra native dispatch is slower for small eager
+# calls. These cutoffs retain the established latency path for those calls.
+_CUDA_WEIGHTED_FUSED_MIN_SINGLE_POSE_ATOMS = 15_000
+_CUDA_WEIGHTED_FUSED_MIN_BATCH_ATOMS_PER_POSE = 2_000
+_CUDA_WEIGHTED_FUSED_MIN_GRAD_COORD_ELEMENTS = 64 * 1024
 _CPU_SCORE_TERM_EXECUTORS: dict[int, ThreadPoolExecutor] = {}
 _CPU_SCORE_TERM_EXECUTOR_LOCK = threading.Lock()
 _ScoreCallResult = TypeVar("_ScoreCallResult")
+
+
+def _use_weighted_fused_score(
+    coords: torch.Tensor,
+    *,
+    force_for_cuda_graph: bool = False,
+    needs_gradient: bool | None = None,
+) -> bool:
+    """Select weighted native score reduction without regressing CUDA latency."""
+    if force_for_cuda_graph:
+        return True
+    if coords.device.type == "cpu":
+        return True
+
+    if needs_gradient is None:
+        needs_gradient = torch.is_grad_enabled() and coords.requires_grad
+    if (
+        needs_gradient
+        and coords.numel() >= _CUDA_WEIGHTED_FUSED_MIN_GRAD_COORD_ELEMENTS
+    ):
+        return True
+
+    n_poses = coords.shape[0]
+    atoms_per_pose = coords.shape[-2]
+    if n_poses == 1:
+        return atoms_per_pose >= _CUDA_WEIGHTED_FUSED_MIN_SINGLE_POSE_ATOMS
+    return atoms_per_pose >= _CUDA_WEIGHTED_FUSED_MIN_BATCH_ATOMS_PER_POSE
 
 
 def _cpu_score_term_executor(n_workers: int) -> ThreadPoolExecutor:
@@ -85,6 +119,8 @@ def _score_call_in_thread(
     autocast_enabled: bool,
     autocast_dtype: torch.dtype,
     autocast_cache_enabled: bool,
+    shared_block_neighbors: torch.Tensor | None = None,
+    fused_score_weights: torch.Tensor | None = None,
 ) -> _ScoreCallResult:
     """Evaluate one CPU score term with the caller's thread-local modes."""
     with (
@@ -97,7 +133,11 @@ def _score_call_in_thread(
             cache_enabled=autocast_cache_enabled,
         ),
     ):
-        return score_call(coords)
+        if fused_score_weights is not None:
+            return score_call(coords, shared_block_neighbors, fused_score_weights)
+        if shared_block_neighbors is None:
+            return score_call(coords)
+        return score_call(coords, shared_block_neighbors)
 
 
 def _score_grad_in_thread(
@@ -128,6 +168,7 @@ class _ParallelScoreTerms(torch.autograd.Function):
     def forward(
         ctx,
         coords: torch.Tensor,
+        shared_block_neighbors: torch.Tensor | None,
         executor: ThreadPoolExecutor,
         term_modules: Sequence[torch.nn.Module],
         autocast_enabled: bool,
@@ -145,6 +186,11 @@ class _ParallelScoreTerms(torch.autograd.Function):
                 autocast_enabled,
                 autocast_dtype,
                 autocast_cache_enabled,
+                (
+                    shared_block_neighbors
+                    if getattr(term, "block_neighbor_cutoff", None) is not None
+                    else None
+                ),
             )
             for term in term_modules
         ]
@@ -199,7 +245,7 @@ class _ParallelScoreTerms(torch.autograd.Function):
                 grad_coords = (
                     term_grad if grad_coords is None else grad_coords + term_grad
                 )
-        return grad_coords, None, None, None, None, None
+        return grad_coords, None, None, None, None, None, None
 
 
 def _linearize_rotamer_indices(indices: torch.Tensor, n_rots: int) -> torch.Tensor:
@@ -457,9 +503,14 @@ class ScoreFunction:
         its output buffer; clone an output that must survive the next call.
         """
         self.pre_work_initialization(pose_stack)
-        term_modules = [
-            t.render_whole_pose_scoring_module(pose_stack) for t in self.all_terms()
-        ]
+        term_modules = []
+        for term in self.all_terms():
+            module = term.render_whole_pose_scoring_module(pose_stack)
+            # Retain the score-lane width without evaluating the module.  The
+            # default weighted fused path uses this metadata to map its scalar
+            # contribution back onto the live score-function weight buffer.
+            module.n_score_types = len(term.score_types())
+            term_modules.append(module)
         scoring_module = WholePoseScoringModule(self.weights_tensor(), term_modules)
         if cuda_graph:
             mode = "both" if cuda_graph is True else cuda_graph
@@ -667,6 +718,122 @@ class ScoreFunction:
         return sorted_term_list, sorted_score_type_list
 
 
+class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
+    """Internal execution group retaining four independent score lanes."""
+
+    def __init__(self, ljlk_module, elec_module):
+        super().__init__()
+        self.ljlk_module = ljlk_module
+        self.elec_module = elec_module
+        self.classname = "LJLK+Elec"
+        self.block_neighbor_cutoff = max(
+            ljlk_module.block_neighbor_cutoff, elec_module.block_neighbor_cutoff
+        )
+        self.n_score_types = ljlk_module.n_score_types + elec_module.n_score_types
+
+    def build_compact_block_neighbors(self, coords, reach):
+        return self.ljlk_module.build_compact_block_neighbors(coords, reach)
+
+    def _native_arguments(self, coords, shared_block_neighbors):
+        """Collect dtype-adjusted arguments shared by fused native entry points."""
+        ljlk = self.ljlk_module
+        elec = self.elec_module
+        ljlk_tail = ljlk._static_tail_for_coords(coords)
+        elec_tail = elec._static_tail_for_coords(coords)
+        n_common = len(ljlk.common_parameters)
+        common = ljlk_tail[:n_common]
+        lp = ljlk_tail[n_common:-1]
+        ep = elec_tail[len(elec.common_parameters) : -1]
+        return (
+            coords.flatten(start_dim=0, end_dim=-2),
+            *common,
+            lp[0],
+            lp[1],
+            lp[2],
+            lp[5],
+            lp[6],
+            lp[7],
+            lp[8],
+            lp[9],
+            lp[10],
+            lp[11],
+            ep[3],
+            ep[6],
+            ep[7],
+            ep[9],
+            shared_block_neighbors,
+        )
+
+    def forward(self, coords, shared_block_neighbors=None):
+        if shared_block_neighbors is None:
+            return torch.cat(
+                (self.ljlk_module(coords), self.elec_module(coords)), dim=0
+            )
+        from tmol.score.ljlk.potentials import ljlk_elec_pose_scores
+
+        # Preserve the normal term wrapper's lazy float64 support.  The
+        # composite selects arguments from each child's dtype-adjusted static
+        # tail rather than bypassing it and reading raw float32 parameters.
+        (scores,) = ljlk_elec_pose_scores(
+            *self._native_arguments(coords, shared_block_neighbors)
+        )
+        return scores
+
+    def forward_weighted(self, coords, shared_block_neighbors, score_weights):
+        """Return one weighted lane while retaining the decomposed fallback."""
+        from tmol.score.ljlk.potentials import ljlk_elec_weighted_pose_scores
+
+        if score_weights.dtype != coords.dtype:
+            score_weights = score_weights.to(dtype=coords.dtype)
+        (scores,) = ljlk_elec_weighted_pose_scores(
+            *self._native_arguments(coords, shared_block_neighbors), score_weights
+        )
+        return scores
+
+
+def _whole_pose_execution_modules(term_modules, device):
+    """Build conservative built-in execution groups without changing lanes."""
+    grouped = []
+    index = 0
+    while index < len(term_modules):
+        if index + 1 < len(term_modules):
+            first = term_modules[index]
+            second = term_modules[index + 1]
+            is_builtin_pair = False
+            if (
+                getattr(first, "classname", None) == "LJLK"
+                and getattr(second, "classname", None) == "Elec"
+            ):
+                from tmol.score.elec.potentials import elec_pose_scores
+                from tmol.score.ljlk.potentials import ljlk_pose_scores
+
+                is_builtin_pair = (
+                    getattr(first, "term_score_poses", None) is ljlk_pose_scores
+                    and getattr(second, "term_score_poses", None) is elec_pose_scores
+                )
+            if (
+                is_builtin_pair
+                and getattr(first, "block_neighbor_cutoff", None) is not None
+                and getattr(second, "block_neighbor_cutoff", None) is not None
+                and not any(
+                    parameter.requires_grad
+                    for term in (first, second)
+                    for parameter in term.parameters()
+                )
+                and not (
+                    device.type == "cpu"
+                    and torch.get_num_threads() > 1
+                    and getattr(first, "n_poses", None) != 1
+                )
+            ):
+                grouped.append(_FusedLJLKAndElecWholePoseModule(first, second))
+                index += 2
+                continue
+        grouped.append(term_modules[index])
+        index += 1
+    return tuple(grouped)
+
+
 class WholePoseScoringModule:
     """Rendered energy modules that score complete poses."""
 
@@ -677,9 +844,12 @@ class WholePoseScoringModule:
     ):
         self.weights = torch.nn.Parameter(weights.unsqueeze(1), requires_grad=False)
         self.term_modules = tuple(term_modules)
+        self._execution_modules = _whole_pose_execution_modules(
+            self.term_modules, weights.device
+        )
         self._active_term_indices = tuple(
             index
-            for index, term in enumerate(self.term_modules)
+            for index, term in enumerate(self._execution_modules)
             if not isinstance(term, ZeroTermPoseScoringModule)
         )
         self._has_trainable_term_parameters = any(
@@ -688,9 +858,115 @@ class WholePoseScoringModule:
             for parameter in term.parameters()
         )
         self._cpu_term_workers = _cpu_score_term_worker_count(
-            len(self.term_modules), weights.device
+            len(self._execution_modules), weights.device
+        )
+        self._fused_ljlk_elec_module_index = next(
+            (
+                index
+                for index, term in enumerate(self._execution_modules)
+                if isinstance(term, _FusedLJLKAndElecWholePoseModule)
+            ),
+            None,
+        )
+        self._fused_ljlk_elec_weight_range = None
+        if self._fused_ljlk_elec_module_index is not None:
+            fused_index = self._fused_ljlk_elec_module_index
+            if all(
+                hasattr(term, "n_score_types")
+                for term in self._execution_modules[: fused_index + 1]
+            ):
+                weight_begin = sum(
+                    term.n_score_types for term in self._execution_modules[:fused_index]
+                )
+                self._fused_ljlk_elec_weight_range = (
+                    weight_begin,
+                    weight_begin + self._execution_modules[fused_index].n_score_types,
+                )
+        cpu_threads = torch.get_num_threads() if weights.device.type == "cpu" else 1
+        self._cpu_fused_shards = (
+            min(8, max(2, cpu_threads // 2))
+            if self._fused_ljlk_elec_module_index is not None
+            and cpu_threads >= 2
+            and self._execution_modules[
+                self._fused_ljlk_elec_module_index
+            ].ljlk_module.n_poses
+            == 1
+            else 0
+        )
+        self._cpu_fused_workers = min(
+            _MAX_CPU_FUSED_SCORE_WORKERS,
+            cpu_threads,
+            self._cpu_fused_shards + max(0, len(self._execution_modules) - 1),
         )
         self._cuda_term_streams: tuple[torch.cuda.Stream, ...] | None = None
+        self._shared_neighbor_term_indices = tuple(
+            index
+            for index, term in enumerate(self.term_modules)
+            if getattr(term, "block_neighbor_cutoff", None) is not None
+        )
+        self._shared_neighbor_cutoff = max(
+            (
+                self.term_modules[index].block_neighbor_cutoff
+                for index in self._shared_neighbor_term_indices
+            ),
+            default=None,
+        )
+
+    def _build_shared_block_neighbors(
+        self, coords: torch.Tensor
+    ) -> torch.Tensor | None:
+        if len(self._shared_neighbor_term_indices) < 2:
+            return None
+        builder = self.term_modules[self._shared_neighbor_term_indices[0]]
+        return builder.build_compact_block_neighbors(
+            coords, self._shared_neighbor_cutoff
+        )
+
+    @staticmethod
+    def _call_term(term, coords, shared_block_neighbors, fused_score_weights=None):
+        if fused_score_weights is not None:
+            return term.forward_weighted(
+                coords, shared_block_neighbors, fused_score_weights
+            )
+        if (
+            shared_block_neighbors is not None
+            and getattr(term, "block_neighbor_cutoff", None) is not None
+        ):
+            return term(coords, shared_block_neighbors)
+        return term(coords)
+
+    def _can_use_weighted_fused_default(self, coords: torch.Tensor) -> bool:
+        """Whether default scoring can consume the fused scalar contribution."""
+        needs_gradient = torch.is_grad_enabled() and coords.requires_grad
+        if self._fused_ljlk_elec_weight_range is None or not _use_weighted_fused_score(
+            coords,
+            force_for_cuda_graph=getattr(
+                self, "_force_weighted_fusion_for_cuda_graph", False
+            ),
+            needs_gradient=needs_gradient,
+        ):
+            return False
+        # The generic CPU parallel autograd wrapper expects canonical term-lane
+        # widths. One-thread CPU, the explicit fused-shard path, and all CUDA
+        # execution paths can consume the compact weighted lane directly.
+        if coords.device.type == "cuda" or self._cpu_term_workers < 2:
+            return True
+        if self._cpu_fused_shards < 2:
+            return False
+        return needs_gradient or self._cpu_fused_shards <= 2
+
+    def _reduce_weighted_fused_lanes(self, score_lanes: torch.Tensor) -> torch.Tensor:
+        """Combine one already-weighted fused lane in one native reduction."""
+        from tmol.score.ljlk.potentials import weighted_fused_score_sum
+
+        weight_begin, weight_end = self._fused_ljlk_elec_weight_range
+        score_weights = self.weights
+        if score_weights.dtype != score_lanes.dtype:
+            score_weights = score_weights.to(dtype=score_lanes.dtype)
+        (scores,) = weighted_fused_score_sum(
+            score_lanes, score_weights, weight_begin, weight_end - weight_begin
+        )
+        return scores
 
     def __call__(
         self,
@@ -710,14 +986,38 @@ class WholePoseScoringModule:
                 return self._cuda_graphed_forward(coords)
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
-        unweighted = self.unweighted_scores(coords)
+        fused_score_weights = None
+        if sum_terms and apply_weights and self._can_use_weighted_fused_default(coords):
+            weight_begin, weight_end = self._fused_ljlk_elec_weight_range
+            fused_score_weights = self.weights[weight_begin:weight_end, 0]
+        unweighted = self.unweighted_scores(
+            coords, fused_score_weights=fused_score_weights
+        )
+        if fused_score_weights is not None:
+            return self._reduce_weighted_fused_lanes(unweighted)
         weighted = unweighted.mul_(self.weights) if apply_weights else unweighted
         summed = torch.sum(weighted, dim=0) if sum_terms else weighted
 
         return summed
 
-    def unweighted_scores(self, coords: torch.Tensor) -> torch.Tensor:
+    def unweighted_scores(
+        self,
+        coords: torch.Tensor,
+        *,
+        fused_score_weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         needs_grad = torch.is_grad_enabled() and coords.requires_grad
+        shared_block_neighbors = self._build_shared_block_neighbors(coords)
+        execution_modules = (
+            self._execution_modules
+            if shared_block_neighbors is not None
+            else self.term_modules
+        )
+        active_term_indices = tuple(
+            index
+            for index, term in enumerate(execution_modules)
+            if not isinstance(term, ZeroTermPoseScoringModule)
+        )
         parallel_min_elements = (
             _CUDA_PARALLEL_GRAD_SCORE_MIN_COORD_ELEMENTS
             if needs_grad
@@ -726,18 +1026,58 @@ class WholePoseScoringModule:
         if (
             coords.device.type == "cuda"
             and not (torch.is_grad_enabled() and self._has_trainable_term_parameters)
-            and len(self._active_term_indices) >= 2
+            and len(active_term_indices) >= 2
             and coords.numel() >= parallel_min_elements
         ):
-            cuda_scores = self._parallel_cuda_scores(coords, needs_grad)
+            cuda_scores = self._parallel_cuda_scores(
+                coords,
+                needs_grad,
+                shared_block_neighbors,
+                execution_modules,
+                active_term_indices,
+                fused_score_weights,
+            )
             if cuda_scores is not None:
                 return torch.cat(cuda_scores, dim=0)
 
         cpu_workers = self._cpu_term_workers
+        if execution_modules is not self._execution_modules:
+            cpu_workers = min(
+                cpu_workers,
+                _cpu_score_term_worker_count(len(execution_modules), coords.device),
+            )
         if torch.is_grad_enabled() and self._has_trainable_term_parameters:
             cpu_workers = 0
+        if (
+            self._cpu_fused_shards >= 2
+            and not self._has_trainable_term_parameters
+            and shared_block_neighbors is not None
+        ):
+            fused_scores = self._parallel_cpu_fused_scores(
+                coords,
+                needs_grad,
+                shared_block_neighbors,
+                fused_score_weights,
+            )
+            if fused_scores is not None:
+                return fused_scores
         if cpu_workers < 2:
-            return torch.cat([term(coords) for term in self.term_modules], dim=0)
+            return torch.cat(
+                [
+                    self._call_term(
+                        term,
+                        coords,
+                        shared_block_neighbors,
+                        (
+                            fused_score_weights
+                            if index == self._fused_ljlk_elec_module_index
+                            else None
+                        ),
+                    )
+                    for index, term in enumerate(execution_modules)
+                ],
+                dim=0,
+            )
 
         executor = _cpu_score_term_executor(cpu_workers)
         autocast_context = (
@@ -748,8 +1088,9 @@ class WholePoseScoringModule:
         if needs_grad:
             return _ParallelScoreTerms.apply(
                 coords,
+                shared_block_neighbors,
                 executor,
-                self.term_modules,
+                execution_modules,
                 *autocast_context,
             )
 
@@ -759,16 +1100,126 @@ class WholePoseScoringModule:
             *autocast_context,
         )
         futures = [
-            executor.submit(_score_call_in_thread, term, coords, *context)
-            for term in self.term_modules
+            executor.submit(
+                _score_call_in_thread,
+                term,
+                coords,
+                *context,
+                (
+                    shared_block_neighbors
+                    if getattr(term, "block_neighbor_cutoff", None) is not None
+                    else None
+                ),
+            )
+            for term in execution_modules
         ]
         return torch.cat([future.result() for future in futures], dim=0)
 
+    def _parallel_cpu_fused_scores(
+        self,
+        coords: torch.Tensor,
+        needs_grad: bool,
+        shared_block_neighbors: torch.Tensor,
+        fused_score_weights: torch.Tensor | None = None,
+    ) -> torch.Tensor | None:
+        """Shard a fused pair traversal while other CPU terms run concurrently."""
+        fused_index = self._fused_ljlk_elec_module_index
+        if fused_index is None or self._cpu_fused_workers < 2:
+            return None
+        n_neighbors = int(shared_block_neighbors[0])
+        desired_shards = self._cpu_fused_shards
+        if coords.numel() < 16 * 1024:
+            desired_shards = min(desired_shards, 4)
+        n_shards = min(desired_shards, max(1, n_neighbors))
+        if n_shards < 2 and fused_score_weights is None:
+            return None
+
+        neighbor_shards = []
+        for shard in range(n_shards):
+            begin = n_neighbors * shard // n_shards
+            end = n_neighbors * (shard + 1) // n_shards
+            neighbor_shards.append(
+                torch.cat(
+                    (
+                        shared_block_neighbors.new_tensor([end - begin]),
+                        shared_block_neighbors[1 + begin : 1 + end],
+                    )
+                )
+            )
+
+        executor = _cpu_score_term_executor(self._cpu_fused_workers)
+        autocast_context = (
+            torch.is_autocast_enabled("cpu"),
+            torch.get_autocast_dtype("cpu"),
+            torch.is_autocast_cache_enabled(),
+        )
+        context = (
+            (True, False, *autocast_context)
+            if needs_grad
+            else (
+                torch.is_grad_enabled(),
+                torch.is_inference_mode_enabled(),
+                *autocast_context,
+            )
+        )
+        fused_term = self._execution_modules[fused_index]
+        fused_score_call = (
+            fused_term.forward_weighted
+            if fused_score_weights is not None
+            else fused_term
+        )
+        # Submit the expensive shards first. Remaining workers immediately
+        # pick up independent terms, keeping both kinds of parallelism.
+        fused_futures = [
+            executor.submit(
+                _score_call_in_thread,
+                fused_score_call,
+                coords,
+                *context,
+                shard,
+                fused_score_weights,
+            )
+            for shard in neighbor_shards
+        ]
+        term_futures = {}
+        for index, term in enumerate(self._execution_modules):
+            if index == fused_index:
+                continue
+            term_futures[index] = executor.submit(
+                _score_call_in_thread,
+                term,
+                coords,
+                *context,
+                (
+                    shared_block_neighbors
+                    if getattr(term, "block_neighbor_cutoff", None) is not None
+                    else None
+                ),
+            )
+
+        fused_scores = torch.stack(
+            [future.result() for future in fused_futures], dim=0
+        ).sum(dim=0)
+        scores = []
+        for index in range(len(self._execution_modules)):
+            scores.append(
+                fused_scores if index == fused_index else term_futures[index].result()
+            )
+        return torch.cat(scores, dim=0)
+
     def _parallel_cuda_scores(
-        self, coords: torch.Tensor, needs_grad: bool
+        self,
+        coords: torch.Tensor,
+        needs_grad: bool,
+        shared_block_neighbors: torch.Tensor | None,
+        execution_modules: Sequence[torch.nn.Module],
+        active_term_indices: Sequence[int],
+        fused_score_weights: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, ...] | None:
         """Run independent large-workload score terms on separate streams."""
-        if self._cuda_term_streams is None:
+        if self._cuda_term_streams is None or len(self._cuda_term_streams) != len(
+            active_term_indices
+        ):
             # Creating side streams during an unrelated user capture is unsafe.
             # Our graph wrapper warms this path first, so its streams already
             # exist when capture begins.
@@ -776,31 +1227,48 @@ class WholePoseScoringModule:
                 if torch.cuda.is_current_stream_capturing():
                     return None
             self._cuda_term_streams = tuple(
-                torch.cuda.Stream(device=coords.device)
-                for _ in self._active_term_indices
+                torch.cuda.Stream(device=coords.device) for _ in active_term_indices
             )
 
         current = torch.cuda.current_stream(coords.device)
-        scores: list[torch.Tensor | None] = [None] * len(self.term_modules)
+        scores: list[torch.Tensor | None] = [None] * len(execution_modules)
         # Distinct zero-copy views give every term a caller-stream autograd
         # node, synchronizing returned gradients before leaf accumulation.
         term_coords = (
-            tuple(coords.view_as(coords) for _ in self._active_term_indices)
+            tuple(coords.view_as(coords) for _ in active_term_indices)
             if needs_grad
-            else (coords,) * len(self._active_term_indices)
+            else (coords,) * len(active_term_indices)
         )
-        for index, term in enumerate(self.term_modules):
+        for index, term in enumerate(execution_modules):
             if isinstance(term, ZeroTermPoseScoringModule):
                 scores[index] = term(coords)
         for stream, index, term_input in zip(
-            self._cuda_term_streams, self._active_term_indices, term_coords
+            self._cuda_term_streams, active_term_indices, term_coords
         ):
             stream.wait_stream(current)
             term_input.record_stream(stream)
+            term = execution_modules[index]
+            term_neighbors = (
+                shared_block_neighbors
+                if shared_block_neighbors is not None
+                and getattr(term, "block_neighbor_cutoff", None) is not None
+                else None
+            )
+            if term_neighbors is not None:
+                term_neighbors.record_stream(stream)
             with torch.cuda.stream(stream):
-                scores[index] = self.term_modules[index](term_input)
+                scores[index] = self._call_term(
+                    term,
+                    term_input,
+                    term_neighbors,
+                    (
+                        fused_score_weights
+                        if index == self._fused_ljlk_elec_module_index
+                        else None
+                    ),
+                )
 
-        for stream, index in zip(self._cuda_term_streams, self._active_term_indices):
+        for stream, index in zip(self._cuda_term_streams, active_term_indices):
             current.wait_stream(stream)
             score = scores[index]
             assert score is not None
@@ -835,13 +1303,22 @@ class WholePoseScoringModule:
         if mode in ("forward", "both") and not hasattr(self, "_cuda_graphed_forward"):
             # Capture this scorer rather than the serial graph module so large
             # inference workloads retain independent term-stream overlap.
-            self._cuda_graphed_forward = _InferenceCUDAGraph(self, example_coords)
+            fused = self._fused_ljlk_elec_module_index is not None
+            self._cuda_forward_graph_uses_fused_execution = fused
+            self._cuda_forward_graph_uses_weighted_fusion = fused
+            self._force_weighted_fusion_for_cuda_graph = True
+            try:
+                self._cuda_graphed_forward = _InferenceCUDAGraph(self, example_coords)
+            finally:
+                del self._force_weighted_fusion_for_cuda_graph
 
         if mode in ("forward_backward", "both") and not hasattr(
             self, "_cuda_graphed_autograd"
         ):
             graph_module = _DefaultWholePoseScoringModule(
-                self.weights, self.term_modules
+                self.weights,
+                self._execution_modules,
+                force_weighted_fusion_for_cuda_graph=True,
             )
             sample = example_coords.detach().clone().requires_grad_(True)
             with (
@@ -865,14 +1342,91 @@ class WholePoseScoringModule:
 class _DefaultWholePoseScoringModule(torch.nn.Module):
     """Graph-capturable default reduction for a whole-pose scorer."""
 
-    def __init__(self, weights, term_modules):
+    def __init__(
+        self, weights, term_modules, *, force_weighted_fusion_for_cuda_graph=False
+    ):
         super().__init__()
         self.weights = weights
         self.term_modules = torch.nn.ModuleList(term_modules)
+        self._force_weighted_fusion_for_cuda_graph = (
+            force_weighted_fusion_for_cuda_graph
+        )
+        self._shared_neighbor_terms = tuple(
+            term
+            for term in self.term_modules
+            if getattr(term, "block_neighbor_cutoff", None) is not None
+        )
+        self._shared_neighbor_cutoff = max(
+            (term.block_neighbor_cutoff for term in self._shared_neighbor_terms),
+            default=None,
+        )
+        self._fused_module_index = next(
+            (
+                index
+                for index, term in enumerate(self.term_modules)
+                if isinstance(term, _FusedLJLKAndElecWholePoseModule)
+            ),
+            None,
+        )
+        self._fused_weight_range = None
+        if self._fused_module_index is not None:
+            weight_begin = sum(
+                term.n_score_types
+                for term in self.term_modules[: self._fused_module_index]
+            )
+            self._fused_weight_range = (
+                weight_begin,
+                weight_begin
+                + self.term_modules[self._fused_module_index].n_score_types,
+            )
 
     def forward(self, coords):
-        unweighted = torch.cat([term(coords) for term in self.term_modules], dim=0)
-        return torch.sum(self.weights * unweighted, dim=0)
+        shared_block_neighbors = None
+        if len(self._shared_neighbor_terms) >= 2:
+            builder = self._shared_neighbor_terms[0]
+            shared_block_neighbors = builder.build_compact_block_neighbors(
+                coords, self._shared_neighbor_cutoff
+            )
+        use_weighted_fusion = (
+            self._fused_weight_range is not None
+            and shared_block_neighbors is not None
+            and _use_weighted_fused_score(
+                coords,
+                force_for_cuda_graph=self._force_weighted_fusion_for_cuda_graph,
+            )
+        )
+        score_lanes = torch.cat(
+            [
+                WholePoseScoringModule._call_term(
+                    term,
+                    coords,
+                    shared_block_neighbors,
+                    (
+                        self.weights[
+                            self._fused_weight_range[0] : self._fused_weight_range[1],
+                            0,
+                        ]
+                        if use_weighted_fusion and index == self._fused_module_index
+                        else None
+                    ),
+                )
+                for index, term in enumerate(self.term_modules)
+            ],
+            dim=0,
+        )
+        if not use_weighted_fusion:
+            return torch.sum(self.weights * score_lanes, dim=0)
+
+        from tmol.score.ljlk.potentials import weighted_fused_score_sum
+
+        weight_begin, weight_end = self._fused_weight_range
+        score_weights = self.weights
+        if score_weights.dtype != score_lanes.dtype:
+            score_weights = score_weights.to(dtype=score_lanes.dtype)
+        (scores,) = weighted_fused_score_sum(
+            score_lanes, score_weights, weight_begin, weight_end - weight_begin
+        )
+        return scores
 
 
 class _InferenceCUDAGraph:
@@ -1076,7 +1630,15 @@ class RotamerScoringModule:
             len(self.term_modules), weights.device
         )
 
-    def __call__(self, coords: torch.Tensor) -> torch.Tensor:
+    def _weighted_entries_by_layout(
+        self, coords: torch.Tensor
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor], int | None, int | None]:
+        """Evaluate terms and combine entries that have identical layouts.
+
+        Keeping this representation outside a PyTorch sparse COO tensor is
+        important to the packer: COO construction promotes coordinates to
+        int64, and coalescing then needs another potentially very large sort.
+        """
         if not torch.is_grad_enabled() and coords.requires_grad:
             coords = coords.detach()
         # Accumulate weighted values and their indices across all terms at the
@@ -1111,13 +1673,61 @@ class RotamerScoringModule:
                 )
                 for term in self.term_modules
             ]
-            term_results = [future.result() for future in futures]
+            term_results = (future.result() for future in futures)
         else:
-            term_results = [term.forward(coords) for term in self.term_modules]
+            # Do not retain every term's complete score/index tensors. CUDA
+            # packing layouts can be many GiB apiece, so consume each result
+            # before evaluating the next term. Neighbor-sphere dispatch is
+            # determined only by the rotamer set and cutoff; exact-compatible
+            # consumers may reuse the preceding layout without retaining the
+            # score tensors for every term.
+            def sequential_term_results():
+                dispatch_by_compatibility = {}
+                for term in self.term_modules:
+                    cutoff = getattr(term, "block_neighbor_cutoff", None)
+                    dispatch_key = getattr(term, "rotamer_dispatch_key", None)
+                    compatibility = (dispatch_key, cutoff)
+                    accepts_shared = getattr(term, "accepts_shared_dispatch", False)
+                    if accepts_shared:
+                        result = term.forward(
+                            coords, dispatch_by_compatibility.get(compatibility)
+                        )
+                    else:
+                        result = term.forward(coords)
+                    if (
+                        dispatch_key is not None
+                        and cutoff is not None
+                        and compatibility not in dispatch_by_compatibility
+                    ):
+                        dispatch_by_compatibility[compatibility] = result[1]
+                    yield result
+
+            term_results = sequential_term_results()
 
         for term, (scores, indices) in zip(self.term_modules, term_results):
             # [n_subterms, nnz], [3, nnz]
             n_subterms = scores.shape[0]
+
+            # Native rotamer terms already return compact int32 coordinates,
+            # while sparse/Python terms (notably constraints) may inherit
+            # PyTorch COO's int64 index dtype. Normalize only that uncommon
+            # path and reject a custom term whose coordinates cannot be
+            # represented by the native interaction graph.
+            if indices.dtype != torch.int32:
+                if indices.dtype != torch.int64:
+                    raise TypeError(
+                        "rotamer score indices must have dtype int32 or int64"
+                    )
+                if indices.numel() != 0:
+                    min_index, max_index = torch.aminmax(indices)
+                    if (
+                        int(min_index) < 0
+                        or int(max_index) > torch.iinfo(torch.int32).max
+                    ):
+                        raise OverflowError(
+                            "rotamer score indices exceed the native int32 range"
+                        )
+                indices = indices.to(torch.int32)
 
             # Apply per-subterm weights and sum to [nnz] — no sparse tensor yet.
             w = self.weights[weights_offset : weights_offset + n_subterms, 0, 0, 0]
@@ -1135,7 +1745,10 @@ class RotamerScoringModule:
                 layouts_by_nnz.get(indices.shape[1], ()) if deduplicate_layout else ()
             )
             for layout_index in candidate_layouts:
-                if torch.equal(indices, all_indices[layout_index]):
+                prior_indices = all_indices[layout_index]
+                if indices.data_ptr() == prior_indices.data_ptr() or torch.equal(
+                    indices, prior_indices
+                ):
                     all_values[layout_index] = (
                         all_values[layout_index] + weighted_values
                     )
@@ -1151,6 +1764,31 @@ class RotamerScoringModule:
             if n_poses is None:
                 n_poses = term.n_poses
                 n_rots = term.n_rots
+
+        return all_indices, all_values, n_poses, n_rots
+
+    def forward_sparse_entries(
+        self, coords: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return weighted, uncoalesced ``(indices, values)`` for packing.
+
+        Duplicate coordinates may remain when two score terms use different
+        layouts. Consumers must accumulate rather than assign their values.
+        Indices remain int32 so the packer avoids an unnecessary int64 COO
+        round-trip.
+        """
+        all_indices, all_values, _, _ = self._weighted_entries_by_layout(coords)
+        if not all_indices:
+            return (
+                torch.zeros((3, 0), dtype=torch.int32, device=coords.device),
+                torch.zeros(0, dtype=torch.float32, device=coords.device),
+            )
+        return torch.cat(all_indices, dim=1), torch.cat(all_values)
+
+    def __call__(self, coords: torch.Tensor) -> torch.Tensor:
+        all_indices, all_values, n_poses, n_rots = self._weighted_entries_by_layout(
+            coords
+        )
 
         if n_poses is None:
             # No terms at all

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
+import sys
 import threading
 from typing import Callable, Dict, Sequence, TypeVar
 import warnings
@@ -59,14 +60,20 @@ def _use_weighted_fused_score(
     force_for_cuda_graph: bool = False,
     needs_gradient: bool | None = None,
 ) -> bool:
-    """Select weighted native score reduction without regressing CUDA latency."""
+    """Select weighted native reduction without latency or stability regressions."""
     if force_for_cuda_graph:
         return True
     if coords.device.type == "cpu":
-        return True
+        if needs_gradient is None:
+            needs_gradient = torch.is_grad_enabled() and coords.requires_grad
+        # Apple's CPU backend needs independent gradient lanes to keep
+        # heterogeneous minimization trajectories stable. Linux CPU backends
+        # retain the faster compact weighted reduction.
+        return not needs_gradient or sys.platform != "darwin"
 
     if needs_gradient is None:
         needs_gradient = torch.is_grad_enabled() and coords.requires_grad
+
     if (
         needs_gradient
         and coords.numel() >= _CUDA_WEIGHTED_FUSED_MIN_GRAD_COORD_ELEMENTS

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -894,14 +894,11 @@ class WholePoseScoringModule:
                     weight_begin + self._execution_modules[fused_index].n_score_types,
                 )
         cpu_threads = torch.get_num_threads() if weights.device.type == "cpu" else 1
+        # Use the same compact execution policy for single- and multi-pose
+        # scorers so batching cannot perturb nonlinear minimization trajectories.
         self._cpu_fused_shards = (
             min(8, max(2, cpu_threads // 2))
-            if self._fused_ljlk_elec_module_index is not None
-            and cpu_threads >= 2
-            and self._execution_modules[
-                self._fused_ljlk_elec_module_index
-            ].ljlk_module.n_poses
-            == 1
+            if self._fused_ljlk_elec_module_index is not None and cpu_threads >= 2
             else 0
         )
         self._cpu_fused_workers = min(

--- a/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
+++ b/tmol/score/backbone_torsion/potentials/backbone_torsion_pose_score.impl.hh
@@ -13,6 +13,7 @@
 #include <tmol/score/unresolved_atom.hh>
 
 #include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/launch_box_macros.hh>
 #include <tmol/score/common/tuple.hh>
@@ -764,7 +765,7 @@ auto BackboneTorsionRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::
   // them in the second step.
 
   auto n_energies_for_block_t =
-      TPack<Int, 2, Dev>::zeros({n_poses, max_n_blocks});
+      TPack<int64_t, 2, Dev>::zeros({n_poses, max_n_blocks});
   auto n_energies_for_block = n_energies_for_block_t.view;
   auto count_n_rotamer_energies = ([=] TMOL_DEVICE_FUNC(int index) {
     // Look at each residue and make sure that it has both upper and lower
@@ -805,21 +806,36 @@ auto BackboneTorsionRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::
     // too.
     int const upper_n_rots = n_rots_for_block[pose_ind][upper_nbr_block_ind];
 
-    n_energies_for_block[pose_ind][block_ind] = n_rots * upper_n_rots;
+    n_energies_for_block[pose_ind][block_ind] = int64_t(n_rots) * upper_n_rots;
   });
+  int const n_pose_block_cells = score::common::checked_dispatch_product(
+      n_poses, max_n_blocks, "backbone-torsion count dispatch");
   DeviceDispatch<Dev>::template forall<launch_t>(
-      mgr, n_poses * max_n_blocks, count_n_rotamer_energies);
+      mgr, n_pose_block_cells, count_n_rotamer_energies);
+
+  int const max_n_rots_per_block = DeviceDispatch<Dev>::reduce(
+      mgr, n_rots_for_block.data(), n_pose_block_cells, mgpu::maximum_t<Int>());
+  int const pose_block_rot_cells = score::common::checked_dispatch_product(
+      n_pose_block_cells,
+      max_n_rots_per_block,
+      "backbone-torsion candidate dispatch");
+  int const candidate_dispatch = score::common::checked_dispatch_product(
+      pose_block_rot_cells,
+      max_n_rots_per_block,
+      "backbone-torsion candidate dispatch");
 
   auto n_energies_for_block_offset_t =
-      TPack<Int, 2, Dev>::zeros({n_poses, max_n_blocks});
+      TPack<int64_t, 2, Dev>::zeros({n_poses, max_n_blocks});
   auto n_energies_for_block_offset = n_energies_for_block_offset_t.view;
-  int n_dispatch_total =
+  int64_t const n_dispatch_total_64 =
       DeviceDispatch<Dev>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           n_energies_for_block.data(),
           n_energies_for_block_offset.data(),
-          n_poses * max_n_blocks,
-          mgpu::plus_t<Int>());
+          n_pose_block_cells,
+          mgpu::plus_t<int64_t>());
+  int const n_dispatch_total = score::common::checked_dispatch_size(
+      n_dispatch_total_64, "backbone-torsion output dispatch");
 
   TPack<Real, 2, Dev> V_t;
   auto dispatch_indices_t = TPack<Int, 2, Dev>::zeros({3, n_dispatch_total});
@@ -829,12 +845,6 @@ auto BackboneTorsionRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::
     V_t = TPack<Real, 2, Dev>::zeros({2, n_poses});
   }
   auto dV_dxyz_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({2, n_atoms});
-
-  int const max_n_rots_per_block = DeviceDispatch<Dev>::reduce(
-      mgr,
-      n_rots_for_block.data(),
-      n_poses * max_n_blocks,
-      mgpu::maximum_t<Int>());
 
   auto V = V_t.view;
   auto dV_dxyz = dV_dxyz_t.view;
@@ -899,9 +909,7 @@ auto BackboneTorsionRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::
     }
   });
   DeviceDispatch<Dev>::template forall<launch_t>(
-      mgr,
-      n_poses * max_n_blocks * max_n_rots_per_block * max_n_rots_per_block,
-      mark_dispatch_indices);
+      mgr, candidate_dispatch, mark_dispatch_indices);
 
   auto rama_omega_func = ([=] TMOL_DEVICE_FUNC(int ind) {
     int const pose_ind = dispatch_indices[0][ind];

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -14,6 +14,7 @@ from tmol.pose import (
     PoseStack,
 )
 from tmol.score.common import make_hashtable_keys_values, add_to_hashtable
+from tmol.score.common._hash_util import hash_fun
 
 debug = False
 
@@ -36,6 +37,7 @@ class CartBondedPackedBlockTypesAnnotations:
     cartbonded_subgraph_offsets: torch.Tensor
     cartbonded_subgraph_type_counts: torch.Tensor
     cartbonded_subgraph_type_offsets: torch.Tensor
+    cartbonded_subgraph_param_indices: torch.Tensor
     cartbonded_max_subgraphs_per_block: int
     cartbonded_atom_unique_id_index: dict
     cartbonded_params_hash_keys: torch.Tensor
@@ -337,14 +339,57 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
             add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
             cur_val += 1
 
+        # Intra-block topology and atom naming are fixed for a packed block
+        # type. Resolve the exact/reversed/wildcard parameter search once here
+        # instead of repeating four hash probes in every scoring invocation.
+        atom_unique_ids = packed_block_types.atom_unique_ids.cpu().numpy()
+        atom_wildcard_ids = packed_block_types.atom_wildcard_ids.cpu().numpy()
+        subgraph_param_indices = numpy.full(total_subgraphs, -1, dtype=numpy.int32)
+
+        def lookup_param_index(key):
+            hash_index = hash_fun(key, hash_keys.shape[0])
+            padded_key = numpy.full(4, -1, dtype=numpy.int32)
+            padded_key[: len(key)] = key
+            while hash_keys[hash_index, 0] != -1:
+                if numpy.array_equal(hash_keys[hash_index, :4], padded_key):
+                    return hash_keys[hash_index, 4]
+                hash_index = (hash_index + 1) % hash_keys.shape[0]
+            return -1
+
+        for block_type_index, block_type in enumerate(
+            packed_block_types.active_block_types
+        ):
+            block_params = block_type.cartbonded_annotations[self.hash]
+            block_offset = subgraph_offsets[block_type_index]
+            for local_index, subgraph in enumerate(block_params.cartbonded_subgraphs):
+                atoms = [int(atom) for atom in subgraph if atom != -1]
+                for atom_ids in (
+                    atom_unique_ids[block_type_index],
+                    atom_wildcard_ids[block_type_index],
+                ):
+                    for oriented_atoms in (atoms, atoms[::-1]):
+                        key = [int(atom_ids[atom]) for atom in oriented_atoms]
+                        param_index = lookup_param_index(key)
+                        if param_index != -1:
+                            subgraph_param_indices[block_offset + local_index] = (
+                                param_index
+                            )
+                            break
+                    if subgraph_param_indices[block_offset + local_index] != -1:
+                        break
+
         hash_keys_tensor = torch.from_numpy(hash_keys).to(device=self.device)
         hash_values_tensor = torch.from_numpy(hash_values).to(device=self.device)
+        subgraph_param_indices_tensor = torch.from_numpy(subgraph_param_indices).to(
+            device=self.device
+        )
 
         cb_pbt_ann = CartBondedPackedBlockTypesAnnotations(
             cartbonded_subgraphs=subgraphs,
             cartbonded_subgraph_offsets=subgraph_offsets,
             cartbonded_subgraph_type_counts=subgraph_type_counts,
             cartbonded_subgraph_type_offsets=subgraph_type_offsets,
+            cartbonded_subgraph_param_indices=subgraph_param_indices_tensor,
             cartbonded_max_subgraphs_per_block=max_subgraphs_per_block,
             cartbonded_atom_unique_id_index=cbet_atom_unique_id_index,
             cartbonded_params_hash_keys=hash_keys_tensor,
@@ -387,4 +432,5 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
             pbt_cb_ann.cartbonded_subgraph_offsets,
             pbt_cb_ann.cartbonded_subgraph_type_counts,
             pbt_cb_ann.cartbonded_subgraph_type_offsets,
+            pbt_cb_ann.cartbonded_subgraph_param_indices,
         ]

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -227,6 +227,46 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
             setattr(block_type, "cartbonded_annotations", {})
         block_type.cartbonded_annotations[self.hash] = cb_block_ann
 
+    @staticmethod
+    def _lookup_param_index(key, hash_keys):
+        hash_index = hash_fun(key, hash_keys.shape[0])
+        padded_key = numpy.full(4, -1, dtype=numpy.int32)
+        padded_key[: len(key)] = key
+        while hash_keys[hash_index, 0] != -1:
+            if numpy.array_equal(hash_keys[hash_index, :4], padded_key):
+                return hash_keys[hash_index, 4]
+            hash_index = (hash_index + 1) % hash_keys.shape[0]
+        return -1
+
+    def _precompute_subgraph_param_indices(
+        self, packed_block_types, subgraph_offsets, total_subgraphs, hash_keys
+    ):
+        """Resolve invariant intra-block parameter searches once during setup."""
+        atom_unique_ids = packed_block_types.atom_unique_ids.cpu().numpy()
+        atom_wildcard_ids = packed_block_types.atom_wildcard_ids.cpu().numpy()
+        param_indices = numpy.full(total_subgraphs, -1, dtype=numpy.int32)
+
+        for block_type_index, block_type in enumerate(
+            packed_block_types.active_block_types
+        ):
+            block_params = block_type.cartbonded_annotations[self.hash]
+            block_offset = subgraph_offsets[block_type_index]
+            for local_index, subgraph in enumerate(block_params.cartbonded_subgraphs):
+                atoms = [int(atom) for atom in subgraph if atom != -1]
+                for atom_ids in (
+                    atom_unique_ids[block_type_index],
+                    atom_wildcard_ids[block_type_index],
+                ):
+                    for oriented_atoms in (atoms, atoms[::-1]):
+                        key = [int(atom_ids[atom]) for atom in oriented_atoms]
+                        param_index = self._lookup_param_index(key, hash_keys)
+                        if param_index != -1:
+                            param_indices[block_offset + local_index] = param_index
+                            break
+                    if param_indices[block_offset + local_index] != -1:
+                        break
+        return param_indices
+
     def setup_packed_block_types(
         self, packed_block_types: PackedBlockTypes
     ):  # noqa: C901
@@ -278,17 +318,9 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
             max_subgraphs_per_block = max(
                 max_subgraphs_per_block, offset - subgraph_offsets[-1]
             )
-        subgraphs = torch.from_numpy(subgraphs).to(device=self.device)
         subgraph_offsets = numpy.asarray(subgraph_offsets, dtype=numpy.int32)
         subgraph_type_counts = numpy.asarray(subgraph_type_counts, dtype=numpy.int32)
         subgraph_type_offsets = numpy.asarray(subgraph_type_offsets, dtype=numpy.int32)
-        subgraph_offsets = torch.from_numpy(subgraph_offsets).to(device=self.device)
-        subgraph_type_counts = torch.from_numpy(subgraph_type_counts).to(
-            device=self.device
-        )
-        subgraph_type_offsets = torch.from_numpy(subgraph_type_offsets).to(
-            device=self.device
-        )
 
         # Aggregate the params
         # we will be adding new "wildcard" atom ids, so we will copy the
@@ -342,42 +374,18 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         # Intra-block topology and atom naming are fixed for a packed block
         # type. Resolve the exact/reversed/wildcard parameter search once here
         # instead of repeating four hash probes in every scoring invocation.
-        atom_unique_ids = packed_block_types.atom_unique_ids.cpu().numpy()
-        atom_wildcard_ids = packed_block_types.atom_wildcard_ids.cpu().numpy()
-        subgraph_param_indices = numpy.full(total_subgraphs, -1, dtype=numpy.int32)
+        subgraph_param_indices = self._precompute_subgraph_param_indices(
+            packed_block_types, subgraph_offsets, total_subgraphs, hash_keys
+        )
 
-        def lookup_param_index(key):
-            hash_index = hash_fun(key, hash_keys.shape[0])
-            padded_key = numpy.full(4, -1, dtype=numpy.int32)
-            padded_key[: len(key)] = key
-            while hash_keys[hash_index, 0] != -1:
-                if numpy.array_equal(hash_keys[hash_index, :4], padded_key):
-                    return hash_keys[hash_index, 4]
-                hash_index = (hash_index + 1) % hash_keys.shape[0]
-            return -1
-
-        for block_type_index, block_type in enumerate(
-            packed_block_types.active_block_types
-        ):
-            block_params = block_type.cartbonded_annotations[self.hash]
-            block_offset = subgraph_offsets[block_type_index]
-            for local_index, subgraph in enumerate(block_params.cartbonded_subgraphs):
-                atoms = [int(atom) for atom in subgraph if atom != -1]
-                for atom_ids in (
-                    atom_unique_ids[block_type_index],
-                    atom_wildcard_ids[block_type_index],
-                ):
-                    for oriented_atoms in (atoms, atoms[::-1]):
-                        key = [int(atom_ids[atom]) for atom in oriented_atoms]
-                        param_index = lookup_param_index(key)
-                        if param_index != -1:
-                            subgraph_param_indices[block_offset + local_index] = (
-                                param_index
-                            )
-                            break
-                    if subgraph_param_indices[block_offset + local_index] != -1:
-                        break
-
+        subgraphs = torch.from_numpy(subgraphs).to(device=self.device)
+        subgraph_offsets = torch.from_numpy(subgraph_offsets).to(device=self.device)
+        subgraph_type_counts = torch.from_numpy(subgraph_type_counts).to(
+            device=self.device
+        )
+        subgraph_type_offsets = torch.from_numpy(subgraph_type_offsets).to(
+            device=self.device
+        )
         hash_keys_tensor = torch.from_numpy(hash_keys).to(device=self.device)
         hash_values_tensor = torch.from_numpy(hash_values).to(device=self.device)
         subgraph_param_indices_tensor = torch.from_numpy(subgraph_param_indices).to(

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.hh
@@ -68,6 +68,7 @@ struct CartBondedPoseScoreDispatch {
       // relative to the offset listed in cart_subgraph_offsets, where
       // do the subgraphs for each of the three types begin?
       TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+      TView<Int, 1, D> cart_subgraph_param_indices,
 
       // int max_subgraphs_per_block,
       bool output_block_pair_energies,
@@ -118,6 +119,7 @@ struct CartBondedPoseScoreDispatch {
       // relative to the offset listed in cart_subgraph_offsets, where
       // do the subgraphs for each of the three types begin?
       TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+      TView<Int, 1, D> cart_subgraph_param_indices,
 
       TView<Real, 4, D> dTdV  // nterms x n-dispatch
       ) -> TPack<Vec<Real, 3>, 2, D>;
@@ -167,6 +169,7 @@ struct CartBondedRotamerScoreDispatch {
       // relative to the offset listed in cart_subgraph_offsets, where
       // do the subgraphs for each of the three types begin?
       TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+      TView<Int, 1, D> cart_subgraph_param_indices,
 
       // int max_subgraphs_per_block,
       bool output_block_pair_energies,
@@ -178,7 +181,7 @@ struct CartBondedRotamerScoreDispatch {
           TPack<Real, 2, D>,          // V_t,
           TPack<Vec<Real, 3>, 2, D>,  // dV_dx_t,
           TPack<Int, 2, D>,           // dispatch_indices_t,
-          TPack<Int, 1, D>,           // n_output_intxns_for_rot_conn_offset,
+          TPack<int64_t, 1, D>,       // n_output_intxns_for_rot_conn_offset,
           TPack<Int, 1, D>            // rotconn_for_output_intxn,
           >;
 
@@ -220,9 +223,10 @@ struct CartBondedRotamerScoreDispatch {
       // relative to the offset listed in cart_subgraph_offsets, where
       // do the subgraphs for each of the three types begin?
       TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+      TView<Int, 1, D> cart_subgraph_param_indices,
 
       TView<Int, 2, D> dispatch_indices,
-      TView<Int, 1, D> n_output_intxns_for_rot_conn_offset,
+      TView<int64_t, 1, D> n_output_intxns_for_rot_conn_offset,
       TView<Int, 1, D> rotconn_for_output_intxn,
 
       TView<Real, 2, D> dTdV  // nterms x n-dispatch

--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -12,6 +12,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/connection.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/count_pair.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
@@ -171,6 +172,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     // relative to the offset listed in cart_subgraph_offsets, where
     // do the subgraphs for each of the three types begin?
     TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+    TView<Int, 1, D> cart_subgraph_param_indices,
 
     // int max_subgraphs_per_block,
     bool output_block_pair_energies,
@@ -230,6 +232,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   assert(cart_subgraph_offsets.size(0) == n_block_types);
   assert(cart_subgraph_type_counts.size(0) == n_block_types);
   assert(cart_subgraph_type_offsets.size(0) == n_block_types);
+  assert(cart_subgraph_param_indices.size(0) == n_subgraphs);
 
   // Algorithm: launch n_rots * (max_n_conns + 1) CTAs, each looking
   // at a single residue's (rotamer's) connection (+ one "connection" to self),
@@ -383,33 +386,11 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         // rot_ind1, block_type1, cta, tid);
 
         for (int i = tid; i < n_subgraphs; i += nt) {
-          int param_index = -1;
-          Vec<Int, 4> subgraph_atom_indices = {-1, -1, -1, -1};
-          for (bool wildcard : {false, true}) {
-            for (bool reverse : {false, true}) {
-              Vec<Int, 4> subgraph = cart_subgraphs[subgraph_offset + i];
-              if (reverse) reverse_subgraph(subgraph);
-
-              const auto& atom_id_table = (wildcard)
-                                              ? atom_wildcard_ids[block_type1]
-                                              : atom_unique_ids[block_type1];
-              Vec<Int, 4> subgraph_atom_ids =
-                  get_atom_ids(atom_id_table, subgraph);
-              param_index =
-                  hash_lookup<Int, 4, D>(subgraph_atom_ids, hash_keys);
-
-              subgraph_atom_indices =
-                  atom_local_to_global_indices(subgraph, rot_coord_offset1);
-
-              if (param_index != -1) {
-                break;
-              }
-            }
-            if (param_index != -1) {
-              break;
-            }
-          }
+          int const subgraph_index = subgraph_offset + i;
+          int const param_index = cart_subgraph_param_indices[subgraph_index];
           if (param_index != -1) {
+            Vec<Int, 4> subgraph_atom_indices = atom_local_to_global_indices(
+                cart_subgraphs[subgraph_index], rot_coord_offset1);
             score_subgraph(subgraph_atom_indices, param_index);
           }
         }
@@ -660,6 +641,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     // relative to the offset listed in cart_subgraph_offsets, where
     // do the subgraphs for each of the three types begin?
     TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+    TView<Int, 1, D> cart_subgraph_param_indices,
 
     TView<Real, 4, D> dTdV  // nterms x n-poses x max_n_blocks x max_n_blocks
     ) -> TPack<Vec<Real, 3>, 2, D> {
@@ -820,33 +802,11 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
       int n_subgraphs = subgraph_offset_next - subgraph_offset;
       auto eval_intra_res_subgraphs = ([&] TMOL_DEVICE_FUNC(int tid) {
         for (int i = tid; i < n_subgraphs; i += nt) {
-          int param_index = -1;
-          Vec<Int, 4> subgraph_atom_indices = {-1, -1, -1, -1};
-          for (bool wildcard : {false, true}) {
-            for (bool reverse : {false, true}) {
-              Vec<Int, 4> subgraph = cart_subgraphs[subgraph_offset + i];
-              if (reverse) reverse_subgraph(subgraph);
-
-              const auto& atom_id_table = (wildcard)
-                                              ? atom_wildcard_ids[block_type1]
-                                              : atom_unique_ids[block_type1];
-              Vec<Int, 4> subgraph_atom_ids =
-                  get_atom_ids(atom_id_table, subgraph);
-              param_index =
-                  hash_lookup<Int, 4, D>(subgraph_atom_ids, hash_keys);
-
-              subgraph_atom_indices =
-                  atom_local_to_global_indices(subgraph, rot_coord_offset1);
-
-              if (param_index != -1) {
-                break;
-              }
-            }
-            if (param_index != -1) {
-              break;
-            }
-          }
+          int const subgraph_index = subgraph_offset + i;
+          int const param_index = cart_subgraph_param_indices[subgraph_index];
           if (param_index != -1) {
+            Vec<Int, 4> subgraph_atom_indices = atom_local_to_global_indices(
+                cart_subgraphs[subgraph_index], rot_coord_offset1);
             score_subgraph(
                 subgraph_atom_indices,
                 param_index,
@@ -1042,6 +1002,7 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     // relative to the offset listed in cart_subgraph_offsets, where
     // do the subgraphs for each of the three types begin?
     TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+    TView<Int, 1, D> cart_subgraph_param_indices,
 
     // int max_subgraphs_per_block,
     bool output_block_pair_energies,
@@ -1051,7 +1012,7 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         TPack<Real, 2, D>,          // V_t,
         TPack<Vec<Real, 3>, 2, D>,  // dV_dx_t,
         TPack<Int, 2, D>,           // dispatch_indices_t,
-        TPack<Int, 1, D>,           // n_output_intxns_for_rot_conn_offset,
+        TPack<int64_t, 1, D>,       // n_output_intxns_for_rot_conn_offset,
         TPack<Int, 1, D>            // rotconn_for_output_intxn,
         > {
   using tmol::score::common::get_connection_spanning_subgraphs_offset;
@@ -1118,14 +1079,15 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // Convention: conn == max_n_conns ==> the intra-rotamer set of cart energies
-  int const max_n_interactions = n_rots * (max_n_conns + 1);
+  int const max_n_interactions = score::common::checked_dispatch_product(
+      n_rots, max_n_conns + 1, "Cartesian-bonded count dispatch");
 
   // Here we only count the rotconns to "upper" neighbors
   auto n_output_intxns_for_rot_conn_t =
-      TPack<Int, 1, D>::zeros({max_n_interactions});
+      TPack<int64_t, 1, D>::zeros({max_n_interactions});
   auto n_output_intxns_for_rot_conn = n_output_intxns_for_rot_conn_t.view;
   auto n_output_intxns_for_rot_conn_offset_t =
-      TPack<Int, 1, D>::zeros({max_n_interactions});
+      TPack<int64_t, 1, D>::zeros({max_n_interactions});
   auto n_output_intxns_for_rot_conn_offset =
       n_output_intxns_for_rot_conn_offset_t.view;
 
@@ -1167,13 +1129,15 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
   // Scan and LBS on n output intxns: figure out how many rotamer pair
   // interactions there are and which pair each work unit should be assigned to.
-  int n_output_intxns_total =
+  int64_t const n_output_intxns_total_64 =
       DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           n_output_intxns_for_rot_conn.data(),
           n_output_intxns_for_rot_conn_offset.data(),
           max_n_interactions,
-          mgpu::plus_t<Int>());
+          mgpu::plus_t<int64_t>());
+  int const n_output_intxns_total = score::common::checked_dispatch_size(
+      n_output_intxns_total_64, "Cartesian-bonded output dispatch");
   TPack<Int, 1, D> rotconn_for_output_intxn_t =
       DeviceDispatch<D>::template load_balancing_search<launch_t>(
           mgr,
@@ -1340,33 +1304,11 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
       int n_subgraphs = subgraph_offset_next - subgraph_offset;
       auto eval_intra_res_subgraphs = ([&] TMOL_DEVICE_FUNC(int tid) {
         for (int i = tid; i < n_subgraphs; i += nt) {
-          int param_index = -1;
-          Vec<Int, 4> subgraph_atom_indices = {-1, -1, -1, -1};
-          for (bool wildcard : {false, true}) {
-            for (bool reverse : {false, true}) {
-              Vec<Int, 4> subgraph = cart_subgraphs[subgraph_offset + i];
-              if (reverse) reverse_subgraph(subgraph);
-
-              const auto& atom_id_table = (wildcard)
-                                              ? atom_wildcard_ids[block_type1]
-                                              : atom_unique_ids[block_type1];
-              Vec<Int, 4> subgraph_atom_ids =
-                  get_atom_ids(atom_id_table, subgraph);
-              param_index =
-                  hash_lookup<Int, 4, D>(subgraph_atom_ids, hash_keys);
-
-              subgraph_atom_indices =
-                  atom_local_to_global_indices(subgraph, rot_coord_offset1);
-
-              if (param_index != -1) {
-                break;
-              }
-            }
-            if (param_index != -1) {
-              break;
-            }
-          }
+          int const subgraph_index = subgraph_offset + i;
+          int const param_index = cart_subgraph_param_indices[subgraph_index];
           if (param_index != -1) {
+            Vec<Int, 4> subgraph_atom_indices = atom_local_to_global_indices(
+                cart_subgraphs[subgraph_index], rot_coord_offset1);
             score_subgraph(subgraph_atom_indices, param_index);
           }
         }
@@ -1593,9 +1535,10 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     // relative to the offset listed in cart_subgraph_offsets, where
     // do the subgraphs for each of the three types begin?
     TView<Vec<Int, 3>, 1, D> cart_subgraph_type_offsets,
+    TView<Int, 1, D> cart_subgraph_param_indices,
 
     TView<Int, 2, D> dispatch_indices,
-    TView<Int, 1, D> n_output_intxns_for_rot_conn_offset,
+    TView<int64_t, 1, D> n_output_intxns_for_rot_conn_offset,
     TView<Int, 1, D> rotconn_for_output_intxn,
 
     TView<Real, 2, D> dTdV  // nterms x n-dispatch
@@ -1752,33 +1695,11 @@ auto CartBondedRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
       int n_subgraphs = subgraph_offset_next - subgraph_offset;
       auto eval_intra_res_subgraphs = ([&] TMOL_DEVICE_FUNC(int tid) {
         for (int i = tid; i < n_subgraphs; i += nt) {
-          int param_index = -1;
-          Vec<Int, 4> subgraph_atom_indices = {-1, -1, -1, -1};
-          for (bool wildcard : {false, true}) {
-            for (bool reverse : {false, true}) {
-              Vec<Int, 4> subgraph = cart_subgraphs[subgraph_offset + i];
-              if (reverse) reverse_subgraph(subgraph);
-
-              const auto& atom_id_table = (wildcard)
-                                              ? atom_wildcard_ids[block_type1]
-                                              : atom_unique_ids[block_type1];
-              Vec<Int, 4> subgraph_atom_ids =
-                  get_atom_ids(atom_id_table, subgraph);
-              param_index =
-                  hash_lookup<Int, 4, D>(subgraph_atom_ids, hash_keys);
-
-              subgraph_atom_indices =
-                  atom_local_to_global_indices(subgraph, rot_coord_offset1);
-
-              if (param_index != -1) {
-                break;
-              }
-            }
-            if (param_index != -1) {
-              break;
-            }
-          }
+          int const subgraph_index = subgraph_offset + i;
+          int const param_index = cart_subgraph_param_indices[subgraph_index];
           if (param_index != -1) {
+            Vec<Int, 4> subgraph_atom_indices = atom_local_to_global_indices(
+                cart_subgraphs[subgraph_index], rot_coord_offset1);
             score_subgraph(subgraph_atom_indices, param_index);
           }
         }

--- a/tmol/score/cartbonded/potentials/compiled.ops.cpp
+++ b/tmol/score/cartbonded/potentials/compiled.ops.cpp
@@ -62,6 +62,7 @@ class CartBondedPoseScoreOp
       Tensor cart_subgraph_offsets,
       Tensor cart_subgraph_type_counts,
       Tensor cart_subgraph_type_offsets,
+      Tensor cart_subgraph_param_indices,
 
       bool output_block_pair_energies) {
     at::Tensor score;
@@ -105,6 +106,7 @@ class CartBondedPoseScoreOp
                       TCAST(cart_subgraph_offsets),
                       TCAST(cart_subgraph_type_counts),
                       TCAST(cart_subgraph_type_offsets),
+                      TCAST(cart_subgraph_param_indices),
 
                       output_block_pair_energies,
                       rot_coords.requires_grad());
@@ -142,7 +144,8 @@ class CartBondedPoseScoreOp
            cart_subgraphs,
            cart_subgraph_offsets,
            cart_subgraph_type_counts,
-           cart_subgraph_type_offsets});
+           cart_subgraph_type_offsets,
+           cart_subgraph_param_indices});
     } else {
       // Return a 2D tensor with shape [5 x n_poses]
       score = score.squeeze(-1).squeeze(-1);
@@ -203,6 +206,7 @@ class CartBondedPoseScoreOp
       auto cart_subgraph_offsets = saved[i++];
       auto cart_subgraph_type_counts = saved[i++];
       auto cart_subgraph_type_offsets = saved[i++];
+      auto cart_subgraph_param_indices = saved[i++];
 
       using Int = int32_t;
 
@@ -244,6 +248,7 @@ class CartBondedPoseScoreOp
                         TCAST(cart_subgraph_offsets),
                         TCAST(cart_subgraph_type_counts),
                         TCAST(cart_subgraph_type_offsets),
+                        TCAST(cart_subgraph_param_indices),
 
                         TCAST(dTdV));
 
@@ -277,6 +282,7 @@ class CartBondedPoseScoreOp
         torch::Tensor(),
         torch::Tensor(),
 
+        torch::Tensor(),
         torch::Tensor(),
         torch::Tensor(),
         torch::Tensor(),
@@ -322,6 +328,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
       Tensor cart_subgraph_offsets,
       Tensor cart_subgraph_type_counts,
       Tensor cart_subgraph_type_offsets,
+      Tensor cart_subgraph_param_indices,
 
       bool output_block_pair_energies) {
     at::Tensor score;
@@ -368,6 +375,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
                       TCAST(cart_subgraph_offsets),
                       TCAST(cart_subgraph_type_counts),
                       TCAST(cart_subgraph_type_offsets),
+                      TCAST(cart_subgraph_param_indices),
 
                       output_block_pair_energies,
                       rot_coords.requires_grad());
@@ -409,6 +417,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
            cart_subgraph_offsets,
            cart_subgraph_type_counts,
            cart_subgraph_type_offsets,
+           cart_subgraph_param_indices,
 
            dispatch_indices,
            n_output_intxns_for_rot_conn_offset,
@@ -478,6 +487,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
       auto cart_subgraph_offsets = saved[i++];
       auto cart_subgraph_type_counts = saved[i++];
       auto cart_subgraph_type_offsets = saved[i++];
+      auto cart_subgraph_param_indices = saved[i++];
 
       // Tensors generated during the forward pass
       auto dispatch_indices = saved[i++];
@@ -524,6 +534,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
                         TCAST(cart_subgraph_offsets),
                         TCAST(cart_subgraph_type_counts),
                         TCAST(cart_subgraph_type_offsets),
+                        TCAST(cart_subgraph_param_indices),
 
                         TCAST(dispatch_indices),
                         TCAST(n_output_intxns_for_rot_conn_offset),
@@ -567,6 +578,7 @@ class CartBondedRotamerScoreOp : public torch::autograd::Function<
         torch::Tensor(),
         torch::Tensor(),
         torch::Tensor(),
+        torch::Tensor(),
 
         torch::Tensor()};
   }
@@ -602,6 +614,7 @@ std::vector<Tensor> cartbonded_pose_scores_op(
     Tensor cart_subgraph_offsets,
     Tensor cart_subgraph_type_counts,
     Tensor cart_subgraph_type_offsets,
+    Tensor cart_subgraph_param_indices,
 
     bool output_block_pair_energies) {
   return CartBondedPoseScoreOp<DispatchMethod>::apply(
@@ -632,6 +645,7 @@ std::vector<Tensor> cartbonded_pose_scores_op(
       cart_subgraph_offsets,
       cart_subgraph_type_counts,
       cart_subgraph_type_offsets,
+      cart_subgraph_param_indices,
       output_block_pair_energies);
 }
 
@@ -665,6 +679,7 @@ std::vector<Tensor> cartbonded_rotamer_scores_op(
     Tensor cart_subgraph_offsets,
     Tensor cart_subgraph_type_counts,
     Tensor cart_subgraph_type_offsets,
+    Tensor cart_subgraph_param_indices,
 
     bool output_block_pair_energies) {
   return CartBondedRotamerScoreOp<DispatchMethod>::apply(
@@ -695,6 +710,7 @@ std::vector<Tensor> cartbonded_rotamer_scores_op(
       cart_subgraph_offsets,
       cart_subgraph_type_counts,
       cart_subgraph_type_offsets,
+      cart_subgraph_param_indices,
       output_block_pair_energies);
 }
 

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -147,21 +147,54 @@ class TermWholePoseScoringModule(TermPoseScoringModule):
         pose_stack,
         term_parameters,
         term_score_poses,
+        block_neighbor_cutoff=None,
     ):
         super(TermWholePoseScoringModule, self).__init__(
             classname, pose_stack, term_parameters, term_score_poses
+        )
+        self.block_neighbor_cutoff = block_neighbor_cutoff
+        self._neighbor_block_type_n_atoms = pose_stack.packed_block_types.n_atoms
+        self.register_buffer(
+            "_empty_block_neighbors",
+            torch.empty((0,), dtype=torch.int32, device=pose_stack.device),
         )
         self._build_static_tails(False)
 
     def forward(
         self,
         coords,
+        shared_block_neighbors=None,
     ):
         flat = coords.flatten(start_dim=0, end_dim=-2)
         tail = self._static_tail_for_coords(coords)
+        if self.block_neighbor_cutoff is not None:
+            if shared_block_neighbors is None:
+                shared_block_neighbors = self._empty_block_neighbors
+            scores, _ = self.term_score_poses(
+                flat,
+                *tail,
+                shared_block_neighbors,
+            )
+            return scores
         # ignore the dispatch_indices return tensor
         scores, _ = self.term_score_poses(flat, *tail)
         return scores
+
+    def build_compact_block_neighbors(self, coords, reach):
+        """Build a common compact list of conservative block-neighbor pairs."""
+        from tmol.score.ljlk.potentials import build_compact_block_neighbors
+
+        flat = coords.detach().flatten(start_dim=0, end_dim=-2)
+        return build_compact_block_neighbors(
+            flat,
+            self.common_parameters[0],
+            self.common_parameters[3],
+            self.common_parameters[4],
+            self.common_parameters[5],
+            self.common_parameters[6],
+            self._neighbor_block_type_n_atoms,
+            reach,
+        )[0]
 
 
 class TermBlockPairScoringModule(TermPoseScoringModule):
@@ -171,9 +204,15 @@ class TermBlockPairScoringModule(TermPoseScoringModule):
         pose_stack,
         term_parameters,
         term_score_poses,
+        block_neighbor_cutoff=None,
     ):
         super(TermBlockPairScoringModule, self).__init__(
             classname, pose_stack, term_parameters, term_score_poses
+        )
+        self.block_neighbor_cutoff = block_neighbor_cutoff
+        self.register_buffer(
+            "_empty_block_neighbors",
+            torch.empty((0,), dtype=torch.int32, device=pose_stack.device),
         )
         self._build_static_tails(True)
 
@@ -183,6 +222,13 @@ class TermBlockPairScoringModule(TermPoseScoringModule):
     ):
         flat = coords.flatten(start_dim=0, end_dim=-2)
         tail = self._static_tail_for_coords(coords)
+        if self.block_neighbor_cutoff is not None:
+            scores, _ = self.term_score_poses(
+                flat,
+                *tail,
+                self._empty_block_neighbors,
+            )
+            return scores
         scores, _ = self.term_score_poses(flat, *tail)
         return scores
 
@@ -194,6 +240,9 @@ class TermRotamerScoringModule(TermScoringModule):
         rotamer_set,
         term_parameters,
         term_score_poses,
+        block_neighbor_cutoff=None,
+        accepts_shared_dispatch=False,
+        rotamer_dispatch_key=None,
     ):
         super(TermRotamerScoringModule, self).__init__(
             classname, term_parameters, term_score_poses
@@ -228,9 +277,16 @@ class TermRotamerScoringModule(TermScoringModule):
         )
         self.n_poses = rotamer_set.n_rots_for_pose.shape[0]
         self.n_rots = rotamer_set.coord_offset_for_rot.shape[0]
+        self.block_neighbor_cutoff = block_neighbor_cutoff
+        self.accepts_shared_dispatch = accepts_shared_dispatch
+        self.rotamer_dispatch_key = rotamer_dispatch_key
+        self.register_buffer(
+            "_empty_dispatch_indices",
+            torch.empty((0, 0), dtype=torch.int32, device=rotamer_set.coords.device),
+        )
         self._build_static_tails(True)
 
-    def forward(self, coords):
+    def forward(self, coords, shared_dispatch_indices=None):
         """Return (scores, indices) without creating any sparse tensor.
 
         scores:  [n_subterms, nnz] float32
@@ -238,7 +294,14 @@ class TermRotamerScoringModule(TermScoringModule):
         """
         flat = coords.flatten(start_dim=0, end_dim=-2)
         tail = self._static_tail_for_coords(coords)
-        scores, indices = self.term_score_poses(flat, *tail)
+        if self.accepts_shared_dispatch:
+            if shared_dispatch_indices is None:
+                shared_dispatch_indices = self._empty_dispatch_indices
+            scores, indices = self.term_score_poses(
+                flat, *tail, shared_dispatch_indices
+            )
+        else:
+            scores, indices = self.term_score_poses(flat, *tail)
         return scores, indices
 
     def forward_split(self, coords):

--- a/tmol/score/common/counting.hh
+++ b/tmol/score/common/counting.hh
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace tmol {
+namespace score {
+namespace common {
+
+inline int checked_dispatch_size(int64_t count, char const* operation) {
+  if (count < 0 || count > std::numeric_limits<int>::max()) {
+    int64_t const minimum_bytes =
+        count <= 0 ? 0
+                   : (count > std::numeric_limits<int64_t>::max() / 16
+                          ? std::numeric_limits<int64_t>::max()
+                          : count * int64_t(16));
+    throw std::overflow_error(
+        std::string(operation) + " requires " + std::to_string(count)
+        + " interactions, exceeding the signed 32-bit native dispatch limit "
+          "(2147483647). The minimum three-int32-index + float-value storage "
+          "alone is "
+        + std::to_string(minimum_bytes)
+        + " bytes. Reduce the dispatched workload; for packing, lower "
+          "TMOL_PACK_MAX_POSES_PER_CHUNK.");
+  }
+  return static_cast<int>(count);
+}
+
+inline int64_t checked_count_product(
+    int64_t lhs, int64_t rhs, char const* operation) {
+  if (lhs < 0 || rhs < 0
+      || (lhs != 0 && rhs > std::numeric_limits<int64_t>::max() / lhs)) {
+    throw std::overflow_error(
+        std::string(operation) + " overflows a signed 64-bit count");
+  }
+  return lhs * rhs;
+}
+
+inline int checked_dispatch_product(
+    int64_t lhs, int64_t rhs, char const* operation) {
+  return checked_dispatch_size(
+      checked_count_product(lhs, rhs, operation), operation);
+}
+
+}  // namespace common
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/common/device_operations.cpu.impl.hh
+++ b/tmol/score/common/device_operations.cpu.impl.hh
@@ -7,6 +7,7 @@ error_this_should_not_be_compiled();  // nvcc should not include this file
 #include <ATen/Parallel.h>
 
 #include "device_operations.hh"
+#include "counting.hh"
 #include <tmol/utility/tensor/context_manager.hh>
 
 namespace tmol {
@@ -42,8 +43,10 @@ struct DeviceOperations<tmol::Device::CPU> {
   template <typename launch_t, typename Func>
   static void forall_grouped(
       ContextManager& mgr, int n_groups, int items_per_group, Func f) {
+    int const n_items = checked_dispatch_product(
+        n_groups, items_per_group, "grouped CPU dispatch");
     if (n_groups <= 1) {
-      forall<launch_t>(mgr, n_groups * items_per_group, f);
+      forall<launch_t>(mgr, n_items, f);
       return;
     }
 
@@ -107,8 +110,10 @@ struct DeviceOperations<tmol::Device::CPU> {
   template <typename launch_t, typename Func>
   static void foreach_grouped_workgroup(
       ContextManager& mgr, int n_groups, int workgroups_per_group, Func f) {
+    int const n_workgroups = checked_dispatch_product(
+        n_groups, workgroups_per_group, "grouped CPU workgroup dispatch");
     if (n_groups <= 1) {
-      foreach_workgroup<launch_t>(mgr, n_groups * workgroups_per_group, f);
+      foreach_workgroup<launch_t>(mgr, n_workgroups, f);
       return;
     }
 
@@ -172,22 +177,22 @@ struct DeviceOperations<tmol::Device::CPU> {
   //   - exc_scan_offsets: the result of running exclusive scan on the
   //     the number of work units that each generator produces
   //.  - n_generators: the number of generators / length of exc_scan_offset
-  template <typename launch_t, typename Int>
+  template <typename launch_t, typename Offset, typename Int = int32_t>
   static TPack<Int, 1, tmol::Device::CPU> load_balancing_search(
       ContextManager&,
       int n_work_units_total,  // The count of the total number of work units
-      Int* exc_scan_offsets,
+      Offset* exc_scan_offsets,
       int n_generators) {
     auto gen_for_work_item_t =
         TPack<Int, 1, tmol::Device::CPU>::zeros({n_work_units_total});
     auto gen_for_work_item = gen_for_work_item_t.view;
 
     for (int i = 0; i < n_generators; ++i) {
-      int i_offset = exc_scan_offsets[i];
-      int i_n_work_units =
+      int64_t i_offset = exc_scan_offsets[i];
+      int64_t i_n_work_units =
           (i + 1 == n_generators ? n_work_units_total : exc_scan_offsets[i + 1])
           - i_offset;
-      for (int j = 0; j < i_n_work_units; ++j) {
+      for (int64_t j = 0; j < i_n_work_units; ++j) {
         gen_for_work_item[i_offset + j] = i;
       }
     }

--- a/tmol/score/common/device_operations.cuda.impl.cuh
+++ b/tmol/score/common/device_operations.cuda.impl.cuh
@@ -12,6 +12,7 @@ error_this_should_not_be_compiled();  // gcc should not include this file
 #include <moderngpu/cta_reduce.hxx>
 
 #include "device_operations.hh"
+#include "counting.hh"
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/kinematics/compiled/kernel_segscan.cuh>
@@ -48,7 +49,9 @@ struct DeviceOperations<tmol::Device::CUDA> {
   template <typename launch_t, typename Func>
   static void forall_grouped(
       ContextManager& mgr, int n_groups, int items_per_group, Func f) {
-    forall<launch_t>(mgr, n_groups * items_per_group, f);
+    int const n_items = checked_dispatch_product(
+        n_groups, items_per_group, "grouped CUDA dispatch");
+    forall<launch_t>(mgr, n_items, f);
   }
 
   static EIGEN_DEVICE_FUNC void store_idempotent(
@@ -72,15 +75,19 @@ struct DeviceOperations<tmol::Device::CUDA> {
       ContextManager& mgr, Int dim1, Int dim2, Int dim3, Func f) {
     // mgpu::standard_context_t context;
     std::shared_ptr<mgpu::standard_context_t> context = _get_context(mgr);
+    int const dim23 =
+        checked_dispatch_product(dim2, dim3, "CUDA combination dispatch");
+    int const n_items =
+        checked_dispatch_product(dim1, dim23, "CUDA combination dispatch");
     mgpu::transform(
         [=] MGPU_DEVICE(int index) {
-          int i = index / (dim2 * dim3);
-          index = index % (dim2 * dim3);
+          int i = index / dim23;
+          index = index % dim23;
           int j = index / dim3;
           int k = index % dim3;
           f(i, j, k);
         },
-        dim1 * dim2 * dim3,
+        n_items,
         *context);
   }
 
@@ -101,7 +108,9 @@ struct DeviceOperations<tmol::Device::CUDA> {
   template <typename launch_t, typename Func>
   static void foreach_grouped_workgroup(
       ContextManager& mgr, int n_groups, int workgroups_per_group, Func f) {
-    foreach_workgroup<launch_t>(mgr, n_groups * workgroups_per_group, f);
+    int const n_workgroups = checked_dispatch_product(
+        n_groups, workgroups_per_group, "grouped CUDA workgroup dispatch");
+    foreach_workgroup<launch_t>(mgr, n_workgroups, f);
   }
 
   template <typename launch_t, typename Func>
@@ -137,11 +146,11 @@ struct DeviceOperations<tmol::Device::CUDA> {
   //   - exc_scan_offsets: the result of running exclusive scan on the
   //     the number of work units that each generator produces
   //.  - n_generators: the number of generators / length of exc_scan_offset
-  template <typename launch_t, typename Int>
+  template <typename launch_t, typename Offset, typename Int = int32_t>
   static TPack<Int, 1, tmol::Device::CUDA> load_balancing_search(
       ContextManager& mgr,
       int n_work_units_total,  // The count of the total number of work units
-      Int* exc_scan_offsets,
+      Offset* exc_scan_offsets,
       int n_generators) {
     std::shared_ptr<mgpu::standard_context_t> context = _get_context(mgr);
     // mgpu::standard_context_t context;

--- a/tmol/score/common/device_operations.hh
+++ b/tmol/score/common/device_operations.hh
@@ -77,11 +77,11 @@ struct DeviceOperations {
   //   - exc_scan_offsets: the result of running exclusive scan on the
   //     the number of work units that each generator produces
   //.  - n_generators: the number of generators / length of exc_scan_offset
-  template <typename launch_t, typename Int>
+  template <typename launch_t, typename Offset, typename Int = int32_t>
   static TPack<Int, 1, D> load_balancing_search(
       ContextManager& mgr,
       int n_work_units_total,  // The count of the total number of work units
-      Int* exc_scan_offsets,
+      Offset* exc_scan_offsets,
       int n_generators);
 
   // Perform a reduction on a given device array and return the result to the

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -79,7 +79,8 @@ struct compute_rot_spheres {
 
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(per_thread_com);
 
-      // The center of mass
+      // CPU's scalar workgroup implementation is faster with the square root
+      // before reduction; CUDA reduces squared distances to execute one sqrt.
       Real dmax(0);
 
       DeviceDispatch<D>::synchronize_workgroup();
@@ -100,20 +101,33 @@ struct compute_rot_spheres {
             d2max = d2;
           }
         }
-        dmax = sqrt(d2max);
+        if constexpr (D == Device::CPU) {
+          dmax = sqrt(d2max);
+        }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(
           per_thread_dist_to_com);
 
-      dmax = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
-          dmax, mgpu::maximum_t<Real>());
+      if constexpr (D == Device::CPU) {
+        dmax = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
+            dmax, mgpu::maximum_t<Real>());
+      } else {
+        d2max = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
+            d2max, mgpu::maximum_t<Real>());
+      }
 
       auto thread0_write_out_result = ([=] TMOL_DEVICE_FUNC(int tid) {
         if (tid == 0) {
           rot_spheres[rot_ind][0] = com[0];
           rot_spheres[rot_ind][1] = com[1];
           rot_spheres[rot_ind][2] = com[2];
-          rot_spheres[rot_ind][3] = dmax;
+          if constexpr (D == Device::CPU) {
+            rot_spheres[rot_ind][3] = dmax;
+          } else {
+            // Reduce squared distances first and take one square root per
+            // block, rather than one per participating GPU thread.
+            rot_spheres[rot_ind][3] = sqrt(d2max);
+          }
         }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(
@@ -168,7 +182,8 @@ struct compute_block_spheres {
 
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(per_thread_com);
 
-      // The center of mass
+      // CPU's scalar workgroup implementation is faster with the square root
+      // before reduction; CUDA reduces squared distances to execute one sqrt.
       Real dmax(0);
 
       DeviceDispatch<D>::synchronize_workgroup();
@@ -189,20 +204,33 @@ struct compute_block_spheres {
             d2max = d2;
           }
         }
-        dmax = sqrt(d2max);
+        if constexpr (D == Device::CPU) {
+          dmax = sqrt(d2max);
+        }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(
           per_thread_dist_to_com);
 
-      dmax = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
-          dmax, mgpu::maximum_t<Real>());
+      if constexpr (D == Device::CPU) {
+        dmax = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
+            dmax, mgpu::maximum_t<Real>());
+      } else {
+        d2max = DeviceDispatch<D>::template shuffle_reduce_in_workgroup<nt>(
+            d2max, mgpu::maximum_t<Real>());
+      }
 
       auto thread0_write_out_result = ([=] TMOL_DEVICE_FUNC(int tid) {
         if (tid == 0) {
           block_spheres[pose_ind][block_ind][0] = com[0];
           block_spheres[pose_ind][block_ind][1] = com[1];
           block_spheres[pose_ind][block_ind][2] = com[2];
-          block_spheres[pose_ind][block_ind][3] = dmax;
+          if constexpr (D == Device::CPU) {
+            block_spheres[pose_ind][block_ind][3] = dmax;
+          } else {
+            // Reduce squared distances first and take one square root per
+            // block, rather than one per participating GPU thread.
+            block_spheres[pose_ind][block_ind][3] = sqrt(d2max);
+          }
         }
       });
       DeviceDispatch<D>::template for_each_in_workgroup<nt>(
@@ -248,10 +276,16 @@ struct detect_rot_neighbors {
 
       if (rot_ind1 >= n_rots_for_pose[pose_ind]
           || rot_ind2 >= n_rots_for_pose[pose_ind]) {
+        if (D == Device::CUDA) {
+          rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
+        }
         return;
       }
 
       if (rot_ind1 > rot_ind2) {
+        if (D == Device::CUDA) {
+          rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
+        }
         return;
       }
 
@@ -264,15 +298,24 @@ struct detect_rot_neighbors {
       bool same_rot = rot_ind1 == rot_ind2;
       bool same_block = block_ind1 == block_ind2;
       if (same_block && !same_rot) {
+        if (D == Device::CUDA) {
+          rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
+        }
         return;
       }
 
       int const block_type1 = block_type_ind_for_rot[global_rot_ind1];
       if (block_type1 < 0) {
+        if (D == Device::CUDA) {
+          rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
+        }
         return;
       }
       int const block_type2 = block_type_ind_for_rot[global_rot_ind2];
       if (block_type2 < 0) {
+        if (D == Device::CUDA) {
+          rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
+        }
         return;
       }
 
@@ -291,8 +334,13 @@ struct detect_rot_neighbors {
 
       Real d_threshold = sphere1[3] + sphere2[3] + reach;
 
+      // CUDA writes every cell so its caller can avoid a separate fill. CPU
+      // retains zero-initialized scratch because skipping non-neighbor stores
+      // is faster there.
       if (d2 < d_threshold * d_threshold) {
         rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 1;
+      } else if (D == Device::CUDA) {
+        rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
       }
     });
     std::uint64_t n_rot_pairs = std::uint64_t(n_rots_for_block.size(0))
@@ -327,15 +375,24 @@ struct detect_block_neighbors {
       int const block_ind2 = pair % max_n_blocks;
 
       if (block_ind1 > block_ind2) {
+        if (D == Device::CUDA) {
+          block_neighbors[pose_ind][block_ind1][block_ind2] = 0;
+        }
         return;
       }
 
       int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
       if (block_type1 < 0) {
+        if (D == Device::CUDA) {
+          block_neighbors[pose_ind][block_ind1][block_ind2] = 0;
+        }
         return;
       }
       int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
       if (block_type2 < 0) {
+        if (D == Device::CUDA) {
+          block_neighbors[pose_ind][block_ind1][block_ind2] = 0;
+        }
         return;
       }
 
@@ -354,8 +411,13 @@ struct detect_block_neighbors {
 
       Real d_threshold = sphere1[3] + sphere2[3] + reach;
 
+      // CUDA writes every cell so its caller can avoid a separate fill. CPU
+      // retains zero-initialized scratch because skipping non-neighbor stores
+      // is faster there.
       if (d2 < d_threshold * d_threshold) {
         block_neighbors[pose_ind][block_ind1][block_ind2] = 1;
+      } else if (D == Device::CUDA) {
+        block_neighbors[pose_ind][block_ind1][block_ind2] = 0;
       }
     });
     DeviceDispatch<D>::template forall_independent<launch_t>(

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -1,16 +1,23 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
 #include <tmol/utility/tensor/TensorAccessor.h>
 #include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/counting.hh>
 
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/launch_box_macros.hh>
 #include <tmol/score/common/upper_triangle_indices.hh>
 
 #include <moderngpu/operators.hxx>
+#include <moderngpu/scan_types.hxx>
 #include <tmol/utility/tensor/context_manager.hh>
 
 namespace tmol {
@@ -29,14 +36,16 @@ inline bool should_compact_block_neighbors(
   constexpr int min_blocks_per_pose = 256;
   constexpr int min_inference_candidates = 1 << 16;
   constexpr int min_batched_blocks_for_derivatives = 1000;
-  int const pairs_per_pose = max_n_blocks * (max_n_blocks + 1) / 2;
+  int64_t const pairs_per_pose =
+      (int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2;
   bool const large_inference_workload =
       max_n_blocks >= min_blocks_per_pose
-      || n_poses * pairs_per_pose >= min_inference_candidates;
+      || int64_t(n_poses) * pairs_per_pose >= min_inference_candidates;
   if (!large_inference_workload) return false;
   return !computes_derivatives
          || (max_n_blocks >= min_blocks_per_pose
-             && n_poses * max_n_blocks >= min_batched_blocks_for_derivatives);
+             && int64_t(n_poses) * max_n_blocks
+                    >= min_batched_blocks_for_derivatives);
 }
 
 template <
@@ -143,7 +152,8 @@ template <
     template <tmol::Device> class DeviceDispatch,
     tmol::Device D,
     typename Real,
-    typename Int>
+    typename Int,
+    bool ResetCount = false>
 struct compute_block_spheres {
   static void f(
       ContextManager& mgr,
@@ -153,11 +163,21 @@ struct compute_block_spheres {
       TView<Int, 1, D> pose_ind_for_rot,
       TView<Int, 1, D> block_type_ind_for_rot,
       TView<Int, 1, D> block_type_n_atoms,
-      TView<Real, 3, D> block_spheres) {
+      TView<Real, 3, D> block_spheres,
+      Int* count_to_reset = nullptr) {
     LAUNCH_BOX_32;
 
     auto compute_spheres = ([=] TMOL_DEVICE_FUNC(int cta) {
       CTA_LAUNCH_T_PARAMS;
+
+      // Define this outside the constexpr branch so NVCC captures the pointer
+      // in an ordinary extended-lambda context.
+      auto reset_count = ([=] TMOL_DEVICE_FUNC(int tid) {
+        if (cta == 0 && tid == 0) count_to_reset[0] = 0;
+      });
+      if constexpr (ResetCount) {
+        DeviceDispatch<D>::template for_each_in_workgroup<nt>(reset_count);
+      }
 
       int const pose_ind = pose_ind_for_rot[cta];
       int const block_ind = block_ind_for_rot[cta];
@@ -262,15 +282,18 @@ struct detect_rot_neighbors {
       Real reach) {
     LAUNCH_BOX_32;
 
+    int const n_poses = n_rots_for_block.size(0);
+    int const max_n_rots = max_n_rots_per_pose;
+    int const rot_pairs_per_pose = common::checked_dispatch_product(
+        max_n_rots, max_n_rots, "rotamer-neighbor candidates per pose");
+    int const n_rot_pairs = common::checked_dispatch_product(
+        n_poses, rot_pairs_per_pose, "rotamer-neighbor candidates");
+
     auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int ind) {
-      int const n_poses = n_rots_for_block.size(0);
-      int const max_n_rots = max_n_rots_per_pose;
       int const n_block_types = block_type_n_atoms.size(0);
 
-      if (ind >= n_poses * max_n_rots * max_n_rots) return;
-
-      int const pose_ind = ind / (max_n_rots * max_n_rots);
-      int const rot_pair_ind = ind % (max_n_rots * max_n_rots);
+      int const pose_ind = ind / rot_pairs_per_pose;
+      int const rot_pair_ind = ind % rot_pairs_per_pose;
       int const rot_ind1 = rot_pair_ind / max_n_rots;
       int const rot_ind2 = rot_pair_ind % max_n_rots;
 
@@ -343,9 +366,6 @@ struct detect_rot_neighbors {
         rot_neighbors[pose_ind][rot_ind1][rot_ind2] = 0;
       }
     });
-    std::uint64_t n_rot_pairs = std::uint64_t(n_rots_for_block.size(0))
-                                * max_n_rots_per_pose * max_n_rots_per_pose;
-
     DeviceDispatch<D>::template forall_independent<launch_t>(
         mgr, n_rot_pairs, detect_neighbors);
   }
@@ -367,7 +387,10 @@ struct detect_block_neighbors {
 
     int const n_poses = pose_stack_block_type.size(0);
     int const max_n_blocks = pose_stack_block_type.size(1);
-    int const block_pairs_per_pose = max_n_blocks * max_n_blocks;
+    int const block_pairs_per_pose = common::checked_dispatch_product(
+        max_n_blocks, max_n_blocks, "block-neighbor candidates per pose");
+    int const n_block_pairs = common::checked_dispatch_product(
+        n_poses, block_pairs_per_pose, "block-neighbor candidates");
     auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int index) {
       int const pose_ind = index / block_pairs_per_pose;
       int const pair = index % block_pairs_per_pose;
@@ -421,7 +444,229 @@ struct detect_block_neighbors {
       }
     });
     DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_poses * block_pairs_per_pose, detect_neighbors);
+        mgr, n_block_pairs, detect_neighbors);
+  }
+};
+
+template <typename Real, typename Int>
+bool try_cpu_spatial_compact_block_neighbors(
+    TView<Int, 2, tmol::Device::CPU> pose_stack_block_type,
+    TView<Real, 3, tmol::Device::CPU> block_spheres,
+    Real reach,
+    std::vector<Int>& retained) {
+  retained.clear();
+  int const n_poses = pose_stack_block_type.size(0);
+  int const max_n_blocks = pose_stack_block_type.size(1);
+  constexpr int min_spatial_sweep_blocks = 150;
+  if (n_poses != 1 || max_n_blocks < min_spatial_sweep_blocks) {
+    return false;
+  }
+
+  std::vector<Int> ordered_blocks;
+  ordered_blocks.reserve(max_n_blocks);
+  Real min_center[3] = {
+      std::numeric_limits<Real>::infinity(),
+      std::numeric_limits<Real>::infinity(),
+      std::numeric_limits<Real>::infinity()};
+  Real max_center[3] = {
+      -std::numeric_limits<Real>::infinity(),
+      -std::numeric_limits<Real>::infinity(),
+      -std::numeric_limits<Real>::infinity()};
+  bool finite_spheres = true;
+  for (int block = 0; block < max_n_blocks; ++block) {
+    if (pose_stack_block_type[0][block] < 0) continue;
+    ordered_blocks.push_back(block);
+    for (int axis = 0; axis < 3; ++axis) {
+      Real const center = block_spheres[0][block][axis];
+      finite_spheres = finite_spheres && std::isfinite(center);
+      min_center[axis] = std::min(min_center[axis], center);
+      max_center[axis] = std::max(max_center[axis], center);
+    }
+    finite_spheres =
+        finite_spheres && std::isfinite(block_spheres[0][block][3]);
+  }
+
+  // NaN/Inf coordinates follow the established quadratic comparison behavior
+  // rather than entering a comparator without a strict order.
+  if (!finite_spheres || ordered_blocks.size() < min_spatial_sweep_blocks) {
+    return false;
+  }
+
+  int sweep_axis = 0;
+  for (int axis = 1; axis < 3; ++axis) {
+    if (max_center[axis] - min_center[axis]
+        > max_center[sweep_axis] - min_center[sweep_axis]) {
+      sweep_axis = axis;
+    }
+  }
+  std::sort(
+      ordered_blocks.begin(), ordered_blocks.end(), [=](Int left, Int right) {
+        Real const left_center = block_spheres[0][left][sweep_axis];
+        Real const right_center = block_spheres[0][right][sweep_axis];
+        return left_center < right_center
+               || (left_center == right_center && left < right);
+      });
+
+  int const n_valid_blocks = static_cast<int>(ordered_blocks.size());
+  std::vector<Real> suffix_max_radius(n_valid_blocks);
+  Real suffix_radius = 0;
+  for (int position = n_valid_blocks - 1; position >= 0; --position) {
+    suffix_radius =
+        std::max(suffix_radius, block_spheres[0][ordered_blocks[position]][3]);
+    suffix_max_radius[position] = suffix_radius;
+  }
+
+  int64_t const n_pairs = (int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2;
+  retained.reserve(
+      std::min<int64_t>(
+          n_pairs, std::max<int64_t>(16, int64_t(n_valid_blocks) * 32)));
+  int const triangle_dimension = max_n_blocks + 1;
+  for (int left_position = 0; left_position < n_valid_blocks; ++left_position) {
+    Int const left = ordered_blocks[left_position];
+    Real const left_axis_center = block_spheres[0][left][sweep_axis];
+    Real const left_radius = block_spheres[0][left][3];
+    for (int right_position = left_position; right_position < n_valid_blocks;
+         ++right_position) {
+      Int const right = ordered_blocks[right_position];
+      Real const axis_separation =
+          block_spheres[0][right][sweep_axis] - left_axis_center;
+      if (right_position != left_position
+          && axis_separation
+                 >= left_radius + suffix_max_radius[right_position] + reach) {
+        break;
+      }
+
+      Real const dx = block_spheres[0][left][0] - block_spheres[0][right][0];
+      Real const dy = block_spheres[0][left][1] - block_spheres[0][right][1];
+      Real const dz = block_spheres[0][left][2] - block_spheres[0][right][2];
+      Real const d2 = dx * dx + dy * dy + dz * dz;
+      Real const threshold = left_radius + block_spheres[0][right][3] + reach;
+      if (d2 >= threshold * threshold) continue;
+
+      Int const block1 = std::min(left, right);
+      Int const block2 = std::max(left, right);
+      int64_t const candidate =
+          int64_t(block1) * (2 * int64_t(triangle_dimension) - block1 - 1) / 2
+          + block2 - block1;
+      retained.push_back(static_cast<Int>(candidate));
+    }
+  }
+  std::sort(retained.begin(), retained.end());
+  return true;
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+struct detect_compact_block_neighbors {
+  static void f(
+      ContextManager& mgr,
+      TView<Int, 2, D> pose_stack_block_type,
+      TView<Real, 3, D> block_spheres,
+      TView<Int, 1, D> neighbor_indices,
+      Real reach) {
+    LAUNCH_BOX_32;
+
+    int const n_poses = pose_stack_block_type.size(0);
+    int const max_n_blocks = pose_stack_block_type.size(1);
+    int const n_pairs = common::checked_dispatch_size(
+        common::checked_count_product(
+            max_n_blocks,
+            int64_t(max_n_blocks) + 1,
+            "compact block-neighbor candidates per pose")
+            / 2,
+        "compact block-neighbor candidates per pose");
+    int const n_candidates = common::checked_dispatch_product(
+        n_poses, n_pairs, "compact block-neighbor candidates");
+    if constexpr (D == tmol::Device::CPU) {
+      // Sorting retained candidate IDs restores the exact canonical order used
+      // by the quadratic path, so downstream accumulation is unchanged.
+      std::vector<Int> retained;
+      if (try_cpu_spatial_compact_block_neighbors(
+              pose_stack_block_type, block_spheres, reach, retained)) {
+        neighbor_indices[0] = static_cast<Int>(retained.size());
+        if (!retained.empty()) {
+          std::memcpy(
+              neighbor_indices.data() + 1,
+              retained.data(),
+              retained.size() * sizeof(Int));
+        }
+        return;
+      }
+
+      auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        // CPU candidates run concurrently. Classify into disjoint slots;
+        // compact them deterministically after the parallel loop instead of
+        // racing on the intentionally non-atomic CPU accumulator.
+        neighbor_indices[candidate + 1] = -1;
+        int const pose_ind = candidate / n_pairs;
+        auto pair = common::upper_triangle_inds_from_linear_index(
+            candidate % n_pairs, max_n_blocks + 1);
+        int const block_ind1 = common::get<0>(pair);
+        int const block_ind2 = common::get<1>(pair) - 1;
+
+        int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+        if (block_type1 < 0) return;
+        int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+        if (block_type2 < 0) return;
+
+        Vec<Real, 4> sphere1(0, 0, 0, 0);
+        Vec<Real, 4> sphere2(0, 0, 0, 0);
+        for (int i = 0; i < 4; ++i) {
+          sphere1[i] = block_spheres[pose_ind][block_ind1][i];
+          sphere2[i] = block_spheres[pose_ind][block_ind2][i];
+        }
+        Real const d2 =
+            ((sphere1[0] - sphere2[0]) * (sphere1[0] - sphere2[0])
+             + (sphere1[1] - sphere2[1]) * (sphere1[1] - sphere2[1])
+             + (sphere1[2] - sphere2[2]) * (sphere1[2] - sphere2[2]));
+        Real const threshold = sphere1[3] + sphere2[3] + reach;
+        if (d2 >= threshold * threshold) return;
+
+        neighbor_indices[candidate + 1] = candidate;
+      });
+      DeviceDispatch<D>::template forall_independent<launch_t>(
+          mgr, n_candidates, detect_neighbors);
+      Int n_neighbors = 0;
+      for (int candidate = 0; candidate < n_candidates; ++candidate) {
+        Int const value = neighbor_indices[candidate + 1];
+        if (value >= 0) neighbor_indices[++n_neighbors] = value;
+      }
+      neighbor_indices[0] = n_neighbors;
+    } else {
+      auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        int const pose_ind = candidate / n_pairs;
+        auto pair = common::upper_triangle_inds_from_linear_index(
+            candidate % n_pairs, max_n_blocks + 1);
+        int const block_ind1 = common::get<0>(pair);
+        int const block_ind2 = common::get<1>(pair) - 1;
+
+        int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+        if (block_type1 < 0) return;
+        int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+        if (block_type2 < 0) return;
+
+        Vec<Real, 4> sphere1(0, 0, 0, 0);
+        Vec<Real, 4> sphere2(0, 0, 0, 0);
+        for (int i = 0; i < 4; ++i) {
+          sphere1[i] = block_spheres[pose_ind][block_ind1][i];
+          sphere2[i] = block_spheres[pose_ind][block_ind2][i];
+        }
+        Real const d2 =
+            ((sphere1[0] - sphere2[0]) * (sphere1[0] - sphere2[0])
+             + (sphere1[1] - sphere2[1]) * (sphere1[1] - sphere2[1])
+             + (sphere1[2] - sphere2[2]) * (sphere1[2] - sphere2[2]));
+        Real const threshold = sphere1[3] + sphere2[3] + reach;
+        if (d2 >= threshold * threshold) return;
+
+        Int const output = accumulate<D, Int>::add(neighbor_indices[0], Int(1));
+        neighbor_indices[output + 1] = candidate;
+      });
+      DeviceDispatch<D>::template forall_independent<launch_t>(
+          mgr, n_candidates, detect_neighbors);
+    }
   }
 };
 
@@ -439,20 +684,48 @@ struct compact_block_neighbors {
 
     int const n_poses = block_neighbors.size(0);
     int const max_n_blocks = block_neighbors.size(1);
-    int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
-    auto compact = ([=] TMOL_DEVICE_FUNC(int candidate) {
-      int const pose = candidate / n_pairs;
-      auto pair = common::upper_triangle_inds_from_linear_index(
-          candidate % n_pairs, max_n_blocks + 1);
-      int const block1 = common::get<0>(pair);
-      int const block2 = common::get<1>(pair) - 1;
-      if (block_neighbors[pose][block1][block2] == 0) return;
-
-      int const output = accumulate<D, Int>::add(n_neighbors[0], Int(1));
-      neighbor_indices[output] = candidate;
-    });
-    DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_poses * n_pairs, compact);
+    int const n_pairs = common::checked_dispatch_size(
+        common::checked_count_product(
+            max_n_blocks,
+            int64_t(max_n_blocks) + 1,
+            "compact block-neighbor candidates per pose")
+            / 2,
+        "compact block-neighbor candidates per pose");
+    int const n_candidates = common::checked_dispatch_product(
+        n_poses, n_pairs, "compact block-neighbor candidates");
+    if constexpr (D == tmol::Device::CPU) {
+      auto compact = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        neighbor_indices[candidate] = -1;
+        int const pose = candidate / n_pairs;
+        auto pair = common::upper_triangle_inds_from_linear_index(
+            candidate % n_pairs, max_n_blocks + 1);
+        int const block1 = common::get<0>(pair);
+        int const block2 = common::get<1>(pair) - 1;
+        if (block_neighbors[pose][block1][block2] == 0) return;
+        neighbor_indices[candidate] = candidate;
+      });
+      DeviceDispatch<D>::template forall_independent<launch_t>(
+          mgr, n_candidates, compact);
+      Int count = 0;
+      for (int candidate = 0; candidate < n_candidates; ++candidate) {
+        Int const value = neighbor_indices[candidate];
+        if (value >= 0) neighbor_indices[count++] = value;
+      }
+      n_neighbors[0] = count;
+    } else {
+      auto compact = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        int const pose = candidate / n_pairs;
+        auto pair = common::upper_triangle_inds_from_linear_index(
+            candidate % n_pairs, max_n_blocks + 1);
+        int const block1 = common::get<0>(pair);
+        int const block2 = common::get<1>(pair) - 1;
+        if (block_neighbors[pose][block1][block2] == 0) return;
+        int const output = accumulate<D, Int>::add(n_neighbors[0], Int(1));
+        neighbor_indices[output] = candidate;
+      });
+      DeviceDispatch<D>::template forall_independent<launch_t>(
+          mgr, n_candidates, compact);
+    }
   }
 };
 
@@ -468,8 +741,15 @@ void launch_compact_block_neighbors(
   // grid then strides over only neighboring pairs without a host sync.
   int const n_poses = block_neighbors.size(0);
   int const max_n_blocks = block_neighbors.size(1);
-  int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
-  int const n_candidates = n_poses * n_pairs;
+  int const n_pairs = common::checked_dispatch_size(
+      common::checked_count_product(
+          max_n_blocks,
+          int64_t(max_n_blocks) + 1,
+          "compact block-neighbor candidates per pose")
+          / 2,
+      "compact block-neighbor candidates per pose");
+  int const n_candidates = common::checked_dispatch_product(
+      n_poses, n_pairs, "compact block-neighbor candidates");
   if (n_candidates == 0) return;
   auto neighbor_indices_t = TPack<Int, 1, D>::empty({n_candidates});
   auto neighbor_indices = neighbor_indices_t.view;
@@ -499,6 +779,37 @@ void launch_compact_block_neighbors(
 template <
     template <tmol::Device> class DeviceDispatch,
     tmol::Device D,
+    typename Launch,
+    typename Int,
+    typename Eval>
+void launch_precomputed_block_neighbors(
+    ContextManager& mgr, TView<Int, 1, D> neighbor_indices, Eval eval) {
+  int const n_candidates = neighbor_indices.size(0) - 1;
+  if (n_candidates <= 0) return;
+#ifdef __NVCC__
+  constexpr int normal_workgroups = 1 << 14;
+  int const n_workgroups =
+      n_candidates < normal_workgroups ? n_candidates : normal_workgroups;
+  auto eval_compact = ([=] TMOL_DEVICE_FUNC(int cta) {
+    for (int index = cta; index < n_candidates; index += n_workgroups) {
+      if (index >= neighbor_indices[0]) return;
+      eval(neighbor_indices[index + 1]);
+    }
+  });
+  DeviceDispatch<D>::template foreach_workgroup<Launch>(
+      mgr, n_workgroups, eval_compact);
+#else
+  int const n_neighbors = neighbor_indices[0];
+  auto eval_compact =
+      ([=] TMOL_DEVICE_FUNC(int index) { eval(neighbor_indices[index + 1]); });
+  DeviceDispatch<D>::template foreach_workgroup<Launch>(
+      mgr, n_neighbors, eval_compact);
+#endif
+}
+
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device D,
     typename Int>
 struct rot_neighbor_indices {
   static auto f(
@@ -510,17 +821,32 @@ struct rot_neighbor_indices {
     int n_pose = rot_neighbors.size(0);
     int n_rot = rot_neighbors.size(1);
 
-    int n_cells = n_pose * n_rot * n_rot;
-    auto offset_for_cell_tp = TPack<Int, 3, D>::zeros_like(rot_neighbors);
+    int const pose_rot_cells = common::checked_dispatch_product(
+        n_pose, n_rot, "rotamer-neighbor dispatch candidates");
+    int const n_cells = common::checked_dispatch_product(
+        pose_rot_cells, n_rot, "rotamer-neighbor dispatch candidates");
+    auto count_for_cell_tp =
+        TPack<int64_t, 3, D>::zeros({n_pose, n_rot, n_rot});
+    auto count_for_cell = count_for_cell_tp.view;
+    auto copy_counts = ([=] TMOL_DEVICE_FUNC(int ind) {
+      count_for_cell.data()[ind] = rot_neighbors.data()[ind];
+    });
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, copy_counts);
+
+    auto offset_for_cell_tp =
+        TPack<int64_t, 3, D>::empty({n_pose, n_rot, n_rot});
     auto offset_for_cell = offset_for_cell_tp.view;
 
-    int n_dispatch_total =
+    int64_t const n_dispatch_total_64 =
         DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
             mgr,
-            rot_neighbors.data(),
+            count_for_cell.data(),
             offset_for_cell.data(),
             n_cells,
-            mgpu::plus_t<Int>());
+            mgpu::plus_t<int64_t>());
+    int const n_dispatch_total = common::checked_dispatch_size(
+        n_dispatch_total_64, "rotamer-neighbor dispatch");
 
     auto rot_neighbor_indices =
         TPack<Int, 2, D>::full({3, n_dispatch_total}, -1);
@@ -559,17 +885,32 @@ struct block_neighbor_indices {
     int n_pose = block_neighbors.size(0);
     int n_res = block_neighbors.size(1);
 
-    int n_cells = n_pose * n_res * n_res;
-    auto offset_for_cell_tp = TPack<Int, 3, D>::zeros_like(block_neighbors);
+    int const pose_res_cells = common::checked_dispatch_product(
+        n_pose, n_res, "block-neighbor dispatch candidates");
+    int const n_cells = common::checked_dispatch_product(
+        pose_res_cells, n_res, "block-neighbor dispatch candidates");
+    auto count_for_cell_tp =
+        TPack<int64_t, 3, D>::zeros({n_pose, n_res, n_res});
+    auto count_for_cell = count_for_cell_tp.view;
+    auto copy_counts = ([=] TMOL_DEVICE_FUNC(int ind) {
+      count_for_cell.data()[ind] = block_neighbors.data()[ind];
+    });
+    DeviceDispatch<D>::template forall_independent<launch_t>(
+        mgr, n_cells, copy_counts);
+
+    auto offset_for_cell_tp =
+        TPack<int64_t, 3, D>::empty({n_pose, n_res, n_res});
     auto offset_for_cell = offset_for_cell_tp.view;
 
-    int n_dispatch_total =
+    int64_t const n_dispatch_total_64 =
         DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
             mgr,
-            block_neighbors.data(),
+            count_for_cell.data(),
             offset_for_cell.data(),
             n_cells,
-            mgpu::plus_t<Int>());
+            mgpu::plus_t<int64_t>());
+    int const n_dispatch_total = common::checked_dispatch_size(
+        n_dispatch_total_64, "block-neighbor dispatch");
 
     auto block_neighbor_indices =
         TPack<Int, 2, D>::full({3, n_dispatch_total}, -1);
@@ -617,6 +958,8 @@ struct compute_block_spheres_from_rot_spheres {
 
     int const n_poses = n_rots_for_block.size(0);
     int const max_n_blocks = n_rots_for_block.size(1);
+    int const n_pose_blocks = common::checked_dispatch_product(
+        n_poses, max_n_blocks, "rotamer block-sphere dispatch");
 
     auto compute = ([=] TMOL_DEVICE_FUNC(int ind) {
       int const pose = ind / max_n_blocks;
@@ -653,7 +996,7 @@ struct compute_block_spheres_from_rot_spheres {
     });
 
     DeviceDispatch<D>::template forall_independent<launch_t>(
-        mgr, n_poses * max_n_blocks, compute);
+        mgr, n_pose_blocks, compute);
   }
 };
 
@@ -676,17 +1019,23 @@ struct rot_neighbor_indices_from_block_neighbors {
 
     int const n_poses = block_neighbors.size(0);
     int const max_n_blocks = block_neighbors.size(1);
-    int const n_cells = n_poses * max_n_blocks * max_n_blocks;
+    int const block_pair_cells = common::checked_dispatch_product(
+        max_n_blocks,
+        max_n_blocks,
+        "rotamer block-pair dispatch candidates per pose");
+    int const n_cells = common::checked_dispatch_product(
+        n_poses, block_pair_cells, "rotamer block-pair dispatch candidates");
 
     // Step 1: per-block-pair rotamer pair counts.
     // For diagonal (b1==b2): only self-pairs (r,r), count = n_rots[b1].
     // For off-diagonal (b1<b2): all pairs, count = n_rots[b1]*n_rots[b2].
-    auto pair_counts_t = TPack<Int, 3, D>::zeros_like(block_neighbors);
+    auto pair_counts_t =
+        TPack<int64_t, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
     auto pair_counts = pair_counts_t.view;
 
     auto compute_counts = ([=] TMOL_DEVICE_FUNC(int ind) {
-      int const pose = ind / (max_n_blocks * max_n_blocks);
-      int const bp = ind % (max_n_blocks * max_n_blocks);
+      int const pose = ind / block_pair_cells;
+      int const bp = ind % block_pair_cells;
       int const b1 = bp / max_n_blocks;
       int const b2 = bp % max_n_blocks;
       if (block_neighbors[pose][b1][b2]) {
@@ -694,7 +1043,7 @@ struct rot_neighbor_indices_from_block_neighbors {
           pair_counts[pose][b1][b2] = n_rots_for_block[pose][b1];
         } else {
           pair_counts[pose][b1][b2] =
-              n_rots_for_block[pose][b1] * n_rots_for_block[pose][b2];
+              int64_t(n_rots_for_block[pose][b1]) * n_rots_for_block[pose][b2];
         }
       }
     });
@@ -702,16 +1051,19 @@ struct rot_neighbor_indices_from_block_neighbors {
         mgr, n_cells, compute_counts);
 
     // Step 2: prefix scan → per-block-pair offsets and total
-    auto pair_offsets_t = TPack<Int, 3, D>::zeros_like(block_neighbors);
+    auto pair_offsets_t =
+        TPack<int64_t, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
     auto pair_offsets = pair_offsets_t.view;
 
-    int const total =
+    int64_t const total_64 =
         DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
             mgr,
             pair_counts.data(),
             pair_offsets.data(),
             n_cells,
-            mgpu::plus_t<Int>());
+            mgpu::plus_t<int64_t>());
+    int const total =
+        common::checked_dispatch_size(total_64, "rotamer block-pair dispatch");
 
     // Step 3: allocate output [3, total]
     auto indices_t = TPack<Int, 2, D>::full({3, total}, -1);
@@ -721,8 +1073,8 @@ struct rot_neighbor_indices_from_block_neighbors {
     // Diagonal (b1==b2): only (r,r) self-pairs (intrares scoring).
     // Off-diagonal (b1<b2): all nr1*nr2 pairs.
     auto fill = ([=] TMOL_DEVICE_FUNC(int ind) {
-      int const pose = ind / (max_n_blocks * max_n_blocks);
-      int const bp = ind % (max_n_blocks * max_n_blocks);
+      int const pose = ind / block_pair_cells;
+      int const bp = ind % block_pair_cells;
       int const b1 = bp / max_n_blocks;
       int const b2 = bp % max_n_blocks;
       if (!block_neighbors[pose][b1][b2]) return;
@@ -733,7 +1085,7 @@ struct rot_neighbor_indices_from_block_neighbors {
       int const off2 = rot_offset_for_block[pose][b2];
       if (off1 < 0 || off2 < 0) return;
 
-      int offset = pair_offsets[pose][b1][b2];
+      int64_t offset = pair_offsets[pose][b1][b2];
       if (b1 == b2) {
         for (int i = 0; i < nr1; ++i) {
           indices[0][offset] = pose;

--- a/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
+++ b/tmol/score/disulfide/potentials/disulfide_pose_score.impl.hh
@@ -11,6 +11,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
@@ -443,7 +444,7 @@ auto DisulfideRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   assert(pose_stack_inter_block_connections.size(1) == max_n_blocks);
   assert(pose_stack_inter_block_connections.size(2) == max_n_conns);
 
-  auto n_energies_for_rot_t = TPack<Int, 1, D>::zeros({n_rots});
+  auto n_energies_for_rot_t = TPack<int64_t, 1, D>::zeros({n_rots});
   auto n_energies_for_rot = n_energies_for_rot_t.view;
 
   // Optimal launch box on v100 and a100 is nt=32, vt=1
@@ -460,7 +461,7 @@ auto DisulfideRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     if (rot_block_type == -1) {
       return;
     }
-    int n_energies = 0;
+    int64_t n_energies = 0;
     for (int conn_index = 0; conn_index < max_n_conns; conn_index++) {
       if (disulfide_conns[rot_block_type][conn_index]) {
         int const other_block_index =
@@ -484,15 +485,25 @@ auto DisulfideRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   });
   DeviceDispatch<D>::template forall<launch_t>(
       mgr, n_rots, count_dispatch_indices);
-  auto n_energies_for_rot_offset_t = TPack<Int, 1, D>::zeros({n_rots});
+
+  int64_t const max_n_energies_for_rot_64 = DeviceDispatch<D>::reduce(
+      mgr, n_energies_for_rot.data(), n_rots, mgpu::maximum_t<int64_t>());
+  int const max_n_energies_for_rot = score::common::checked_dispatch_size(
+      max_n_energies_for_rot_64, "disulfide per-rotamer dispatch");
+  int const candidate_dispatch = score::common::checked_dispatch_product(
+      n_rots, max_n_energies_for_rot, "disulfide candidate dispatch");
+
+  auto n_energies_for_rot_offset_t = TPack<int64_t, 1, D>::zeros({n_rots});
   auto n_energies_for_rot_offset = n_energies_for_rot_offset_t.view;
-  int n_dispatch_total =
+  int64_t const n_dispatch_total_64 =
       DeviceDispatch<D>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           n_energies_for_rot.data(),
           n_energies_for_rot_offset.data(),
           n_rots,
-          mgpu::plus_t<Int>());
+          mgpu::plus_t<int64_t>());
+  int const n_dispatch_total = score::common::checked_dispatch_size(
+      n_dispatch_total_64, "disulfide output dispatch");
 
   TPack<Real, 2, D> V_t;
   auto dispatch_indices_t = TPack<Int, 2, D>::zeros({3, n_dispatch_total});
@@ -513,9 +524,6 @@ auto DisulfideRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // to imagine a disulfide-like chemical bond forming twice
   // between two residues
   auto conns_for_dispatch_indices = conns_for_dispatch_indices_t.view;
-
-  int const max_n_energies_for_rot = DeviceDispatch<D>::reduce(
-      mgr, n_energies_for_rot.data(), n_rots, mgpu::maximum_t<Int>());
 
   auto mark_dispatch_indices = ([=] TMOL_DEVICE_FUNC(int ind) {
     int const rot_ind1 = ind / max_n_energies_for_rot;
@@ -584,7 +592,7 @@ auto DisulfideRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     }
   });
   DeviceDispatch<D>::template forall<launch_t>(
-      mgr, n_rots * max_n_energies_for_rot, mark_dispatch_indices);
+      mgr, candidate_dispatch, mark_dispatch_indices);
 
   auto eval_energies = ([=] TMOL_DEVICE_FUNC(int dispatch_ind) {
     int const pose_ind = dispatch_indices[0][dispatch_ind];

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -162,39 +162,61 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                      ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
                      : TPack<Vec<Real, 3>, 2, D>::empty({3, 0});
 
+  // The derivative-enabled CUDA kernel fully writes every scratch element it
+  // consumes.  Skip separate initialization launches there, while retaining
+  // the established CPU and inference allocation paths.
   auto dihedral_atom_inds_t =
-      TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih});
+      D == Device::CPU || !accumulate_derivs
+          ? TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih})
+          : TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_atom_inds = dihedral_atom_inds_t.view;
-  auto dihedral_values_t = TPack<Real, 2, D>::zeros({n_rots, max_n_dih});
+  auto dihedral_values_t = D == Device::CPU || !accumulate_derivs
+                               ? TPack<Real, 2, D>::zeros({n_rots, max_n_dih})
+                               : TPack<Real, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
   auto dihedral_deriv_t =
       accumulate_derivs
-          ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
-                {n_rots, max_n_dih})
+          ? (D == Device::CPU
+                 ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
+                       {n_rots, max_n_dih})
+                 : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
+                       {n_rots, max_n_dih}))
           : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
                 {n_rots, max_n_dih});
   auto dihedral_deriv = dihedral_deriv_t.view;
 
-  auto rotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
+  auto rotameric_rottable_assignment_t =
+      D == Device::CPU || !accumulate_derivs
+          ? TPack<Int, 1, D>::zeros({n_rots})
+          : TPack<Int, 1, D>::empty({n_rots});
   auto rotameric_rottable_assignment = rotameric_rottable_assignment_t.view;
 
-  auto semirotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
+  auto semirotameric_rottable_assignment_t =
+      D == Device::CPU || !accumulate_derivs
+          ? TPack<Int, 1, D>::zeros({n_rots})
+          : TPack<Int, 1, D>::empty({n_rots});
   auto semirotameric_rottable_assignment =
       semirotameric_rottable_assignment_t.view;
 
   auto dneglnprob_rot_dbb_xyz_t =
-      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
-                        : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
+      accumulate_derivs
+          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
+                              : TPack<CoordQuad, 2, D>::empty({n_rots, 2}))
+          : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
   auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
 
   auto drotchi_devpen_dtor_xyz_t =
-      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                        : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      accumulate_derivs
+          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                              : TPack<CoordQuad, 2, D>::empty({n_rots, 3}))
+          : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
 
   auto dneglnprob_nonrot_dtor_xyz_t =
-      accumulate_derivs ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                        : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      accumulate_derivs
+          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                              : TPack<CoordQuad, 2, D>::empty({n_rots, 3}))
+          : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
 
   auto V = V_t.view;
@@ -562,31 +584,49 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
 
   auto dV_dx_t = TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms});
 
+  // Each CUDA work item fully initializes the scratch for its rotamer; retain
+  // the prior zero-initialized allocation on CPU.
   auto dihedral_atom_inds_t =
-      TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih});
+      D == Device::CPU
+          ? TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih})
+          : TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_atom_inds = dihedral_atom_inds_t.view;
-  auto dihedral_values_t = TPack<Real, 2, D>::zeros({n_rots, max_n_dih});
+  auto dihedral_values_t = D == Device::CPU
+                               ? TPack<Real, 2, D>::zeros({n_rots, max_n_dih})
+                               : TPack<Real, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
   auto dihedral_deriv_t =
-      TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
-          {n_rots, max_n_dih});
+      D == Device::CPU
+          ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
+                {n_rots, max_n_dih})
+          : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
+                {n_rots, max_n_dih});
   auto dihedral_deriv = dihedral_deriv_t.view;
 
-  auto rotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
+  auto rotameric_rottable_assignment_t =
+      D == Device::CPU ? TPack<Int, 1, D>::zeros({n_rots})
+                       : TPack<Int, 1, D>::empty({n_rots});
   auto rotameric_rottable_assignment = rotameric_rottable_assignment_t.view;
 
-  auto semirotameric_rottable_assignment_t = TPack<Int, 1, D>::zeros({n_rots});
+  auto semirotameric_rottable_assignment_t =
+      D == Device::CPU ? TPack<Int, 1, D>::zeros({n_rots})
+                       : TPack<Int, 1, D>::empty({n_rots});
   auto semirotameric_rottable_assignment =
       semirotameric_rottable_assignment_t.view;
 
-  auto dneglnprob_rot_dbb_xyz_t = TPack<CoordQuad, 2, D>::zeros({n_rots, 2});
+  auto dneglnprob_rot_dbb_xyz_t =
+      D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
+                       : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
   auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
 
-  auto drotchi_devpen_dtor_xyz_t = TPack<CoordQuad, 2, D>::zeros({n_rots, 3});
+  auto drotchi_devpen_dtor_xyz_t =
+      D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                       : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
 
   auto dneglnprob_nonrot_dtor_xyz_t =
-      TPack<CoordQuad, 2, D>::zeros({n_rots, 3});
+      D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
+                       : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
   auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
 
   auto dV_dx = dV_dx_t.view;

--- a/tmol/score/dunbrack/potentials/potentials.hh
+++ b/tmol/score/dunbrack/potentials/potentials.hh
@@ -271,7 +271,7 @@ def block_interpolate_rotameric_tables(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = rotameric_bb_periodicity[table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
 
@@ -351,7 +351,7 @@ def interpolate_rotameric_tables(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = rotameric_bb_periodicity[table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
 
@@ -674,7 +674,7 @@ def block_rotameric_chi_probability(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = rotameric_bb_periodicity[table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
 
@@ -730,7 +730,7 @@ def rotameric_chi_probability(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = rotameric_bb_periodicity[table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
 
@@ -889,7 +889,7 @@ def block_semirotameric_energy(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = semirot_periodicity[semirot_table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
     temp_dihe_deg(ii) = wrap_iidihe * 180 / M_PI;
@@ -970,7 +970,7 @@ def semirotameric_energy(
       wrap_iidihe += 2 * M_PI;
     }
     Real ii_period = semirot_periodicity[semirot_table_set][ii];
-    while (wrap_iidihe > ii_period) {
+    while (wrap_iidihe >= ii_period) {
       wrap_iidihe -= ii_period;
     }
     temp_dihe_deg(ii) = wrap_iidihe * 180 / M_PI;

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -163,6 +163,12 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
 
         return elec_rotamer_scores
 
+    def get_block_neighbor_cutoff(self):
+        return self._max_dis
+
+    def rotamer_dispatch_key(self):
+        return "sphere_overlap"
+
     def get_score_term_attributes(self, pose_stack):
         if self._scoring_global_params is None:
             D = self.global_params.elec_sigmoidal_die_D

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -159,15 +159,18 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         return elec_pose_scores
 
     def get_rotamer_score_term_function(self):
-        from tmol.score.elec.potentials import elec_rotamer_scores
+        from tmol.score.elec.potentials import elec_rotamer_scores_shared
 
-        return elec_rotamer_scores
+        return elec_rotamer_scores_shared
 
     def get_block_neighbor_cutoff(self):
         return self._max_dis
 
     def rotamer_dispatch_key(self):
         return "sphere_overlap"
+
+    def accepts_shared_rotamer_dispatch(self):
+        return True
 
     def get_score_term_attributes(self, pose_stack):
         if self._scoring_global_params is None:

--- a/tmol/score/elec/potentials/__init__.py
+++ b/tmol/score/elec/potentials/__init__.py
@@ -1,3 +1,7 @@
 """Compiled electrostatic potentials."""
 
-from ._compiled import elec_pose_scores, elec_rotamer_scores  # noqa: F401
+from ._compiled import (  # noqa: F401
+    elec_pose_scores,
+    elec_rotamer_scores,
+    elec_rotamer_scores_shared,
+)

--- a/tmol/score/elec/potentials/_compiled.py
+++ b/tmol/score/elec/potentials/_compiled.py
@@ -13,3 +13,4 @@ _ops = load_ops(
 
 elec_pose_scores = _ops.elec_pose_scores
 elec_rotamer_scores = _ops.elec_rotamer_scores
+elec_rotamer_scores_shared = _ops.elec_rotamer_scores_shared

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -304,7 +304,8 @@ class ElecRotamerScoreOp
       Tensor block_type_is_ligand_fragment,
       Tensor global_params,
       double max_dis,  // host scalar; needed by detect-neighbors call
-      bool output_block_pair_energies) {
+      bool output_block_pair_energies,
+      Tensor shared_dispatch_indices) {
     assert(output_block_pair_energies);
     at::Tensor score;
     at::Tensor dscore_dcoords;
@@ -349,7 +350,8 @@ class ElecRotamerScoreOp
                   TCAST(global_params),
                   (Real)max_dis,
                   output_block_pair_energies,
-                  rot_coords.requires_grad());
+                  rot_coords.requires_grad(),
+                  TCAST(shared_dispatch_indices));
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
@@ -507,7 +509,7 @@ class ElecRotamerScoreOp
         dV_d_pose_coords, torch::Tensor(), torch::Tensor(), torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),
+        torch::Tensor(),  torch::Tensor(),
 
         torch::Tensor(),  torch::Tensor(),
 
@@ -615,6 +617,8 @@ std::vector<Tensor> elec_rotamer_scores_op(
     Tensor global_params,
     double max_dis,
     bool output_block_pair_energies) {
+  auto empty_dispatch_indices =
+      torch::empty({0, 0}, rot_coord_offset.options().dtype(torch::kInt32));
   return ElecRotamerScoreOp<DispatchMethod>::apply(
       rot_coords,
       rot_coord_offset,
@@ -643,7 +647,77 @@ std::vector<Tensor> elec_rotamer_scores_op(
       block_type_is_ligand_fragment,
       global_params,
       max_dis,
-      output_block_pair_energies);
+      output_block_pair_energies,
+      empty_dispatch_indices);
+}
+
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> elec_rotamer_scores_shared_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_partial_charge,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_inter_repr_path_distance,
+    Tensor block_type_intra_repr_path_distance,
+    Tensor block_type_is_ligand_fragment,
+    Tensor global_params,
+    double max_dis,
+    bool output_block_pair_energies,
+    Tensor shared_dispatch_indices) {
+  TORCH_CHECK(
+      shared_dispatch_indices.dim() == 2
+          && (shared_dispatch_indices.size(0) == 3
+              || (shared_dispatch_indices.size(0) == 0
+                  && shared_dispatch_indices.size(1) == 0)),
+      "shared rotamer dispatch indices must have shape [3, nnz] or [0, 0]");
+  TORCH_CHECK(
+      shared_dispatch_indices.scalar_type() == torch::kInt32,
+      "shared rotamer dispatch indices must have dtype int32");
+  TORCH_CHECK(
+      shared_dispatch_indices.device() == rot_coords.device(),
+      "shared rotamer dispatch indices must be on the coordinate device");
+  return ElecRotamerScoreOp<DispatchMethod>::apply(
+      rot_coords,
+      rot_coord_offset,
+      pose_ind_for_atom,
+      first_rot_for_block,
+      first_rot_block_type,
+      block_ind_for_rot,
+      pose_ind_for_rot,
+      block_type_ind_for_rot,
+      n_rots_for_pose,
+      rot_offset_for_pose,
+      n_rots_for_block,
+      rot_offset_for_block,
+      max_n_rots_per_pose,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_partial_charge,
+      block_type_n_interblock_bonds,
+      block_type_atoms_forming_chemical_bonds,
+      block_type_inter_repr_path_distance,
+      block_type_intra_repr_path_distance,
+      block_type_is_ligand_fragment,
+      global_params,
+      max_dis,
+      output_block_pair_energies,
+      shared_dispatch_indices);
 }
 
 // See https://stackoverflow.com/a/3221914
@@ -651,6 +725,9 @@ TORCH_LIBRARY(tmol_elec, m) {
   m.def("elec_pose_scores", &elec_pose_scores_op<common::DeviceOperations>);
   m.def(
       "elec_rotamer_scores", &elec_rotamer_scores_op<common::DeviceOperations>);
+  m.def(
+      "elec_rotamer_scores_shared",
+      &elec_rotamer_scores_shared_op<common::DeviceOperations>);
 }
 
 }  // namespace potentials

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -57,7 +57,8 @@ class ElecPoseScoreOp
       Tensor block_type_is_ligand_fragment,
       Tensor global_params,
       double max_dis,  // host scalar; needed by detect-neighbors call
-      bool output_block_pair_energies) {
+      bool output_block_pair_energies,
+      Tensor shared_compact_block_neighbors) {
     at::Tensor score;
     at::Tensor dscore_dcoords;
     at::Tensor block_neighbors;
@@ -100,12 +101,15 @@ class ElecPoseScoreOp
                   TCAST(block_type_is_ligand_fragment),
                   TCAST(global_params),
                   (Real)max_dis,
+                  TCAST(shared_compact_block_neighbors),
                   output_block_pair_energies,
                   rot_coords.requires_grad());
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
-          block_neighbors = std::get<2>(result).tensor;
+          block_neighbors = shared_compact_block_neighbors.numel() != 0
+                                ? shared_compact_block_neighbors
+                                : std::get<2>(result).tensor;
         }));
 
     if (output_block_pair_energies) {
@@ -253,7 +257,7 @@ class ElecPoseScoreOp
         dV_d_pose_coords, torch::Tensor(), torch::Tensor(), torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(),
+        torch::Tensor(),  torch::Tensor(), torch::Tensor(),
 
         torch::Tensor(),  torch::Tensor(),
 
@@ -546,7 +550,8 @@ std::vector<Tensor> elec_pose_scores_op(
     Tensor block_type_is_ligand_fragment,
     Tensor global_params,
     double max_dis,
-    bool output_block_pair_energies) {
+    bool output_block_pair_energies,
+    Tensor shared_compact_block_neighbors) {
   return ElecPoseScoreOp<DispatchMethod>::apply(
       rot_coords,
       rot_coord_offset,
@@ -575,7 +580,8 @@ std::vector<Tensor> elec_pose_scores_op(
       block_type_is_ligand_fragment,
       global_params,
       max_dis,
-      output_block_pair_energies);
+      output_block_pair_energies,
+      shared_compact_block_neighbors);
 }
 
 template <template <tmol::Device> class DispatchMethod>

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -94,6 +94,7 @@ struct ElecPoseScoreDispatch {
       // LJ parameters
       TView<ElecGlobalParams<Real>, 1, D> global_params,
       Real max_dis,
+      TView<Int, 1, D> shared_compact_block_neighbors,
       bool output_block_pair_energies,
       bool compute_derivs) -> std::
       tuple<TPack<Real, 4, D>, TPack<Vec<Real, 3>, 2, D>, TPack<Int, 3, D> >;

--- a/tmol/score/elec/potentials/elec_pose_score.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.hh
@@ -239,7 +239,8 @@ struct ElecRotamerScoreDispatch {
       TView<ElecGlobalParams<Real>, 1, D> global_params,
       Real max_dis,
       bool output_block_pair_energies,
-      bool compute_derivs) -> std::
+      bool compute_derivs,
+      TPack<Int, 2, D> shared_dispatch_indices) -> std::
       tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 2, D>, TPack<Int, 2, D> >;
 
   static auto backward(

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -511,11 +511,14 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
-      TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4});
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_rot_neighbors_t =
-      TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      D == Device::CPU
+          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
   score::common::sphere_overlap::
@@ -1259,15 +1262,20 @@ auto ElecRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t = TPack<Real, 2, D>::zeros({n_rots, 4});
+  auto scratch_rot_spheres_t = D == Device::CPU
+                                   ? TPack<Real, 2, D>::zeros({n_rots, 4})
+                                   : TPack<Real, 2, D>::empty({n_rots, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_block_spheres_t =
-      TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4});
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
   auto scratch_block_spheres = scratch_block_spheres_t.view;
 
   auto scratch_block_neighbors_t =
-      TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      D == Device::CPU
+          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
   score::common::sphere_overlap::

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -1241,7 +1241,8 @@ auto ElecRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     TView<ElecGlobalParams<Real>, 1, D> global_params,
     Real max_dis,
     bool output_block_pair_energies,
-    bool compute_derivs) -> std::
+    bool compute_derivs,
+    TPack<Int, 2, D> shared_dispatch_indices) -> std::
     tuple<TPack<Real, 2, D>, TPack<Vec<Real, 3>, 2, D>, TPack<Int, 2, D> > {
   using tmol::score::common::accumulate;
   using Real3 = Vec<Real, 3>;
@@ -1299,50 +1300,58 @@ auto ElecRotamerScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, D>::zeros({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t = D == Device::CPU
-                                   ? TPack<Real, 2, D>::zeros({n_rots, 4})
-                                   : TPack<Real, 2, D>::empty({n_rots, 4});
-  auto scratch_rot_spheres = scratch_rot_spheres_t.view;
+  TPack<Int, 2, D> dispatch_indices_t;
+  if (shared_dispatch_indices.size(0) == 3) {
+    dispatch_indices_t = shared_dispatch_indices;
+  } else {
+    auto scratch_rot_spheres_t = D == Device::CPU
+                                     ? TPack<Real, 2, D>::zeros({n_rots, 4})
+                                     : TPack<Real, 2, D>::empty({n_rots, 4});
+    auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
-  auto scratch_block_spheres_t =
-      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
-                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_block_spheres = scratch_block_spheres_t.view;
+    auto scratch_block_spheres_t =
+        D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                         : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+    auto scratch_block_spheres = scratch_block_spheres_t.view;
 
-  auto scratch_block_neighbors_t =
-      D == Device::CPU
-          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+    auto scratch_block_neighbors_t =
+        D == Device::CPU
+            ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
+    auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
-  score::common::sphere_overlap::
-      compute_rot_spheres<DeviceDispatch, D, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
+    score::common::sphere_overlap::
+        compute_rot_spheres<DeviceDispatch, D, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres);
 
-  score::common::sphere_overlap::
-      compute_block_spheres_from_rot_spheres<DeviceDispatch, D, Real, Int>::f(
-          mgr,
-          scratch_rot_spheres,
-          n_rots_for_block,
-          rot_offset_for_block,
-          scratch_block_spheres);
+    score::common::sphere_overlap::
+        compute_block_spheres_from_rot_spheres<DeviceDispatch, D, Real, Int>::f(
+            mgr,
+            scratch_rot_spheres,
+            n_rots_for_block,
+            rot_offset_for_block,
+            scratch_block_spheres);
 
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceDispatch, D, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_block_spheres,
-          scratch_block_neighbors,
-          max_dis);
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceDispatch, D, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_block_spheres,
+            scratch_block_neighbors,
+            max_dis);
 
-  auto dispatch_indices_t = score::common::sphere_overlap::
-      rot_neighbor_indices_from_block_neighbors<DeviceDispatch, D, Int>::f(
-          mgr, scratch_block_neighbors, n_rots_for_block, rot_offset_for_block);
+    dispatch_indices_t = score::common::sphere_overlap::
+        rot_neighbor_indices_from_block_neighbors<DeviceDispatch, D, Int>::f(
+            mgr,
+            scratch_block_neighbors,
+            n_rots_for_block,
+            rot_offset_for_block);
+  }
 
   auto dispatch_indices = dispatch_indices_t.view;
 

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -447,6 +447,7 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     // LJ parameters
     TView<ElecGlobalParams<Real>, 1, D> global_params,
     Real max_dis,
+    TView<Int, 1, D> shared_compact_block_neighbors,
     bool output_block_pair_energies,
     bool compute_derivs) -> std::
     tuple<TPack<Real, 4, D>, TPack<Vec<Real, 3>, 2, D>, TPack<Int, 3, D> > {
@@ -510,35 +511,42 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                           : TPack<Vec<Real, 3>, 2, D>::empty({1, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t =
-      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
-                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_rot_spheres = scratch_rot_spheres_t.view;
+  bool const use_shared_compact_block_neighbors =
+      shared_compact_block_neighbors.size(0) != 0;
+  TPack<Real, 3, D> scratch_rot_spheres_t;
+  TPack<Int, 3, D> scratch_rot_neighbors_t;
+  TView<Real, 3, D> scratch_rot_spheres;
+  TView<Int, 3, D> scratch_rot_neighbors;
+  if (!use_shared_compact_block_neighbors) {
+    scratch_rot_spheres_t =
+        D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                         : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+    scratch_rot_neighbors_t =
+        D == Device::CPU
+            ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
+    scratch_rot_spheres = scratch_rot_spheres_t.view;
+    scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
-  auto scratch_rot_neighbors_t =
-      D == Device::CPU
-          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceDispatch, D, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_ind_for_rot,
+            pose_ind_for_rot,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres);
 
-  score::common::sphere_overlap::
-      compute_block_spheres<DeviceDispatch, D, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_ind_for_rot,
-          pose_ind_for_rot,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
-
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceDispatch, D, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_rot_spheres,
-          scratch_rot_neighbors,
-          max_dis);
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceDispatch, D, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_rot_spheres,
+            scratch_rot_neighbors,
+            max_dis);
+  }
 
   TPack<Real, 4, D> output_t;
   if (output_block_pair_energies) {
@@ -556,7 +564,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   // We define two device lambdas, one for block-pair scoring and
   // one for full pose scoring. They are nearly identical, except
@@ -617,7 +626,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
     // But we still kill everything that involves non-neighboring blocks
     // and that can be a lot!
-    if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+    if (!use_shared_compact_block_neighbors
+        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
 
@@ -750,7 +760,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
 
     // But we still kill everything that involves non-neighboring blocks
     // and that can be a lot!
-    if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+    if (!use_shared_compact_block_neighbors
+        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
 
@@ -833,7 +844,18 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // Score neighboring block pairs. Sparse large CUDA poses use a
   // device-resident compact list to avoid launching dead scoring CTAs.
 #ifdef __NVCC__
-  if (!output_block_pair_energies
+  if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+    if (compute_derivs) {
+      score::common::sphere_overlap::
+          launch_precomputed_block_neighbors<DeviceDispatch, D, launch_t, Int>(
+              mgr, shared_compact_block_neighbors, eval_energies);
+    } else {
+      score::common::sphere_overlap::
+          launch_precomputed_block_neighbors<DeviceDispatch, D, launch_t, Int>(
+              mgr, shared_compact_block_neighbors, eval_energies_by_block);
+    }
+  } else if (
+      !output_block_pair_energies
       && score::common::sphere_overlap::should_compact_block_neighbors(
           n_poses, max_n_blocks, compute_derivs)) {
     if (compute_derivs) {
@@ -848,7 +870,21 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   } else
 #endif
   {
-    if (output_block_pair_energies || !compute_derivs) {
+    if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+      if (compute_derivs) {
+        score::common::sphere_overlap::launch_precomputed_block_neighbors<
+            DeviceDispatch,
+            D,
+            launch_t,
+            Int>(mgr, shared_compact_block_neighbors, eval_energies);
+      } else {
+        score::common::sphere_overlap::launch_precomputed_block_neighbors<
+            DeviceDispatch,
+            D,
+            launch_t,
+            Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+      }
+    } else if (output_block_pair_energies || !compute_derivs) {
       DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
           mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
     } else {
@@ -994,7 +1030,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto elec_atom_energy_and_derivs =

--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -60,6 +60,9 @@ def elec_delec_ddist(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> tuple<Real, Real> {
+  if (bonded_path_length < Real(4)) {
+    return {0, 0};
+  }
   Real low_poly_start = params.min_dis - Real(0.25);
   Real low_poly_end = params.min_dis + Real(0.25);
   Real hi_poly_start = params.max_dis - Real(1);
@@ -121,6 +124,9 @@ def elec(
     Real e_j,
     Real bonded_path_length,
     ElecGlobalParams<Real> const& params) -> Real {
+  if (bonded_path_length < Real(4)) {
+    return 0;
+  }
   Real low_poly_start = params.min_dis - Real(0.25);
   Real low_poly_end = params.min_dis + Real(0.25);
   Real hi_poly_start = params.max_dis - Real(1);

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.hh
@@ -188,7 +188,7 @@ struct GenBondedRotamerScoreDispatch {
           TPack<Real, 2, D>,          // V_t
           TPack<Vec<Real, 3>, 2, D>,  // dV_dx_t
           TPack<Int, 2, D>,           // dispatch_indices_t
-          TPack<Int, 1, D>,           // n_output_intxns_for_rot_conn_offset
+          TPack<int64_t, 1, D>,       // n_output_intxns_for_rot_conn_offset
           TPack<Int, 1, D>            // rotconn_for_output_intxn
           >;
 
@@ -223,7 +223,7 @@ struct GenBondedRotamerScoreDispatch {
       TView<Vec<Real, 5>, 1, D> gen_inter_improper_hash_values,
 
       TView<Int, 2, D> dispatch_indices,
-      TView<Int, 1, D> n_output_intxns_for_rot_conn_offset,
+      TView<int64_t, 1, D> n_output_intxns_for_rot_conn_offset,
       TView<Int, 1, D> rotconn_for_output_intxn,
       TView<Real, 2, D> dTdV) -> TPack<Vec<Real, 3>, 2, D>;
 };

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -12,6 +12,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/connection.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
 #include <tmol/score/common/hash_util.hh>
@@ -995,7 +996,7 @@ auto GenBondedRotamerScoreDispatch<DeviceOps, D, Real, Int>::forward(
         TPack<Real, 2, D>,
         TPack<Vec<Real, 3>, 2, D>,
         TPack<Int, 2, D>,
-        TPack<Int, 1, D>,
+        TPack<int64_t, 1, D>,
         TPack<Int, 1, D>> {
   int const n_atoms = rot_coords.size(0);
   int const n_rots = rot_coord_offset.size(0);
@@ -1009,13 +1010,14 @@ auto GenBondedRotamerScoreDispatch<DeviceOps, D, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // Convention: conn == max_n_conns => intra-rotamer interactions.
-  int const max_n_interactions = n_rots * (max_n_conns + 1);
+  int const max_n_interactions = score::common::checked_dispatch_product(
+      n_rots, max_n_conns + 1, "generic-bonded count dispatch");
 
   auto n_output_intxns_for_rot_conn_t =
-      TPack<Int, 1, D>::zeros({max_n_interactions});
+      TPack<int64_t, 1, D>::zeros({max_n_interactions});
   auto n_output_intxns_for_rot_conn = n_output_intxns_for_rot_conn_t.view;
   auto n_output_intxns_for_rot_conn_offset_t =
-      TPack<Int, 1, D>::zeros({max_n_interactions});
+      TPack<int64_t, 1, D>::zeros({max_n_interactions});
   auto n_output_intxns_for_rot_conn_offset =
       n_output_intxns_for_rot_conn_offset_t.view;
 
@@ -1043,13 +1045,15 @@ auto GenBondedRotamerScoreDispatch<DeviceOps, D, Real, Int>::forward(
   DeviceOps<D>::template forall<launch_t>(
       mgr, max_n_interactions, count_intxns_for_rot_conn);
 
-  int n_output_intxns_total =
+  int64_t const n_output_intxns_total_64 =
       DeviceOps<D>::template scan_and_return_total<mgpu::scan_type_exc>(
           mgr,
           n_output_intxns_for_rot_conn.data(),
           n_output_intxns_for_rot_conn_offset.data(),
           max_n_interactions,
-          mgpu::plus_t<Int>());
+          mgpu::plus_t<int64_t>());
+  int const n_output_intxns_total = score::common::checked_dispatch_size(
+      n_output_intxns_total_64, "generic-bonded output dispatch");
   TPack<Int, 1, D> rotconn_for_output_intxn_t =
       DeviceOps<D>::template load_balancing_search<launch_t>(
           mgr,
@@ -1319,7 +1323,7 @@ auto GenBondedRotamerScoreDispatch<DeviceOps, D, Real, Int>::backward(
     TView<Vec<Real, 5>, 1, D> gen_inter_improper_hash_values,
 
     TView<Int, 2, D> dispatch_indices,
-    TView<Int, 1, D> n_output_intxns_for_rot_conn_offset,
+    TView<int64_t, 1, D> n_output_intxns_for_rot_conn_offset,
     TView<Int, 1, D> rotconn_for_output_intxn,
     TView<Real, 2, D> dTdV) -> TPack<Vec<Real, 3>, 2, D> {
   int const n_atoms = rot_coords.size(0);

--- a/tmol/score/hbond/_hbond_energy_term.py
+++ b/tmol/score/hbond/_hbond_energy_term.py
@@ -69,9 +69,10 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             gen_hbond_bases,
         )
 
-        common_args = args[:-2]
-        pose_stack = args[-2]
-        block_pair_scoring = args[-1]
+        common_args = args[:-3]
+        pose_stack = args[-3]
+        block_pair_scoring = args[-2]
+        shared_block_neighbors = args[-1]
         coords_dtype = common_args[0].dtype
         pair_param_table, pair_poly_table, global_param_table = self._param_tables(
             coords_dtype
@@ -130,6 +131,7 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             derived_coords,
             derived_atom_inds,
             block_pair_scoring,
+            shared_block_neighbors,
         )
 
     def rotamer_score_hbond(self, *args):
@@ -203,6 +205,9 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     def get_rotamer_score_term_function(self):
         return self.rotamer_score_hbond
+
+    def get_block_neighbor_cutoff(self):
+        return 5.5
 
     def get_score_term_attributes(self, pose_stack: PoseStack):
         return [pose_stack]

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -80,7 +80,8 @@ class HBondPoseScoresOp
       Tensor derived_coords,
       Tensor derived_atom_inds,
 
-      bool output_block_pair_energies
+      bool output_block_pair_energies,
+      Tensor shared_compact_block_neighbors
 
   ) {
     at::Tensor score;
@@ -145,12 +146,15 @@ class HBondPoseScoresOp
                   TCAST(derived_coords),
                   TCAST(derived_atom_inds),
 
+                  TCAST(shared_compact_block_neighbors),
                   output_block_pair_energies,
                   rot_coords.requires_grad());
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
-          block_neighbors = std::get<2>(result).tensor;
+          block_neighbors = shared_compact_block_neighbors.numel() != 0
+                                ? shared_compact_block_neighbors
+                                : std::get<2>(result).tensor;
         }));
 
     if (output_block_pair_energies) {
@@ -364,7 +368,7 @@ class HBondPoseScoresOp
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor()};
+            torch::Tensor(),  torch::Tensor()};
   }
 };
 
@@ -764,7 +768,8 @@ std::vector<Tensor> hbond_pose_scores_op(
     Tensor derived_coords,
     Tensor derived_atom_inds,
 
-    bool output_block_pair_energies) {
+    bool output_block_pair_energies,
+    Tensor shared_compact_block_neighbors) {
   return HBondPoseScoresOp<DispatchMethod>::apply(
       // common params
       rot_coords,
@@ -814,7 +819,8 @@ std::vector<Tensor> hbond_pose_scores_op(
       derived_coords,
       derived_atom_inds,
 
-      output_block_pair_energies);
+      output_block_pair_energies,
+      shared_compact_block_neighbors);
 }
 
 template <template <tmol::Device> class DispatchMethod>

--- a/tmol/score/hbond/potentials/hbond_pose_score.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.hh
@@ -110,6 +110,7 @@ struct HBondPoseScoreDispatch {
       TView<Vec<Real, 3>, 2, Dev> derived_coords,
       TView<Int, 2, Dev> derived_atom_inds,
 
+      TView<Int, 1, Dev> shared_compact_block_neighbors,
       bool output_block_pair_energies,
       bool compute_derivs)
       -> std::tuple<

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -495,6 +495,7 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     TView<Vec<Real, 3>, 2, Dev> derived_coords,
     TView<Int, 2, Dev> derived_atom_inds,
 
+    TView<Int, 1, Dev> shared_compact_block_neighbors,
     bool output_block_pair_energies,
     bool compute_derivs
 
@@ -592,36 +593,43 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
                           : TPack<Vec<Real, 3>, 2, Dev>::empty({1, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t =
-      Dev == Device::CPU
-          ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
-          : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_rot_spheres = scratch_rot_spheres_t.view;
+  bool const use_shared_compact_block_neighbors =
+      shared_compact_block_neighbors.size(0) != 0;
+  TPack<Real, 3, Dev> scratch_rot_spheres_t;
+  TPack<Int, 3, Dev> scratch_rot_neighbors_t;
+  TView<Real, 3, Dev> scratch_rot_spheres;
+  TView<Int, 3, Dev> scratch_rot_neighbors;
+  if (!use_shared_compact_block_neighbors) {
+    scratch_rot_spheres_t =
+        Dev == Device::CPU
+            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
+    scratch_rot_neighbors_t =
+        Dev == Device::CPU
+            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
+    scratch_rot_spheres = scratch_rot_spheres_t.view;
+    scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
-  auto scratch_rot_neighbors_t =
-      Dev == Device::CPU
-          ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_ind_for_rot,
+            pose_ind_for_rot,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres);
 
-  score::common::sphere_overlap::
-      compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_ind_for_rot,
-          pose_ind_for_rot,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
-
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_rot_spheres,
-          scratch_rot_neighbors,
-          Real(5.5));
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_rot_spheres,
+            scratch_rot_neighbors,
+            Real(5.5));
+  }
 
   TPack<Real, 4, Dev> output_t;
   if (output_block_pair_energies) {
@@ -645,7 +653,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   auto eval_energies = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto hbond_atom_energy = ([=] HBOND_ATOM_ENERGY);
@@ -676,7 +685,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
     // We still kill CTAs targetting non-neighboring block pairs, though,
     // and that can be a lot
-    if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+    if (!use_shared_compact_block_neighbors
+        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
     int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
@@ -751,29 +761,13 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
         store_calculated_energies);
   });
 
-  // Build block neighbors, then score the retained H-bond pairs.
-  score::common::sphere_overlap::
-      compute_block_spheres<DeviceOperations, Dev, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_ind_for_rot,
-          pose_ind_for_rot,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
-  // printf("computed block spheres\n");
-
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceOperations, Dev, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_rot_spheres,
-          scratch_rot_neighbors,
-          Real(5.5));
-
 #ifdef __NVCC__
-  if (!output_block_pair_energies
+  if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+    score::common::sphere_overlap::
+        launch_precomputed_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
+            mgr, shared_compact_block_neighbors, eval_energies);
+  } else if (
+      !output_block_pair_energies
       && score::common::sphere_overlap::should_compact_block_neighbors(
           n_poses, max_n_blocks, compute_derivs)) {
     score::common::sphere_overlap::
@@ -782,8 +776,16 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   } else
 #endif
   {
-    DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
-        mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
+    if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceDispatch,
+          Dev,
+          launch_t,
+          Int>(mgr, shared_compact_block_neighbors, eval_energies);
+    } else {
+      DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
+          mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
+    }
   }
 
   // DeviceDispatch<Dev>::synchronize_device();
@@ -908,7 +910,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     int const max_important_bond_separation = 4;

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -593,11 +593,15 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
-      TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+      Dev == Device::CPU
+          ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+          : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_rot_neighbors_t =
-      TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      Dev == Device::CPU
+          ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
   score::common::sphere_overlap::
@@ -1229,15 +1233,21 @@ auto HBondRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t = TPack<Real, 2, Dev>::zeros({n_rots, 4});
+  auto scratch_rot_spheres_t = Dev == Device::CPU
+                                   ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
+                                   : TPack<Real, 2, Dev>::empty({n_rots, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_block_spheres_t =
-      TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+      Dev == Device::CPU
+          ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+          : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
   auto scratch_block_spheres = scratch_block_spheres_t.view;
 
   auto scratch_block_neighbors_t =
-      TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      Dev == Device::CPU
+          ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
   score::common::sphere_overlap::

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -126,6 +126,12 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
 
         return ljlk_rotamer_scores
 
+    def get_block_neighbor_cutoff(self):
+        return self._max_dis
+
+    def rotamer_dispatch_key(self):
+        return "sphere_overlap"
+
     def get_score_term_attributes(self, pose_stack):
         def _t(ts):
             return tuple(map(lambda t: t.to(torch.float), ts))

--- a/tmol/score/ljlk/potentials/__init__.py
+++ b/tmol/score/ljlk/potentials/__init__.py
@@ -1,3 +1,10 @@
 """Compiled Lennard-Jones and isotropic solvation potentials."""
 
-from ._compiled import ljlk_pose_scores, ljlk_rotamer_scores  # noqa: F401
+from ._compiled import (  # noqa: F401
+    build_compact_block_neighbors,
+    ljlk_elec_pose_scores,
+    ljlk_elec_weighted_pose_scores,
+    weighted_fused_score_sum,
+    ljlk_pose_scores,
+    ljlk_rotamer_scores,
+)

--- a/tmol/score/ljlk/potentials/_compiled.py
+++ b/tmol/score/ljlk/potentials/_compiled.py
@@ -7,6 +7,8 @@ _ops = load_ops(
         "compiled.ops.cpp",
         "ljlk_pose_score.cpu.cpp",
         "ljlk_pose_score.cuda.cu",
+        "ljlk_elec_pose_score.cpu.cpp",
+        "ljlk_elec_pose_score.cuda.cu",
         # "rotamer_pair_energy_lk.cpu.cpp",
         # "rotamer_pair_energy_lk.cuda.cu",
     ],
@@ -14,4 +16,8 @@ _ops = load_ops(
 )
 
 ljlk_pose_scores = _ops.ljlk_pose_scores
+ljlk_elec_pose_scores = _ops.ljlk_elec_pose_scores
+ljlk_elec_weighted_pose_scores = _ops.ljlk_elec_weighted_pose_scores
+weighted_fused_score_sum = _ops.weighted_fused_score_sum
 ljlk_rotamer_scores = _ops.ljlk_rotamer_scores
+build_compact_block_neighbors = _ops.build_compact_block_neighbors

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -1,6 +1,8 @@
 #include <torch/torch.h>
 #include <torch/script.h>
 
+#include <limits>
+
 #include <tmol/utility/tensor/TensorCast.h>
 #include <tmol/utility/tensor/context_manager.hh>
 #include <tmol/utility/function_dispatch/aten.hh>
@@ -9,6 +11,7 @@
 #include <tmol/score/common/whole_pose_scoring.hh>
 
 #include "ljlk_pose_score.hh"
+#include "ljlk_elec_pose_score.hh"
 // #include "rotamer_pair_energy_lj.hh"
 // #include "rotamer_pair_energy_lk.hh"
 
@@ -63,7 +66,8 @@ class LJLKPoseScoreOp
       Tensor type_params,
       Tensor global_params,
       double max_dis,  // host scalar; needed by detect-neighbors call
-      bool output_block_pair_energies) {
+      bool output_block_pair_energies,
+      Tensor shared_compact_block_neighbors) {
     at::Tensor score, dscore_dcoords, block_neighbors;
 
     using Int = int32_t;
@@ -106,12 +110,15 @@ class LJLKPoseScoreOp
                   TCAST(type_params),
                   TCAST(global_params),
                   (Real)max_dis,
+                  TCAST(shared_compact_block_neighbors),
                   output_block_pair_energies,
                   rot_coords.requires_grad());
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
-          block_neighbors = std::get<2>(result).tensor;
+          block_neighbors = shared_compact_block_neighbors.numel() != 0
+                                ? shared_compact_block_neighbors
+                                : std::get<2>(result).tensor;
         }));
 
     if (output_block_pair_energies) {
@@ -270,7 +277,203 @@ class LJLKPoseScoreOp
             torch::Tensor(),  torch::Tensor(),
 
             torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor()};
+            torch::Tensor(),  torch::Tensor(), torch::Tensor()};
+  }
+};
+
+template <template <tmol::Device> class DispatchMethod, bool weighted>
+class LJLKAndElecPoseScoreOp
+    : public torch::autograd::Function<
+          LJLKAndElecPoseScoreOp<DispatchMethod, weighted>> {
+ public:
+  static std::vector<Tensor> forward(
+      AutogradContext* ctx,
+      Tensor rot_coords,
+      Tensor rot_coord_offset,
+      Tensor pose_ind_for_atom,
+      Tensor first_rot_for_block,
+      Tensor first_rot_block_type,
+      Tensor block_ind_for_rot,
+      Tensor pose_ind_for_rot,
+      Tensor block_type_ind_for_rot,
+      Tensor n_rots_for_pose,
+      Tensor rot_offset_for_pose,
+      Tensor n_rots_for_block,
+      Tensor rot_offset_for_block,
+      int64_t max_n_rots_per_pose,
+      Tensor pose_stack_min_bond_separation,
+      Tensor pose_stack_inter_block_bondsep,
+      Tensor block_type_n_atoms,
+      Tensor block_type_atom_types,
+      Tensor block_type_n_interblock_bonds,
+      Tensor block_type_atoms_forming_chemical_bonds,
+      Tensor block_type_ljlk_path_distance,
+      Tensor block_type_is_ligand_fragment,
+      Tensor ljlk_type_params,
+      Tensor ljlk_global_params,
+      Tensor block_type_partial_charge,
+      Tensor block_type_elec_inter_repr_path_distance,
+      Tensor block_type_elec_intra_repr_path_distance,
+      Tensor elec_global_params,
+      Tensor shared_compact_block_neighbors,
+      Tensor score_weights) {
+    TORCH_CHECK(
+        shared_compact_block_neighbors.numel() != 0,
+        "fused LJ/LK + electrostatics requires compact block neighbors");
+    if constexpr (weighted) {
+      TORCH_CHECK(
+          score_weights.dim() == 1 && score_weights.size(0) == 4,
+          "weighted fused LJ/LK + electrostatics requires four score weights");
+      TORCH_CHECK(
+          score_weights.device() == rot_coords.device()
+              && score_weights.scalar_type() == rot_coords.scalar_type(),
+          "fused score weights must match coordinate dtype and device");
+    }
+    Tensor score;
+    Tensor dscore_dcoords;
+    using Int = int32_t;
+#define TMOL_FUSED_SCORE_ARGS                                                 \
+  mgr, TCAST(rot_coords), TCAST(rot_coord_offset), TCAST(pose_ind_for_atom),  \
+      TCAST(first_rot_for_block), TCAST(first_rot_block_type),                \
+      TCAST(block_ind_for_rot), TCAST(pose_ind_for_rot),                      \
+      TCAST(block_type_ind_for_rot), TCAST(n_rots_for_pose),                  \
+      TCAST(rot_offset_for_pose), TCAST(n_rots_for_block),                    \
+      TCAST(rot_offset_for_block), max_n_rots_per_pose,                       \
+      TCAST(pose_stack_min_bond_separation),                                  \
+      TCAST(pose_stack_inter_block_bondsep), TCAST(block_type_n_atoms),       \
+      TCAST(block_type_atom_types), TCAST(block_type_n_interblock_bonds),     \
+      TCAST(block_type_atoms_forming_chemical_bonds),                         \
+      TCAST(block_type_ljlk_path_distance),                                   \
+      TCAST(block_type_is_ligand_fragment), TCAST(ljlk_type_params),          \
+      TCAST(ljlk_global_params), TCAST(block_type_partial_charge),            \
+      TCAST(block_type_elec_inter_repr_path_distance),                        \
+      TCAST(block_type_elec_intra_repr_path_distance),                        \
+      TCAST(elec_global_params), TCAST(shared_compact_block_neighbors)
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        rot_coords.options(), "ljlk_elec_pose_score_op", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+          auto result = [&]() {
+            if constexpr (weighted) {
+              return LJLKAndElecPoseScoreDispatch<
+                  DispatchMethod,
+                  Dev,
+                  Real,
+                  Int>::forward_weighted(
+                  TMOL_FUSED_SCORE_ARGS,
+                  TCAST(score_weights),
+                  rot_coords.requires_grad());
+            } else {
+              return LJLKAndElecPoseScoreDispatch<
+                  DispatchMethod,
+                  Dev,
+                  Real,
+                  Int>::forward(
+                  TMOL_FUSED_SCORE_ARGS, rot_coords.requires_grad());
+            }
+          }();
+          score = std::get<0>(result).tensor.squeeze(-1).squeeze(-1);
+          dscore_dcoords = std::get<1>(result).tensor;
+        }));
+#undef TMOL_FUSED_SCORE_ARGS
+    ctx->save_for_backward({dscore_dcoords, pose_ind_for_atom});
+    return {score};
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    auto const saved = ctx->get_saved_variables();
+    tensor_list gradients(29);
+    gradients[0] =
+        common::accumulate_whole_pose_gradients(saved[0], grad_outputs[0]);
+    return gradients;
+  }
+};
+
+template <template <tmol::Device> class DispatchMethod>
+class WeightedFusedScoreSumOp
+    : public torch::autograd::Function<WeightedFusedScoreSumOp<DispatchMethod>> {
+ public:
+  static std::vector<Tensor> forward(
+      AutogradContext* ctx,
+      Tensor score_lanes,
+      Tensor score_weights,
+      int64_t fused_weight_begin,
+      int64_t fused_weight_width) {
+    TORCH_CHECK(
+        score_lanes.dim() == 2 && score_weights.dim() == 2
+            && score_weights.size(1) == 1,
+        "weighted score reduction expects [lane, pose] scores and [lane, 1] "
+        "weights");
+    TORCH_CHECK(
+        score_lanes.device() == score_weights.device()
+            && score_lanes.scalar_type() == score_weights.scalar_type(),
+        "score lanes and weights must have the same dtype and device");
+    TORCH_CHECK(
+        fused_weight_begin >= 0 && fused_weight_width > 0
+            && fused_weight_begin < score_lanes.size(0)
+            && score_lanes.size(0)
+                == score_weights.size(0) - fused_weight_width + 1,
+        "invalid fused score-lane mapping");
+
+    Tensor output;
+    using Int = int32_t;
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        score_lanes.options(), "weighted_fused_score_sum_op", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+          output = LJLKAndElecPoseScoreDispatch<
+                       DispatchMethod,
+                       Dev,
+                       Real,
+                       Int>::reduce_weighted_scores(
+                       mgr,
+                       TCAST(score_lanes),
+                       TCAST(score_weights),
+                       fused_weight_begin,
+                       fused_weight_width)
+                       .tensor;
+        }));
+    ctx->save_for_backward({score_weights});
+    ctx->saved_data["n_score_lanes"] = score_lanes.size(0);
+    ctx->saved_data["fused_weight_begin"] = fused_weight_begin;
+    ctx->saved_data["fused_weight_width"] = fused_weight_width;
+    return {output};
+  }
+
+  static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    Tensor const score_weights = ctx->get_saved_variables()[0];
+    // TView preserves the incoming stride, including the zero stride produced
+    // by score.sum()'s expanded gradient. Avoid materializing that expansion:
+    // the native reduction reads it correctly and saves one CPU copy or CUDA
+    // kernel launch from every default score-plus-gradient call.
+    Tensor const output_gradient = grad_outputs[0];
+    int64_t const n_score_lanes = ctx->saved_data["n_score_lanes"].toInt();
+    int64_t const fused_weight_begin =
+        ctx->saved_data["fused_weight_begin"].toInt();
+    int64_t const fused_weight_width =
+        ctx->saved_data["fused_weight_width"].toInt();
+    Tensor score_lane_gradients;
+    using Int = int32_t;
+    TMOL_DISPATCH_FLOATING_DEVICE(
+        output_gradient.options(), "weighted_fused_score_sum_backward", ([&] {
+          using Real = scalar_t;
+          constexpr tmol::Device Dev = device_t;
+          score_lane_gradients = LJLKAndElecPoseScoreDispatch<
+                                     DispatchMethod,
+                                     Dev,
+                                     Real,
+                                     Int>::reduce_weighted_score_gradients(
+                                     mgr,
+                                     TCAST(output_gradient),
+                                     TCAST(score_weights),
+                                     n_score_lanes,
+                                     fused_weight_begin,
+                                     fused_weight_width)
+                                     .tensor;
+        }));
+    tensor_list gradients(4);
+    gradients[0] = score_lane_gradients;
+    return gradients;
   }
 };
 
@@ -557,7 +760,8 @@ std::vector<Tensor> ljlk_pose_scores_op(
     Tensor ljlk_type_params,
     Tensor global_params,
     double max_dis,
-    bool output_block_pair_energies) {
+    bool output_block_pair_energies,
+    Tensor shared_compact_block_neighbors) {
   return LJLKPoseScoreOp<DispatchMethod>::apply(
       // common params
       rot_coords,
@@ -589,7 +793,200 @@ std::vector<Tensor> ljlk_pose_scores_op(
       ljlk_type_params,
       global_params,
       max_dis,
-      output_block_pair_energies);
+      output_block_pair_energies,
+      shared_compact_block_neighbors);
+}
+
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> ljlk_elec_pose_scores_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_atom_types,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_ljlk_path_distance,
+    Tensor block_type_is_ligand_fragment,
+    Tensor ljlk_type_params,
+    Tensor ljlk_global_params,
+    Tensor block_type_partial_charge,
+    Tensor block_type_elec_inter_repr_path_distance,
+    Tensor block_type_elec_intra_repr_path_distance,
+    Tensor elec_global_params,
+    Tensor shared_compact_block_neighbors) {
+  return LJLKAndElecPoseScoreOp<DispatchMethod, false>::apply(
+      rot_coords,
+      rot_coord_offset,
+      pose_ind_for_atom,
+      first_rot_for_block,
+      first_rot_block_type,
+      block_ind_for_rot,
+      pose_ind_for_rot,
+      block_type_ind_for_rot,
+      n_rots_for_pose,
+      rot_offset_for_pose,
+      n_rots_for_block,
+      rot_offset_for_block,
+      max_n_rots_per_pose,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_atom_types,
+      block_type_n_interblock_bonds,
+      block_type_atoms_forming_chemical_bonds,
+      block_type_ljlk_path_distance,
+      block_type_is_ligand_fragment,
+      ljlk_type_params,
+      ljlk_global_params,
+      block_type_partial_charge,
+      block_type_elec_inter_repr_path_distance,
+      block_type_elec_intra_repr_path_distance,
+      elec_global_params,
+      shared_compact_block_neighbors,
+      torch::empty({0}, rot_coords.options()));
+}
+
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> ljlk_elec_weighted_pose_scores_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_atom_types,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_ljlk_path_distance,
+    Tensor block_type_is_ligand_fragment,
+    Tensor ljlk_type_params,
+    Tensor ljlk_global_params,
+    Tensor block_type_partial_charge,
+    Tensor block_type_elec_inter_repr_path_distance,
+    Tensor block_type_elec_intra_repr_path_distance,
+    Tensor elec_global_params,
+    Tensor shared_compact_block_neighbors,
+    Tensor score_weights) {
+  return LJLKAndElecPoseScoreOp<DispatchMethod, true>::apply(
+      rot_coords,
+      rot_coord_offset,
+      pose_ind_for_atom,
+      first_rot_for_block,
+      first_rot_block_type,
+      block_ind_for_rot,
+      pose_ind_for_rot,
+      block_type_ind_for_rot,
+      n_rots_for_pose,
+      rot_offset_for_pose,
+      n_rots_for_block,
+      rot_offset_for_block,
+      max_n_rots_per_pose,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_atom_types,
+      block_type_n_interblock_bonds,
+      block_type_atoms_forming_chemical_bonds,
+      block_type_ljlk_path_distance,
+      block_type_is_ligand_fragment,
+      ljlk_type_params,
+      ljlk_global_params,
+      block_type_partial_charge,
+      block_type_elec_inter_repr_path_distance,
+      block_type_elec_intra_repr_path_distance,
+      elec_global_params,
+      shared_compact_block_neighbors,
+      score_weights);
+}
+
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> weighted_fused_score_sum_op(
+    Tensor score_lanes,
+    Tensor score_weights,
+    int64_t fused_weight_begin,
+    int64_t fused_weight_width) {
+  return WeightedFusedScoreSumOp<DispatchMethod>::apply(
+      score_lanes, score_weights, fused_weight_begin, fused_weight_width);
+}
+
+std::vector<Tensor> build_compact_block_neighbors_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor block_type_n_atoms,
+    double reach) {
+  TORCH_CHECK(
+      first_rot_block_type.dim() == 2,
+      "first_rot_block_type must have shape [n_poses, max_n_blocks]");
+  int64_t const n_poses = first_rot_block_type.size(0);
+  int64_t const max_n_blocks = first_rot_block_type.size(1);
+  int64_t constexpr max_int = std::numeric_limits<int32_t>::max();
+  TORCH_CHECK(
+      n_poses <= max_int,
+      "compact block-neighbor indexing supports at most ",
+      max_int,
+      " poses; got ",
+      n_poses);
+  TORCH_CHECK(
+      max_n_blocks <= 65535,
+      "compact block-neighbor indexing supports at most 65,535 blocks per "
+      "pose; got ",
+      max_n_blocks);
+  int64_t const pairs_per_pose = max_n_blocks * (max_n_blocks + 1) / 2;
+  TORCH_CHECK(
+      pairs_per_pose == 0 || n_poses <= (max_int - 1) / pairs_per_pose,
+      "compact block-neighbor indexing exceeds int32 capacity for ",
+      n_poses,
+      " poses and ",
+      max_n_blocks,
+      " blocks per pose");
+  Tensor neighbor_indices;
+  using Int = int32_t;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      rot_coords.options(), "build_compact_block_neighbors", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        neighbor_indices =
+            LJLKPoseScoreDispatch<DeviceOperations, Dev, Real, Int>::
+                build_compact_block_neighbors(
+                    mgr,
+                    TCAST(rot_coords),
+                    TCAST(rot_coord_offset),
+                    TCAST(first_rot_block_type),
+                    TCAST(block_ind_for_rot),
+                    TCAST(pose_ind_for_rot),
+                    TCAST(block_type_ind_for_rot),
+                    TCAST(block_type_n_atoms),
+                    (Real)reach)
+                    .tensor;
+      }));
+  return {neighbor_indices};
 }
 
 template <template <tmol::Device> class DispatchMethod>
@@ -662,7 +1059,15 @@ std::vector<Tensor> ljlk_rotamer_scores_op(
 // See https://stackoverflow.com/a/3221914
 TORCH_LIBRARY(tmol_ljlk, m) {
   m.def("ljlk_pose_scores", &ljlk_pose_scores_op<DeviceOperations>);
+  m.def("ljlk_elec_pose_scores", &ljlk_elec_pose_scores_op<DeviceOperations>);
+  m.def(
+      "ljlk_elec_weighted_pose_scores",
+      &ljlk_elec_weighted_pose_scores_op<DeviceOperations>);
+  m.def(
+      "weighted_fused_score_sum",
+      &weighted_fused_score_sum_op<DeviceOperations>);
   m.def("ljlk_rotamer_scores", &ljlk_rotamer_scores_op<DeviceOperations>);
+  m.def("build_compact_block_neighbors", &build_compact_block_neighbors_op);
 }
 
 }  // namespace potentials

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -332,22 +332,22 @@ class LJLKAndElecPoseScoreOp
     Tensor score;
     Tensor dscore_dcoords;
     using Int = int32_t;
-#define TMOL_FUSED_SCORE_ARGS                                                 \
-  mgr, TCAST(rot_coords), TCAST(rot_coord_offset), TCAST(pose_ind_for_atom),  \
-      TCAST(first_rot_for_block), TCAST(first_rot_block_type),                \
-      TCAST(block_ind_for_rot), TCAST(pose_ind_for_rot),                      \
-      TCAST(block_type_ind_for_rot), TCAST(n_rots_for_pose),                  \
-      TCAST(rot_offset_for_pose), TCAST(n_rots_for_block),                    \
-      TCAST(rot_offset_for_block), max_n_rots_per_pose,                       \
-      TCAST(pose_stack_min_bond_separation),                                  \
-      TCAST(pose_stack_inter_block_bondsep), TCAST(block_type_n_atoms),       \
-      TCAST(block_type_atom_types), TCAST(block_type_n_interblock_bonds),     \
-      TCAST(block_type_atoms_forming_chemical_bonds),                         \
-      TCAST(block_type_ljlk_path_distance),                                   \
-      TCAST(block_type_is_ligand_fragment), TCAST(ljlk_type_params),          \
-      TCAST(ljlk_global_params), TCAST(block_type_partial_charge),            \
-      TCAST(block_type_elec_inter_repr_path_distance),                        \
-      TCAST(block_type_elec_intra_repr_path_distance),                        \
+#define TMOL_FUSED_SCORE_ARGS                                                \
+  mgr, TCAST(rot_coords), TCAST(rot_coord_offset), TCAST(pose_ind_for_atom), \
+      TCAST(first_rot_for_block), TCAST(first_rot_block_type),               \
+      TCAST(block_ind_for_rot), TCAST(pose_ind_for_rot),                     \
+      TCAST(block_type_ind_for_rot), TCAST(n_rots_for_pose),                 \
+      TCAST(rot_offset_for_pose), TCAST(n_rots_for_block),                   \
+      TCAST(rot_offset_for_block), max_n_rots_per_pose,                      \
+      TCAST(pose_stack_min_bond_separation),                                 \
+      TCAST(pose_stack_inter_block_bondsep), TCAST(block_type_n_atoms),      \
+      TCAST(block_type_atom_types), TCAST(block_type_n_interblock_bonds),    \
+      TCAST(block_type_atoms_forming_chemical_bonds),                        \
+      TCAST(block_type_ljlk_path_distance),                                  \
+      TCAST(block_type_is_ligand_fragment), TCAST(ljlk_type_params),         \
+      TCAST(ljlk_global_params), TCAST(block_type_partial_charge),           \
+      TCAST(block_type_elec_inter_repr_path_distance),                       \
+      TCAST(block_type_elec_intra_repr_path_distance),                       \
       TCAST(elec_global_params), TCAST(shared_compact_block_neighbors)
     TMOL_DISPATCH_FLOATING_DEVICE(
         rot_coords.options(), "ljlk_elec_pose_score_op", ([&] {
@@ -359,17 +359,18 @@ class LJLKAndElecPoseScoreOp
                   DispatchMethod,
                   Dev,
                   Real,
-                  Int>::forward_weighted(
-                  TMOL_FUSED_SCORE_ARGS,
-                  TCAST(score_weights),
-                  rot_coords.requires_grad());
+                  Int>::
+                  forward_weighted(
+                      TMOL_FUSED_SCORE_ARGS,
+                      TCAST(score_weights),
+                      rot_coords.requires_grad());
             } else {
               return LJLKAndElecPoseScoreDispatch<
                   DispatchMethod,
                   Dev,
                   Real,
-                  Int>::forward(
-                  TMOL_FUSED_SCORE_ARGS, rot_coords.requires_grad());
+                  Int>::
+                  forward(TMOL_FUSED_SCORE_ARGS, rot_coords.requires_grad());
             }
           }();
           score = std::get<0>(result).tensor.squeeze(-1).squeeze(-1);
@@ -390,8 +391,8 @@ class LJLKAndElecPoseScoreOp
 };
 
 template <template <tmol::Device> class DispatchMethod>
-class WeightedFusedScoreSumOp
-    : public torch::autograd::Function<WeightedFusedScoreSumOp<DispatchMethod>> {
+class WeightedFusedScoreSumOp : public torch::autograd::Function<
+                                    WeightedFusedScoreSumOp<DispatchMethod>> {
  public:
   static std::vector<Tensor> forward(
       AutogradContext* ctx,
@@ -412,7 +413,7 @@ class WeightedFusedScoreSumOp
         fused_weight_begin >= 0 && fused_weight_width > 0
             && fused_weight_begin < score_lanes.size(0)
             && score_lanes.size(0)
-                == score_weights.size(0) - fused_weight_width + 1,
+                   == score_weights.size(0) - fused_weight_width + 1,
         "invalid fused score-lane mapping");
 
     Tensor output;
@@ -421,17 +422,15 @@ class WeightedFusedScoreSumOp
         score_lanes.options(), "weighted_fused_score_sum_op", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
-          output = LJLKAndElecPoseScoreDispatch<
-                       DispatchMethod,
-                       Dev,
-                       Real,
-                       Int>::reduce_weighted_scores(
-                       mgr,
-                       TCAST(score_lanes),
-                       TCAST(score_weights),
-                       fused_weight_begin,
-                       fused_weight_width)
-                       .tensor;
+          output =
+              LJLKAndElecPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::
+                  reduce_weighted_scores(
+                      mgr,
+                      TCAST(score_lanes),
+                      TCAST(score_weights),
+                      fused_weight_begin,
+                      fused_weight_width)
+                      .tensor;
         }));
     ctx->save_for_backward({score_weights});
     ctx->saved_data["n_score_lanes"] = score_lanes.size(0);
@@ -458,18 +457,16 @@ class WeightedFusedScoreSumOp
         output_gradient.options(), "weighted_fused_score_sum_backward", ([&] {
           using Real = scalar_t;
           constexpr tmol::Device Dev = device_t;
-          score_lane_gradients = LJLKAndElecPoseScoreDispatch<
-                                     DispatchMethod,
-                                     Dev,
-                                     Real,
-                                     Int>::reduce_weighted_score_gradients(
-                                     mgr,
-                                     TCAST(output_gradient),
-                                     TCAST(score_weights),
-                                     n_score_lanes,
-                                     fused_weight_begin,
-                                     fused_weight_width)
-                                     .tensor;
+          score_lane_gradients =
+              LJLKAndElecPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::
+                  reduce_weighted_score_gradients(
+                      mgr,
+                      TCAST(output_gradient),
+                      TCAST(score_weights),
+                      n_score_lanes,
+                      fused_weight_begin,
+                      fused_weight_width)
+                      .tensor;
         }));
     tensor_list gradients(4);
     gradients[0] = score_lane_gradients;

--- a/tmol/score/ljlk/potentials/lj.hh
+++ b/tmol/score/ljlk/potentials/lj.hh
@@ -69,6 +69,9 @@ struct lj_score {
       LJTypeParams<Real> i,
       LJTypeParams<Real> j,
       LJGlobalParams<Real> global) -> std::array<Real, 2> {
+    if (bonded_path_length < Real(4)) {
+      return {0.0, 0.0};
+    }
     Real cpoly_dmax = global.max_dis;
     Real spline_start = global.max_dis - Real(1.5);
 
@@ -116,6 +119,9 @@ struct lj_score {
       LJTypeParams<Real> i,
       LJTypeParams<Real> j,
       LJGlobalParams<Real> global) -> V_dV_t {
+    if (bonded_path_length < Real(4)) {
+      return {0.0, 0.0, 0.0, 0.0};
+    }
     if (dist >= global.max_dis) {
       return {0.0, 0.0, 0.0, 0.0};
     }

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.cpu.cpp
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.cpu.cpp
@@ -1,29 +1,17 @@
 #include <tmol/score/common/device_operations.cpu.impl.hh>
-#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+#include <tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh>
 
 namespace tmol {
 namespace score {
 namespace ljlk {
 namespace potentials {
 
-template struct LJLKPoseScoreDispatch<
+template struct LJLKAndElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CPU,
     float,
     int>;
-
-template struct LJLKPoseScoreDispatch<
-    DeviceOperations,
-    tmol::Device::CPU,
-    double,
-    int>;
-
-template struct LJLKRotamerScoreDispatch<
-    DeviceOperations,
-    tmol::Device::CPU,
-    float,
-    int>;
-template struct LJLKRotamerScoreDispatch<
+template struct LJLKAndElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CPU,
     double,

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.cuda.cu
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.cuda.cu
@@ -1,29 +1,17 @@
 #include <tmol/score/common/device_operations.cuda.impl.cuh>
-#include <tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh>
+#include <tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh>
 
 namespace tmol {
 namespace score {
 namespace ljlk {
 namespace potentials {
 
-template struct LJLKPoseScoreDispatch<
+template struct LJLKAndElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CUDA,
     float,
     int>;
-
-template struct LJLKPoseScoreDispatch<
-    DeviceOperations,
-    tmol::Device::CUDA,
-    double,
-    int>;
-
-template struct LJLKRotamerScoreDispatch<
-    DeviceOperations,
-    tmol::Device::CUDA,
-    float,
-    int>;
-template struct LJLKRotamerScoreDispatch<
+template struct LJLKAndElecPoseScoreDispatch<
     DeviceOperations,
     tmol::Device::CUDA,
     double,

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include <tmol/utility/tensor/TensorAccessor.h>
+#include <tmol/utility/tensor/TensorPack.h>
+#include <tmol/utility/tensor/context_manager.hh>
+
+#include <tmol/score/elec/potentials/params.hh>
+#include <tmol/score/ljlk/potentials/params.hh>
+
+namespace tmol {
+namespace score {
+namespace ljlk {
+namespace potentials {
+
+template <typename Real, int N>
+using LJLKExternalVec = Eigen::Matrix<Real, N, 1>;
+
+/// Whole-pose LJ/LK + electrostatics evaluation over one precomputed compact
+/// block-neighbor list. The four unweighted score lanes remain separate so
+/// score-term weights and decomposed-score APIs retain their existing meaning.
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+struct LJLKAndElecPoseScoreDispatch {
+  static auto forward(
+      ContextManager& mgr,
+      TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+      TView<Int, 1, D> rot_coord_offset,
+      TView<Int, 1, D> pose_ind_for_atom,
+      TView<Int, 2, D> first_rot_for_block,
+      TView<Int, 2, D> first_rot_block_type,
+      TView<Int, 1, D> block_ind_for_rot,
+      TView<Int, 1, D> pose_ind_for_rot,
+      TView<Int, 1, D> block_type_ind_for_rot,
+      TView<Int, 1, D> n_rots_for_pose,
+      TView<Int, 1, D> rot_offset_for_pose,
+      TView<Int, 2, D> n_rots_for_block,
+      TView<Int, 2, D> rot_offset_for_block,
+      Int max_n_rots_per_pose,
+      TView<Int, 3, D> pose_stack_min_bond_separation,
+      TView<Int, 5, D> pose_stack_inter_block_bondsep,
+      TView<Int, 1, D> block_type_n_atoms,
+      TView<Int, 2, D> block_type_atom_types,
+      TView<Int, 1, D> block_type_n_interblock_bonds,
+      TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+      TView<Int, 3, D> block_type_ljlk_path_distance,
+      TView<Int, 1, D> block_type_is_ligand_fragment,
+      TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+      TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+      TView<Real, 2, D> block_type_partial_charge,
+      TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+      TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+      TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+          elec_global_params,
+      TView<Int, 1, D> shared_compact_block_neighbors,
+      bool require_gradient)
+      -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
+
+  /// Evaluate the same four potentials while reducing them with live score
+  /// weights inside the native traversal. The single output lane preserves
+  /// ordinary autograd semantics and avoids four-lane derivative scratch.
+  static auto forward_weighted(
+      ContextManager& mgr,
+      TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+      TView<Int, 1, D> rot_coord_offset,
+      TView<Int, 1, D> pose_ind_for_atom,
+      TView<Int, 2, D> first_rot_for_block,
+      TView<Int, 2, D> first_rot_block_type,
+      TView<Int, 1, D> block_ind_for_rot,
+      TView<Int, 1, D> pose_ind_for_rot,
+      TView<Int, 1, D> block_type_ind_for_rot,
+      TView<Int, 1, D> n_rots_for_pose,
+      TView<Int, 1, D> rot_offset_for_pose,
+      TView<Int, 2, D> n_rots_for_block,
+      TView<Int, 2, D> rot_offset_for_block,
+      Int max_n_rots_per_pose,
+      TView<Int, 3, D> pose_stack_min_bond_separation,
+      TView<Int, 5, D> pose_stack_inter_block_bondsep,
+      TView<Int, 1, D> block_type_n_atoms,
+      TView<Int, 2, D> block_type_atom_types,
+      TView<Int, 1, D> block_type_n_interblock_bonds,
+      TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+      TView<Int, 3, D> block_type_ljlk_path_distance,
+      TView<Int, 1, D> block_type_is_ligand_fragment,
+      TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+      TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+      TView<Real, 2, D> block_type_partial_charge,
+      TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+      TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+      TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+          elec_global_params,
+      TView<Int, 1, D> shared_compact_block_neighbors,
+      TView<Real, 1, D> score_weights,
+      bool require_gradient)
+      -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
+
+  /// Reduce score lanes with live weights in one device pass. The lane at
+  /// fused_weight_begin is already weighted and represents fused_weight_width
+  /// canonical lanes; all later lanes map past that canonical range.
+  static auto reduce_weighted_scores(
+      ContextManager& mgr,
+      TView<Real, 2, D> score_lanes,
+      TView<Real, 2, D> score_weights,
+      Int fused_weight_begin,
+      Int fused_weight_width) -> TPack<Real, 1, D>;
+
+  /// Backward mapping for reduce_weighted_scores.
+  static auto reduce_weighted_score_gradients(
+      ContextManager& mgr,
+      TView<Real, 1, D> output_gradient,
+      TView<Real, 2, D> score_weights,
+      Int n_score_lanes,
+      Int fused_weight_begin,
+      Int fused_weight_width) -> TPack<Real, 2, D>;
+};
+
+}  // namespace potentials
+}  // namespace ljlk
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -203,11 +203,10 @@ TMOL_DEVICE_FUNC std::array<Real, 4> score_atom_pair(
     Real const radial_derivs[4] = {
         ljatr_deriv, ljrep_deriv, lk_deriv, elec_deriv};
     if constexpr (weighted) {
-      Real const weighted_deriv =
-          score_weights[0] * radial_derivs[0]
-          + score_weights[1] * radial_derivs[1]
-          + score_weights[2] * radial_derivs[2]
-          + score_weights[3] * radial_derivs[3];
+      Real const weighted_deriv = score_weights[0] * radial_derivs[0]
+                                  + score_weights[1] * radial_derivs[1]
+                                  + score_weights[2] * radial_derivs[2]
+                                  + score_weights[3] * radial_derivs[3];
       Real3 const dxyz1 = weighted_deriv * unit_delta;
 #pragma unroll
       for (int axis = 0; axis < 3; ++axis) {
@@ -338,13 +337,11 @@ auto ljlk_elec_forward_impl(
   (void)max_n_rots_per_pose;
 
   int constexpr n_output_scores = weighted ? 1 : 4;
-  auto output_t =
-      TPack<Real, 4, D>::zeros({n_output_scores, n_poses, 1, 1});
+  auto output_t = TPack<Real, 4, D>::zeros({n_output_scores, n_poses, 1, 1});
   auto output = output_t.view;
   auto dV_dcoords_t =
-      require_gradient
-          ? TPack<Real3, 2, D>::zeros({n_output_scores, n_atoms})
-          : TPack<Real3, 2, D>::empty({n_output_scores, 0});
+      require_gradient ? TPack<Real3, 2, D>::zeros({n_output_scores, n_atoms})
+                       : TPack<Real3, 2, D>::empty({n_output_scores, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
   LAUNCH_BOX_32_OCC_AS(launch_t, 32);
@@ -833,9 +830,9 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
             elec_global_params,
         TView<Int, 1, D> shared_compact_block_neighbors,
         TView<Real, 1, D> score_weights,
-        bool require_gradient)
-    -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
-#define TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS                                 \
+        bool require_gradient) -> std::
+        tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
+#define TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS                                  \
   mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
       first_rot_block_type, block_ind_for_rot, pose_ind_for_rot,              \
       block_type_ind_for_rot, n_rots_for_pose, rot_offset_for_pose,           \
@@ -907,8 +904,7 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
         Int fused_weight_begin,
         Int fused_weight_width) -> TPack<Real, 2, D> {
   int const n_poses = output_gradient.size(0);
-  auto lane_gradients_t =
-      TPack<Real, 2, D>::empty({n_score_lanes, n_poses});
+  auto lane_gradients_t = TPack<Real, 2, D>::empty({n_score_lanes, n_poses});
   auto lane_gradients = lane_gradients_t.view;
   LAUNCH_BOX_32_OCC_AS(launch_t, 32);
   DeviceOperations<D>::template forall<launch_t>(

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -1,0 +1,934 @@
+#pragma once
+
+#include <cmath>
+
+#include <moderngpu/operators.hxx>
+
+#include <tmol/score/common/accumulate.hh>
+#include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/device_operations.hh>
+#include <tmol/score/common/launch_box_macros.hh>
+#include <tmol/score/common/sphere_overlap.impl.hh>
+#include <tmol/score/common/tile_atom_pair_evaluation.hh>
+#include <tmol/score/common/upper_triangle_indices.hh>
+#include <tmol/score/elec/potentials/potentials.hh>
+#include <tmol/score/ljlk/potentials/ljlk.hh>
+
+#include "ljlk_elec_pose_score.hh"
+
+namespace tmol {
+namespace score {
+namespace ljlk {
+namespace potentials {
+
+namespace ljlk_elec_detail {
+
+constexpr int tile_size = 32;
+constexpr int max_n_conn = 4;
+
+template <typename Real>
+struct SingleResData {
+  int block_type;
+  int rot_coord_offset;
+  int n_atoms;
+  int n_conn;
+  Real* coords;
+  LJLKTypeParams<Real>* ljlk_params;
+  Real* charges;
+  unsigned char* ljlk_path_dist;
+  unsigned char* elec_path_dist;
+};
+
+template <typename Real>
+struct ScoringData {
+  int pose_ind;
+  int block_ind1;
+  int block_ind2;
+  SingleResData<Real> r1;
+  SingleResData<Real> r2;
+  int min_separation;
+  bool in_count_pair_striking_dist;
+  unsigned char* conn_seps;
+  LJGlobalParams<Real> ljlk_global_params;
+  tmol::score::elec::potentials::ElecGlobalParams<Real> elec_global_params;
+  Real total_ljatr;
+  Real total_ljrep;
+  Real total_lk;
+  Real total_elec;
+  Real total_weighted;
+};
+
+template <typename Real>
+struct SharedData {
+  Real coords1[tile_size * 3];
+  Real coords2[tile_size * 3];
+  LJLKTypeParams<Real> ljlk_params1[tile_size];
+  LJLKTypeParams<Real> ljlk_params2[tile_size];
+  Real charges1[tile_size];
+  Real charges2[tile_size];
+  unsigned char conn_ats1[max_n_conn];
+  unsigned char conn_ats2[max_n_conn];
+  unsigned char ljlk_path_dist1[max_n_conn * tile_size];
+  unsigned char ljlk_path_dist2[max_n_conn * tile_size];
+  unsigned char elec_path_dist1[max_n_conn * tile_size];
+  unsigned char elec_path_dist2[max_n_conn * tile_size];
+  unsigned char conn_seps[max_n_conn * max_n_conn];
+};
+
+template <typename Real>
+TMOL_DEVICE_FUNC int inter_separation(
+    ScoringData<Real> const& data,
+    int atom1,
+    int atom2,
+    bool elec_path,
+    bool crossover_3full) {
+  int separation = data.min_separation;
+  if (data.in_count_pair_striking_dist) {
+    auto path1 = elec_path ? data.r1.elec_path_dist : data.r1.ljlk_path_dist;
+    auto path2 = elec_path ? data.r2.elec_path_dist : data.r2.ljlk_path_dist;
+    separation =
+        common::count_pair::shared_mem_inter_block_separation<tile_size>(
+            4,
+            atom1,
+            atom2,
+            data.r1.n_conn,
+            data.r2.n_conn,
+            path1,
+            path2,
+            data.conn_seps);
+  }
+  if (crossover_3full && (separation == 3 || separation == 4)) {
+    separation = 5;
+  }
+  return separation;
+}
+
+template <bool require_gradient, bool weighted, typename Real, tmol::Device D>
+TMOL_DEVICE_FUNC std::array<Real, 4> score_atom_pair(
+    int atom1,
+    int atom2,
+    int start1,
+    int start2,
+    ScoringData<Real> const& data,
+    int ljlk_separation,
+    int elec_separation,
+    TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords,
+    TView<Real, 1, D> score_weights) {
+  if (ljlk_separation < 4 && elec_separation < 4) {
+    return {0, 0, 0, 0};
+  }
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+  Real3 const coord1 = coord_from_shared(data.r1.coords, atom1);
+  Real3 const coord2 = coord_from_shared(data.r2.coords, atom2);
+  Real3 const delta = coord1 - coord2;
+  Real const dist2 = delta.squaredNorm();
+  Real const max_dis =
+      max(data.ljlk_global_params.max_dis, data.elec_global_params.max_dis);
+  if (dist2 >= max_dis * max_dis) return {0, 0, 0, 0};
+
+  Real const dist = std::sqrt(dist2);
+  auto const& p1 = data.r1.ljlk_params[atom1];
+  auto const& p2 = data.r2.ljlk_params[atom2];
+
+  Real ljatr = 0;
+  Real ljrep = 0;
+  Real lk_value = 0;
+  Real ljatr_deriv = 0;
+  Real ljrep_deriv = 0;
+  Real lk_deriv = 0;
+  if (dist2
+      < data.ljlk_global_params.max_dis * data.ljlk_global_params.max_dis) {
+    if (require_gradient) {
+      auto const lj = lj_score<Real>::V_dV(
+          dist,
+          ljlk_separation,
+          p1.lj_params(),
+          p2.lj_params(),
+          data.ljlk_global_params);
+      ljatr = lj.Vatr;
+      ljrep = lj.Vrep;
+      ljatr_deriv = lj.dVatr_ddist;
+      ljrep_deriv = lj.dVrep_ddist;
+      if (!p1.is_hydrogen && !p2.is_hydrogen) {
+        auto const lk = lk_isotropic_score<Real>::V_dV(
+            dist,
+            ljlk_separation,
+            p1.lk_params(),
+            p2.lk_params(),
+            data.ljlk_global_params);
+        lk_value = lk.V;
+        lk_deriv = lk.dV_ddist;
+      }
+    } else {
+      auto const lj = lj_score<Real>::V(
+          dist,
+          ljlk_separation,
+          p1.lj_params(),
+          p2.lj_params(),
+          data.ljlk_global_params);
+      ljatr = lj[0];
+      ljrep = lj[1];
+      if (!p1.is_hydrogen && !p2.is_hydrogen) {
+        lk_value = lk_isotropic_score<Real>::V(
+            dist,
+            ljlk_separation,
+            p1.lk_params(),
+            p2.lk_params(),
+            data.ljlk_global_params);
+      }
+    }
+  }
+
+  Real elec_value = 0;
+  Real elec_deriv = 0;
+  if (require_gradient) {
+    common::tie(elec_value, elec_deriv) =
+        tmol::score::elec::potentials::elec_delec_ddist(
+            dist,
+            data.r1.charges[atom1],
+            data.r2.charges[atom2],
+            Real(elec_separation),
+            data.elec_global_params);
+  } else {
+    elec_value = tmol::score::elec::potentials::elec(
+        dist,
+        data.r1.charges[atom1],
+        data.r2.charges[atom2],
+        Real(elec_separation),
+        data.elec_global_params);
+  }
+
+  if (require_gradient && dist != 0) {
+    Real3 const unit_delta = delta / dist;
+    Real const radial_derivs[4] = {
+        ljatr_deriv, ljrep_deriv, lk_deriv, elec_deriv};
+    if constexpr (weighted) {
+      Real const weighted_deriv =
+          score_weights[0] * radial_derivs[0]
+          + score_weights[1] * radial_derivs[1]
+          + score_weights[2] * radial_derivs[2]
+          + score_weights[3] * radial_derivs[3];
+      Real3 const dxyz1 = weighted_deriv * unit_delta;
+#pragma unroll
+      for (int axis = 0; axis < 3; ++axis) {
+        if (dxyz1[axis] == 0) continue;
+        accumulate<D, Real>::add(
+            dV_dcoords[0][data.r1.rot_coord_offset + start1 + atom1][axis],
+            dxyz1[axis]);
+        accumulate<D, Real>::add(
+            dV_dcoords[0][data.r2.rot_coord_offset + start2 + atom2][axis],
+            -dxyz1[axis]);
+      }
+    } else {
+#pragma unroll
+      for (int score_type = 0; score_type < 4; ++score_type) {
+        Real3 const dxyz1 = radial_derivs[score_type] * unit_delta;
+#pragma unroll
+        for (int axis = 0; axis < 3; ++axis) {
+          if (dxyz1[axis] == 0) continue;
+          accumulate<D, Real>::add(
+              dV_dcoords[score_type][data.r1.rot_coord_offset + start1 + atom1]
+                        [axis],
+              dxyz1[axis]);
+          accumulate<D, Real>::add(
+              dV_dcoords[score_type][data.r2.rot_coord_offset + start2 + atom2]
+                        [axis],
+              -dxyz1[axis]);
+        }
+      }
+    }
+  }
+  return {ljatr, ljrep, lk_value, elec_value};
+}
+
+template <
+    bool weighted,
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    int nt,
+    typename Real,
+    typename Shared>
+TMOL_DEVICE_FUNC void store_score_totals(
+    int tid,
+    ScoringData<Real>& data,
+    Shared& shared,
+    TView<Real, 4, D> output) {
+  if constexpr (weighted) {
+    Real const total = DeviceOperations<D>::template reduce_in_workgroup<nt>(
+        data.total_weighted, shared, mgpu::plus_t<Real>());
+    if (tid == 0) {
+      accumulate<D, Real>::add(output[0][data.pose_ind][0][0], total);
+    }
+  } else {
+    Real const totals[4] = {
+        DeviceOperations<D>::template reduce_in_workgroup<nt>(
+            data.total_ljatr, shared, mgpu::plus_t<Real>()),
+        DeviceOperations<D>::template reduce_in_workgroup<nt>(
+            data.total_ljrep, shared, mgpu::plus_t<Real>()),
+        DeviceOperations<D>::template reduce_in_workgroup<nt>(
+            data.total_lk, shared, mgpu::plus_t<Real>()),
+        DeviceOperations<D>::template reduce_in_workgroup<nt>(
+            data.total_elec, shared, mgpu::plus_t<Real>())};
+    if (tid == 0) {
+      for (int score_type = 0; score_type < 4; ++score_type) {
+        accumulate<D, Real>::add(
+            output[score_type][data.pose_ind][0][0], totals[score_type]);
+      }
+    }
+  }
+}
+
+}  // namespace ljlk_elec_detail
+
+template <
+    bool require_gradient,
+    bool weighted,
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto ljlk_elec_forward_impl(
+    ContextManager& mgr,
+    TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+    TView<Int, 1, D> rot_coord_offset,
+    TView<Int, 1, D> pose_ind_for_atom,
+    TView<Int, 2, D> first_rot_for_block,
+    TView<Int, 2, D> first_rot_block_type,
+    TView<Int, 1, D> block_ind_for_rot,
+    TView<Int, 1, D> pose_ind_for_rot,
+    TView<Int, 1, D> block_type_ind_for_rot,
+    TView<Int, 1, D> n_rots_for_pose,
+    TView<Int, 1, D> rot_offset_for_pose,
+    TView<Int, 2, D> n_rots_for_block,
+    TView<Int, 2, D> rot_offset_for_block,
+    Int max_n_rots_per_pose,
+    TView<Int, 3, D> pose_stack_min_bond_separation,
+    TView<Int, 5, D> pose_stack_inter_block_bondsep,
+    TView<Int, 1, D> block_type_n_atoms,
+    TView<Int, 2, D> block_type_atom_types,
+    TView<Int, 1, D> block_type_n_interblock_bonds,
+    TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+    TView<Int, 3, D> block_type_ljlk_path_distance,
+    TView<Int, 1, D> block_type_is_ligand_fragment,
+    TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+    TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+    TView<Real, 2, D> block_type_partial_charge,
+    TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+    TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+    TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+        elec_global_params,
+    TView<Int, 1, D> shared_compact_block_neighbors,
+    TView<Real, 1, D> score_weights)
+    -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
+  using namespace ljlk_elec_detail;
+  using Real3 = Eigen::Matrix<Real, 3, 1>;
+
+  int const n_atoms = rot_coords.size(0);
+  int const n_poses = first_rot_for_block.size(0);
+  int const max_n_blocks = first_rot_for_block.size(1);
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  (void)pose_ind_for_atom;
+  (void)first_rot_block_type;
+  (void)block_ind_for_rot;
+  (void)pose_ind_for_rot;
+  (void)n_rots_for_pose;
+  (void)rot_offset_for_pose;
+  (void)n_rots_for_block;
+  (void)max_n_rots_per_pose;
+
+  int constexpr n_output_scores = weighted ? 1 : 4;
+  auto output_t =
+      TPack<Real, 4, D>::zeros({n_output_scores, n_poses, 1, 1});
+  auto output = output_t.view;
+  auto dV_dcoords_t =
+      require_gradient
+          ? TPack<Real3, 2, D>::zeros({n_output_scores, n_atoms})
+          : TPack<Real3, 2, D>::empty({n_output_scores, 0});
+  auto dV_dcoords = dV_dcoords_t.view;
+
+  LAUNCH_BOX_32_OCC_AS(launch_t, 32);
+  CTA_REAL_REDUCE_T_TYPEDEF;
+
+  auto eval_neighbor = ([=] TMOL_DEVICE_FUNC(int candidate) {
+    int const pose_ind = candidate / max_n_upper_triangle_inds;
+    auto const pair = common::upper_triangle_inds_from_linear_index(
+        candidate % max_n_upper_triangle_inds, max_n_blocks + 1);
+    int const block_ind1 = common::get<0>(pair);
+    int const block_ind2 = common::get<1>(pair) - 1;
+    int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
+    int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
+    if (rot_ind1 < 0 || rot_ind2 < 0) return;
+    int const block_type1 = block_type_ind_for_rot[rot_ind1];
+    int const block_type2 = block_type_ind_for_rot[rot_ind2];
+    if (block_type1 < 0 || block_type2 < 0) return;
+    int const n_atoms1 = block_type_n_atoms[block_type1];
+    int const n_atoms2 = block_type_n_atoms[block_type2];
+
+    SHARED_MEMORY union shared_mem_union {
+      shared_mem_union() {}
+      SharedData<Real> m;
+      CTA_REAL_REDUCE_T_VARIABLE;
+    } shared;
+
+    auto initialize_common = ([=] TMOL_DEVICE_FUNC(
+                                  int p,
+                                  int r1,
+                                  int r2,
+                                  int b1,
+                                  int b2,
+                                  int bt1,
+                                  int bt2,
+                                  int na1,
+                                  int na2,
+                                  ScoringData<Real>& data,
+                                  shared_mem_union& sm) {
+      data.pose_ind = p;
+      data.block_ind1 = b1;
+      data.block_ind2 = b2;
+      data.r1.block_type = bt1;
+      data.r2.block_type = bt2;
+      data.r1.rot_coord_offset = rot_coord_offset[r1];
+      data.r2.rot_coord_offset = rot_coord_offset[r2];
+      data.r1.n_atoms = na1;
+      data.r2.n_atoms = na2;
+      data.r1.n_conn = block_type_n_interblock_bonds[bt1];
+      data.r2.n_conn = block_type_n_interblock_bonds[bt2];
+      data.min_separation = pose_stack_min_bond_separation[p][b1][b2];
+      data.in_count_pair_striking_dist = data.min_separation <= 4;
+      data.r1.coords = sm.m.coords1;
+      data.r2.coords = sm.m.coords2;
+      data.r1.ljlk_params = sm.m.ljlk_params1;
+      data.r2.ljlk_params = sm.m.ljlk_params2;
+      data.r1.charges = sm.m.charges1;
+      data.r2.charges = sm.m.charges2;
+      data.r1.ljlk_path_dist = sm.m.ljlk_path_dist1;
+      data.r2.ljlk_path_dist = sm.m.ljlk_path_dist2;
+      data.r1.elec_path_dist = sm.m.elec_path_dist1;
+      data.r2.elec_path_dist = sm.m.elec_path_dist2;
+      data.conn_seps = sm.m.conn_seps;
+      data.ljlk_global_params = ljlk_global_params[0];
+      data.elec_global_params = elec_global_params[0];
+      data.total_ljatr = 0;
+      data.total_ljrep = 0;
+      data.total_lk = 0;
+      data.total_elec = 0;
+      data.total_weighted = 0;
+    });
+
+    auto load_tile = ([=] TMOL_DEVICE_FUNC(
+                          int start,
+                          int count,
+                          ScoringData<Real>& data,
+                          SingleResData<Real>& residue,
+                          Real* coord_dst,
+                          LJLKTypeParams<Real>* params_dst,
+                          Real* charge_dst,
+                          unsigned char* lj_path_dst,
+                          unsigned char* elec_path_dst,
+                          unsigned char* conn_ats) {
+      DeviceOperations<D>::template copy_contiguous_data<nt, 3>(
+          coord_dst,
+          reinterpret_cast<Real*>(
+              &rot_coords[residue.rot_coord_offset + start]),
+          count * 3);
+      auto load_atom_data = ([=](int tid) {
+        for (int atom = tid; atom < count; atom += nt) {
+          int const atid = start + atom;
+          int const atom_type = block_type_atom_types[residue.block_type][atid];
+          if (atom_type >= 0) params_dst[atom] = ljlk_type_params[atom_type];
+          charge_dst[atom] =
+              block_type_partial_charge[residue.block_type][atid];
+          if (!data.in_count_pair_striking_dist) continue;
+          for (int conn = 0; conn < residue.n_conn; ++conn) {
+            int const conn_atom = conn_ats[conn];
+            lj_path_dst[conn * tile_size + atom] =
+                block_type_ljlk_path_distance[residue.block_type][conn_atom]
+                                             [atid];
+            elec_path_dst[conn * tile_size + atom] =
+                block_type_elec_inter_repr_path_distance[residue.block_type]
+                                                        [conn_atom][atid];
+          }
+        }
+      });
+      DeviceOperations<D>::template for_each_in_workgroup<nt>(load_atom_data);
+    });
+
+    auto load_tile_invariant_inter = ([=] TMOL_DEVICE_FUNC(
+                                          int p,
+                                          int r1,
+                                          int r2,
+                                          int b1,
+                                          int b2,
+                                          int bt1,
+                                          int bt2,
+                                          int na1,
+                                          int na2,
+                                          ScoringData<Real>& data,
+                                          shared_mem_union& sm) {
+      initialize_common(p, r1, r2, b1, b2, bt1, bt2, na1, na2, data, sm);
+      if (!data.in_count_pair_striking_dist) return;
+      auto load_connections = ([&](int tid) {
+        int const n1 = data.r1.n_conn;
+        int const n2 = data.r2.n_conn;
+        int const total = n1 + n2 + n1 * n2;
+        for (int index = tid; index < total; index += nt) {
+          if (index < n1) {
+            sm.m.conn_ats1[index] =
+                block_type_atoms_forming_chemical_bonds[bt1][index];
+          } else if (index < n1 + n2) {
+            sm.m.conn_ats2[index - n1] =
+                block_type_atoms_forming_chemical_bonds[bt2][index - n1];
+          } else {
+            int const pair_index = index - n1 - n2;
+            sm.m.conn_seps[pair_index] =
+                pose_stack_inter_block_bondsep[p][b1][b2][pair_index / n2]
+                                              [pair_index % n2];
+          }
+        }
+      });
+      DeviceOperations<D>::template for_each_in_workgroup<nt>(load_connections);
+    });
+
+    auto load_inter1 = ([=] TMOL_DEVICE_FUNC(
+                            int,
+                            int start,
+                            int count,
+                            ScoringData<Real>& data,
+                            shared_mem_union& sm) {
+      load_tile(
+          start,
+          count,
+          data,
+          data.r1,
+          sm.m.coords1,
+          sm.m.ljlk_params1,
+          sm.m.charges1,
+          sm.m.ljlk_path_dist1,
+          sm.m.elec_path_dist1,
+          sm.m.conn_ats1);
+    });
+    auto load_inter2 = ([=] TMOL_DEVICE_FUNC(
+                            int,
+                            int start,
+                            int count,
+                            ScoringData<Real>& data,
+                            shared_mem_union& sm) {
+      load_tile(
+          start,
+          count,
+          data,
+          data.r2,
+          sm.m.coords2,
+          sm.m.ljlk_params2,
+          sm.m.charges2,
+          sm.m.ljlk_path_dist2,
+          sm.m.elec_path_dist2,
+          sm.m.conn_ats2);
+    });
+    auto finish_inter_load =
+        ([=] TMOL_DEVICE_FUNC(int, int, shared_mem_union&, ScoringData<Real>&) {
+        });
+
+    auto eval_pairs = ([=] TMOL_DEVICE_FUNC(
+                           ScoringData<Real> & data,
+                           int start1,
+                           int start2,
+                           bool intra) {
+      bool const crossover_3full =
+          block_type_is_ligand_fragment[data.r1.block_type]
+          && block_type_is_ligand_fragment[data.r2.block_type];
+      auto pair_score = ([=] TMOL_DEVICE_FUNC(
+                             int pair_start1,
+                             int pair_start2,
+                             int atom1,
+                             int atom2,
+                             ScoringData<Real> const& pair_data) {
+        int lj_sep;
+        int elec_sep;
+        if (intra) {
+          int const global_atom1 = pair_start1 + atom1;
+          int const global_atom2 = pair_start2 + atom2;
+          lj_sep = block_type_ljlk_path_distance[pair_data.r1.block_type]
+                                                [global_atom1][global_atom2];
+          elec_sep =
+              block_type_elec_intra_repr_path_distance[pair_data.r1.block_type]
+                                                      [global_atom1]
+                                                      [global_atom2];
+        } else {
+          lj_sep =
+              inter_separation(pair_data, atom1, atom2, false, crossover_3full);
+          elec_sep =
+              inter_separation(pair_data, atom1, atom2, true, crossover_3full);
+        }
+        return score_atom_pair<require_gradient, weighted, Real, D>(
+            atom1,
+            atom2,
+            pair_start1,
+            pair_start2,
+            pair_data,
+            lj_sep,
+            elec_sep,
+            dV_dcoords,
+            score_weights);
+      });
+      auto evaluate = ([&](int tid) {
+        std::array<Real, 4> scores;
+        if (intra) {
+          scores = common::IntraResBlockEvaluation<
+              ScoringData,
+              common::AllAtomPairSelector,
+              D,
+              tile_size,
+              nt,
+              4,
+              Real,
+              Int>::
+              eval_intrares_atom_pairs(tid, start1, start2, pair_score, data);
+        } else {
+          scores = common::InterResBlockEvaluation<
+              ScoringData,
+              common::AllAtomPairSelector,
+              D,
+              tile_size,
+              nt,
+              4,
+              Real,
+              Int>::
+              eval_interres_atom_pair(tid, start1, start2, pair_score, data);
+        }
+        // Keep the per-pair accumulation in this hot lambda. In particular,
+        // GCC did not reliably inline the earlier helper through the CPU
+        // workgroup abstraction, erasing the compact path's CPU gain.
+        if constexpr (weighted) {
+          data.total_weighted +=
+              score_weights[0] * scores[0] + score_weights[1] * scores[1]
+              + score_weights[2] * scores[2] + score_weights[3] * scores[3];
+        } else {
+          data.total_ljatr += scores[0];
+          data.total_ljrep += scores[1];
+          data.total_lk += scores[2];
+          data.total_elec += scores[3];
+        }
+      });
+      DeviceOperations<D>::template for_each_in_workgroup<nt>(evaluate);
+    });
+    auto eval_inter = ([=] TMOL_DEVICE_FUNC(
+                           ScoringData<Real> & data, int start1, int start2) {
+      eval_pairs(data, start1, start2, false);
+    });
+
+    auto load_tile_invariant_intra = ([=] TMOL_DEVICE_FUNC(
+                                          int p,
+                                          int r1,
+                                          int b1,
+                                          int bt1,
+                                          int na1,
+                                          ScoringData<Real>& data,
+                                          shared_mem_union& sm) {
+      initialize_common(p, r1, r1, b1, b1, bt1, bt1, na1, na1, data, sm);
+      data.r1.n_conn = 0;
+      data.r2.n_conn = 0;
+      data.in_count_pair_striking_dist = false;
+    });
+    auto load_intra1 = ([=] TMOL_DEVICE_FUNC(
+                            int,
+                            int start,
+                            int count,
+                            ScoringData<Real>& data,
+                            shared_mem_union& sm) {
+      load_tile(
+          start,
+          count,
+          data,
+          data.r1,
+          sm.m.coords1,
+          sm.m.ljlk_params1,
+          sm.m.charges1,
+          sm.m.ljlk_path_dist1,
+          sm.m.elec_path_dist1,
+          sm.m.conn_ats1);
+    });
+    auto load_intra2 = ([=] TMOL_DEVICE_FUNC(
+                            int,
+                            int start,
+                            int count,
+                            ScoringData<Real>& data,
+                            shared_mem_union& sm) {
+      data.r2.coords = sm.m.coords2;
+      data.r2.ljlk_params = sm.m.ljlk_params2;
+      data.r2.charges = sm.m.charges2;
+      load_tile(
+          start,
+          count,
+          data,
+          data.r2,
+          sm.m.coords2,
+          sm.m.ljlk_params2,
+          sm.m.charges2,
+          sm.m.ljlk_path_dist2,
+          sm.m.elec_path_dist2,
+          sm.m.conn_ats2);
+    });
+    auto finish_intra_load = ([=] TMOL_DEVICE_FUNC(
+                                  int tile1,
+                                  int tile2,
+                                  shared_mem_union& sm,
+                                  ScoringData<Real>& data) {
+      bool const same_tile = tile1 == tile2;
+      data.r1.coords = sm.m.coords1;
+      data.r1.ljlk_params = sm.m.ljlk_params1;
+      data.r1.charges = sm.m.charges1;
+      data.r2.coords = same_tile ? sm.m.coords1 : sm.m.coords2;
+      data.r2.ljlk_params = same_tile ? sm.m.ljlk_params1 : sm.m.ljlk_params2;
+      data.r2.charges = same_tile ? sm.m.charges1 : sm.m.charges2;
+    });
+    auto eval_intra = ([=] TMOL_DEVICE_FUNC(
+                           ScoringData<Real> & data, int start1, int start2) {
+      eval_pairs(data, start1, start2, true);
+    });
+
+    auto store_energies =
+        ([=] TMOL_DEVICE_FUNC(ScoringData<Real> & data, shared_mem_union & sm) {
+          auto reduce = ([&](int tid) {
+            store_score_totals<weighted, DeviceOperations, D, nt>(
+                tid, data, sm, output);
+          });
+          DeviceOperations<D>::template for_each_in_workgroup<nt>(reduce);
+        });
+
+    common::tile_evaluate_rot_pair<
+        DeviceOperations,
+        D,
+        ScoringData<Real>,
+        ScoringData<Real>,
+        Real,
+        tile_size>(
+        shared,
+        pose_ind,
+        rot_ind1,
+        rot_ind2,
+        block_ind1,
+        block_ind2,
+        block_type1,
+        block_type2,
+        n_atoms1,
+        n_atoms2,
+        load_tile_invariant_inter,
+        load_inter1,
+        load_inter2,
+        finish_inter_load,
+        eval_inter,
+        store_energies,
+        load_tile_invariant_intra,
+        load_intra1,
+        load_intra2,
+        finish_intra_load,
+        eval_intra,
+        store_energies);
+  });
+
+  common::sphere_overlap::
+      launch_precomputed_block_neighbors<DeviceOperations, D, launch_t, Int>(
+          mgr, shared_compact_block_neighbors, eval_neighbor);
+  return {output_t, dV_dcoords_t};
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
+    ContextManager& mgr,
+    TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+    TView<Int, 1, D> rot_coord_offset,
+    TView<Int, 1, D> pose_ind_for_atom,
+    TView<Int, 2, D> first_rot_for_block,
+    TView<Int, 2, D> first_rot_block_type,
+    TView<Int, 1, D> block_ind_for_rot,
+    TView<Int, 1, D> pose_ind_for_rot,
+    TView<Int, 1, D> block_type_ind_for_rot,
+    TView<Int, 1, D> n_rots_for_pose,
+    TView<Int, 1, D> rot_offset_for_pose,
+    TView<Int, 2, D> n_rots_for_block,
+    TView<Int, 2, D> rot_offset_for_block,
+    Int max_n_rots_per_pose,
+    TView<Int, 3, D> pose_stack_min_bond_separation,
+    TView<Int, 5, D> pose_stack_inter_block_bondsep,
+    TView<Int, 1, D> block_type_n_atoms,
+    TView<Int, 2, D> block_type_atom_types,
+    TView<Int, 1, D> block_type_n_interblock_bonds,
+    TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+    TView<Int, 3, D> block_type_ljlk_path_distance,
+    TView<Int, 1, D> block_type_is_ligand_fragment,
+    TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+    TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+    TView<Real, 2, D> block_type_partial_charge,
+    TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+    TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+    TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+        elec_global_params,
+    TView<Int, 1, D> shared_compact_block_neighbors,
+    bool require_gradient)
+    -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
+#define TMOL_LJLK_ELEC_FORWARD_ARGS                                           \
+  mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
+      first_rot_block_type, block_ind_for_rot, pose_ind_for_rot,              \
+      block_type_ind_for_rot, n_rots_for_pose, rot_offset_for_pose,           \
+      n_rots_for_block, rot_offset_for_block, max_n_rots_per_pose,            \
+      pose_stack_min_bond_separation, pose_stack_inter_block_bondsep,         \
+      block_type_n_atoms, block_type_atom_types,                              \
+      block_type_n_interblock_bonds, block_type_atoms_forming_chemical_bonds, \
+      block_type_ljlk_path_distance, block_type_is_ligand_fragment,           \
+      ljlk_type_params, ljlk_global_params, block_type_partial_charge,        \
+      block_type_elec_inter_repr_path_distance,                               \
+      block_type_elec_intra_repr_path_distance, elec_global_params,           \
+      shared_compact_block_neighbors
+  auto empty_weights = TPack<Real, 1, D>::empty({0});
+  if (require_gradient) {
+    return ljlk_elec_forward_impl<true, false, DeviceOperations, D, Real, Int>(
+        TMOL_LJLK_ELEC_FORWARD_ARGS, empty_weights.view);
+  }
+  return ljlk_elec_forward_impl<false, false, DeviceOperations, D, Real, Int>(
+      TMOL_LJLK_ELEC_FORWARD_ARGS, empty_weights.view);
+#undef TMOL_LJLK_ELEC_FORWARD_ARGS
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
+    forward_weighted(
+        ContextManager& mgr,
+        TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+        TView<Int, 1, D> rot_coord_offset,
+        TView<Int, 1, D> pose_ind_for_atom,
+        TView<Int, 2, D> first_rot_for_block,
+        TView<Int, 2, D> first_rot_block_type,
+        TView<Int, 1, D> block_ind_for_rot,
+        TView<Int, 1, D> pose_ind_for_rot,
+        TView<Int, 1, D> block_type_ind_for_rot,
+        TView<Int, 1, D> n_rots_for_pose,
+        TView<Int, 1, D> rot_offset_for_pose,
+        TView<Int, 2, D> n_rots_for_block,
+        TView<Int, 2, D> rot_offset_for_block,
+        Int max_n_rots_per_pose,
+        TView<Int, 3, D> pose_stack_min_bond_separation,
+        TView<Int, 5, D> pose_stack_inter_block_bondsep,
+        TView<Int, 1, D> block_type_n_atoms,
+        TView<Int, 2, D> block_type_atom_types,
+        TView<Int, 1, D> block_type_n_interblock_bonds,
+        TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+        TView<Int, 3, D> block_type_ljlk_path_distance,
+        TView<Int, 1, D> block_type_is_ligand_fragment,
+        TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+        TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+        TView<Real, 2, D> block_type_partial_charge,
+        TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+        TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+        TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+            elec_global_params,
+        TView<Int, 1, D> shared_compact_block_neighbors,
+        TView<Real, 1, D> score_weights,
+        bool require_gradient)
+    -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
+#define TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS                                 \
+  mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
+      first_rot_block_type, block_ind_for_rot, pose_ind_for_rot,              \
+      block_type_ind_for_rot, n_rots_for_pose, rot_offset_for_pose,           \
+      n_rots_for_block, rot_offset_for_block, max_n_rots_per_pose,            \
+      pose_stack_min_bond_separation, pose_stack_inter_block_bondsep,         \
+      block_type_n_atoms, block_type_atom_types,                              \
+      block_type_n_interblock_bonds, block_type_atoms_forming_chemical_bonds, \
+      block_type_ljlk_path_distance, block_type_is_ligand_fragment,           \
+      ljlk_type_params, ljlk_global_params, block_type_partial_charge,        \
+      block_type_elec_inter_repr_path_distance,                               \
+      block_type_elec_intra_repr_path_distance, elec_global_params,           \
+      shared_compact_block_neighbors, score_weights
+  if (require_gradient) {
+    return ljlk_elec_forward_impl<true, true, DeviceOperations, D, Real, Int>(
+        TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS);
+  }
+  return ljlk_elec_forward_impl<false, true, DeviceOperations, D, Real, Int>(
+      TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS);
+#undef TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
+    reduce_weighted_scores(
+        ContextManager& mgr,
+        TView<Real, 2, D> score_lanes,
+        TView<Real, 2, D> score_weights,
+        Int fused_weight_begin,
+        Int fused_weight_width) -> TPack<Real, 1, D> {
+  int const n_score_lanes = score_lanes.size(0);
+  int const n_poses = score_lanes.size(1);
+  auto output_t = TPack<Real, 1, D>::empty({n_poses});
+  auto output = output_t.view;
+  LAUNCH_BOX_32_OCC_AS(launch_t, 32);
+  DeviceOperations<D>::template forall<launch_t>(
+      mgr, n_poses, [=] TMOL_DEVICE_FUNC(int pose) {
+        Real total = 0;
+        for (int lane = 0; lane < n_score_lanes; ++lane) {
+          if (lane == fused_weight_begin) {
+            total += score_lanes[lane][pose];
+            continue;
+          }
+          int weight_index = lane;
+          if (lane > fused_weight_begin) {
+            weight_index += fused_weight_width - 1;
+          }
+          total += score_weights[weight_index][0] * score_lanes[lane][pose];
+        }
+        output[pose] = total;
+      });
+  return output_t;
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
+    reduce_weighted_score_gradients(
+        ContextManager& mgr,
+        TView<Real, 1, D> output_gradient,
+        TView<Real, 2, D> score_weights,
+        Int n_score_lanes,
+        Int fused_weight_begin,
+        Int fused_weight_width) -> TPack<Real, 2, D> {
+  int const n_poses = output_gradient.size(0);
+  auto lane_gradients_t =
+      TPack<Real, 2, D>::empty({n_score_lanes, n_poses});
+  auto lane_gradients = lane_gradients_t.view;
+  LAUNCH_BOX_32_OCC_AS(launch_t, 32);
+  DeviceOperations<D>::template forall<launch_t>(
+      mgr, n_score_lanes * n_poses, [=] TMOL_DEVICE_FUNC(int index) {
+        int const lane = index / n_poses;
+        int const pose = index - lane * n_poses;
+        Real multiplier = 1;
+        if (lane != fused_weight_begin) {
+          int weight_index = lane;
+          if (lane > fused_weight_begin) {
+            weight_index += fused_weight_width - 1;
+          }
+          multiplier = score_weights[weight_index][0];
+        }
+        lane_gradients[lane][pose] = multiplier * output_gradient[pose];
+      });
+  return lane_gradients_t;
+}
+
+}  // namespace potentials
+}  // namespace ljlk
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.hh
@@ -31,6 +31,17 @@ template <
     typename Real,
     typename Int>
 struct LJLKPoseScoreDispatch {
+  static auto build_compact_block_neighbors(
+      ContextManager& mgr,
+      TView<Vec<Real, 3>, 1, D> rot_coords,
+      TView<Int, 1, D> rot_coord_offset,
+      TView<Int, 2, D> first_rot_for_block,
+      TView<Int, 1, D> block_ind_for_rot,
+      TView<Int, 1, D> pose_ind_for_rot,
+      TView<Int, 1, D> block_type_ind_for_rot,
+      TView<Int, 1, D> block_type_n_atoms,
+      Real reach) -> TPack<Int, 1, D>;
+
   static auto forward(
       ContextManager& mgr,
       // common params
@@ -94,6 +105,10 @@ struct LJLKPoseScoreDispatch {
 
       // host-side copy of LJGlobalParams::max_dis
       Real max_dis,
+
+      // Optional shared compact superset. An empty tensor requests local
+      // construction, preserving standalone and block-pair scoring APIs.
+      TView<Int, 1, D> shared_compact_block_neighbors,
 
       // should the output be per-pose (npose x nterms x 1 x 1)
       //   or per block-pair (npose x nterms x len x len)

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -686,6 +686,91 @@ template <
     tmol::Device D,
     typename Real,
     typename Int>
+auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::
+    build_compact_block_neighbors(
+        ContextManager& mgr,
+        TView<Vec<Real, 3>, 1, D> rot_coords,
+        TView<Int, 1, D> rot_coord_offset,
+        TView<Int, 2, D> first_rot_for_block,
+        TView<Int, 1, D> block_ind_for_rot,
+        TView<Int, 1, D> pose_ind_for_rot,
+        TView<Int, 1, D> block_type_ind_for_rot,
+        TView<Int, 1, D> block_type_n_atoms,
+        Real reach) -> TPack<Int, 1, D> {
+  int const n_poses = first_rot_for_block.size(0);
+  int const max_n_blocks = first_rot_for_block.size(1);
+  int const n_pairs =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  auto block_spheres_t =
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+  if constexpr (D == Device::CUDA) {
+    auto neighbor_indices_t =
+        rot_coord_offset.size(0) == 0
+            ? TPack<Int, 1, D>::zeros({n_poses * n_pairs + 1})
+            : TPack<Int, 1, D>::empty({n_poses * n_pairs + 1});
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceOperations, D, Real, Int, true>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_ind_for_rot,
+            pose_ind_for_rot,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            block_spheres_t.view,
+            neighbor_indices_t.view.data());
+    score::common::sphere_overlap::
+        detect_compact_block_neighbors<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            first_rot_for_block,
+            block_spheres_t.view,
+            neighbor_indices_t.view,
+            reach);
+    return neighbor_indices_t;
+  } else {
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_ind_for_rot,
+            pose_ind_for_rot,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            block_spheres_t.view);
+    std::vector<Int> retained;
+    if (score::common::sphere_overlap::try_cpu_spatial_compact_block_neighbors(
+            first_rot_for_block, block_spheres_t.view, reach, retained)) {
+      auto neighbor_indices_t =
+          TPack<Int, 1, D>::empty({int64_t(retained.size()) + 1});
+      neighbor_indices_t.view[0] = static_cast<Int>(retained.size());
+      if (!retained.empty()) {
+        std::memcpy(
+            neighbor_indices_t.view.data() + 1,
+            retained.data(),
+            retained.size() * sizeof(Int));
+      }
+      return neighbor_indices_t;
+    }
+    auto neighbor_indices_t =
+        TPack<Int, 1, D>::zeros({int64_t(n_poses) * n_pairs + 1});
+    score::common::sphere_overlap::
+        detect_compact_block_neighbors<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            first_rot_for_block,
+            block_spheres_t.view,
+            neighbor_indices_t.view,
+            reach);
+    return neighbor_indices_t;
+  }
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
 auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     ContextManager& mgr,
     // common params
@@ -748,6 +833,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     TView<LJGlobalParams<Real>, 1, D> global_params,
 
     Real max_dis,
+
+    TView<Int, 1, D> shared_compact_block_neighbors,
 
     // should the output be per-pose (npose x nterms x 1 x 1)
     //   or per block-pair (npose x nterms x len x len)
@@ -821,16 +908,23 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
                           : TPack<Vec<Real, 3>, 2, D>::empty({3, 0});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t =
-      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
-                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_rot_spheres = scratch_rot_spheres_t.view;
-
-  auto scratch_rot_neighbors_t =
-      D == Device::CPU
-          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+  bool const use_shared_compact_block_neighbors =
+      shared_compact_block_neighbors.size(0) != 0;
+  TPack<Real, 3, D> scratch_rot_spheres_t;
+  TPack<Int, 3, D> scratch_rot_neighbors_t;
+  TView<Real, 3, D> scratch_rot_spheres;
+  TView<Int, 3, D> scratch_rot_neighbors;
+  if (!use_shared_compact_block_neighbors) {
+    scratch_rot_spheres_t =
+        D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                         : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+    scratch_rot_neighbors_t =
+        D == Device::CPU
+            ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
+    scratch_rot_spheres = scratch_rot_spheres_t.view;
+    scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+  }
 
   TPack<Real, 4, D> output_t;
   if (output_block_pair_energies) {
@@ -851,7 +945,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   // There are two versions of scoring:
   // Block-pair scoring, where the output is written to an n-pose x n-blocks x
@@ -911,7 +1006,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     // We still kill CTAs targetting non-neighboring block pairs, though,
     // and that can be a lot
-    if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+    if (!use_shared_compact_block_neighbors
+        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
     int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
@@ -1049,7 +1145,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
 
     // We still kill CTAs targetting non-neighboring block pairs, though,
     // and that can be a lot
-    if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+    if (!use_shared_compact_block_neighbors
+        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
       return;
     }
     int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
@@ -1139,26 +1236,42 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // each other
   // 3: launch a kernel to evaluate lj/lk between pairs of blocks
   // within striking distance
-  score::common::sphere_overlap::
-      compute_block_spheres<DeviceOperations, D, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_ind_for_rot,
-          pose_ind_for_rot,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
+  if (!use_shared_compact_block_neighbors) {
+    score::common::sphere_overlap::
+        compute_block_spheres<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_ind_for_rot,
+            pose_ind_for_rot,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres);
 
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceOperations, D, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_rot_spheres,
-          scratch_rot_neighbors,
-          max_dis);
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_rot_spheres,
+            scratch_rot_neighbors,
+            max_dis);
+  }
 
-  if (output_block_pair_energies) {
+  if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+    if (require_gradient) {
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceOperations,
+          D,
+          launch_t_high_occupancy,
+          Int>(mgr, shared_compact_block_neighbors, eval_energies);
+    } else {
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceOperations,
+          D,
+          launch_t_high_occupancy,
+          Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+    }
+  } else if (output_block_pair_energies) {
     DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
         mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
   } else {
@@ -1341,7 +1454,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::backward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds = (max_n_blocks * (max_n_blocks + 1)) / 2;
+  int const max_n_upper_triangle_inds =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto atom_pair_lj_fn =

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -822,11 +822,14 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   auto dV_dcoords = dV_dcoords_t.view;
 
   auto scratch_rot_spheres_t =
-      TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4});
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_rot_neighbors_t =
-      TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      D == Device::CPU
+          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
   TPack<Real, 4, D> output_t;
@@ -1657,15 +1660,20 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t = TPack<Real, 2, D>::zeros({n_rots, 4});
+  auto scratch_rot_spheres_t = D == Device::CPU
+                                   ? TPack<Real, 2, D>::zeros({n_rots, 4})
+                                   : TPack<Real, 2, D>::empty({n_rots, 4});
   auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
   auto scratch_block_spheres_t =
-      TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4});
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
   auto scratch_block_spheres = scratch_block_spheres_t.view;
 
   auto scratch_block_neighbors_t =
-      TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks});
+      D == Device::CPU
+          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
   auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
   score::common::sphere_overlap::

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -105,6 +105,9 @@ struct lk_isotropic_pair {
       Real lk_inv_lambda2_i,
       Real max_dis,
       bool is_cc_pair) -> Real {
+    if (bonded_path_length < Real(4)) {
+      return 0.0;
+    }
     Real d_min = lj_sigma_ij * .89;
     if (is_cc_pair)
       d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
@@ -175,6 +178,9 @@ struct lk_isotropic_pair {
       Real lk_inv_lambda2_i,
       Real max_dis,
       bool is_cc_pair) -> V_dV_t {
+    if (bonded_path_length < Real(4)) {
+      return {0.0, 0.0};
+    }
     Real d_min = lj_sigma_ij * .89;
     if (is_cc_pair)
       d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
@@ -259,6 +265,9 @@ struct lk_isotropic_score {
       LKTypeParams<Real> i,
       LKTypeParams<Real> j,
       LJGlobalParams<Real> global) -> Real {
+    if (bonded_path_length < Real(4)) {
+      return 0.0;
+    }
     if (dist > global.max_dis) {
       return 0.0;
     }
@@ -358,6 +367,9 @@ struct lk_isotropic_score {
       LKTypeParams<Real> i,
       LKTypeParams<Real> j,
       LJGlobalParams<Real> global) -> V_dV_t {
+    if (bonded_path_length < Real(4)) {
+      return {0.0, 0.0};
+    }
     Real sigma = lj_sigma<Real>(i, j, global);
     bool is_cc_pair = i.is_carbon_lk && j.is_carbon_lk;
 

--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -248,9 +248,10 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             gen_pose_waters,
         )
 
-        common_args = args[:-2]
-        pose_stack = args[-2]
-        block_pair_scoring = args[-1]
+        common_args = args[:-3]
+        pose_stack = args[-3]
+        block_pair_scoring = args[-2]
+        shared_block_neighbors = args[-1]
 
         args = [
             *common_args,
@@ -298,6 +299,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             self._max_dis,
             water_coords,
             block_pair_scoring,
+            shared_block_neighbors,
         ]
         if common_args[0].dtype == torch.float64:
             convert_float64(args)
@@ -306,13 +308,14 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     def rotamer_score_lk_ball(self, *args):
         from tmol.score.lk_ball.potentials import (
-            lk_ball_rotamer_score,
+            lk_ball_rotamer_score_shared,
             gen_pose_waters,
         )
 
-        common_args = args[:-2]
-        pose_stack = args[-2]
-        block_pair_scoring = args[-1]
+        common_args = args[:-3]
+        pose_stack = args[-3]
+        shared_dispatch_indices = args[-1]
+        block_pair_scoring = args[-2]
 
         args = [
             *common_args,
@@ -364,13 +367,22 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         if common_args[0].dtype == torch.float64:
             convert_float64(args)
 
-        return lk_ball_rotamer_score(*args)
+        return lk_ball_rotamer_score_shared(*args, shared_dispatch_indices)
 
     def get_pose_score_term_function(self):
         return self.pose_score_lk_ball
 
     def get_rotamer_score_term_function(self):
         return self.rotamer_score_lk_ball
+
+    def get_block_neighbor_cutoff(self):
+        return self._max_dis
+
+    def accepts_shared_rotamer_dispatch(self):
+        return True
+
+    def rotamer_dispatch_key(self):
+        return "sphere_overlap"
 
     def get_score_term_attributes(self, pose_stack):
         return [pose_stack]

--- a/tmol/score/lk_ball/potentials/__init__.py
+++ b/tmol/score/lk_ball/potentials/__init__.py
@@ -4,4 +4,5 @@ from ._compiled import (  # noqa: F401
     gen_pose_waters,
     lk_ball_pose_score,
     lk_ball_rotamer_score,
+    lk_ball_rotamer_score_shared,
 )  # noqa: F401

--- a/tmol/score/lk_ball/potentials/_compiled.py
+++ b/tmol/score/lk_ball/potentials/_compiled.py
@@ -18,3 +18,4 @@ _ops = load_ops(
 gen_pose_waters = _ops.gen_pose_waters
 lk_ball_pose_score = _ops.lk_ball_pose_score
 lk_ball_rotamer_score = _ops.lk_ball_rotamer_score
+lk_ball_rotamer_score_shared = _ops.lk_ball_rotamer_score_shared

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -394,7 +394,8 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
       Tensor global_params,
       double max_dis,  // host scalar; needed by detect-neighbors call
       Tensor water_coords,
-      bool output_block_pair_energies) {
+      bool output_block_pair_energies,
+      Tensor shared_compact_block_neighbors) {
     at::Tensor score;
     at::Tensor block_neighbors;
 
@@ -442,6 +443,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
                   TCAST(global_params),
                   (Real)max_dis,
                   TCAST(water_coords),
+                  TCAST(shared_compact_block_neighbors),
                   output_block_pair_energies);
 
           score = std::get<0>(result).tensor;
@@ -486,11 +488,15 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 
          global_params,
          water_coords,
-         block_neighbors});
+         block_neighbors,
+         shared_compact_block_neighbors});
 
     ctx->saved_data["block_pair_scoring"] = output_block_pair_energies;
 
-    return {score, block_neighbors};
+    auto returned_neighbors = shared_compact_block_neighbors.numel() != 0
+                                  ? shared_compact_block_neighbors
+                                  : block_neighbors;
+    return {score, returned_neighbors};
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
@@ -529,6 +535,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     auto global_params = saved[i++];
     auto water_coords = saved[i++];
     auto block_neighbors = saved[i++];
+    auto compact_block_neighbors = saved[i++];
 
     at::Tensor dV_d_pose_coords, dV_d_water_coords;
     using Int = int32_t;
@@ -582,6 +589,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
 
                   TCAST(global_params),
                   TCAST(block_neighbors),
+                  TCAST(compact_block_neighbors),
                   TCAST(dTdV),
                   block_pair_scoring);
 
@@ -597,6 +605,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
         torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), dV_d_water_coords, torch::Tensor(),
+        torch::Tensor(),
     };
   }
 };
@@ -638,7 +647,8 @@ class LKBallRotamerScoreOp
       Tensor global_params,
       double max_dis,  // host scalar; needed by detect-neighbors call
       Tensor water_coords,
-      bool output_block_pair_energies) {
+      bool output_block_pair_energies,
+      Tensor shared_dispatch_indices) {
     at::Tensor score;
     at::Tensor dispatch_indices;
 
@@ -686,7 +696,8 @@ class LKBallRotamerScoreOp
                   TCAST(global_params),
                   (Real)max_dis,
                   TCAST(water_coords),
-                  output_block_pair_energies);
+                  output_block_pair_energies,
+                  TCAST(shared_dispatch_indices));
 
           score = std::get<0>(result).tensor;
           dispatch_indices = std::get<1>(result).tensor;
@@ -828,6 +839,7 @@ class LKBallRotamerScoreOp
         torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
         torch::Tensor(),  torch::Tensor(), dV_d_water_coords, torch::Tensor(),
+        torch::Tensor(),
     };
   }
 };
@@ -865,7 +877,8 @@ std::vector<Tensor> lkball_pose_score(
     Tensor global_params,
     double max_dis,
     Tensor water_coords,
-    bool output_block_pair_energies) {
+    bool output_block_pair_energies,
+    Tensor shared_compact_block_neighbors) {
   return LKBallPoseScoreOp::apply(
       // common params
       rot_coords,
@@ -898,7 +911,8 @@ std::vector<Tensor> lkball_pose_score(
       global_params,
       max_dis,
       water_coords,
-      output_block_pair_energies);
+      output_block_pair_energies,
+      shared_compact_block_neighbors);
 }
 
 std::vector<Tensor> lkball_rotamer_score(
@@ -935,6 +949,8 @@ std::vector<Tensor> lkball_rotamer_score(
     double max_dis,
     Tensor water_coords,
     bool output_block_pair_energies) {
+  auto empty_dispatch_indices =
+      torch::empty({0, 0}, rot_coord_offset.options().dtype(torch::kInt32));
   return LKBallRotamerScoreOp::apply(
       // common params
       rot_coords,
@@ -967,12 +983,88 @@ std::vector<Tensor> lkball_rotamer_score(
       global_params,
       max_dis,
       water_coords,
-      output_block_pair_energies);
+      output_block_pair_energies,
+      empty_dispatch_indices);
+}
+
+std::vector<Tensor> lkball_rotamer_score_shared(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_inter_residue_connections,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_tile_n_polar_atoms,
+    Tensor block_type_tile_n_occluder_atoms,
+    Tensor block_type_tile_pol_occ_inds,
+    Tensor block_type_tile_lk_ball_params,
+    Tensor block_type_path_distance,
+    Tensor global_params,
+    double max_dis,
+    Tensor water_coords,
+    bool output_block_pair_energies,
+    Tensor shared_dispatch_indices) {
+  TORCH_CHECK(
+      shared_dispatch_indices.dim() == 2
+          && (shared_dispatch_indices.size(0) == 3
+              || (shared_dispatch_indices.size(0) == 0
+                  && shared_dispatch_indices.size(1) == 0)),
+      "shared rotamer dispatch indices must have shape [3, nnz] or [0, 0]");
+  TORCH_CHECK(
+      shared_dispatch_indices.scalar_type() == torch::kInt32,
+      "shared rotamer dispatch indices must have dtype int32");
+  TORCH_CHECK(
+      shared_dispatch_indices.device() == rot_coords.device(),
+      "shared rotamer dispatch indices must be on the coordinate device");
+  return LKBallRotamerScoreOp::apply(
+      rot_coords,
+      rot_coord_offset,
+      pose_ind_for_atom,
+      first_rot_for_block,
+      first_rot_block_type,
+      block_ind_for_rot,
+      pose_ind_for_rot,
+      block_type_ind_for_rot,
+      n_rots_for_pose,
+      rot_offset_for_pose,
+      n_rots_for_block,
+      rot_offset_for_block,
+      max_n_rots_per_pose,
+      pose_stack_inter_residue_connections,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_n_interblock_bonds,
+      block_type_atoms_forming_chemical_bonds,
+      block_type_tile_n_polar_atoms,
+      block_type_tile_n_occluder_atoms,
+      block_type_tile_pol_occ_inds,
+      block_type_tile_lk_ball_params,
+      block_type_path_distance,
+      global_params,
+      max_dis,
+      water_coords,
+      output_block_pair_energies,
+      shared_dispatch_indices);
 }
 
 TORCH_LIBRARY(tmol_lk_ball, m) {
   m.def("lk_ball_pose_score", &lkball_pose_score);
   m.def("lk_ball_rotamer_score", &lkball_rotamer_score);
+  m.def("lk_ball_rotamer_score_shared", &lkball_rotamer_score_shared);
   m.def("gen_pose_waters", &pose_watergen_op);
 }
 

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -96,6 +96,7 @@ struct LKBallPoseScoreDispatch {
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       Real max_dis,
       TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Int, 1, Dev> shared_compact_block_neighbors,
       bool output_block_pair_energies)
       -> std::tuple<TPack<Real, 4, Dev>, TPack<Int, 3, Dev>>;
 
@@ -163,6 +164,7 @@ struct LKBallPoseScoreDispatch {
       // LKBall potential parameters
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       TView<Int, 3, Dev> block_neighbors,  // from forward pass
+      TView<Int, 1, Dev> compact_block_neighbors,
       TView<Real, 4, Dev> dTdV,
       bool block_pair_scoring)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>>;
@@ -239,7 +241,8 @@ struct LKBallRotamerScoreDispatch {
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       Real max_dis,
       TView<Vec<Real, 3>, 2, Dev> water_coords,
-      bool output_block_pair_energies)
+      bool output_block_pair_energies,
+      TPack<Int, 2, Dev> shared_dispatch_indices)
       -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 2, Dev>>;
 
   static auto backward(

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -360,7 +360,8 @@ template <common::TilePairMode Mode>
 inline TMOL_DEVICE_FUNC common::tuple<int, int, int> lk_ball_pose_pair_indices(
     int cta, int max_n_blocks) {
   if constexpr (Mode == common::TilePairMode::Inter) {
-    int const n_pairs = max_n_blocks * (max_n_blocks - 1) / 2;
+    int const n_pairs =
+        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks - 1)) / 2);
     auto pair = common::upper_triangle_inds_from_linear_index(
         cta % n_pairs, max_n_blocks);
     return common::make_tuple(
@@ -369,7 +370,8 @@ inline TMOL_DEVICE_FUNC common::tuple<int, int, int> lk_ball_pose_pair_indices(
     int const block = cta % max_n_blocks;
     return common::make_tuple(cta / max_n_blocks, block, block);
   } else {
-    int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+    int const n_pairs =
+        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
     auto pair = common::upper_triangle_inds_from_linear_index(
         cta % n_pairs, max_n_blocks + 1);
     return common::make_tuple(
@@ -384,7 +386,8 @@ template <
     typename Eval>
 void launch_lk_ball_pose_pair_workgroups(
     ContextManager& mgr, int n_poses, int max_n_blocks, Eval eval) {
-  int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+  int const n_pairs =
+      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
 #ifdef __NVCC__
   auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
     eval(cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
@@ -400,7 +403,7 @@ void launch_lk_ball_pose_pair_workgroups(
       eval(cta, TilePairModeTag<common::TilePairMode::Intra>{});
     });
     DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
-        mgr, n_poses, max_n_blocks * (max_n_blocks - 1) / 2, eval_interres);
+        mgr, n_poses, n_pairs - max_n_blocks, eval_interres);
     DeviceDispatch<Dev>::template foreach_pose_workgroup<Launch>(
         mgr, n_poses, max_n_blocks, eval_intrares);
     return;
@@ -485,6 +488,7 @@ class LKBallPoseScoreDispatch {
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       Real max_dis,
       TView<Vec<Real, 3>, 2, Dev> water_coords,
+      TView<Int, 1, Dev> shared_compact_block_neighbors,
       bool output_block_pair_energies)
       -> std::tuple<TPack<Real, 4, Dev>, TPack<Int, 3, Dev>> {
     using tmol::score::common::accumulate;
@@ -501,17 +505,25 @@ class LKBallPoseScoreDispatch {
         block_type_atoms_forming_chemical_bonds.size(1);
     int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
-    auto scratch_rot_spheres_t =
-        Dev == Device::CPU
-            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
-            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
-    auto scratch_rot_spheres = scratch_rot_spheres_t.view;
-
-    auto scratch_rot_neighbors_t =
-        Dev == Device::CPU
-            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
-            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
-    auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+    bool const use_shared_compact_block_neighbors =
+        shared_compact_block_neighbors.size(0) != 0;
+    TPack<Real, 3, Dev> scratch_rot_spheres_t;
+    auto scratch_rot_neighbors_t = TPack<Int, 3, Dev>::empty({0, 0, 0});
+    TView<Real, 3, Dev> scratch_rot_spheres;
+    TView<Int, 3, Dev> scratch_rot_neighbors;
+    if (!use_shared_compact_block_neighbors) {
+      scratch_rot_spheres_t =
+          Dev == Device::CPU
+              ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+              : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
+      scratch_rot_neighbors_t =
+          Dev == Device::CPU
+              ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+              : TPack<Int, 3, Dev>::empty(
+                    {n_poses, max_n_blocks, max_n_blocks});
+      scratch_rot_spheres = scratch_rot_spheres_t.view;
+      scratch_rot_neighbors = scratch_rot_neighbors_t.view;
+    }
 
     TPack<Real, 4, Dev> output_t;
     if (output_block_pair_energies) {
@@ -622,7 +634,8 @@ class LKBallPoseScoreDispatch {
 
       // We still kill CTAs targetting non-neighboring block pairs, though,
       // and that can be a lot
-      if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      if (!use_shared_compact_block_neighbors
+          && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
         return;
       }
       int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
@@ -705,26 +718,39 @@ class LKBallPoseScoreDispatch {
     });
 
     // Build block neighbors before dispatching LK-ball pair scoring.
-    score::common::sphere_overlap::
-        compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
-            mgr,
-            rot_coords,
-            rot_coord_offset,
-            block_ind_for_rot,
-            pose_ind_for_rot,
-            block_type_ind_for_rot,
-            block_type_n_atoms,
-            scratch_rot_spheres);
+    if (!use_shared_compact_block_neighbors) {
+      score::common::sphere_overlap::
+          compute_block_spheres<DeviceDispatch, Dev, Real, Int>::f(
+              mgr,
+              rot_coords,
+              rot_coord_offset,
+              block_ind_for_rot,
+              pose_ind_for_rot,
+              block_type_ind_for_rot,
+              block_type_n_atoms,
+              scratch_rot_spheres);
 
-    score::common::sphere_overlap::
-        detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
-            mgr,
-            first_rot_block_type,
-            scratch_rot_spheres,
-            scratch_rot_neighbors,
-            max_dis);
+      score::common::sphere_overlap::
+          detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+              mgr,
+              first_rot_block_type,
+              scratch_rot_spheres,
+              scratch_rot_neighbors,
+              max_dis);
+    }
 #ifdef __NVCC__
-    if (!output_block_pair_energies
+    if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+      auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
+        eval_energies_by_block(
+            cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
+      });
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceDispatch,
+          Dev,
+          launch_t,
+          Int>(mgr, shared_compact_block_neighbors, eval_all);
+    } else if (
+        !output_block_pair_energies
         && score::common::sphere_overlap::should_compact_block_neighbors(
             n_poses, max_n_blocks, false)) {
       auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
@@ -734,12 +760,22 @@ class LKBallPoseScoreDispatch {
       score::common::sphere_overlap::
           launch_compact_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
               mgr, scratch_rot_neighbors, eval_all);
-    } else
-#endif
-    {
+    } else {
       launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
           mgr, n_poses, max_n_blocks, eval_energies_by_block);
     }
+#else
+    if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceDispatch,
+          Dev,
+          launch_t,
+          Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+    } else {
+      launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
+          mgr, n_poses, max_n_blocks, eval_energies_by_block);
+    }
+#endif
 
     return {output_t, scratch_rot_neighbors_t};
   }
@@ -808,6 +844,7 @@ class LKBallPoseScoreDispatch {
       // LKBall potential parameters
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       TView<Int, 3, Dev> scratch_rot_neighbors,  // from forward pass
+      TView<Int, 1, Dev> compact_block_neighbors,
       TView<Real, 4, Dev> dTdV,
       bool block_pair_scoring)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>> {
@@ -825,6 +862,8 @@ class LKBallPoseScoreDispatch {
     int const max_n_interblock_bonds =
         block_type_atoms_forming_chemical_bonds.size(1);
     int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
+    bool const use_compact_block_neighbors =
+        compact_block_neighbors.size(0) != 0;
 
     auto dV_d_pose_coords_t = TPack<Vec<Real, 3>, 1, Dev>::zeros({n_atoms});
     auto dV_d_pose_coords = dV_d_pose_coords_t.view;
@@ -854,7 +893,8 @@ class LKBallPoseScoreDispatch {
       int const block_ind2 = common::get<2>(pair_indices);
 
       // Reject empty work before setting up the derivative machinery below.
-      if (scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+      if (!use_compact_block_neighbors
+          && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
         return;
       }
       int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
@@ -1054,7 +1094,20 @@ class LKBallPoseScoreDispatch {
     // a prefix scan, this has no device-to-host synchronization and is safe to
     // capture in a CUDA graph.
 #ifdef __NVCC__
-    int const n_pairs = max_n_blocks * (max_n_blocks + 1) / 2;
+    if (use_compact_block_neighbors) {
+      auto eval_compact = ([=] TMOL_DEVICE_FUNC(int cta) {
+        eval_derivs(
+            cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
+      });
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceDispatch,
+          Dev,
+          launch_t,
+          Int>(mgr, compact_block_neighbors, eval_compact);
+      return {dV_d_pose_coords_t, dV_d_water_coords_t};
+    }
+    int const n_pairs =
+        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
     int const n_candidate_pairs = n_poses * n_pairs;
     constexpr int max_persistent_workgroups = 1 << 14;
     int const n_workgroups = n_candidate_pairs < max_persistent_workgroups
@@ -1070,8 +1123,16 @@ class LKBallPoseScoreDispatch {
     DeviceDispatch<Dev>::template foreach_workgroup<launch_t>(
         mgr, n_workgroups, eval_derivs_strided);
 #else
-    launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
-        mgr, n_poses, max_n_blocks, eval_derivs);
+    if (use_compact_block_neighbors) {
+      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceDispatch,
+          Dev,
+          launch_t,
+          Int>(mgr, compact_block_neighbors, eval_derivs);
+    } else {
+      launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
+          mgr, n_poses, max_n_blocks, eval_derivs);
+    }
 #endif
 
     return {dV_d_pose_coords_t, dV_d_water_coords_t};
@@ -1150,7 +1211,8 @@ class LKBallRotamerScoreDispatch {
       TView<LKBallGlobalParams<Real>, 1, Dev> global_params,
       Real max_dis,
       TView<Vec<Real, 3>, 2, Dev> water_coords,
-      bool output_block_pair_energies)
+      bool output_block_pair_energies,
+      TPack<Int, 2, Dev> shared_dispatch_indices)
       -> std::tuple<TPack<Real, 2, Dev>, TPack<Int, 2, Dev>> {
     using tmol::score::common::accumulate;
     using Real3 = Vec<Real, 3>;
@@ -1219,54 +1281,63 @@ class LKBallRotamerScoreDispatch {
     assert(block_type_path_distance.size(1) == max_n_block_atoms);
     assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-    auto scratch_rot_spheres_t = Dev == Device::CPU
-                                     ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
-                                     : TPack<Real, 2, Dev>::empty({n_rots, 4});
-    auto scratch_rot_spheres = scratch_rot_spheres_t.view;
+    TPack<Int, 2, Dev> dispatch_indices_t;
+    if (shared_dispatch_indices.size(0) == 3) {
+      dispatch_indices_t = shared_dispatch_indices;
+    } else {
+      auto scratch_rot_spheres_t =
+          Dev == Device::CPU ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
+                             : TPack<Real, 2, Dev>::empty({n_rots, 4});
+      auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
-    auto scratch_block_spheres_t =
-        Dev == Device::CPU
-            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
-            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
-    auto scratch_block_spheres = scratch_block_spheres_t.view;
+      auto scratch_block_spheres_t =
+          Dev == Device::CPU
+              ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+              : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
+      auto scratch_block_spheres = scratch_block_spheres_t.view;
 
-    auto scratch_block_neighbors_t =
-        Dev == Device::CPU
-            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
-            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
-    auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+      auto scratch_block_neighbors_t =
+          Dev == Device::CPU
+              ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+              : TPack<Int, 3, Dev>::empty(
+                    {n_poses, max_n_blocks, max_n_blocks});
+      auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
-    score::common::sphere_overlap::
-        compute_rot_spheres<DeviceDispatch, Dev, Real, Int>::f(
-            mgr,
-            rot_coords,
-            rot_coord_offset,
-            block_type_ind_for_rot,
-            block_type_n_atoms,
-            scratch_rot_spheres);
+      score::common::sphere_overlap::
+          compute_rot_spheres<DeviceDispatch, Dev, Real, Int>::f(
+              mgr,
+              rot_coords,
+              rot_coord_offset,
+              block_type_ind_for_rot,
+              block_type_n_atoms,
+              scratch_rot_spheres);
 
-    score::common::sphere_overlap::
-        compute_block_spheres_from_rot_spheres<DeviceDispatch, Dev, Real, Int>::
-            f(mgr,
-              scratch_rot_spheres,
-              n_rots_for_block,
-              rot_offset_for_block,
-              scratch_block_spheres);
-
-    score::common::sphere_overlap::
-        detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
-            mgr,
-            first_rot_block_type,
-            scratch_block_spheres,
-            scratch_block_neighbors,
-            max_dis);
-
-    auto dispatch_indices_t = score::common::sphere_overlap::
-        rot_neighbor_indices_from_block_neighbors<DeviceDispatch, Dev, Int>::f(
-            mgr,
-            scratch_block_neighbors,
+      score::common::sphere_overlap::compute_block_spheres_from_rot_spheres<
+          DeviceDispatch,
+          Dev,
+          Real,
+          Int>::
+          f(mgr,
+            scratch_rot_spheres,
             n_rots_for_block,
-            rot_offset_for_block);
+            rot_offset_for_block,
+            scratch_block_spheres);
+
+      score::common::sphere_overlap::
+          detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+              mgr,
+              first_rot_block_type,
+              scratch_block_spheres,
+              scratch_block_neighbors,
+              max_dis);
+
+      dispatch_indices_t = score::common::sphere_overlap::
+          rot_neighbor_indices_from_block_neighbors<DeviceDispatch, Dev, Int>::
+              f(mgr,
+                scratch_block_neighbors,
+                n_rots_for_block,
+                rot_offset_for_block);
+    }
     auto dispatch_indices = dispatch_indices_t.view;
 
     TPack<Real, 2, Dev> output_t;

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -502,11 +502,15 @@ class LKBallPoseScoreDispatch {
     int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
 
     auto scratch_rot_spheres_t =
-        TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+        Dev == Device::CPU
+            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
     auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
     auto scratch_rot_neighbors_t =
-        TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+        Dev == Device::CPU
+            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
     auto scratch_rot_neighbors = scratch_rot_neighbors_t.view;
 
     TPack<Real, 4, Dev> output_t;
@@ -1215,15 +1219,21 @@ class LKBallRotamerScoreDispatch {
     assert(block_type_path_distance.size(1) == max_n_block_atoms);
     assert(block_type_path_distance.size(2) == max_n_block_atoms);
 
-    auto scratch_rot_spheres_t = TPack<Real, 2, Dev>::zeros({n_rots, 4});
+    auto scratch_rot_spheres_t = Dev == Device::CPU
+                                     ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
+                                     : TPack<Real, 2, Dev>::empty({n_rots, 4});
     auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
     auto scratch_block_spheres_t =
-        TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4});
+        Dev == Device::CPU
+            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
     auto scratch_block_spheres = scratch_block_spheres_t.view;
 
     auto scratch_block_neighbors_t =
-        TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks});
+        Dev == Device::CPU
+            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
     auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
     score::common::sphere_overlap::

--- a/tmol/tests/optimization/test_armijo_compiled.py
+++ b/tmol/tests/optimization/test_armijo_compiled.py
@@ -1,0 +1,175 @@
+import pytest
+import torch
+
+from tmol.optimization._armijo_compiled import (
+    armijo_classify,
+    armijo_finalize,
+    armijo_start,
+    armijo_trial,
+    armijo_update,
+)
+
+_LS_DONE = 0
+_LS_INCREASE = 1
+_LS_BACKTRACK = 2
+_LS_FAILED = 3
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_armijo_start_and_classify_match_tensor_reference(torch_device, dtype):
+    searching = torch.tensor([False, True, True, True], device=torch_device)
+    alpha0 = torch.ones(4, dtype=dtype, device=torch_device)
+    phi0 = torch.full_like(alpha0, 10.0)
+    derphi0 = torch.full_like(alpha0, -1.0)
+    phi = torch.tensor([20.0, 9.0, 9.5, 10.0], dtype=dtype, device=torch_device)
+    sigma_increase = 0.8
+    sigma_decrease = 0.1
+
+    expected_alpha = torch.where(searching, alpha0, torch.zeros_like(alpha0))
+    linear = phi <= phi0 + expected_alpha * sigma_increase * derphi0
+    sufficient = phi <= phi0 + expected_alpha * sigma_decrease * derphi0
+    expected_status = torch.full(
+        alpha0.shape, _LS_DONE, dtype=torch.int64, device=torch_device
+    )
+    expected_status = torch.where(searching & linear, _LS_INCREASE, expected_status)
+    expected_status = torch.where(
+        searching & ~linear & ~sufficient, _LS_BACKTRACK, expected_status
+    )
+    took = searching & (linear | sufficient)
+    expected_accepted = torch.where(took, expected_alpha, torch.zeros_like(alpha0))
+    expected_phi_accepted = torch.where(took, phi, phi0)
+
+    alpha = armijo_start(searching, alpha0)
+    accepted, phi_accepted, status, active = armijo_classify(
+        searching,
+        alpha,
+        phi,
+        phi0,
+        derphi0,
+        sigma_increase,
+        sigma_decrease,
+    )
+
+    torch.testing.assert_close(alpha, expected_alpha, rtol=0, atol=0)
+    torch.testing.assert_close(accepted, expected_accepted, rtol=0, atol=0)
+    torch.testing.assert_close(phi_accepted, expected_phi_accepted, rtol=0, atol=0)
+    torch.testing.assert_close(status, expected_status, rtol=0, atol=0)
+    expected_active = (expected_status == _LS_INCREASE) | (
+        expected_status == _LS_BACKTRACK
+    )
+    torch.testing.assert_close(active, expected_active, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_armijo_trial_and_update_match_tensor_reference(torch_device, dtype):
+    status = torch.tensor(
+        [
+            _LS_INCREASE,
+            _LS_INCREASE,
+            _LS_BACKTRACK,
+            _LS_BACKTRACK,
+            _LS_BACKTRACK,
+            _LS_DONE,
+        ],
+        dtype=torch.int64,
+        device=torch_device,
+    )
+    alpha = torch.tensor(
+        [1.0, 1.0, 1.0, 0.1, 0.1, 0.0], dtype=dtype, device=torch_device
+    )
+    accepted = torch.tensor(
+        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0], dtype=dtype, device=torch_device
+    )
+    phi_accepted = torch.tensor(
+        [9.0, 9.0, 10.0, 10.0, 10.0, 10.0], dtype=dtype, device=torch_device
+    )
+    phi = torch.tensor(
+        [9.0, 9.0, 10.0, 10.0, 10.0, 10.0], dtype=dtype, device=torch_device
+    )
+    phi_trial = torch.tensor(
+        [8.0, 9.5, 9.8, 9.999, 10.1, 123.0], dtype=dtype, device=torch_device
+    )
+    phi0 = torch.full_like(alpha, 10.0)
+    derphi0 = torch.full_like(alpha, -1.0)
+    factor = 0.5
+    sigma_decrease = 0.1
+    minstep = 0.03
+
+    expected_trial = torch.where(status == _LS_INCREASE, alpha / factor, accepted)
+    expected_trial = torch.where(
+        status == _LS_BACKTRACK, alpha * factor * factor, expected_trial
+    )
+
+    increasing = status == _LS_INCREASE
+    better = increasing & (phi_trial < phi)
+    expected_accepted = torch.where(better, expected_trial, accepted)
+    expected_phi_accepted = torch.where(better, phi_trial, phi_accepted)
+    expected_status = torch.where(increasing, _LS_DONE, status)
+
+    backtracking = expected_status == _LS_BACKTRACK
+    armijo = backtracking & (
+        phi_trial <= phi0 + expected_trial * sigma_decrease * derphi0
+    )
+    expected_accepted = torch.where(armijo, expected_trial, expected_accepted)
+    expected_phi_accepted = torch.where(armijo, phi_trial, expected_phi_accepted)
+    expected_status = torch.where(armijo, _LS_DONE, expected_status)
+
+    floored = backtracking & ~armijo & (expected_trial < minstep)
+    downhill = floored & (phi_trial < phi0)
+    expected_accepted = torch.where(downhill, expected_trial, expected_accepted)
+    expected_phi_accepted = torch.where(downhill, phi_trial, expected_phi_accepted)
+    expected_status = torch.where(downhill, _LS_DONE, expected_status)
+    expected_failed = floored & ~downhill
+    expected_accepted = torch.where(
+        expected_failed, torch.zeros_like(alpha), expected_accepted
+    )
+    expected_phi_accepted = torch.where(expected_failed, phi0, expected_phi_accepted)
+    expected_status = torch.where(expected_failed, _LS_FAILED, expected_status)
+
+    trial = armijo_trial(status, alpha, accepted, factor)
+    next_accepted, next_phi_accepted, next_status, failed, active = armijo_update(
+        status,
+        trial,
+        accepted,
+        phi_accepted,
+        phi,
+        phi_trial,
+        phi0,
+        derphi0,
+        sigma_decrease,
+        minstep,
+    )
+
+    torch.testing.assert_close(trial, expected_trial, rtol=0, atol=0)
+    torch.testing.assert_close(next_accepted, expected_accepted, rtol=0, atol=0)
+    torch.testing.assert_close(next_phi_accepted, expected_phi_accepted, rtol=0, atol=0)
+    torch.testing.assert_close(next_status, expected_status, rtol=0, atol=0)
+    torch.testing.assert_close(failed, expected_failed, rtol=0, atol=0)
+    expected_active = (expected_status == _LS_INCREASE) | (
+        expected_status == _LS_BACKTRACK
+    )
+    torch.testing.assert_close(active, expected_active, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_armijo_finalize_matches_tensor_reference(torch_device, dtype):
+    status = torch.tensor(
+        [_LS_DONE, _LS_FAILED, _LS_FAILED, _LS_DONE],
+        dtype=torch.int64,
+        device=torch_device,
+    )
+    derphi0 = torch.tensor([-4.0, -4.0, -0.25, -1.0], dtype=dtype, device=torch_device)
+    accepted = torch.tensor([0.5, 0.0, 0.0, 0.75], dtype=dtype, device=torch_device)
+    start = torch.tensor([1.0, 0.8, 0.6, 0.4], dtype=dtype, device=torch_device)
+    searching = torch.tensor([True, True, True, False], device=torch_device)
+    minstep = 1e-12
+
+    expected_failed = status == _LS_FAILED
+    retry = torch.clamp((-derphi0).clamp(min=minstep).rsqrt(), max=1.0)
+    expected_step = torch.where(expected_failed, retry, accepted)
+    expected_step = torch.where(searching, expected_step, start)
+
+    step, failed = armijo_finalize(status, derphi0, accepted, start, searching, minstep)
+
+    torch.testing.assert_close(step, expected_step)
+    torch.testing.assert_close(failed, expected_failed, rtol=0, atol=0)

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -95,6 +95,62 @@ def test_large_negative_gradient_does_not_converge():
     torch.testing.assert_close(x.grad, torch.tensor([-10.0], dtype=x.dtype))
 
 
+def test_short_run_allocates_only_reachable_history():
+    x = torch.nn.Parameter(torch.tensor([3.0, -2.0]))
+    optimizer = LBFGS_Armijo(
+        [x], max_iter=3, history_size=128, rtol=0.0, atol=0.0, gradtol=0.0
+    )
+
+    def closure():
+        optimizer.zero_grad()
+        loss = (x * x).sum()
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+
+    assert optimizer.state[x]["old_dirs_mat"].shape[0] == 2
+    assert optimizer.state[x]["old_stps_mat"].shape[0] == 2
+
+
+def test_reset_reuses_scratch_and_restarts_trajectory():
+    initial = torch.tensor([3.0, -2.0])
+    x = torch.nn.Parameter(initial.clone())
+    optimizer = LBFGS_Armijo([x], max_iter=3, rtol=0.0, atol=0.0, gradtol=0.0)
+
+    def closure():
+        optimizer.zero_grad()
+        loss = (x * x).sum()
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+    first = x.detach().clone()
+    history_ptr = optimizer.state[x]["old_dirs_mat"].data_ptr()
+    with torch.no_grad():
+        x.copy_(initial)
+    optimizer.reset()
+    optimizer.step(closure)
+
+    torch.testing.assert_close(x, first)
+    assert optimizer.state[x]["old_dirs_mat"].data_ptr() == history_ptr
+
+
+def test_fixed_iterations_skips_early_convergence():
+    x = torch.nn.Parameter(torch.zeros(2))
+    optimizer = LBFGS_Armijo([x], max_iter=4, fixed_iterations=True)
+
+    def closure():
+        optimizer.zero_grad()
+        loss = (x * x).sum()
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+
+    assert optimizer.state[x]["n_iter"] == 4
+
+
 @pytest.mark.xfail(reason="sparse tensor _copy failure in torch 1.6")
 def test_lbfgs_armijo_sparse():
     indices = torch.LongTensor([[0, 0, 1], [0, 1, 1]])

--- a/tmol/tests/optimization/test_minimizers.py
+++ b/tmol/tests/optimization/test_minimizers.py
@@ -1,6 +1,7 @@
 import torch
 
 from tmol import (
+    CartesianMinimizer,
     PoseStack,
     run_cart_min,
     run_kin_min,
@@ -9,6 +10,7 @@ from tmol import (
     FoldForest,
     MoveMap,
 )
+import attrs
 
 
 def test_build_kinforest_sfxn_network_smoke(
@@ -66,6 +68,29 @@ def test_run_cart_min_smoke(
     end_score = wpsm(minimized_pose_stack.coords)
 
     assert torch.all(end_score < start_score)
+
+
+def test_cartesian_minimizer_reuses_compatible_network(
+    jagged_stack_of_465_res_ubqs: PoseStack,
+    torch_device,
+):
+    pose_stack = jagged_stack_of_465_res_ubqs
+    sfxn = beta2016_score_function(torch_device)
+    minimizer = CartesianMinimizer(cuda_graph=torch_device.type == "cuda")
+    kwargs = {"max_iter": 3, "gradtol": 0.0, "atol": 0.0, "rtol": 0.0}
+
+    first = minimizer(pose_stack, sfxn, optimizer_kwargs=kwargs)
+    network = minimizer.network
+    optimizer = minimizer.optimizer
+    assert network is not None
+    assert optimizer is not None
+    second_input = attrs.evolve(pose_stack, coords=pose_stack.coords.clone())
+    second = minimizer(second_input, sfxn, optimizer_kwargs=kwargs)
+
+    assert minimizer.network is network
+    assert minimizer.optimizer is optimizer
+    assert minimizer.last_optimizer_reused
+    torch.testing.assert_close(second.coords, first.coords)
 
 
 def test_run_kin_min_torch_lbfgs(

--- a/tmol/tests/pack/rotamer/dunbrack/test_dunbrack_chi_sampler.py
+++ b/tmol/tests/pack/rotamer/dunbrack/test_dunbrack_chi_sampler.py
@@ -275,6 +275,34 @@ def test_interpolate_probabilities_for_possible_rotamers(
         rotprob_gold, rotamer_probability.cpu().numpy(), rtol=1e-5, atol=1e-5
     )
 
+    # The upper endpoint is the same periodic coordinate as the table start.
+    # It must wrap to bin zero instead of indexing one beyond the table.
+    table_start = dun_params.rotameric_bb_start[12]
+    table_period = dun_params.rotameric_bb_periodicity[12]
+    endpoint_dihedrals = table_start + table_period
+    endpoint_probability = torch.full_like(rotamer_probability, -1.0)
+    start_probability = torch.full_like(rotamer_probability, -1.0)
+    for dihedrals, output in (
+        (endpoint_dihedrals, endpoint_probability),
+        (table_start, start_probability),
+    ):
+        compiled.interpolate_probabilities_for_possible_rotamers(
+            dun_params.rotameric_prob_tables,
+            dun_params.rotprob_table_sizes,
+            dun_params.rotprob_table_strides,
+            dun_params.rotameric_bb_start,
+            dun_params.rotameric_bb_step,
+            dun_params.rotameric_bb_periodicity,
+            dun_params.n_rotamers_for_tableset_offsets,
+            dun_params.sorted_rotamer_2_rotamer,
+            rottable_set_for_buildable_restype,
+            brt_for_possible_rotamer,
+            possible_rotamer_offset_for_brt,
+            dihedrals,
+            output,
+        )
+    torch.testing.assert_close(endpoint_probability, start_probability)
+
 
 def test_determine_n_base_rotamers_to_build_1(torch_device):
     compiled = get_compiled()

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -2,6 +2,7 @@ import attrs
 import pytest
 import torch
 import math
+from types import SimpleNamespace
 
 from tmol.pose import (
     ConstraintSet,
@@ -30,6 +31,12 @@ from tmol.pack.rotamer import (
 from tmol.io import pose_stack_from_pdb
 
 from tmol.score.constraint import ConstraintEnergyTerm
+from tmol.pack._pack_rotamers import (
+    _PACKER_TASK_POSE_TENSORS,
+    _max_poses_per_packing_chunk,
+    _slice_packer_task,
+    _slice_pose_stack_for_packing,
+)
 
 
 def setup_pose_stack_and_task(poses, torch_device, dun_sampler):
@@ -44,10 +51,21 @@ def setup_pose_stack_and_task(poses, torch_device, dun_sampler):
     return pose_stack, task
 
 
-def build_packer_energy_tables(pose_stack, rotamer_set, sfxn, chunk_size=16):
+def build_packer_energy_tables(
+    pose_stack, rotamer_set, sfxn, chunk_size=16, raw_entries=False
+):
     pbt = pose_stack.packed_block_types
     rotamer_scoring_module = sfxn.render_rotamer_scoring_module(pose_stack, rotamer_set)
-    energies = rotamer_scoring_module(rotamer_set.coords).coalesce()
+    if raw_entries:
+        energy_indices, energy_values = rotamer_scoring_module.forward_sparse_entries(
+            rotamer_set.coords
+        )
+    else:
+        energies = rotamer_scoring_module(rotamer_set.coords).coalesce()
+        energy_indices, energy_values = (
+            energies.indices().to(torch.int32),
+            energies.values(),
+        )
 
     (
         max_n_bump_checked_rotamers_per_pose_tensor,
@@ -75,8 +93,8 @@ def build_packer_energy_tables(pose_stack, rotamer_set, sfxn, chunk_size=16):
         rotamer_set.pose_for_rot,
         rotamer_set.block_type_ind_for_rot,
         rotamer_set.block_ind_for_rot,
-        energies.indices().to(torch.int32),
-        energies.values(),
+        energy_indices,
+        energy_values,
         False,
     )
 
@@ -237,6 +255,137 @@ def test_pack_rotamers(
     )
 
 
+def test_raw_rotamer_entries_match_coalesced_interaction_graph(
+    default_database, ubq_pdb, dun_sampler, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("raw duplicate accumulation requires CUDA atomics")
+
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=20)
+    pose_stack, task = setup_pose_stack_and_task([pose] * 2, torch_device, dun_sampler)
+    task = SetPackerTask.from_packer_task(task)
+    sfxn = get_packer_sfxn(default_database, torch_device)
+    pose_stack, rotamer_set = build_rotamers(
+        pose_stack, task, pose_stack.packed_block_types.chem_db
+    )
+    coalesced = build_packer_energy_tables(pose_stack, rotamer_set, sfxn)
+    raw = build_packer_energy_tables(pose_stack, rotamer_set, sfxn, raw_entries=True)
+
+    for coalesced_tensor, raw_tensor in zip(coalesced[:-1], raw[:-1]):
+        torch.testing.assert_close(coalesced_tensor, raw_tensor)
+    coalesced_tables, raw_tables = coalesced[-1], raw[-1]
+    assert (
+        coalesced_tables.max_n_rotamers_per_pose == raw_tables.max_n_rotamers_per_pose
+    )
+    assert coalesced_tables.chunk_size == raw_tables.chunk_size
+    for attribute in (
+        "pose_n_res",
+        "pose_n_rotamers",
+        "pose_rotamer_offset",
+        "nrotamers_for_res",
+        "oneb_offsets",
+        "res_for_rot",
+        "chunk_offset_offsets",
+        "chunk_offsets",
+        "energy1b",
+        "energy2b",
+    ):
+        torch.testing.assert_close(
+            getattr(coalesced_tables, attribute),
+            getattr(raw_tables, attribute),
+            atol=1e-3,
+            rtol=1e-5,
+        )
+
+
+def test_pack_rotamers_pose_chunks_preserve_pose_order_and_task(
+    default_database, ubq_pdb, dun_sampler, torch_device, monkeypatch
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=20)
+    pose_stack, task = setup_pose_stack_and_task([pose] * 4, torch_device, dun_sampler)
+    sliced_pose_stack = _slice_pose_stack_for_packing(pose_stack, 1, 3)
+    assert sliced_pose_stack.n_poses == 2
+    assert torch.equal(sliced_pose_stack.coords, pose_stack.coords[1:3])
+    assert (
+        sliced_pose_stack.coords.untyped_storage().data_ptr()
+        == pose_stack.coords.untyped_storage().data_ptr()
+    )
+    sliced_task = _slice_packer_task(task, 1, 3)
+    for attribute in _PACKER_TASK_POSE_TENSORS:
+        assert torch.equal(
+            getattr(sliced_task, attribute), getattr(task, attribute)[1:3]
+        )
+    sfxn = get_packer_sfxn(default_database, torch_device)
+
+    torch.manual_seed(11723)
+    monkeypatch.setenv("TMOL_PACK_MAX_POSES_PER_CHUNK", "100")
+    unchunked = pack_rotamers(pose_stack, sfxn, task)
+
+    torch.manual_seed(11723)
+    monkeypatch.setenv("TMOL_PACK_MAX_POSES_PER_CHUNK", "2")
+    chunked = pack_rotamers(pose_stack, sfxn, task)
+
+    # Annealing intentionally consumes a different RNG stream when the batch
+    # shape changes, so exact rotamer coordinates need not match. Residue
+    # identities, pose order, shapes, and validity must be preserved.
+    assert torch.equal(unchunked.block_type_ind, chunked.block_type_ind)
+    assert unchunked.coords.shape == chunked.coords.shape
+    assert torch.isfinite(chunked.coords).all()
+
+
+@pytest.mark.parametrize("n_blocks,expected", [(256, 25), (257, 10), (1025, 10)])
+def test_default_packing_chunk_size_tiers(n_blocks, expected, monkeypatch):
+    monkeypatch.delenv("TMOL_PACK_MAX_POSES_PER_CHUNK", raising=False)
+    pose_stack = SimpleNamespace(max_n_blocks=n_blocks, device=torch.device("cpu"))
+    assert _max_poses_per_packing_chunk(pose_stack) == expected
+
+
+@pytest.mark.parametrize("configured", ["0", "-1", "not-an-int"])
+def test_packing_chunk_size_rejects_invalid_override(configured, monkeypatch):
+    monkeypatch.setenv("TMOL_PACK_MAX_POSES_PER_CHUNK", configured)
+    pose_stack = SimpleNamespace(max_n_blocks=20, device=torch.device("cpu"))
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _max_poses_per_packing_chunk(pose_stack)
+
+
+def test_shared_rotamer_dispatch_matches_independent_lk_ball_layout(
+    default_database, ubq_pdb, dun_sampler, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=10)
+    pose_stack, task = setup_pose_stack_and_task([pose], torch_device, dun_sampler)
+    task = SetPackerTask.from_packer_task(task)
+    sfxn = get_packer_sfxn(default_database, torch_device)
+    pose_stack, rotamer_set = build_rotamers(
+        pose_stack, task, pose_stack.packed_block_types.chem_db
+    )
+    scorer = sfxn.render_rotamer_scoring_module(pose_stack, rotamer_set)
+
+    shared_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    shared = scorer(shared_coords).coalesce()
+    (shared_grad,) = torch.autograd.grad(shared.values().sum(), shared_coords)
+
+    lk_ball = next(term for term in scorer.term_modules if term.classname == "LKBall")
+    lk_ball.block_neighbor_cutoff += 0.5
+    fallback_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    fallback = scorer(fallback_coords).coalesce()
+    (fallback_grad,) = torch.autograd.grad(fallback.values().sum(), fallback_coords)
+
+    torch.testing.assert_close(shared.to_dense(), fallback.to_dense())
+    if torch_device.type == "cuda":
+        # Rotamer gradients use atomics, so even two independent evaluations
+        # need not be elementwise deterministic. Require the shared-layout
+        # error to remain inside the measured independent-repeat envelope.
+        repeat_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+        repeat = scorer(repeat_coords).coalesce()
+        (repeat_grad,) = torch.autograd.grad(repeat.values().sum(), repeat_coords)
+        torch.testing.assert_close(fallback.to_dense(), repeat.to_dense())
+        repeat_error = torch.max(torch.abs(fallback_grad - repeat_grad))
+        shared_error = torch.max(torch.abs(shared_grad - fallback_grad))
+        assert shared_error <= 2 * repeat_error + 1e-6
+    else:
+        torch.testing.assert_close(shared_grad, fallback_grad)
+
+
 def test_pack_rotamers_optH(default_database, ubq_pdb, torch_device):
     n_poses = 4
     p = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=76)
@@ -314,7 +463,9 @@ def test_pack_rotamers_optH(default_database, ubq_pdb, torch_device):
     )
 
 
-def test_pack_rotamers_w_cst(default_database, ubq_pdb, dun_sampler, torch_device):
+def test_pack_rotamers_w_cst(
+    default_database, ubq_pdb, dun_sampler, torch_device, monkeypatch
+):
     n_poses = 4
     p = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=76)
     pose_stack, task = setup_pose_stack_and_task(
@@ -378,31 +529,26 @@ def test_pack_rotamers_w_cst(default_database, ubq_pdb, dun_sampler, torch_devic
     )
 
     pose_stack = attrs.evolve(pose_stack, constraint_set=constraints)
-    (
-        rotamer_for_nonmolten_block,
-        n_molten_blocks_per_pose,
-        bc_rot_offset_for_molten_block,
-        bc_rot_to_orig_rot,
-        bg_bg_energies,
-        packer_energy_tables,
-    ) = build_packer_energy_tables(pose_stack, rotamer_set, sfxn)
-    # bg_bg_energies, packer_energy_tables = build_packer_energy_tables(
-    #     pose_stack, rotamer_set, sfxn
-    # )
-    # run_pack_and_assert_scores(
-    #     pose_stack, rotamer_set, packer_energy_tables, sfxn, bg_bg_energies
-    # )
-    _, _ = run_pack_and_assert_scores(
-        pose_stack,
-        rotamer_set,
-        packer_energy_tables,
-        sfxn,
-        rotamer_for_nonmolten_block,
-        n_molten_blocks_per_pose,
-        bc_rot_offset_for_molten_block,
-        bc_rot_to_orig_rot,
-        bg_bg_energies,
+    # Exercise constraint slicing and remapping: constraint pose indices must
+    # be remapped independently for every packing chunk.
+    monkeypatch.setenv("TMOL_PACK_MAX_POSES_PER_CHUNK", "2")
+    packed = pack_rotamers(pose_stack, sfxn, task)
+    assert packed.n_poses == n_poses
+    assert packed.constraint_set is not None
+    assert (
+        packed.constraint_set.constraint_functions == constraints.constraint_functions
     )
+    for attribute in (
+        "constraint_function_inds",
+        "constraint_atoms",
+        "constraint_params",
+        "constraint_num_unique_blocks",
+        "constraint_unique_blocks",
+    ):
+        torch.testing.assert_close(
+            getattr(packed.constraint_set, attribute), getattr(constraints, attribute)
+        )
+    assert torch.isfinite(packed.coords).all()
     if torch_device == torch.device("cuda"):
         torch.cuda.synchronize()
 

--- a/tmol/tests/score/common/device_operations/test.pybind.cpp
+++ b/tmol/tests/score/common/device_operations/test.pybind.cpp
@@ -1,5 +1,7 @@
 #include <tmol/utility/tensor/pybind.h>
+#include <tmol/score/common/counting.hh>
 #include <tmol/tests/score/common/device_operations/test.hh>
+#include <moderngpu/meta.hxx>
 
 namespace tmol {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -7,6 +9,27 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   using namespace tmol::tests::score::common::device_operations;
 
   using CPU = DevOpsTests<Device::CPU>;
+
+  m.def(
+      "test_checked_dispatch_size",
+      [](int64_t count) {
+        return tmol::score::common::checked_dispatch_size(
+            count, "test dispatch");
+      },
+      "count"_a);
+  m.def(
+      "test_checked_dispatch_product",
+      [](int64_t lhs, int64_t rhs) {
+        return tmol::score::common::checked_dispatch_product(
+            lhs, rhs, "test dispatch product");
+      },
+      "lhs"_a,
+      "rhs"_a);
+  m.def(
+      "test_safe_div_up",
+      [](int value, int divisor) { return mgpu::div_up(value, divisor); },
+      "value"_a,
+      "divisor"_a);
 
   m.def("test_forall", &CPU::test_forall, "src"_a);
   m.def("test_forall_independent", &CPU::test_forall_independent, "src"_a);

--- a/tmol/tests/score/common/device_operations/test_device_operations.py
+++ b/tmol/tests/score/common/device_operations/test_device_operations.py
@@ -112,6 +112,40 @@ def test_foreach_pose_workgroup(ext, torch_device):
 
 
 # ---------------------------------------------------------------------------
+# checked dispatch size (no allocation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("count", [2**31 - 2, 2**31 - 1])
+def test_checked_dispatch_size_accepts_int32_boundary(ext, count):
+    assert ext.test_checked_dispatch_size(count) == count
+
+
+@pytest.mark.parametrize("count", [-1, 2**31])
+def test_checked_dispatch_size_rejects_out_of_range(ext, count):
+    with pytest.raises(OverflowError, match="signed 32-bit native dispatch limit"):
+        ext.test_checked_dispatch_size(count)
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs,expected",
+    [(1, 2**31 - 1, 2**31 - 1), (46340, 46340, 2147395600)],
+)
+def test_checked_dispatch_product_accepts_int32_boundary(ext, lhs, rhs, expected):
+    assert ext.test_checked_dispatch_product(lhs, rhs) == expected
+
+
+@pytest.mark.parametrize("lhs,rhs", [(46341, 46341), (2**63 - 1, 2)])
+def test_checked_dispatch_product_rejects_overflow(ext, lhs, rhs):
+    with pytest.raises(OverflowError, match="(signed 32-bit|signed 64-bit)"):
+        ext.test_checked_dispatch_product(lhs, rhs)
+
+
+def test_dispatch_ceiling_division_does_not_overflow(ext):
+    assert ext.test_safe_div_up(2**31 - 1, 32) == 2**26
+
+
+# ---------------------------------------------------------------------------
 # scan inclusive: cumulative prefix sum (inclusive)
 # ---------------------------------------------------------------------------
 

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -17,6 +17,7 @@ from tmol.score._score_function import (
 )
 from tmol.score.common import ZeroTermPoseScoringModule
 from tmol.score.common._scoring_module import _coordinate_independent_score
+from tmol.score.ljlk.potentials import build_compact_block_neighbors
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
     DEFAULT_ATOM_OCCUPANCY,
@@ -30,6 +31,11 @@ from tmol import (
     default_packed_block_types,
     pose_stack_from_canonical_form,
 )
+
+
+def _separate_unweighted_scores(scorer, coords):
+    """Evaluate the original term modules without shared/fused execution."""
+    return torch.cat([term(coords) for term in scorer.term_modules], dim=0)
 
 
 def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
@@ -46,6 +52,288 @@ def test_pose_score_smoke(ubq_pdb, default_database, torch_device):
     scores = scorer(pose_stack100.coords)
 
     assert scores is not None
+
+
+def test_shared_block_neighbors_preserve_scores_and_gradients(ubq_pdb, torch_device):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device)
+    sfxn = beta2016_score_function(torch_device)
+    scorer = sfxn.render_whole_pose_scoring_module(pose)
+
+    legacy_coords = pose.coords.detach().clone().requires_grad_(True)
+    legacy_scores = _separate_unweighted_scores(scorer, legacy_coords)
+    (legacy_grad,) = torch.autograd.grad(legacy_scores.sum(), legacy_coords)
+
+    shared_coords = pose.coords.detach().clone().requires_grad_(True)
+    shared_neighbors = scorer._build_shared_block_neighbors(shared_coords)
+    assert shared_neighbors is not None
+    assert shared_neighbors.dtype == torch.int32
+    assert shared_neighbors.ndim == 1
+    assert 0 <= int(shared_neighbors[0]) < shared_neighbors.numel()
+    shared_scores = scorer.unweighted_scores(shared_coords)
+    (shared_grad,) = torch.autograd.grad(shared_scores.sum(), shared_coords)
+
+    torch.testing.assert_close(shared_scores, legacy_scores, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(shared_grad, legacy_grad, atol=1e-5, rtol=1e-5)
+
+
+def test_shared_block_neighbors_follow_active_terms(
+    ubq_pdb, default_database, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    sfxn = ScoreFunction(default_database, torch_device)
+    sfxn.set_weight(ScoreType.fa_ljatr, 1.0)
+
+    one_pair_term = sfxn.render_whole_pose_scoring_module(pose)
+    assert len(one_pair_term._shared_neighbor_term_indices) == 1
+    assert one_pair_term._build_shared_block_neighbors(pose.coords) is None
+    assert all(
+        term.classname != "LJLK+Elec" for term in one_pair_term._execution_modules
+    )
+
+    sfxn.set_weight(ScoreType.fa_elec, 1.0)
+    two_pair_terms = sfxn.render_whole_pose_scoring_module(pose)
+    assert len(two_pair_terms._shared_neighbor_term_indices) == 2
+    assert two_pair_terms._build_shared_block_neighbors(pose.coords) is not None
+    assert two_pair_terms._execution_modules[0].classname == "LJLK+Elec"
+
+    sfxn.set_weight(ScoreType.fa_elec, 0.0)
+    one_pair_term_again = sfxn.render_whole_pose_scoring_module(pose)
+    assert len(one_pair_term_again._shared_neighbor_term_indices) == 1
+    assert one_pair_term_again._build_shared_block_neighbors(pose.coords) is None
+    assert all(
+        term.classname != "LJLK+Elec" for term in one_pair_term_again._execution_modules
+    )
+
+
+def test_fused_ljlk_elec_preserves_term_lanes_weights_and_gradients(
+    ubq_pdb, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+
+    fused = beta2016_score_function(torch_device).render_whole_pose_scoring_module(pose)
+
+    assert [term.classname for term in fused.term_modules][:2] == ["LJLK", "Elec"]
+    assert fused._execution_modules[0].classname == "LJLK+Elec"
+
+    separate_coords = pose.coords.detach().clone().requires_grad_(True)
+    fused_coords = pose.coords.detach().clone().requires_grad_(True)
+    separate_lanes = _separate_unweighted_scores(fused, separate_coords)
+    fused_lanes = fused(fused_coords, sum_terms=False, apply_weights=False)
+    torch.testing.assert_close(fused_lanes, separate_lanes, atol=2e-5, rtol=2e-5)
+
+    (separate_gradient,) = torch.autograd.grad(separate_lanes.sum(), separate_coords)
+    (fused_gradient,) = torch.autograd.grad(fused_lanes.sum(), fused_coords)
+    torch.testing.assert_close(fused_gradient, separate_gradient, atol=3e-5, rtol=3e-5)
+
+    # Runtime weight edits remain independent because fusion emits the same
+    # canonical score lanes. In particular, electrostatics can be disabled
+    # without changing the execution object's public representation.
+    with torch.no_grad():
+        fused.weights[ScoreType.fa_ljatr.value] = 0.25
+        fused.weights[ScoreType.fa_ljrep.value] = -0.5
+        fused.weights[ScoreType.fa_lk.value] = 1.25
+        fused.weights[ScoreType.fa_elec.value] = 0.0
+    weighted_lanes = fused(pose.coords, sum_terms=False, apply_weights=True)
+    torch.testing.assert_close(weighted_lanes, fused_lanes.detach() * fused.weights)
+    torch.testing.assert_close(fused(pose.coords), weighted_lanes.sum(dim=0))
+
+
+def test_fused_ljlk_elec_weighted_gradient_finite_difference(
+    ubq_pdb, default_database, torch_device
+):
+    if torch_device.type != "cpu":
+        pytest.skip("CPU double-precision finite-difference check")
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=2)
+    sfxn = ScoreFunction(default_database, torch_device)
+    for score_type, weight in (
+        (ScoreType.fa_ljatr, 0.7),
+        (ScoreType.fa_ljrep, -0.3),
+        (ScoreType.fa_lk, 1.1),
+        (ScoreType.fa_elec, 0.4),
+    ):
+        sfxn.set_weight(score_type, weight)
+    scorer = sfxn.render_whole_pose_scoring_module(pose)
+    assert scorer._execution_modules[0].classname == "LJLK+Elec"
+
+    coords = pose.coords.double().requires_grad_(True)
+    torch.autograd.gradcheck(
+        lambda x: scorer(x).sum(),
+        (coords,),
+        eps=1e-6,
+        atol=2e-5,
+        rtol=2e-3,
+        fast_mode=True,
+    )
+
+
+def test_fused_ljlk_elec_backward_respects_lane_and_pose_weights(
+    ubq_pdb, default_database, torch_device, monkeypatch
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    pose_batch = PoseStackBuilder.from_poses([pose, pose], torch_device)
+
+    if torch_device.type == "cpu":
+        monkeypatch.setattr(torch, "get_num_threads", lambda: 1)
+    fused = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose_batch)
+    assert fused._execution_modules[0].classname == "LJLK+Elec"
+
+    separate_coords = pose_batch.coords.detach().clone().requires_grad_(True)
+    fused_coords = pose_batch.coords.detach().clone().requires_grad_(True)
+    separate_lanes = _separate_unweighted_scores(fused, separate_coords)
+    fused_lanes = fused(fused_coords, sum_terms=False, apply_weights=False)
+    upstream = torch.linspace(
+        -1.25,
+        1.75,
+        separate_lanes.numel(),
+        device=torch_device,
+        dtype=separate_lanes.dtype,
+    ).reshape_as(separate_lanes)
+    (separate_gradient,) = torch.autograd.grad(
+        (separate_lanes * upstream).sum(), separate_coords
+    )
+    (fused_gradient,) = torch.autograd.grad(
+        (fused_lanes * upstream).sum(), fused_coords
+    )
+
+    torch.testing.assert_close(fused_lanes, separate_lanes, atol=2e-4, rtol=3e-5)
+    torch.testing.assert_close(fused_gradient, separate_gradient, atol=5e-5, rtol=5e-5)
+
+
+def test_cpu_fused_shard_planner_preserves_fallbacks(
+    ubq_pdb, default_database, torch_device, monkeypatch
+):
+    if torch_device.type != "cpu":
+        pytest.skip("CPU execution-planner check")
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
+    fused = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose)
+    assert fused._execution_modules[0].classname == "LJLK+Elec"
+    assert fused._cpu_fused_shards == 2
+    assert fused._can_use_weighted_fused_default(pose.coords.detach())
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 16)
+    wide = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose)
+    assert wide._cpu_fused_shards == 8
+    assert not wide._can_use_weighted_fused_default(pose.coords.detach())
+    assert wide._can_use_weighted_fused_default(
+        pose.coords.detach().requires_grad_(True)
+    )
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
+
+    separate_coords = pose.coords.detach().clone().requires_grad_(True)
+    fused_coords = pose.coords.detach().clone().requires_grad_(True)
+    separate_lanes = _separate_unweighted_scores(fused, separate_coords)
+    separate_score = (separate_lanes * fused.weights).sum(dim=0)
+    fused_score = fused(fused_coords)
+    (separate_grad,) = torch.autograd.grad(separate_score.sum(), separate_coords)
+    (fused_grad,) = torch.autograd.grad(fused_score.sum(), fused_coords)
+    torch.testing.assert_close(fused_score, separate_score, atol=2e-3, rtol=3e-5)
+    torch.testing.assert_close(fused_grad, separate_grad, atol=5e-5, rtol=5e-5)
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 2)
+    two_threads = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose)
+    assert two_threads._execution_modules[0].classname == "LJLK+Elec"
+    assert two_threads._cpu_fused_shards == 2
+
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
+    pose_batch = PoseStackBuilder.from_poses([pose, pose], torch_device)
+    batched = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose_batch)
+    assert all(term.classname != "LJLK+Elec" for term in batched._execution_modules)
+
+
+def test_weighted_fused_score_adaptive_dispatch():
+    cpu = torch.zeros((1, 10, 3))
+    assert score_function_module._use_weighted_fused_score(cpu)
+
+
+def test_weighted_fused_score_cuda_adaptive_dispatch():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    device = torch.device("cuda")
+
+    assert not score_function_module._use_weighted_fused_score(
+        torch.zeros((1, 14_999, 3), device=device)
+    )
+    assert score_function_module._use_weighted_fused_score(
+        torch.zeros((1, 15_000, 3), device=device)
+    )
+    assert not score_function_module._use_weighted_fused_score(
+        torch.zeros((32, 1_999, 3), device=device)
+    )
+    assert score_function_module._use_weighted_fused_score(
+        torch.zeros((32, 2_000, 3), device=device)
+    )
+    assert not score_function_module._use_weighted_fused_score(
+        torch.zeros((29, 730, 3), device=device), needs_gradient=True
+    )
+    assert score_function_module._use_weighted_fused_score(
+        torch.zeros((30, 730, 3), device=device), needs_gradient=True
+    )
+
+
+@pytest.mark.parametrize(
+    "shape, message",
+    [
+        ((1, 65_536), "at most 65,535 blocks"),
+        ((2, 46_341), "exceeds int32 capacity"),
+    ],
+)
+def test_compact_block_neighbor_capacity_checks(shape, message):
+    empty_float = torch.empty((0, 3), dtype=torch.float32)
+    empty_int = torch.empty((0,), dtype=torch.int32)
+    first_rot_block_type = torch.empty(shape, dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match=message):
+        build_compact_block_neighbors(
+            empty_float,
+            empty_int,
+            first_rot_block_type,
+            empty_int,
+            empty_int,
+            empty_int,
+            empty_int,
+            6.0,
+        )
+
+
+def test_large_cpu_spatial_neighbor_build_is_deterministic(
+    systems_bysize, default_database, torch_device
+):
+    if torch_device.type != "cpu":
+        pytest.skip("CPU compact-list determinism check")
+    pose = pose_stack_from_pdb(systems_bysize[300], torch_device)
+    scorer = beta2016_score_function(
+        torch_device, param_db=default_database
+    ).render_whole_pose_scoring_module(pose)
+    original_threads = torch.get_num_threads()
+    try:
+        torch.set_num_threads(1)
+        serial = scorer._build_shared_block_neighbors(pose.coords)
+        torch.set_num_threads(4)
+        parallel_first = scorer._build_shared_block_neighbors(pose.coords)
+        parallel_second = scorer._build_shared_block_neighbors(pose.coords)
+    finally:
+        torch.set_num_threads(original_threads)
+
+    assert serial is not None
+    n_neighbors = int(serial[0])
+    assert serial.numel() == n_neighbors + 1
+    assert torch.equal(parallel_first, serial)
+    assert torch.equal(parallel_second, serial)
+
+    legacy_scores = _separate_unweighted_scores(scorer, pose.coords)
+    compact_scores = scorer.unweighted_scores(pose.coords)
+    torch.testing.assert_close(compact_scores, legacy_scores, atol=1e-5, rtol=1e-5)
 
 
 def test_score_function_resolves_unindexed_cuda(default_database, torch_device):
@@ -322,7 +610,9 @@ def test_cpu_parallel_whole_pose_gradient_matches_serial_order(
     serial_score, serial_gradient = score_and_gradient()
 
     assert torch.equal(parallel_score, serial_score)
-    assert torch.equal(parallel_gradient, serial_gradient)
+    # Independent shard graphs may reach the leaf accumulator in a different
+    # order; the resulting difference is limited to float32 roundoff.
+    torch.testing.assert_close(parallel_gradient, serial_gradient, atol=5e-6, rtol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -408,6 +698,34 @@ def test_rotamer_scorer_combines_identical_sparse_layouts(
     torch.testing.assert_close(coords.grad, torch.tensor(61.0, device=torch_device))
 
 
+def test_rotamer_scorer_raw_entries_keep_int32_and_uncoalesced_duplicates() -> None:
+    class SparseTerm(torch.nn.Module):
+        n_poses = 1
+        n_rots = 2
+
+        def __init__(self, indices: list[tuple[int, int]], values: list[float]) -> None:
+            super().__init__()
+            self.indices = torch.tensor(
+                [[0] * len(indices), *zip(*indices)], dtype=torch.int32
+            )
+            self.values = torch.tensor([values])
+
+        def forward(self, coords: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return self.values * coords, self.indices
+
+    scorer = RotamerScoringModule(
+        torch.tensor([2.0, 3.0]),
+        [SparseTerm([(0, 0), (0, 1)], [4.0, 5.0]), SparseTerm([(0, 1)], [7.0])],
+    )
+
+    indices, values = scorer.forward_sparse_entries(torch.ones(()))
+
+    assert indices.dtype == torch.int32
+    assert indices.shape == (3, 3)
+    assert torch.equal(indices[:, 1], indices[:, 2])
+    torch.testing.assert_close(values, torch.tensor([8.0, 10.0, 21.0]))
+
+
 def test_cpu_rotamer_scorer_coalesces_subset_layouts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -446,6 +764,51 @@ def test_cpu_rotamer_scorer_coalesces_subset_layouts(
     torch.testing.assert_close(coords.grad, torch.tensor(24.0))
 
 
+def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        score_function_module, "_cpu_score_term_worker_count", lambda *_: 1
+    )
+    indices = torch.tensor([[0], [0], [0]], dtype=torch.int32)
+
+    class Producer(torch.nn.Module):
+        n_poses = 1
+        n_rots = 1
+        block_neighbor_cutoff = 5.5
+        rotamer_dispatch_key = "sphere_overlap"
+
+        def forward(self, coords):
+            return coords.reshape(1, 1), indices
+
+    class Consumer(torch.nn.Module):
+        n_poses = 1
+        n_rots = 1
+        accepts_shared_dispatch = True
+        rotamer_dispatch_key = "sphere_overlap"
+
+        def __init__(self, cutoff):
+            super().__init__()
+            self.block_neighbor_cutoff = cutoff
+            self.received = None
+
+        def forward(self, coords, shared_dispatch=None):
+            self.received = shared_dispatch
+            return coords.reshape(1, 1), (
+                indices.clone() if shared_dispatch is None else shared_dispatch
+            )
+
+    matching = Consumer(5.5)
+    changed = Consumer(6.0)
+    scorer = RotamerScoringModule(torch.ones(3), [Producer(), matching, changed])
+
+    scores = scorer(torch.ones(()))
+
+    assert matching.received is indices
+    assert changed.received is None
+    torch.testing.assert_close(scores.to_dense(), torch.tensor([[[3.0]]]))
+
+
 def test_cpu_rotamer_terms_run_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
     barrier = threading.Barrier(2, timeout=2)
 
@@ -481,6 +844,8 @@ def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):
     expected_terms = eager(pose_stack.coords, sum_terms=False, apply_weights=False)
 
     graphed = sfxn.render_whole_pose_scoring_module(pose_stack, cuda_graph=True)
+    assert graphed._cuda_forward_graph_uses_fused_execution
+    assert graphed._cuda_forward_graph_uses_weighted_fusion
     graph_coords = pose_stack.coords.detach().clone().requires_grad_(True)
     graph_score = graphed(graph_coords)
     (graph_grad,) = torch.autograd.grad(graph_score.sum(), graph_coords)
@@ -497,6 +862,40 @@ def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):
     torch.testing.assert_close(
         graphed(pose_stack.coords, sum_terms=False, apply_weights=False),
         expected_terms,
+    )
+
+    # Captured graphs read the scorer's weight buffer at replay time.  Keep
+    # every canonical lane independently editable even when the internal
+    # execution planner groups compatible terms into one traversal.
+    with torch.no_grad():
+        eager.weights.copy_(
+            torch.linspace(
+                0.0,
+                1.0,
+                eager.weights.numel(),
+                device=eager.weights.device,
+                dtype=eager.weights.dtype,
+            ).reshape_as(eager.weights)
+        )
+        graphed.weights.copy_(eager.weights)
+    reweighted_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    expected_reweighted = eager(reweighted_coords)
+    (expected_reweighted_grad,) = torch.autograd.grad(
+        expected_reweighted.sum(), reweighted_coords
+    )
+    graph_reweighted_coords = pose_stack.coords.detach().clone().requires_grad_(True)
+    graph_reweighted = graphed(graph_reweighted_coords)
+    (graph_reweighted_grad,) = torch.autograd.grad(
+        graph_reweighted.sum(), graph_reweighted_coords
+    )
+    torch.testing.assert_close(
+        graph_reweighted, expected_reweighted, rtol=1e-5, atol=1e-3
+    )
+    torch.testing.assert_close(
+        graph_reweighted_grad,
+        expected_reweighted_grad,
+        rtol=1e-4,
+        atol=1e-3,
     )
 
     changed_coords = pose_stack.coords.detach().clone()
@@ -633,9 +1032,12 @@ def test_large_cuda_compact_scores_match_block_pair_reference(
     torch.testing.assert_close(whole_score, block_score, rtol=1e-5, atol=1e-2)
     torch.testing.assert_close(whole_grad, block_grad, rtol=2e-3, atol=2e-3)
 
-    # Both the inference graph's side streams and the autograd graph must
-    # preserve the device-resident compact neighbor count.
+    # Compact weighted fusion is profitable inside capture even above the
+    # eager forward threshold. Both graph paths must preserve the
+    # device-resident compact neighbor count.
     whole_scorer.enable_cuda_graphs(whole_coords, mode="both")
+    assert whole_scorer._cuda_forward_graph_uses_fused_execution
+    assert whole_scorer._cuda_forward_graph_uses_weighted_fusion
     graph_coords = pose.coords.detach().clone().requires_grad_(True)
     graph_score = whole_scorer(graph_coords).sum()
     graph_grad = torch.autograd.grad(graph_score, graph_coords)[0]

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -214,6 +214,9 @@ def test_cpu_fused_shard_planner_preserves_fallbacks(
     assert fused._execution_modules[0].classname == "LJLK+Elec"
     assert fused._cpu_fused_shards == 2
     assert fused._can_use_weighted_fused_default(pose.coords.detach())
+    assert fused._can_use_weighted_fused_default(
+        pose.coords.detach().requires_grad_(True)
+    ) == (score_function_module.sys.platform != "darwin")
 
     monkeypatch.setattr(torch, "get_num_threads", lambda: 16)
     wide = beta2016_score_function(
@@ -223,7 +226,7 @@ def test_cpu_fused_shard_planner_preserves_fallbacks(
     assert not wide._can_use_weighted_fused_default(pose.coords.detach())
     assert wide._can_use_weighted_fused_default(
         pose.coords.detach().requires_grad_(True)
-    )
+    ) == (score_function_module.sys.platform != "darwin")
     monkeypatch.setattr(torch, "get_num_threads", lambda: 4)
 
     separate_coords = pose.coords.detach().clone().requires_grad_(True)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -764,7 +764,7 @@ def test_cpu_rotamer_scorer_coalesces_subset_layouts(
     torch.testing.assert_close(coords.grad, torch.tensor(24.0))
 
 
-def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch(
+def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch_on_cpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -775,7 +775,7 @@ def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch(
     class Producer(torch.nn.Module):
         n_poses = 1
         n_rots = 1
-        block_neighbor_cutoff = 5.5
+        block_neighbor_cutoff = 6.0
         rotamer_dispatch_key = "sphere_overlap"
 
         def forward(self, coords):
@@ -798,8 +798,8 @@ def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch(
                 indices.clone() if shared_dispatch is None else shared_dispatch
             )
 
-    matching = Consumer(5.5)
-    changed = Consumer(6.0)
+    matching = Consumer(6.0)
+    changed = Consumer(6.5)
     scorer = RotamerScoringModule(torch.ones(3), [Producer(), matching, changed])
 
     scores = scorer(torch.ones(()))
@@ -807,6 +807,15 @@ def test_rotamer_scorer_reuses_only_exact_cutoff_dispatch(
     assert matching.received is indices
     assert changed.received is None
     torch.testing.assert_close(scores.to_dense(), torch.tensor([[[3.0]]]))
+
+
+def test_rotamer_superset_dispatch_policy() -> None:
+    compatible = score_function_module._rotamer_dispatch_cutoff_compatible
+
+    assert compatible("cpu", 6.0, 6.0)
+    assert not compatible("cpu", 6.0, 5.5)
+    assert compatible("cuda", 6.0, 5.5)
+    assert not compatible("cuda", 5.5, 6.0)
 
 
 def test_cpu_rotamer_terms_run_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- harden large-batch rotamer packing with checked 64-bit totals, bounded native
  work units, automatic pose chunking, and direct raw-entry interaction-graph
  accumulation instead of the large PyTorch sparse-COO/coalesce round trip
- accelerate repeated Cartesian minimization by reusing compatible topology and
  right-sized scratch and fusing launch-bound Armijo state transitions
- build/reuse compact neighbor layouts across compatible score terms and fuse
  default weighted LJ/LK + electrostatics without removing canonical term lanes
- use compact weighted CPU gradient fusion on Linux and the same fused traversal
  with independent lanes on macOS for batch-stable minimization
- wrap exact Dunbrack periodic endpoints onto the half-open interval, fixing the
  reproduced 2opf FastRelax bounds failure
- add affinity-aware CPU thread documentation and focused repository skills for
  setup, scoring, packing/relax, and development

The branch contains production code, regression tests, and user documentation.
One-off benchmark harnesses, raw profiles, plots, and results remain external.

## Correctness and flexibility

- callers can still independently change or zero every score term
- `sum_terms=False` and `apply_weights=False` retain canonical decomposed lanes
- unequal cutoffs, unsupported layouts, and dynamic calls retain eager/general
  fallbacks
- CUDA Graph is optional: compact packing memory and native fusion do not depend
  on capture
- CPU execution follows `torch.get_num_threads()` and remains user-overridable
  before scorer construction
- exact 2opf protein/nucleic FastRelax completes after the endpoint fix
- final local optimization/packing/scoring gate: **1,221 passed, 26 skipped,
  4 expected failures, and 1 expected pass**; the exact post-cleanup
  CartBonded/score-function CPU+H200 rerun passed **91 tests** (8 skipped)
- after the cross-platform numerical-stability finding, the exact reproducer and
  backend-policy tests pass with the two validated fused CPU reductions; the
  final full run is linked in the PR checks
- all four repository skills pass the current skill validator; strict Sphinx
  parsing reports no warnings from the new pages

## Performance

Representative matched measurements against `origin/master`:

- final one-thread Linux CPU scoring: **1.375–1.864x faster** across 43–1,300 residues
- final one-thread Linux CPU score + Cartesian gradient: **1.532–2.149x faster**
- final weighted-fusion increment: **1.047–1.070x** Linux CPU score and
  **1.015–1.053x** gradient; macOS keeps independent lanes for stability
- selected H200 B32 paths: **1.025–1.030x** score and **1.029–1.053x** gradient,
  with **6–12% less** gradient scratch memory
- profiled physical CUDA launches: **1,798 → 1,140** (**36.6% fewer**)
- 154 residues × 1,000 poses now completes in 130.3 s with 6.73 GiB incremental
  H200 memory (formerly about 26.8 GiB); 1,300 residues × 100 poses completes in
  228.5 s with 20.9 GiB (formerly about 51.5 GiB)

On the matched one-thread Linux protein set, TMol is faster than PyRosetta for
score + gradient at all four sizes and for plain scoring from 154 residues up.
The remaining 43-residue plain-score gap is 6.7%; larger FastRelax workflows
remain strongly favorable to TMol.

## Implementation notes

The final policy keeps only measured crossovers and structural fallbacks. Six
A/B-only environment switches and an unreachable graph fallback were removed.
The only retained tuning override is `TMOL_PACK_MAX_POSES_PER_CHUNK`, which
lowers or fixes the automatic safety/memory bound for deterministic testing and
deployment tuning; native overflow checks remain authoritative.
