### PR TITLE
Accelerate rotamer scoring on CPU and CUDA

### DIFF
--- a/docs/user_guide/development.md
+++ b/docs/user_guide/development.md
@@ -87,6 +87,10 @@ Environment variables:
 | `TMOL_JIT_FALLBACK=1` | Try AOT first, then JIT if AOT is unavailable. |
 
 Use JIT mode while editing kernels. Use AOT mode for normal installed packages.
+On Linux, the JIT loader detects PyTorch's OpenMP CPU backend and propagates
+the corresponding compiler and linker flags, so `at::parallel_for` has the
+same thread behavior as the CMake-built extension. `OMP_NUM_THREADS` and
+`torch.set_num_threads()` therefore apply consistently in both modes.
 
 ## Tests
 

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -144,8 +144,14 @@ kinematic `min_fn`.
 
 On CUDA, `fast_relax()` automatically uses graph replay for poses containing
 DNA or RNA, where repeated kernel-launch overhead is significant. Protein-only
-and protein–ligand poses remain eager. Pass `cuda_graph=True` or
-`cuda_graph=False` to override that choice; custom minimizers manage their own
-execution mode and cannot be combined with `cuda_graph=True`. Graph capture has
-a one-time startup cost, so explicitly disable it for a single latency-sensitive
-nucleic-acid relaxation that will not be repeated in the same process.
+and protein–ligand poses remain eager by default because graph capture does
+not consistently recover its setup cost in a single relaxation. For repeated
+protein workloads, pass `cuda_graph=True` to favor steady-state throughput;
+pass `cuda_graph=False` to force eager execution.
+
+Graph replay lowers latency by replacing the repeated Python, autograd, and
+CUDA-driver launch sequence; it does not make an individual scoring kernel
+execute faster. Capture also retains its working tensors, so benchmark memory
+as well as runtime for unusually large workloads. Custom minimizers manage
+their own execution mode and cannot be combined with `cuda_graph=True`. CPU
+execution remains eager.

--- a/tmol/pack/_pack_rotamers.py
+++ b/tmol/pack/_pack_rotamers.py
@@ -114,6 +114,17 @@ _SMALL_PACKING_POSE_CHUNK = 25
 _DEFAULT_PACKING_POSE_CHUNK = 10
 _ESTIMATED_PACKING_BYTES_PER_BLOCK = 2 * 1024 * 1024
 _PACKING_FREE_MEMORY_FRACTION = 0.25
+_CPU_INTERACTION_GRAPH_CHUNK_SIZE = 16
+_CUDA_INTERACTION_GRAPH_CHUNK_SIZE = 32
+
+
+def _interaction_graph_chunk_size(device: torch.device) -> int:
+    """Select the benchmarked backend-specific sparse-table chunk width."""
+    return (
+        _CUDA_INTERACTION_GRAPH_CHUNK_SIZE
+        if device.type == "cuda"
+        else _CPU_INTERACTION_GRAPH_CHUNK_SIZE
+    )
 
 
 def _max_poses_per_packing_chunk(pose_stack: PoseStack) -> int:
@@ -288,7 +299,7 @@ def _calculate_packer_energies(pose_stack, sfxn, rotamer_set, task, verbose=Fals
         synchronize_device(pose_stack.device)
     end_time2 = time.perf_counter()
 
-    chunk_size = 16
+    chunk_size = _interaction_graph_chunk_size(pose_stack.device)
 
     (
         max_n_bump_checked_rotamers_per_pose_tensor,

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -449,7 +449,7 @@ template <tmol::Device D, class IG, int ChunkSize>
 struct Annealer {
   static auto run_simulated_annealing(
       ContextManager& mgr, IG ig, at::CUDAGeneratorImpl* gen)
-      -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D> > {
+      -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D>> {
     int const n_poses = ig.n_poses_cpu();
     int const max_n_res = ig.max_n_res_cpu();
     int const max_n_rotamers = ig.max_n_rotamers_per_pose_cpu();
@@ -919,7 +919,7 @@ auto AnnealerDispatch<D>::forward(
     TView<int64_t, 1, D> chunk_offsets,
     TView<float, 1, D> energy1b,
     TView<float, 1, D> energy2b)
-    -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D> > {
+    -> std::tuple<TPack<float, 2, D>, TPack<int, 3, D>> {
   int const n_poses_cpu = pose_n_res.size(0);
   int const max_n_res_cpu = chunk_offset_offsets.size(1);
 
@@ -983,11 +983,20 @@ auto AnnealerDispatch<D>::forward(
   auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
       std::nullopt, at::cuda::detail::getDefaultCUDAGenerator());
 
-  auto result = chunk_size == 16
-                    ? Annealer<D, InteractionGraph<D, int, float>, 16>::
-                          run_simulated_annealing(mgr, ig, gen)
-                    : Annealer<D, InteractionGraph<D, int, float>, 0>::
-                          run_simulated_annealing(mgr, ig, gen);
+  std::tuple<TPack<float, 2, D>, TPack<int, 3, D>> result;
+  switch (chunk_size) {
+    case 16:
+      result = Annealer<D, InteractionGraph<D, int, float>, 16>::
+          run_simulated_annealing(mgr, ig, gen);
+      break;
+    case 32:
+      result = Annealer<D, InteractionGraph<D, int, float>, 32>::
+          run_simulated_annealing(mgr, ig, gen);
+      break;
+    default:
+      result = Annealer<D, InteractionGraph<D, int, float>, 0>::
+          run_simulated_annealing(mgr, ig, gen);
+  }
 
   return result;
 }

--- a/tmol/relax/_fast_relax.py
+++ b/tmol/relax/_fast_relax.py
@@ -244,8 +244,10 @@ def fast_relax(  # noqa: C901
             move map, and verbosity. Defaults to Cartesian minimization.
         cuda_graph: Capture the default Cartesian minimizer's repeated CUDA
             scoring path. By default, enable it automatically for CUDA poses
-            containing DNA or RNA, where launch overhead dominates. Pass ``False``
-            to disable it. It cannot be combined with a custom ``min_fn``.
+            containing DNA or RNA, where replay savings exceed capture setup.
+            Pass ``True`` for repeated protein workloads where steady-state
+            throughput matters more than first-call latency, or ``False`` to
+            disable it. It cannot be combined with a custom ``min_fn``.
         verbose: Print timing information for each step.
 
     Returns:

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -152,6 +152,8 @@ def _score_call_in_thread(
         ),
     ):
         if fused_score_weights is not None:
+            if shared_block_neighbors is None:
+                return score_call(coords, fused_score_weights)
             return score_call(coords, shared_block_neighbors, fused_score_weights)
         if shared_block_neighbors is None:
             return score_call(coords)
@@ -576,10 +578,11 @@ class ScoreFunction:
             results may already be coalesced.
         """
         self.pre_work_initialization(pose_stack)
-        term_modules = [
-            t.render_rotamer_scoring_module(pose_stack, rotamer_set)
-            for t in self.all_terms()
-        ]
+        term_modules = []
+        for term in self.all_terms():
+            module = term.render_rotamer_scoring_module(pose_stack, rotamer_set)
+            module.n_score_types = len(term.score_types())
+            term_modules.append(module)
         return RotamerScoringModule(self.weights_tensor(), term_modules)
 
     def pre_work_initialization(self, pose_stack: PoseStack) -> None:
@@ -736,6 +739,35 @@ class ScoreFunction:
         return sorted_term_list, sorted_score_type_list
 
 
+def _ljlk_elec_native_arguments(ljlk, elec, coords):
+    """Collect dtype-adjusted arguments shared by LJ/LK--Elec fusion paths."""
+    ljlk_tail = ljlk._static_tail_for_coords(coords)
+    elec_tail = elec._static_tail_for_coords(coords)
+    n_common = len(ljlk.common_parameters)
+    common = ljlk_tail[:n_common]
+    # Every ordinary term wrapper appends its block-pair-scoring flag.
+    lp = ljlk_tail[n_common:-1]
+    ep = elec_tail[len(elec.common_parameters) : -1]
+    return (
+        coords.flatten(start_dim=0, end_dim=-2),
+        *common,
+        lp[0],
+        lp[1],
+        lp[2],
+        lp[5],
+        lp[6],
+        lp[7],
+        lp[8],
+        lp[9],
+        lp[10],
+        lp[11],
+        ep[3],
+        ep[6],
+        ep[7],
+        ep[9],
+    )
+
+
 class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
     """Internal execution group retaining four independent score lanes."""
 
@@ -753,32 +785,8 @@ class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
         return self.ljlk_module.build_compact_block_neighbors(coords, reach)
 
     def _native_arguments(self, coords, shared_block_neighbors):
-        """Collect dtype-adjusted arguments shared by fused native entry points."""
-        ljlk = self.ljlk_module
-        elec = self.elec_module
-        ljlk_tail = ljlk._static_tail_for_coords(coords)
-        elec_tail = elec._static_tail_for_coords(coords)
-        n_common = len(ljlk.common_parameters)
-        common = ljlk_tail[:n_common]
-        lp = ljlk_tail[n_common:-1]
-        ep = elec_tail[len(elec.common_parameters) : -1]
         return (
-            coords.flatten(start_dim=0, end_dim=-2),
-            *common,
-            lp[0],
-            lp[1],
-            lp[2],
-            lp[5],
-            lp[6],
-            lp[7],
-            lp[8],
-            lp[9],
-            lp[10],
-            lp[11],
-            ep[3],
-            ep[6],
-            ep[7],
-            ep[9],
+            *_ljlk_elec_native_arguments(self.ljlk_module, self.elec_module, coords),
             shared_block_neighbors,
         )
 
@@ -953,6 +961,11 @@ class WholePoseScoringModule:
     def _can_use_weighted_fused_default(self, coords: torch.Tensor) -> bool:
         """Whether default scoring can consume the fused scalar contribution."""
         needs_gradient = torch.is_grad_enabled() and coords.requires_grad
+        # Weighted fusion intentionally discards the four independent native
+        # lanes. Preserve the canonical Python weighting path when callers opt
+        # into fitting score-function weights.
+        if torch.is_grad_enabled() and self.weights.requires_grad:
+            return False
         if self._fused_ljlk_elec_weight_range is None or not _use_weighted_fused_score(
             coords,
             force_for_cuda_graph=getattr(
@@ -1625,6 +1638,95 @@ class BlockPairScoringModule:
         )
 
 
+class _FusedLJLKAndElecRotamerModule(torch.nn.Module):
+    """Internal packing-only group that emits one live-weighted sparse lane."""
+
+    def __init__(self, ljlk_module, elec_module):
+        super().__init__()
+        self.ljlk_module = ljlk_module
+        self.elec_module = elec_module
+        self.classname = "LJLK+Elec"
+        self.n_score_types = 4
+        self.n_poses = ljlk_module.n_poses
+        self.n_rots = ljlk_module.n_rots
+        self.block_neighbor_cutoff = max(
+            ljlk_module.block_neighbor_cutoff, elec_module.block_neighbor_cutoff
+        )
+        self.rotamer_dispatch_key = ljlk_module.rotamer_dispatch_key
+
+    def is_compatible(self) -> bool:
+        """Return whether the live modules still satisfy the fast-path contract."""
+        return (
+            self.ljlk_module.block_neighbor_cutoff == 6.0
+            and self.elec_module.block_neighbor_cutoff == 5.5
+            and not any(
+                parameter.requires_grad
+                for term in (self.ljlk_module, self.elec_module)
+                for parameter in term.parameters()
+            )
+        )
+
+    def _native_arguments(self, coords):
+        ljlk = self.ljlk_module
+        elec = self.elec_module
+        return (
+            *_ljlk_elec_native_arguments(ljlk, elec, coords),
+            max(ljlk.block_neighbor_cutoff, elec.block_neighbor_cutoff),
+        )
+
+    def forward(self, coords, score_weights):
+        from tmol.score.ljlk.potentials import ljlk_elec_weighted_rotamer_scores
+
+        if score_weights.dtype != coords.dtype:
+            score_weights = score_weights.to(dtype=coords.dtype)
+        return ljlk_elec_weighted_rotamer_scores(
+            *self._native_arguments(coords), score_weights
+        )
+
+
+def _fused_ljlk_elec_rotamer_module(term_modules):
+    """Return the canonical default LJ/LK+Elec packing group, if present."""
+    weight_offset = 0
+    for index, first in enumerate(term_modules[:-1]):
+        second = term_modules[index + 1]
+        first_width = getattr(first, "n_score_types", None)
+        second_width = getattr(second, "n_score_types", None)
+        if first_width is None or second_width is None:
+            return None
+        is_builtin_pair = False
+        if (
+            getattr(first, "classname", None) == "LJLK"
+            and getattr(second, "classname", None) == "Elec"
+        ):
+            from tmol.score.elec.potentials import elec_rotamer_scores_shared
+            from tmol.score.ljlk.potentials import ljlk_rotamer_scores
+
+            is_builtin_pair = (
+                getattr(first, "term_score_poses", None) is ljlk_rotamer_scores
+                and getattr(second, "term_score_poses", None)
+                is elec_rotamer_scores_shared
+            )
+        if (
+            is_builtin_pair
+            and first_width == 3
+            and second_width == 1
+            and first.block_neighbor_cutoff == 6.0
+            and second.block_neighbor_cutoff == 5.5
+            and not any(
+                parameter.requires_grad
+                for term in (first, second)
+                for parameter in term.parameters()
+            )
+        ):
+            return (
+                _FusedLJLKAndElecRotamerModule(first, second),
+                index,
+                weight_offset,
+            )
+        weight_offset += first_width
+    return None
+
+
 class RotamerScoringModule:
     """Rendered energy modules that build sparse rotamer-pair energy tables.
 
@@ -1641,9 +1743,106 @@ class RotamerScoringModule:
             weights.view(-1, 1, 1, 1), requires_grad=False
         )
         self.term_modules = tuple(term_modules)
+        fused = _fused_ljlk_elec_rotamer_module(self.term_modules)
+        self._fused_ljlk_elec = fused[0] if fused is not None else None
+        self._fused_ljlk_elec_index = fused[1] if fused is not None else None
+        self._fused_ljlk_elec_weight_offset = fused[2] if fused is not None else None
+        self._has_trainable_term_parameters = any(
+            parameter.requires_grad
+            for term in self.term_modules
+            for parameter in term.parameters()
+        )
         self._cpu_term_workers = _cpu_score_term_worker_count(
             len(self.term_modules), weights.device
         )
+
+    def _execution_terms(self, use_fused):
+        """Return native calls, weights, and canonical-lane accounting."""
+        execution_terms = []
+        term_index = 0
+        while term_index < len(self.term_modules):
+            term = self.term_modules[term_index]
+            if use_fused and term_index == self._fused_ljlk_elec_index:
+                weight_begin = self._fused_ljlk_elec_weight_offset
+                assert weight_begin is not None
+                score_weights = self.weights[weight_begin : weight_begin + 4, 0, 0, 0]
+                execution_terms.append((self._fused_ljlk_elec, score_weights, True))
+                term_index += 2
+            else:
+                execution_terms.append((term, None, False))
+                term_index += 1
+        return execution_terms
+
+    @staticmethod
+    def _compatible_dispatch(term, dispatch_by_key, device_type):
+        """Return the narrowest previously built compatible term layout.
+
+        CUDA may reuse a larger-cutoff sphere-overlap layout because the
+        consumer's native potential still applies its own distance cutoff.
+        CPU reuse remains exact-cutoff only, as favored by measurements.
+        """
+        cutoff = getattr(term, "block_neighbor_cutoff", None)
+        dispatch_key = getattr(term, "rotamer_dispatch_key", None)
+        if (
+            not getattr(term, "accepts_shared_dispatch", False)
+            or dispatch_key is None
+            or cutoff is None
+        ):
+            return None
+        compatible = [
+            (producer_cutoff, indices)
+            for producer_cutoff, indices in dispatch_by_key.get(dispatch_key, ())
+            if _rotamer_dispatch_cutoff_compatible(device_type, producer_cutoff, cutoff)
+        ]
+        return min(compatible, key=lambda item: item[0])[1] if compatible else None
+
+    def _sequential_term_results(self, coords, execution_terms):
+        """Evaluate terms in order while reusing compatible sparse dispatches."""
+        dispatch_by_key = {}
+        for term, score_weights, already_weighted in execution_terms:
+            shared_dispatch = self._compatible_dispatch(
+                term, dispatch_by_key, coords.device.type
+            )
+            if already_weighted:
+                assert score_weights is not None
+                result = term(coords, score_weights)
+            elif shared_dispatch is not None:
+                result = term.forward(coords, shared_dispatch)
+            else:
+                result = term.forward(coords)
+
+            cutoff = getattr(term, "block_neighbor_cutoff", None)
+            dispatch_key = getattr(term, "rotamer_dispatch_key", None)
+            if dispatch_key is not None and cutoff is not None:
+                dispatch_by_key.setdefault(dispatch_key, []).append((cutoff, result[1]))
+            yield term, result, already_weighted
+
+    @staticmethod
+    def _matching_layout(indices, all_indices, layouts_by_nnz):
+        """Find an identical prior layout and whether content checks are enabled."""
+        layout_index = next(
+            (
+                index
+                for index, prior_indices in enumerate(all_indices)
+                if indices.is_set_to(prior_indices)
+            ),
+            None,
+        )
+        compare_contents = (
+            indices.device.type == "cpu"
+            or indices.numel() * indices.element_size()
+            >= _CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES
+        )
+        if layout_index is None and compare_contents:
+            layout_index = next(
+                (
+                    index
+                    for index in layouts_by_nnz.get(indices.shape[1], ())
+                    if torch.equal(indices, all_indices[index])
+                ),
+                None,
+            )
+        return layout_index, compare_contents
 
     def _weighted_entries_by_layout(
         self, coords: torch.Tensor
@@ -1667,9 +1866,18 @@ class RotamerScoringModule:
         n_rots: int | None = None
         weights_offset = 0
 
-        parallel = self._cpu_term_workers >= 2 and not (
-            torch.is_grad_enabled() and coords.requires_grad
+        differentiable = torch.is_grad_enabled() and (
+            coords.requires_grad
+            or self.weights.requires_grad
+            or self._has_trainable_term_parameters
         )
+        use_fused = (
+            self._fused_ljlk_elec is not None
+            and self._fused_ljlk_elec.is_compatible()
+            and not differentiable
+        )
+        execution_terms = self._execution_terms(use_fused)
+        parallel = self._cpu_term_workers >= 2 and not differentiable
         if parallel:
             executor = _cpu_score_term_executor(self._cpu_term_workers)
             context = (
@@ -1685,59 +1893,24 @@ class RotamerScoringModule:
                     term.forward,
                     coords,
                     *context,
+                    None,
+                    score_weights,
                 )
-                for term in self.term_modules
+                for term, score_weights, _ in execution_terms
             ]
-            term_results = (future.result() for future in futures)
+            term_results = (
+                (term, future.result(), already_weighted)
+                for (term, _, already_weighted), future in zip(execution_terms, futures)
+            )
         else:
             # Do not retain every term's complete score/index tensors. CUDA
             # packing layouts can be many GiB apiece, so consume each result
             # before evaluating the next term.
-            def sequential_term_results():
-                # A larger-cutoff sphere-overlap layout is a safe superset for
-                # a smaller consumer, whose native potential still applies its
-                # own cutoff. Measurements favor this on CUDA; exact layouts
-                # remain reusable on every device.
-                dispatch_by_key = {}
-                for term in self.term_modules:
-                    cutoff = getattr(term, "block_neighbor_cutoff", None)
-                    dispatch_key = getattr(term, "rotamer_dispatch_key", None)
-                    accepts_shared = getattr(term, "accepts_shared_dispatch", False)
-                    compatible_dispatch = None
-                    if (
-                        accepts_shared
-                        and dispatch_key is not None
-                        and cutoff is not None
-                    ):
-                        producers = dispatch_by_key.get(dispatch_key, ())
-                        compatible = [
-                            (producer_cutoff, indices)
-                            for producer_cutoff, indices in producers
-                            if _rotamer_dispatch_cutoff_compatible(
-                                coords.device.type,
-                                producer_cutoff,
-                                cutoff,
-                            )
-                        ]
-                        if compatible:
-                            _, compatible_dispatch = min(
-                                compatible, key=lambda item: item[0]
-                            )
-                    if compatible_dispatch is not None:
-                        result = term.forward(coords, compatible_dispatch)
-                    else:
-                        result = term.forward(coords)
-                    if dispatch_key is not None and cutoff is not None:
-                        dispatch_by_key.setdefault(dispatch_key, []).append(
-                            (cutoff, result[1])
-                        )
-                    yield result
+            term_results = self._sequential_term_results(coords, execution_terms)
 
-            term_results = sequential_term_results()
-
-        for term, (scores, indices) in zip(self.term_modules, term_results):
+        for term, (scores, indices), already_weighted in term_results:
             # [n_subterms, nnz], [3, nnz]
-            n_subterms = scores.shape[0]
+            n_subterms = term.n_score_types if already_weighted else scores.shape[0]
 
             # Native rotamer terms already return compact int32 coordinates,
             # while sparse/Python terms (notably constraints) may inherit
@@ -1761,35 +1934,27 @@ class RotamerScoringModule:
                 indices = indices.to(torch.int32)
 
             # Apply per-subterm weights and sum to [nnz] — no sparse tensor yet.
-            w = self.weights[weights_offset : weights_offset + n_subterms, 0, 0, 0]
-            weighted_values = (w[:, None] * scores).sum(dim=0)
-
-            # Several terms share the same block-pair dispatch. Combine their
-            # values now so the sparse coalesce does not sort another copy of
-            # the same, potentially multi-gigabyte, index layout.
-            deduplicate_layout = (
-                indices.device.type == "cpu"
-                or indices.numel() * indices.element_size()
-                >= _CUDA_ROTAMER_LAYOUT_DEDUP_MIN_BYTES
-            )
-            candidate_layouts = (
-                layouts_by_nnz.get(indices.shape[1], ()) if deduplicate_layout else ()
-            )
-            for layout_index in candidate_layouts:
-                prior_indices = all_indices[layout_index]
-                if indices.data_ptr() == prior_indices.data_ptr() or torch.equal(
-                    indices, prior_indices
-                ):
-                    all_values[layout_index] = (
-                        all_values[layout_index] + weighted_values
-                    )
-                    break
+            if already_weighted:
+                weighted_values = scores[0]
             else:
+                w = self.weights[weights_offset : weights_offset + n_subterms, 0, 0, 0]
+                weighted_values = (w[:, None] * scores).sum(dim=0)
+
+            # Several terms share the same block-pair dispatch. Pointer
+            # identity is free to check at every size; reserve the device-wide
+            # equality comparison for layouts large enough to recover its
+            # synchronization cost.
+            layout_index, compare_layout_contents = self._matching_layout(
+                indices, all_indices, layouts_by_nnz
+            )
+            if layout_index is None:
                 layout_index = len(all_indices)
                 all_values.append(weighted_values)
                 all_indices.append(indices)
-                if deduplicate_layout:
+                if compare_layout_contents:
                     layouts_by_nnz.setdefault(indices.shape[1], []).append(layout_index)
+            else:
+                all_values[layout_index] = all_values[layout_index] + weighted_values
             weights_offset += n_subterms
 
             if n_poses is None:

--- a/tmol/score/hbond/_hbond_energy_term.py
+++ b/tmol/score/hbond/_hbond_energy_term.py
@@ -137,12 +137,14 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
     def rotamer_score_hbond(self, *args):
         from tmol.score.hbond.potentials import (
             hbond_rotamer_scores,
+            hbond_rotamer_scores_shared,
             gen_hbond_bases,
         )
 
-        common_args = args[:-2]
-        pose_stack = args[-2]
-        block_pair_scoring = args[-1]
+        common_args = args[:-3]
+        pose_stack = args[-3]
+        block_pair_scoring = args[-2]
+        shared_dispatch_indices = args[-1]
         coords_dtype = common_args[0].dtype
         pair_param_table, pair_poly_table, global_param_table = self._param_tables(
             coords_dtype
@@ -172,7 +174,12 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
                 pose_stack.packed_block_types.hbpbt_params.is_hydrogen,
             )
 
-        return hbond_rotamer_scores(
+        score_op = (
+            hbond_rotamer_scores_shared
+            if shared_dispatch_indices.numel() != 0
+            else hbond_rotamer_scores
+        )
+        score_args = (
             *common_args,
             pose_stack.inter_residue_connections,
             pose_stack.min_block_bondsep,
@@ -199,6 +206,9 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             derived_atom_inds,
             block_pair_scoring,
         )
+        if shared_dispatch_indices.numel() != 0:
+            score_args += (shared_dispatch_indices,)
+        return score_op(*score_args)
 
     def get_pose_score_term_function(self):
         return self.pose_score_hbond
@@ -208,6 +218,12 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     def get_block_neighbor_cutoff(self):
         return 5.5
+
+    def accepts_shared_rotamer_dispatch(self):
+        return True
+
+    def rotamer_dispatch_key(self):
+        return "sphere_overlap"
 
     def get_score_term_attributes(self, pose_stack: PoseStack):
         return [pose_stack]

--- a/tmol/score/hbond/potentials/__init__.py
+++ b/tmol/score/hbond/potentials/__init__.py
@@ -4,4 +4,5 @@ from ._compiled import (  # noqa: F401
     gen_hbond_bases,
     hbond_pose_scores,
     hbond_rotamer_scores,
+    hbond_rotamer_scores_shared,
 )  # noqa: F401

--- a/tmol/score/hbond/potentials/_compiled.py
+++ b/tmol/score/hbond/potentials/_compiled.py
@@ -15,4 +15,5 @@ _ops = load_ops(
 
 hbond_pose_scores = _ops.hbond_pose_scores
 hbond_rotamer_scores = _ops.hbond_rotamer_scores
+hbond_rotamer_scores_shared = _ops.hbond_rotamer_scores_shared
 gen_hbond_bases = _ops.gen_hbond_bases

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -426,7 +426,8 @@ class HBondRotamerScoresOp
       Tensor derived_coords,
       Tensor derived_atom_inds,
 
-      bool output_block_pair_energies
+      bool output_block_pair_energies,
+      Tensor shared_dispatch_indices
 
   ) {
     at::Tensor score;
@@ -493,7 +494,8 @@ class HBondRotamerScoresOp
                       TCAST(derived_atom_inds),
 
                       output_block_pair_energies,
-                      rot_coords.requires_grad());
+                      rot_coords.requires_grad(),
+                      TCAST(shared_dispatch_indices));
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
@@ -714,7 +716,7 @@ class HBondRotamerScoresOp
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
             torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor()};
+            torch::Tensor(),  torch::Tensor()};
   }
 };
 
@@ -874,6 +876,8 @@ std::vector<Tensor> hbond_rotamer_scores_op(
     Tensor derived_atom_inds,
 
     bool output_block_pair_energies) {
+  Tensor empty_dispatch_indices = torch::empty(
+      {0, 0}, rot_coords.options().dtype(torch::kInt32).requires_grad(false));
   return HBondRotamerScoresOp<DispatchMethod>::apply(
       // common params
       rot_coords,
@@ -923,7 +927,99 @@ std::vector<Tensor> hbond_rotamer_scores_op(
       derived_coords,
       derived_atom_inds,
 
-      output_block_pair_energies);
+      output_block_pair_energies,
+      empty_dispatch_indices);
+}
+
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> hbond_rotamer_scores_shared_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_inter_residue_connections,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_n_all_bonds,
+    Tensor block_type_all_bonds,
+    Tensor block_type_atom_all_bond_ranges,
+    Tensor block_type_path_distance,
+    Tensor block_type_tile_n_donH,
+    Tensor block_type_tile_n_acc,
+    Tensor block_type_tile_donH_inds,
+    Tensor block_type_tile_acc_inds,
+    Tensor block_type_tile_donor_type,
+    Tensor block_type_tile_acceptor_type,
+    Tensor block_type_tile_hybridization,
+    Tensor block_type_atom_is_hydrogen,
+    Tensor pair_params,
+    Tensor pair_polynomials,
+    Tensor global_params,
+    Tensor derived_coords,
+    Tensor derived_atom_inds,
+    bool output_block_pair_energies,
+    Tensor shared_dispatch_indices) {
+  TORCH_CHECK(
+      shared_dispatch_indices.dim() == 2
+          && shared_dispatch_indices.size(0) == 3,
+      "shared hydrogen-bond rotamer dispatch must have shape [3, nnz]");
+  TORCH_CHECK(
+      shared_dispatch_indices.scalar_type() == torch::kInt32,
+      "shared hydrogen-bond rotamer dispatch must have dtype int32");
+  TORCH_CHECK(
+      shared_dispatch_indices.device() == rot_coords.device(),
+      "shared hydrogen-bond rotamer dispatch must be on the coordinate device");
+  return HBondRotamerScoresOp<DispatchMethod>::apply(
+      rot_coords,
+      rot_coord_offset,
+      pose_ind_for_atom,
+      first_rot_for_block,
+      first_rot_block_type,
+      block_ind_for_rot,
+      pose_ind_for_rot,
+      block_type_ind_for_rot,
+      n_rots_for_pose,
+      rot_offset_for_pose,
+      n_rots_for_block,
+      rot_offset_for_block,
+      max_n_rots_per_pose,
+      pose_stack_inter_residue_connections,
+      pose_stack_min_bond_separation,
+      pose_stack_inter_block_bondsep,
+      block_type_n_atoms,
+      block_type_n_interblock_bonds,
+      block_type_atoms_forming_chemical_bonds,
+      block_type_n_all_bonds,
+      block_type_all_bonds,
+      block_type_atom_all_bond_ranges,
+      block_type_path_distance,
+      block_type_tile_n_donH,
+      block_type_tile_n_acc,
+      block_type_tile_donH_inds,
+      block_type_tile_acc_inds,
+      block_type_tile_donor_type,
+      block_type_tile_acceptor_type,
+      block_type_tile_hybridization,
+      block_type_atom_is_hydrogen,
+      pair_params,
+      pair_polynomials,
+      global_params,
+      derived_coords,
+      derived_atom_inds,
+      output_block_pair_energies,
+      shared_dispatch_indices);
 }
 
 // Plain (non-autograd) op that runs the hbond derived-atom (D / B / B0)
@@ -1000,6 +1096,9 @@ TORCH_LIBRARY(tmol_hbond, m) {
   m.def(
       "hbond_rotamer_scores",
       &hbond_rotamer_scores_op<common::DeviceOperations>);
+  m.def(
+      "hbond_rotamer_scores_shared",
+      &hbond_rotamer_scores_shared_op<common::DeviceOperations>);
   m.def("gen_hbond_bases", &gen_hbond_bases_op);
 }
 

--- a/tmol/score/hbond/potentials/hbond_pose_score.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.hh
@@ -290,7 +290,8 @@ struct HBondRotamerScoreDispatch {
       TView<Int, 2, Dev> derived_atom_inds,
 
       bool output_block_pair_energies,
-      bool compute_derivs)
+      bool compute_derivs,
+      TPack<Int, 2, Dev> shared_dispatch_indices)
       -> std::tuple<
           TPack<Real, 2, Dev>,
           TPack<Vec<Real, 3>, 2, Dev>,

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -1143,7 +1143,8 @@ auto HBondRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
     TView<Int, 2, Dev> derived_atom_inds,
 
     bool output_block_pair_energies,
-    bool compute_derivs
+    bool compute_derivs,
+    TPack<Int, 2, Dev> shared_dispatch_indices
 
     )
     -> std::tuple<
@@ -1236,51 +1237,59 @@ auto HBondRotamerScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   auto dV_dcoords_t = TPack<Vec<Real, 3>, 2, Dev>::zeros({1, n_atoms});
   auto dV_dcoords = dV_dcoords_t.view;
 
-  auto scratch_rot_spheres_t = Dev == Device::CPU
-                                   ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
-                                   : TPack<Real, 2, Dev>::empty({n_rots, 4});
-  auto scratch_rot_spheres = scratch_rot_spheres_t.view;
+  TPack<Int, 2, Dev> dispatch_indices_t;
+  if (shared_dispatch_indices.size(0) == 3) {
+    dispatch_indices_t = shared_dispatch_indices;
+  } else {
+    auto scratch_rot_spheres_t = Dev == Device::CPU
+                                     ? TPack<Real, 2, Dev>::zeros({n_rots, 4})
+                                     : TPack<Real, 2, Dev>::empty({n_rots, 4});
+    auto scratch_rot_spheres = scratch_rot_spheres_t.view;
 
-  auto scratch_block_spheres_t =
-      Dev == Device::CPU
-          ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
-          : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_block_spheres = scratch_block_spheres_t.view;
+    auto scratch_block_spheres_t =
+        Dev == Device::CPU
+            ? TPack<Real, 3, Dev>::zeros({n_poses, max_n_blocks, 4})
+            : TPack<Real, 3, Dev>::empty({n_poses, max_n_blocks, 4});
+    auto scratch_block_spheres = scratch_block_spheres_t.view;
 
-  auto scratch_block_neighbors_t =
-      Dev == Device::CPU
-          ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
-  auto scratch_block_neighbors = scratch_block_neighbors_t.view;
+    auto scratch_block_neighbors_t =
+        Dev == Device::CPU
+            ? TPack<Int, 3, Dev>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, Dev>::empty({n_poses, max_n_blocks, max_n_blocks});
+    auto scratch_block_neighbors = scratch_block_neighbors_t.view;
 
-  score::common::sphere_overlap::
-      compute_rot_spheres<DeviceDispatch, Dev, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres);
+    score::common::sphere_overlap::
+        compute_rot_spheres<DeviceDispatch, Dev, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres);
 
-  score::common::sphere_overlap::
-      compute_block_spheres_from_rot_spheres<DeviceDispatch, Dev, Real, Int>::f(
-          mgr,
-          scratch_rot_spheres,
-          n_rots_for_block,
-          rot_offset_for_block,
-          scratch_block_spheres);
+    score::common::sphere_overlap::
+        compute_block_spheres_from_rot_spheres<DeviceDispatch, Dev, Real, Int>::
+            f(mgr,
+              scratch_rot_spheres,
+              n_rots_for_block,
+              rot_offset_for_block,
+              scratch_block_spheres);
 
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_block_spheres,
-          scratch_block_neighbors,
-          Real(5.5));  // 5.5A hard coded here. Please fix! TEMP!
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceDispatch, Dev, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_block_spheres,
+            scratch_block_neighbors,
+            Real(5.5));  // 5.5A hard coded here. Please fix! TEMP!
 
-  auto dispatch_indices_t = score::common::sphere_overlap::
-      rot_neighbor_indices_from_block_neighbors<DeviceDispatch, Dev, Int>::f(
-          mgr, scratch_block_neighbors, n_rots_for_block, rot_offset_for_block);
+    dispatch_indices_t = score::common::sphere_overlap::
+        rot_neighbor_indices_from_block_neighbors<DeviceDispatch, Dev, Int>::f(
+            mgr,
+            scratch_block_neighbors,
+            n_rots_for_block,
+            rot_offset_for_block);
+  }
 
   auto dispatch_indices = dispatch_indices_t.view;
 

--- a/tmol/score/ljlk/potentials/__init__.py
+++ b/tmol/score/ljlk/potentials/__init__.py
@@ -7,4 +7,5 @@ from ._compiled import (  # noqa: F401
     weighted_fused_score_sum,
     ljlk_pose_scores,
     ljlk_rotamer_scores,
+    ljlk_elec_weighted_rotamer_scores,
 )

--- a/tmol/score/ljlk/potentials/_compiled.py
+++ b/tmol/score/ljlk/potentials/_compiled.py
@@ -20,4 +20,5 @@ ljlk_elec_pose_scores = _ops.ljlk_elec_pose_scores
 ljlk_elec_weighted_pose_scores = _ops.ljlk_elec_weighted_pose_scores
 weighted_fused_score_sum = _ops.weighted_fused_score_sum
 ljlk_rotamer_scores = _ops.ljlk_rotamer_scores
+ljlk_elec_weighted_rotamer_scores = _ops.ljlk_elec_weighted_rotamer_scores
 build_compact_block_neighbors = _ops.build_compact_block_neighbors

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -1053,6 +1053,94 @@ std::vector<Tensor> ljlk_rotamer_scores_op(
       output_block_pair_energies);
 }
 
+template <template <tmol::Device> class DispatchMethod>
+std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
+    Tensor rot_coords,
+    Tensor rot_coord_offset,
+    Tensor pose_ind_for_atom,
+    Tensor first_rot_for_block,
+    Tensor first_rot_block_type,
+    Tensor block_ind_for_rot,
+    Tensor pose_ind_for_rot,
+    Tensor block_type_ind_for_rot,
+    Tensor n_rots_for_pose,
+    Tensor rot_offset_for_pose,
+    Tensor n_rots_for_block,
+    Tensor rot_offset_for_block,
+    int64_t max_n_rots_per_pose,
+    Tensor pose_stack_min_bond_separation,
+    Tensor pose_stack_inter_block_bondsep,
+    Tensor block_type_n_atoms,
+    Tensor block_type_atom_types,
+    Tensor block_type_n_interblock_bonds,
+    Tensor block_type_atoms_forming_chemical_bonds,
+    Tensor block_type_ljlk_path_distance,
+    Tensor block_type_is_ligand_fragment,
+    Tensor ljlk_type_params,
+    Tensor ljlk_global_params,
+    Tensor block_type_partial_charge,
+    Tensor block_type_elec_inter_repr_path_distance,
+    Tensor block_type_elec_intra_repr_path_distance,
+    Tensor elec_global_params,
+    double max_dis,
+    Tensor score_weights) {
+  TORCH_CHECK(
+      !torch::GradMode::is_enabled()
+          || (!rot_coords.requires_grad() && !score_weights.requires_grad()),
+      "weighted fused rotamer scoring is a packing-only forward path");
+  TORCH_CHECK(
+      score_weights.dim() == 1 && score_weights.size(0) == 4,
+      "weighted fused rotamer scoring requires four score weights");
+  TORCH_CHECK(
+      score_weights.scalar_type() == rot_coords.scalar_type()
+          && score_weights.device() == rot_coords.device(),
+      "fused rotamer weights must match coordinate dtype and device");
+
+  Tensor score, dispatch_indices;
+  using Int = int32_t;
+  TMOL_DISPATCH_FLOATING_DEVICE(
+      rot_coords.options(), "ljlk_elec_weighted_rotamer_scores", ([&] {
+        using Real = scalar_t;
+        constexpr tmol::Device Dev = device_t;
+        auto result =
+            LJLKAndElecPoseScoreDispatch<DispatchMethod, Dev, Real, Int>::
+                forward_weighted_rotamers(
+                    mgr,
+                    TCAST(rot_coords),
+                    TCAST(rot_coord_offset),
+                    TCAST(pose_ind_for_atom),
+                    TCAST(first_rot_for_block),
+                    TCAST(first_rot_block_type),
+                    TCAST(block_ind_for_rot),
+                    TCAST(pose_ind_for_rot),
+                    TCAST(block_type_ind_for_rot),
+                    TCAST(n_rots_for_pose),
+                    TCAST(rot_offset_for_pose),
+                    TCAST(n_rots_for_block),
+                    TCAST(rot_offset_for_block),
+                    max_n_rots_per_pose,
+                    TCAST(pose_stack_min_bond_separation),
+                    TCAST(pose_stack_inter_block_bondsep),
+                    TCAST(block_type_n_atoms),
+                    TCAST(block_type_atom_types),
+                    TCAST(block_type_n_interblock_bonds),
+                    TCAST(block_type_atoms_forming_chemical_bonds),
+                    TCAST(block_type_ljlk_path_distance),
+                    TCAST(block_type_is_ligand_fragment),
+                    TCAST(ljlk_type_params),
+                    TCAST(ljlk_global_params),
+                    TCAST(block_type_partial_charge),
+                    TCAST(block_type_elec_inter_repr_path_distance),
+                    TCAST(block_type_elec_intra_repr_path_distance),
+                    TCAST(elec_global_params),
+                    (Real)max_dis,
+                    TCAST(score_weights));
+        score = std::get<0>(result).tensor.squeeze(1).squeeze(1);
+        dispatch_indices = std::get<2>(result).tensor;
+      }));
+  return {score, dispatch_indices};
+}
+
 // See https://stackoverflow.com/a/3221914
 TORCH_LIBRARY(tmol_ljlk, m) {
   m.def("ljlk_pose_scores", &ljlk_pose_scores_op<DeviceOperations>);
@@ -1064,6 +1152,9 @@ TORCH_LIBRARY(tmol_ljlk, m) {
       "weighted_fused_score_sum",
       &weighted_fused_score_sum_op<DeviceOperations>);
   m.def("ljlk_rotamer_scores", &ljlk_rotamer_scores_op<DeviceOperations>);
+  m.def(
+      "ljlk_elec_weighted_rotamer_scores",
+      &ljlk_elec_weighted_rotamer_scores_op<DeviceOperations>);
   m.def("build_compact_block_neighbors", &build_compact_block_neighbors_op);
 }
 

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
@@ -98,6 +98,47 @@ struct LJLKAndElecPoseScoreDispatch {
       bool require_gradient)
       -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
 
+  /// Evaluate weighted LJ/LK + electrostatics for a prepared sparse rotamer
+  /// pair dispatch. Packing does not differentiate the energy table, so this
+  /// compact path emits one live-weighted value per dispatch entry without
+  /// allocating canonical score lanes or derivative scratch.
+  static auto forward_weighted_rotamers(
+      ContextManager& mgr,
+      TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+      TView<Int, 1, D> rot_coord_offset,
+      TView<Int, 1, D> pose_ind_for_atom,
+      TView<Int, 2, D> first_rot_for_block,
+      TView<Int, 2, D> first_rot_block_type,
+      TView<Int, 1, D> block_ind_for_rot,
+      TView<Int, 1, D> pose_ind_for_rot,
+      TView<Int, 1, D> block_type_ind_for_rot,
+      TView<Int, 1, D> n_rots_for_pose,
+      TView<Int, 1, D> rot_offset_for_pose,
+      TView<Int, 2, D> n_rots_for_block,
+      TView<Int, 2, D> rot_offset_for_block,
+      Int max_n_rots_per_pose,
+      TView<Int, 3, D> pose_stack_min_bond_separation,
+      TView<Int, 5, D> pose_stack_inter_block_bondsep,
+      TView<Int, 1, D> block_type_n_atoms,
+      TView<Int, 2, D> block_type_atom_types,
+      TView<Int, 1, D> block_type_n_interblock_bonds,
+      TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+      TView<Int, 3, D> block_type_ljlk_path_distance,
+      TView<Int, 1, D> block_type_is_ligand_fragment,
+      TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+      TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+      TView<Real, 2, D> block_type_partial_charge,
+      TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+      TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+      TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+          elec_global_params,
+      Real max_dis,
+      TView<Real, 1, D> score_weights)
+      -> std::tuple<
+          TPack<Real, 4, D>,
+          TPack<LJLKExternalVec<Real, 3>, 2, D>,
+          TPack<Int, 2, D>>;
+
   /// Reduce score lanes with live weights in one device pass. The lane at
   /// fused_weight_begin is already weighted and represents fused_weight_width
   /// canonical lanes; all later lanes map past that canonical range.

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -42,6 +42,7 @@ struct SingleResData {
 template <typename Real>
 struct ScoringData {
   int pose_ind;
+  int output_ind;
   int block_ind1;
   int block_ind2;
   SingleResData<Real> r1;
@@ -242,6 +243,7 @@ TMOL_DEVICE_FUNC std::array<Real, 4> score_atom_pair(
 
 template <
     bool weighted,
+    bool rotamer_pairs,
     template <tmol::Device> class DeviceOperations,
     tmol::Device D,
     int nt,
@@ -256,7 +258,11 @@ TMOL_DEVICE_FUNC void store_score_totals(
     Real const total = DeviceOperations<D>::template reduce_in_workgroup<nt>(
         data.total_weighted, shared, mgpu::plus_t<Real>());
     if (tid == 0) {
-      accumulate<D, Real>::add(output[0][data.pose_ind][0][0], total);
+      if constexpr (rotamer_pairs) {
+        output[0][0][0][data.output_ind] = total;
+      } else {
+        accumulate<D, Real>::add(output[0][data.pose_ind][0][0], total);
+      }
     }
   } else {
     Real const totals[4] = {
@@ -282,6 +288,7 @@ TMOL_DEVICE_FUNC void store_score_totals(
 template <
     bool require_gradient,
     bool weighted,
+    bool rotamer_pairs,
     template <tmol::Device> class DeviceOperations,
     tmol::Device D,
     typename Real,
@@ -317,6 +324,7 @@ auto ljlk_elec_forward_impl(
     TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
         elec_global_params,
     TView<Int, 1, D> shared_compact_block_neighbors,
+    TView<Int, 2, D> rotamer_dispatch_indices,
     TView<Real, 1, D> score_weights)
     -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
   using namespace ljlk_elec_detail;
@@ -337,7 +345,12 @@ auto ljlk_elec_forward_impl(
   (void)max_n_rots_per_pose;
 
   int constexpr n_output_scores = weighted ? 1 : 4;
-  auto output_t = TPack<Real, 4, D>::zeros({n_output_scores, n_poses, 1, 1});
+  int const n_outputs =
+      rotamer_pairs ? rotamer_dispatch_indices.size(1) : n_poses;
+  auto output_t =
+      rotamer_pairs
+          ? TPack<Real, 4, D>::empty({n_output_scores, 1, 1, n_outputs})
+          : TPack<Real, 4, D>::zeros({n_output_scores, n_outputs, 1, 1});
   auto output = output_t.view;
   auto dV_dcoords_t =
       require_gradient ? TPack<Real3, 2, D>::zeros({n_output_scores, n_atoms})
@@ -348,17 +361,39 @@ auto ljlk_elec_forward_impl(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   auto eval_neighbor = ([=] TMOL_DEVICE_FUNC(int candidate) {
-    int const pose_ind = candidate / max_n_upper_triangle_inds;
-    auto const pair = common::upper_triangle_inds_from_linear_index(
-        candidate % max_n_upper_triangle_inds, max_n_blocks + 1);
-    int const block_ind1 = common::get<0>(pair);
-    int const block_ind2 = common::get<1>(pair) - 1;
-    int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
-    int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
-    if (rot_ind1 < 0 || rot_ind2 < 0) return;
+    int pose_ind;
+    int rot_ind1;
+    int rot_ind2;
+    int block_ind1;
+    int block_ind2;
+    // A normal branch is intentional here. NVCC rejects first capture of a
+    // view from an extended device lambda inside constexpr-if; rotamer_pairs
+    // is a template constant, so optimized code still contains one path.
+    if (rotamer_pairs) {
+      pose_ind = rotamer_dispatch_indices[0][candidate];
+      rot_ind1 = rotamer_dispatch_indices[1][candidate];
+      rot_ind2 = rotamer_dispatch_indices[2][candidate];
+      block_ind1 = block_ind_for_rot[rot_ind1];
+      block_ind2 = block_ind_for_rot[rot_ind2];
+    } else {
+      pose_ind = candidate / max_n_upper_triangle_inds;
+      auto const pair = common::upper_triangle_inds_from_linear_index(
+          candidate % max_n_upper_triangle_inds, max_n_blocks + 1);
+      block_ind1 = common::get<0>(pair);
+      block_ind2 = common::get<1>(pair) - 1;
+      rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
+      rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
+    }
+    if (rot_ind1 < 0 || rot_ind2 < 0) {
+      if (rotamer_pairs) output[0][0][0][candidate] = 0;
+      return;
+    }
     int const block_type1 = block_type_ind_for_rot[rot_ind1];
     int const block_type2 = block_type_ind_for_rot[rot_ind2];
-    if (block_type1 < 0 || block_type2 < 0) return;
+    if (block_type1 < 0 || block_type2 < 0) {
+      if (rotamer_pairs) output[0][0][0][candidate] = 0;
+      return;
+    }
     int const n_atoms1 = block_type_n_atoms[block_type1];
     int const n_atoms2 = block_type_n_atoms[block_type2];
 
@@ -381,6 +416,7 @@ auto ljlk_elec_forward_impl(
                                   ScoringData<Real>& data,
                                   shared_mem_union& sm) {
       data.pose_ind = p;
+      data.output_ind = candidate;
       data.block_ind1 = b1;
       data.block_ind2 = b2;
       data.r1.block_type = bt1;
@@ -685,14 +721,15 @@ auto ljlk_elec_forward_impl(
       eval_pairs(data, start1, start2, true);
     });
 
-    auto store_energies =
-        ([=] TMOL_DEVICE_FUNC(ScoringData<Real> & data, shared_mem_union & sm) {
-          auto reduce = ([&](int tid) {
-            store_score_totals<weighted, DeviceOperations, D, nt>(
-                tid, data, sm, output);
-          });
-          DeviceOperations<D>::template for_each_in_workgroup<nt>(reduce);
-        });
+    auto store_energies = ([=] TMOL_DEVICE_FUNC(
+                               ScoringData<Real> & data,
+                               shared_mem_union & sm) {
+      auto reduce = ([&](int tid) {
+        store_score_totals<weighted, rotamer_pairs, DeviceOperations, D, nt>(
+            tid, data, sm, output);
+      });
+      DeviceOperations<D>::template for_each_in_workgroup<nt>(reduce);
+    });
 
     common::tile_evaluate_rot_pair<
         DeviceOperations,
@@ -725,9 +762,14 @@ auto ljlk_elec_forward_impl(
         store_energies);
   });
 
-  common::sphere_overlap::
-      launch_precomputed_block_neighbors<DeviceOperations, D, launch_t, Int>(
-          mgr, shared_compact_block_neighbors, eval_neighbor);
+  if constexpr (rotamer_pairs) {
+    DeviceOperations<D>::template foreach_independent_workgroup<launch_t>(
+        mgr, n_outputs, eval_neighbor);
+  } else {
+    common::sphere_overlap::
+        launch_precomputed_block_neighbors<DeviceOperations, D, launch_t, Int>(
+            mgr, shared_compact_block_neighbors, eval_neighbor);
+  }
   return {output_t, dV_dcoords_t};
 }
 
@@ -783,12 +825,31 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       block_type_elec_intra_repr_path_distance, elec_global_params,           \
       shared_compact_block_neighbors
   auto empty_weights = TPack<Real, 1, D>::empty({0});
+  auto empty_rotamer_dispatch = TPack<Int, 2, D>::empty({0, 0});
   if (require_gradient) {
-    return ljlk_elec_forward_impl<true, false, DeviceOperations, D, Real, Int>(
-        TMOL_LJLK_ELEC_FORWARD_ARGS, empty_weights.view);
+    return ljlk_elec_forward_impl<
+        true,
+        false,
+        false,
+        DeviceOperations,
+        D,
+        Real,
+        Int>(
+        TMOL_LJLK_ELEC_FORWARD_ARGS,
+        empty_rotamer_dispatch.view,
+        empty_weights.view);
   }
-  return ljlk_elec_forward_impl<false, false, DeviceOperations, D, Real, Int>(
-      TMOL_LJLK_ELEC_FORWARD_ARGS, empty_weights.view);
+  return ljlk_elec_forward_impl<
+      false,
+      false,
+      false,
+      DeviceOperations,
+      D,
+      Real,
+      Int>(
+      TMOL_LJLK_ELEC_FORWARD_ARGS,
+      empty_rotamer_dispatch.view,
+      empty_weights.view);
 #undef TMOL_LJLK_ELEC_FORWARD_ARGS
 }
 
@@ -844,14 +905,153 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       ljlk_type_params, ljlk_global_params, block_type_partial_charge,        \
       block_type_elec_inter_repr_path_distance,                               \
       block_type_elec_intra_repr_path_distance, elec_global_params,           \
-      shared_compact_block_neighbors, score_weights
+      shared_compact_block_neighbors
+  auto empty_rotamer_dispatch = TPack<Int, 2, D>::empty({0, 0});
   if (require_gradient) {
-    return ljlk_elec_forward_impl<true, true, DeviceOperations, D, Real, Int>(
-        TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS);
+    return ljlk_elec_forward_impl<
+        true,
+        true,
+        false,
+        DeviceOperations,
+        D,
+        Real,
+        Int>(
+        TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
+        empty_rotamer_dispatch.view,
+        score_weights);
   }
-  return ljlk_elec_forward_impl<false, true, DeviceOperations, D, Real, Int>(
-      TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS);
+  return ljlk_elec_forward_impl<
+      false,
+      true,
+      false,
+      DeviceOperations,
+      D,
+      Real,
+      Int>(
+      TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
+      empty_rotamer_dispatch.view,
+      score_weights);
 #undef TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS
+}
+
+template <
+    template <tmol::Device> class DeviceOperations,
+    tmol::Device D,
+    typename Real,
+    typename Int>
+auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
+    forward_weighted_rotamers(
+        ContextManager& mgr,
+        TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
+        TView<Int, 1, D> rot_coord_offset,
+        TView<Int, 1, D> pose_ind_for_atom,
+        TView<Int, 2, D> first_rot_for_block,
+        TView<Int, 2, D> first_rot_block_type,
+        TView<Int, 1, D> block_ind_for_rot,
+        TView<Int, 1, D> pose_ind_for_rot,
+        TView<Int, 1, D> block_type_ind_for_rot,
+        TView<Int, 1, D> n_rots_for_pose,
+        TView<Int, 1, D> rot_offset_for_pose,
+        TView<Int, 2, D> n_rots_for_block,
+        TView<Int, 2, D> rot_offset_for_block,
+        Int max_n_rots_per_pose,
+        TView<Int, 3, D> pose_stack_min_bond_separation,
+        TView<Int, 5, D> pose_stack_inter_block_bondsep,
+        TView<Int, 1, D> block_type_n_atoms,
+        TView<Int, 2, D> block_type_atom_types,
+        TView<Int, 1, D> block_type_n_interblock_bonds,
+        TView<Int, 2, D> block_type_atoms_forming_chemical_bonds,
+        TView<Int, 3, D> block_type_ljlk_path_distance,
+        TView<Int, 1, D> block_type_is_ligand_fragment,
+        TView<LJLKTypeParams<Real>, 1, D> ljlk_type_params,
+        TView<LJGlobalParams<Real>, 1, D> ljlk_global_params,
+        TView<Real, 2, D> block_type_partial_charge,
+        TView<Int, 3, D> block_type_elec_inter_repr_path_distance,
+        TView<Int, 3, D> block_type_elec_intra_repr_path_distance,
+        TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
+            elec_global_params,
+        Real max_dis,
+        TView<Real, 1, D> score_weights)
+        -> std::tuple<
+            TPack<Real, 4, D>,
+            TPack<LJLKExternalVec<Real, 3>, 2, D>,
+            TPack<Int, 2, D>> {
+  int const n_rots = rot_coord_offset.size(0);
+  int const n_poses = first_rot_for_block.size(0);
+  int const max_n_blocks = first_rot_for_block.size(1);
+  auto scratch_rot_spheres_t = D == Device::CPU
+                                   ? TPack<Real, 2, D>::zeros({n_rots, 4})
+                                   : TPack<Real, 2, D>::empty({n_rots, 4});
+  auto scratch_block_spheres_t =
+      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+  auto scratch_block_neighbors_t =
+      D == Device::CPU
+          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
+  score::common::sphere_overlap::
+      compute_rot_spheres<DeviceOperations, D, Real, Int>::f(
+          mgr,
+          rot_coords,
+          rot_coord_offset,
+          block_type_ind_for_rot,
+          block_type_n_atoms,
+          scratch_rot_spheres_t.view);
+  score::common::sphere_overlap::
+      compute_block_spheres_from_rot_spheres<DeviceOperations, D, Real, Int>::f(
+          mgr,
+          scratch_rot_spheres_t.view,
+          n_rots_for_block,
+          rot_offset_for_block,
+          scratch_block_spheres_t.view);
+  score::common::sphere_overlap::
+      detect_block_neighbors<DeviceOperations, D, Real, Int>::f(
+          mgr,
+          first_rot_block_type,
+          scratch_block_spheres_t.view,
+          scratch_block_neighbors_t.view,
+          max_dis);
+  auto rotamer_dispatch_indices = score::common::sphere_overlap::
+      rot_neighbor_indices_from_block_neighbors<DeviceOperations, D, Int>::f(
+          mgr,
+          scratch_block_neighbors_t.view,
+          n_rots_for_block,
+          rot_offset_for_block);
+  auto empty_compact_block_neighbors = TPack<Int, 1, D>::empty({0});
+  auto result =
+      ljlk_elec_forward_impl<false, true, true, DeviceOperations, D, Real, Int>(
+          mgr,
+          rot_coords,
+          rot_coord_offset,
+          pose_ind_for_atom,
+          first_rot_for_block,
+          first_rot_block_type,
+          block_ind_for_rot,
+          pose_ind_for_rot,
+          block_type_ind_for_rot,
+          n_rots_for_pose,
+          rot_offset_for_pose,
+          n_rots_for_block,
+          rot_offset_for_block,
+          max_n_rots_per_pose,
+          pose_stack_min_bond_separation,
+          pose_stack_inter_block_bondsep,
+          block_type_n_atoms,
+          block_type_atom_types,
+          block_type_n_interblock_bonds,
+          block_type_atoms_forming_chemical_bonds,
+          block_type_ljlk_path_distance,
+          block_type_is_ligand_fragment,
+          ljlk_type_params,
+          ljlk_global_params,
+          block_type_partial_charge,
+          block_type_elec_inter_repr_path_distance,
+          block_type_elec_intra_repr_path_distance,
+          elec_global_params,
+          empty_compact_block_neighbors.view,
+          rotamer_dispatch_indices.view,
+          score_weights);
+  return {std::get<0>(result), std::get<1>(result), rotamer_dispatch_indices};
 }
 
 template <

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -33,10 +33,16 @@ from tmol.io import pose_stack_from_pdb
 from tmol.score.constraint import ConstraintEnergyTerm
 from tmol.pack._pack_rotamers import (
     _PACKER_TASK_POSE_TENSORS,
+    _interaction_graph_chunk_size,
     _max_poses_per_packing_chunk,
     _slice_packer_task,
     _slice_pose_stack_for_packing,
 )
+
+
+def test_interaction_graph_chunk_size_is_backend_specific(torch_device):
+    expected = 32 if torch_device.type == "cuda" else 16
+    assert _interaction_graph_chunk_size(torch_device) == expected
 
 
 def setup_pose_stack_and_task(poses, torch_device, dun_sampler):
@@ -384,6 +390,166 @@ def test_shared_rotamer_dispatch_matches_independent_lk_ball_layout(
         assert shared_error <= 2 * repeat_error + 1e-6
     else:
         torch.testing.assert_close(shared_grad, fallback_grad)
+
+
+def test_shared_rotamer_dispatch_matches_independent_hbond_layout(
+    default_database, ubq_pdb, dun_sampler, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=10)
+    pose_stack, task = setup_pose_stack_and_task([pose], torch_device, dun_sampler)
+    sfxn = get_packer_sfxn(default_database, torch_device)
+    pose_stack, rotamer_set = build_rotamers(
+        pose_stack,
+        SetPackerTask.from_packer_task(task),
+        pose_stack.packed_block_types.chem_db,
+    )
+    scorer = sfxn.render_rotamer_scoring_module(pose_stack, rotamer_set)
+    ljlk = next(term for term in scorer.term_modules if term.classname == "LJLK")
+    hbond = next(term for term in scorer.term_modules if term.classname == "HBond")
+
+    def dense_hbond(coords, shared_indices=None):
+        if shared_indices is None:
+            scores, indices = hbond.forward(coords)
+        else:
+            scores, indices = hbond.forward(coords, shared_indices)
+            assert indices.is_set_to(shared_indices)
+        sparse = torch.sparse_coo_tensor(
+            indices.to(torch.int64),
+            scores[0],
+            (hbond.n_poses, hbond.n_rots, hbond.n_rots),
+            check_invariants=False,
+        )
+        return sparse.coalesce().to_dense()
+
+    shared_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    _, shared_indices = ljlk.forward(shared_coords)
+    shared = dense_hbond(shared_coords, shared_indices)
+    (shared_grad,) = torch.autograd.grad(shared.sum(), shared_coords)
+
+    independent_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    independent = dense_hbond(independent_coords)
+    (independent_grad,) = torch.autograd.grad(independent.sum(), independent_coords)
+
+    torch.testing.assert_close(shared, independent)
+    if torch_device.type == "cuda":
+        repeat_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+        repeat = dense_hbond(repeat_coords)
+        (repeat_grad,) = torch.autograd.grad(repeat.sum(), repeat_coords)
+        torch.testing.assert_close(independent, repeat)
+        repeat_error = torch.max(torch.abs(independent_grad - repeat_grad))
+        shared_error = torch.max(torch.abs(shared_grad - independent_grad))
+        assert shared_error <= 2 * repeat_error + 1e-6
+    else:
+        torch.testing.assert_close(shared_grad, independent_grad)
+
+    if torch_device.type == "cuda":
+        dispatch_key = hbond.rotamer_dispatch_key
+        with torch.no_grad():
+            hbond.rotamer_dispatch_key = None
+            independent_indices, *_ = scorer._weighted_entries_by_layout(
+                rotamer_set.coords
+            )
+            hbond.rotamer_dispatch_key = dispatch_key
+            shared_indices, *_ = scorer._weighted_entries_by_layout(rotamer_set.coords)
+        assert sum(layout.shape[1] for layout in shared_indices) < sum(
+            layout.shape[1] for layout in independent_indices
+        )
+
+
+def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
+    default_database, ubq_pdb, dun_sampler, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=10)
+    pose_stack, task = setup_pose_stack_and_task([pose], torch_device, dun_sampler)
+    task = SetPackerTask.from_packer_task(task)
+    sfxn = get_packer_sfxn(default_database, torch_device)
+    pose_stack, rotamer_set = build_rotamers(
+        pose_stack, task, pose_stack.packed_block_types.chem_db
+    )
+    scorer = sfxn.render_rotamer_scoring_module(pose_stack, rotamer_set)
+    assert scorer._fused_ljlk_elec is not None
+    if torch_device.type == "cpu":
+        scorer._cpu_term_workers = 1
+
+    with torch.no_grad():
+        fused = scorer(rotamer_set.coords).coalesce()
+        fused_group = scorer._fused_ljlk_elec
+        scorer._fused_ljlk_elec = None
+        separate = scorer(rotamer_set.coords).coalesce()
+        scorer._fused_ljlk_elec = fused_group
+
+    assert torch.equal(fused.indices(), separate.indices())
+    torch.testing.assert_close(fused.values(), separate.values(), atol=2e-3, rtol=2e-5)
+
+    # Weights are read at every call instead of being specialized into the
+    # rendered module.
+    weight_begin = scorer._fused_ljlk_elec_weight_offset
+    with torch.no_grad():
+        scorer.weights[weight_begin : weight_begin + 4, 0, 0, 0] *= torch.tensor(
+            [0.5, 1.25, 0.75, 0.0], device=torch_device
+        )
+        reweighted_fused = scorer(rotamer_set.coords).coalesce()
+        scorer._fused_ljlk_elec = None
+        reweighted_separate = scorer(rotamer_set.coords).coalesce()
+        scorer._fused_ljlk_elec = fused_group
+    assert torch.equal(reweighted_fused.indices(), reweighted_separate.indices())
+    torch.testing.assert_close(
+        reweighted_fused.values(),
+        reweighted_separate.values(),
+        atol=2e-3,
+        rtol=2e-5,
+    )
+
+    # Fusion remains the measured fast path when the term pool has four CPU
+    # workers; each native operator can still use ATen's inner CPU parallelism.
+    if torch_device.type == "cpu":
+        original_forward = fused_group.forward
+        fused_calls = []
+
+        def record_fused_call(*args):
+            fused_calls.append(None)
+            return original_forward(*args)
+
+        fused_group.forward = record_fused_call
+        scorer._cpu_term_workers = 4
+        with torch.no_grad():
+            parallel_scores = scorer(rotamer_set.coords).coalesce()
+        assert len(fused_calls) == 1
+        assert torch.equal(parallel_scores.indices(), reweighted_fused.indices())
+        torch.testing.assert_close(
+            parallel_scores.values(), reweighted_fused.values(), atol=2e-3, rtol=2e-5
+        )
+        scorer._cpu_term_workers = 1
+        fused_group.forward = original_forward
+
+    # A caller that changes either dispatch cutoff must use the canonical
+    # operators, since the fused traversal assumes the default compatible pair.
+    original_cutoff = fused_group.ljlk_module.block_neighbor_cutoff
+    fused_group.ljlk_module.block_neighbor_cutoff = original_cutoff + 0.25
+    fused_group.forward = lambda *_: pytest.fail(
+        "fusion used after changing a live dispatch cutoff"
+    )
+    with torch.no_grad():
+        changed_cutoff = scorer(rotamer_set.coords).coalesce()
+    assert changed_cutoff._nnz() != 0
+    fused_group.ljlk_module.block_neighbor_cutoff = original_cutoff
+
+    # Differentiable callers must retain the canonical independent operators.
+    fused_group.forward = lambda *_: pytest.fail(
+        "packing-only fusion used for a differentiable call"
+    )
+    coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    differentiable = scorer(coords).coalesce()
+    differentiable.values().sum().backward()
+    assert coords.grad is not None
+    assert torch.isfinite(coords.grad).all()
+
+    scorer.weights.requires_grad_(True)
+    weight_differentiable = scorer(rotamer_set.coords.detach()).coalesce()
+    weight_differentiable.values().sum().backward()
+    assert scorer.weights.grad is not None
+    assert torch.isfinite(scorer.weights.grad).all()
+    assert torch.count_nonzero(scorer.weights.grad[:4]) != 0
 
 
 def test_pack_rotamers_optH(default_database, ubq_pdb, torch_device):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -137,6 +137,15 @@ def test_fused_ljlk_elec_preserves_term_lanes_weights_and_gradients(
     torch.testing.assert_close(weighted_lanes, fused_lanes.detach() * fused.weights)
     torch.testing.assert_close(fused(pose.coords), weighted_lanes.sum(dim=0))
 
+    # Compact weighted fusion intentionally has no weight backward. If callers
+    # make the score-function weights trainable, retain the canonical lanes so
+    # PyTorch can differentiate the ordinary elementwise weighting operation.
+    fused.weights.requires_grad_(True)
+    fused(pose.coords.detach()).sum().backward()
+    assert fused.weights.grad is not None
+    assert torch.isfinite(fused.weights.grad).all()
+    assert torch.count_nonzero(fused.weights.grad[:4]) != 0
+
 
 def test_fused_ljlk_elec_weighted_gradient_finite_difference(
     ubq_pdb, default_database, torch_device

--- a/tmol/tests/utility/test_cpp_extension.py
+++ b/tmol/tests/utility/test_cpp_extension.py
@@ -16,6 +16,17 @@ def test_active_torch_cxx_standard_flags_match():
     assert f"-std=c++{expected}" in _cpp_extension._required_cuda_flags
 
 
+def test_jit_openmp_flags_match_torch_backend():
+    select = _cpp_extension._jit_openmp_flags
+
+    assert select("linux", "ATen parallel backend: OpenMP") == (
+        ["-fopenmp"],
+        ["-fopenmp"],
+    )
+    assert select("linux", "ATen parallel backend: native thread pool") == ([], [])
+    assert select("darwin", "ATen parallel backend: OpenMP") == ([], [])
+
+
 def test_select_cuda_architecture_prefers_active_device():
     select = _cpp_extension._select_cuda_architecture
     assert select(None, (9, 0)) == "9.0"
@@ -37,6 +48,18 @@ def test_custom_extension_flags_preserve_release_optimization():
 
     assert kwargs["extra_cflags"][:2] == ["-O3", "-DCUSTOM_CXX"]
     assert kwargs["extra_cuda_cflags"][:2] == ["-O3", "-DCUSTOM_CUDA"]
+
+
+def test_custom_extension_linker_flags_are_preserved():
+    kwargs = _cpp_extension._augment_kwargs(
+        "test_extension",
+        ["test.cpp"],
+        extra_ldflags=["-Wl,--custom"],
+        with_cuda=False,
+    )
+
+    assert kwargs["extra_ldflags"][0] == "-Wl,--custom"
+    assert kwargs["extra_ldflags"][1:] == _cpp_extension._openmp_ldflags
 
 
 def test_custom_extension_include_paths_are_preserved():

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 import warnings
 from functools import wraps
 
@@ -84,6 +85,27 @@ _required_cuda_flags = [
 ]
 
 
+def _jit_openmp_flags(platform, parallel_info):
+    """Return compiler and linker flags for Torch's OpenMP CPU backend.
+
+    Linux Torch wheels use OpenMP for ``at::parallel_for``. Unlike the CMake
+    build, ``torch.utils.cpp_extension`` does not propagate Torch's OpenMP
+    flags to extensions, so JIT-built CPU kernels would otherwise run serially.
+    Other Torch backends and platforms need no additional flags here.
+    """
+    if (
+        platform.startswith("linux")
+        and "ATen parallel backend: OpenMP" in parallel_info
+    ):
+        return ["-fopenmp"], ["-fopenmp"]
+    return [], []
+
+
+_openmp_cflags, _openmp_ldflags = _jit_openmp_flags(
+    sys.platform, torch.__config__.parallel_info()
+)
+
+
 def _select_cuda_architecture(arch_list, device_capability):
     """Choose the active device from a possibly multi-architecture setting."""
     current = ".".join(str(part) for part in device_capability)
@@ -150,7 +172,10 @@ _default_cuda_flags = ["-O3"]
 # commands to the terminal
 def _augment_kwargs(name, sources, **kwargs):
     kwargs["extra_cflags"] = (
-        _default_flags + list(kwargs.get("extra_cflags", [])) + _required_flags
+        _default_flags
+        + list(kwargs.get("extra_cflags", []))
+        + _required_flags
+        + _openmp_cflags
     )
     kwargs["extra_cuda_cflags"] = (
         _default_cuda_flags
@@ -160,6 +185,7 @@ def _augment_kwargs(name, sources, **kwargs):
     kwargs["extra_include_paths"] = (
         list(kwargs.get("extra_include_paths", [])) + _default_include_paths
     )
+    kwargs["extra_ldflags"] = list(kwargs.get("extra_ldflags", [])) + _openmp_ldflags
 
     if kwargs.get("with_cuda") is None:
         with_cuda = any(map(_is_cuda_file, sources))


### PR DESCRIPTION
## Summary

- fuse canonical LJ/LK and electrostatics rotamer scoring into one live-weighted native traversal, with the ordinary term path retained for custom terms, changed cutoffs, trainable parameters, or differentiable scoring
- reuse compatible sparse rotamer dispatches between pairwise terms and widen CUDA interaction-graph chunks from 16 to 32
- make JIT CPU extensions honor the same OpenMP execution model as packaged builds
- keep automatic FastRelax CUDA Graph capture workload-aware while retaining the explicit user override
- document CPU thread control and CUDA Graph latency tradeoffs

Term weights remain live and may be changed or set to zero after rendering. Individual terms can still be enabled or disabled; unsupported configurations automatically use the existing independent scoring path.

## Performance

All comparisons use `origin/master` (`4d11ef713`) as the baseline. End-to-end figures use clean AOT wheels; focused causal studies use isolated JIT caches:

- CPU FastRelax for a 43-residue protein, 208-residue protein-ligand complex, and 154-residue protein-nucleic-acid complex: 1.18-1.19x at one thread, 1.08-1.10x at four threads, and 1.09-1.14x at eight threads
- CPU rotamer score-table construction: approximately 1.21-1.32x in the measured default packing workloads
- H200 shared H-bond dispatch: 1.006-1.035x end-to-end with about 44-46% less dispatch scratch memory
- H200 interaction graph chunking: 1.007-1.053x across the six accepted batch/size measurements

Steady score+gradient throughput is unchanged within measurement noise: 1.0000x geometric mean across 96 clean AOT records (range 0.984-1.011x). This PR targets packing and FastRelax work.

## Validation

- focused CPU suites: 127 passed, 92 skipped, 2 expected failures
- focused CUDA suites: 207 passed, 12 skipped, 2 expected failures
- clean AOT CPU and CUDA builds
- clang-format, Black, and Flake8
- reversed-order, repeated A/B benchmarks with strict source and wheel provenance

Benchmark harnesses and raw results are intentionally kept outside the repository.
