### PR TITLE
Harden block-pair dispatch arithmetic

### DIFF
--- a/tmol/score/common/counting.hh
+++ b/tmol/score/common/counting.hh
@@ -44,6 +44,28 @@ inline int checked_dispatch_product(
       checked_count_product(lhs, rhs, operation), operation);
 }
 
+inline int checked_triangular_size(
+    int64_t count, bool include_diagonal, char const* operation) {
+  if (count < 0) {
+    throw std::overflow_error(
+        std::string(operation) + " received a negative dimension");
+  }
+  if (!include_diagonal && count < 2) {
+    return 0;
+  }
+  if (include_diagonal && count == std::numeric_limits<int64_t>::max()) {
+    return checked_dispatch_size(count, operation);
+  }
+  int64_t lhs = count;
+  int64_t rhs = count + (include_diagonal ? 1 : -1);
+  if (lhs % 2 == 0) {
+    lhs /= 2;
+  } else {
+    rhs /= 2;
+  }
+  return checked_dispatch_product(lhs, rhs, operation);
+}
+
 }  // namespace common
 }  // namespace score
 }  // namespace tmol

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -37,10 +37,13 @@ inline bool should_compact_block_neighbors(
   constexpr int min_inference_candidates = 1 << 16;
   constexpr int min_batched_blocks_for_derivatives = 1000;
   int64_t const pairs_per_pose =
-      (int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2;
+      (int64_t(max_n_blocks) * (int64_t(max_n_blocks) + 1)) / 2;
+  bool const enough_inference_candidates =
+      n_poses > 0
+      && pairs_per_pose
+             >= (min_inference_candidates + int64_t(n_poses) - 1) / n_poses;
   bool const large_inference_workload =
-      max_n_blocks >= min_blocks_per_pose
-      || int64_t(n_poses) * pairs_per_pose >= min_inference_candidates;
+      max_n_blocks >= min_blocks_per_pose || enough_inference_candidates;
   if (!large_inference_workload) return false;
   return !computes_derivatives
          || (max_n_blocks >= min_blocks_per_pose
@@ -516,7 +519,8 @@ bool try_cpu_spatial_compact_block_neighbors(
     suffix_max_radius[position] = suffix_radius;
   }
 
-  int64_t const n_pairs = (int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2;
+  int64_t const n_pairs =
+      (int64_t(max_n_blocks) * (int64_t(max_n_blocks) + 1)) / 2;
   retained.reserve(
       std::min<int64_t>(
           n_pairs, std::max<int64_t>(16, int64_t(n_valid_blocks) * 32)));

--- a/tmol/score/common/upper_triangle_indices.hh
+++ b/tmol/score/common/upper_triangle_indices.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/tuple.hh>
 
@@ -13,8 +15,11 @@ inline tuple<int, int> TMOL_DEVICE_FUNC upper_triangle_inds_from_linear_index(
 ) {
   // from
   // https://stackoverflow.com/questions/27086195/linear-index-upper-triangular-matrix
-  int i = n - 2 - floor(sqrt(-8 * k + 4 * n * (n - 1) - 7) / 2.0 - 0.5);
-  int j = k + i + 1 - n * (n - 1) / 2 + (n - i) * ((n - i) - 1) / 2;
+  int64_t const discriminant =
+      -8 * int64_t(k) + 4 * int64_t(n) * int64_t(n - 1) - 7;
+  int const i = n - 2 - int(floor(sqrt(double(discriminant)) / 2.0 - 0.5));
+  int64_t const row_start = int64_t(i) * (2 * int64_t(n) - int64_t(i) - 1) / 2;
+  int const j = int(int64_t(k) - row_start + int64_t(i) + 1);
   return make_tuple(i, j);
 }
 

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -11,6 +11,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
@@ -564,8 +565,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "electrostatics block-pair dispatch");
 
   // We define two device lambdas, one for block-pair scoring and
   // one for full pose scoring. They are nearly identical, except
@@ -1030,8 +1031,8 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "electrostatics derivative block-pair dispatch");
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto elec_atom_energy_and_derivs =

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -11,6 +11,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
@@ -653,8 +654,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "hydrogen-bond block-pair dispatch");
 
   auto eval_energies = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto hbond_atom_energy = ([=] HBOND_ATOM_ENERGY);
@@ -910,8 +911,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::backward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "hydrogen-bond derivative block-pair dispatch");
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     int const max_important_bond_separation = 4;

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -6,6 +6,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/device_operations.hh>
 #include <tmol/score/common/launch_box_macros.hh>
 #include <tmol/score/common/sphere_overlap.impl.hh>
@@ -333,8 +334,8 @@ auto ljlk_elec_forward_impl(
   int const n_atoms = rot_coords.size(0);
   int const n_poses = first_rot_for_block.size(0);
   int const max_n_blocks = first_rot_for_block.size(1);
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "fused LJ/LK-electrostatics block-pair dispatch");
   (void)pose_ind_for_atom;
   (void)first_rot_block_type;
   (void)block_ind_for_rot;

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -11,6 +11,7 @@
 #include <tmol/utility/nvtx.hh>
 
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
@@ -699,16 +700,18 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::
         Real reach) -> TPack<Int, 1, D> {
   int const n_poses = first_rot_for_block.size(0);
   int const max_n_blocks = first_rot_for_block.size(1);
-  int const n_pairs =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const n_pairs = score::common::checked_triangular_size(
+      max_n_blocks, true, "LJ/LK compact block-neighbor dispatch");
+  int const n_candidates = score::common::checked_dispatch_product(
+      n_poses, n_pairs, "LJ/LK compact block-neighbor dispatch");
   auto block_spheres_t =
       D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
                        : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
   if constexpr (D == Device::CUDA) {
     auto neighbor_indices_t =
         rot_coord_offset.size(0) == 0
-            ? TPack<Int, 1, D>::zeros({n_poses * n_pairs + 1})
-            : TPack<Int, 1, D>::empty({n_poses * n_pairs + 1});
+            ? TPack<Int, 1, D>::zeros({int64_t(n_candidates) + 1})
+            : TPack<Int, 1, D>::empty({int64_t(n_candidates) + 1});
     score::common::sphere_overlap::
         compute_block_spheres<DeviceOperations, D, Real, Int, true>::f(
             mgr,
@@ -754,7 +757,7 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       return neighbor_indices_t;
     }
     auto neighbor_indices_t =
-        TPack<Int, 1, D>::zeros({int64_t(n_poses) * n_pairs + 1});
+        TPack<Int, 1, D>::zeros({int64_t(n_candidates) + 1});
     score::common::sphere_overlap::
         detect_compact_block_neighbors<DeviceOperations, D, Real, Int>::f(
             mgr,
@@ -945,8 +948,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "LJ/LK block-pair dispatch");
 
   // There are two versions of scoring:
   // Block-pair scoring, where the output is written to an n-pose x n-blocks x
@@ -1275,7 +1278,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(
         mgr, n_poses, max_n_upper_triangle_inds, eval_energies_by_block);
   } else {
-    int const n_workgroups = n_poses * max_n_upper_triangle_inds;
+    int const n_workgroups = score::common::checked_dispatch_product(
+        n_poses, max_n_upper_triangle_inds, "LJ/LK block-pair dispatch");
 #ifdef __NVCC__
     if (score::common::sphere_overlap::should_compact_block_neighbors(
             n_poses, max_n_blocks, require_gradient)) {
@@ -1454,8 +1458,8 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::backward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
   // The total number of unique block pairs (including self-pairs)
-  int const max_n_upper_triangle_inds =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
+      max_n_blocks, true, "LJ/LK derivative block-pair dispatch");
 
   auto eval_derivs = ([=] TMOL_DEVICE_FUNC(int cta) {
     auto atom_pair_lj_fn =

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -12,6 +12,7 @@
 
 #include <tmol/score/common/accumulate.hh>
 #include <tmol/score/common/count_pair.hh>
+#include <tmol/score/common/counting.hh>
 #include <tmol/score/common/data_loading.hh>
 #include <tmol/score/common/diamond_macros.hh>
 #include <tmol/score/common/geom.hh>
@@ -358,10 +359,9 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 
 template <common::TilePairMode Mode>
 inline TMOL_DEVICE_FUNC common::tuple<int, int, int> lk_ball_pose_pair_indices(
-    int cta, int max_n_blocks) {
+    int cta, int max_n_blocks, int n_pairs_with_diagonal) {
   if constexpr (Mode == common::TilePairMode::Inter) {
-    int const n_pairs =
-        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks - 1)) / 2);
+    int const n_pairs = n_pairs_with_diagonal - max_n_blocks;
     auto pair = common::upper_triangle_inds_from_linear_index(
         cta % n_pairs, max_n_blocks);
     return common::make_tuple(
@@ -370,8 +370,7 @@ inline TMOL_DEVICE_FUNC common::tuple<int, int, int> lk_ball_pose_pair_indices(
     int const block = cta % max_n_blocks;
     return common::make_tuple(cta / max_n_blocks, block, block);
   } else {
-    int const n_pairs =
-        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+    int const n_pairs = n_pairs_with_diagonal;
     auto pair = common::upper_triangle_inds_from_linear_index(
         cta % n_pairs, max_n_blocks + 1);
     return common::make_tuple(
@@ -386,8 +385,10 @@ template <
     typename Eval>
 void launch_lk_ball_pose_pair_workgroups(
     ContextManager& mgr, int n_poses, int max_n_blocks, Eval eval) {
-  int const n_pairs =
-      static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
+  int const n_pairs = score::common::checked_triangular_size(
+      max_n_blocks, true, "LK-ball block-pair dispatch");
+  int const n_candidate_pairs = score::common::checked_dispatch_product(
+      n_poses, n_pairs, "LK-ball block-pair dispatch");
 #ifdef __NVCC__
   auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
     eval(cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
@@ -395,7 +396,7 @@ void launch_lk_ball_pose_pair_workgroups(
   // The specialized kernels remove the cold intra/inter instruction path.
   // Use them only once their throughput gain exceeds the extra launch cost.
   constexpr int min_split_workgroups = 1 << 15;
-  if (max_n_blocks > 1 && n_poses * n_pairs >= min_split_workgroups) {
+  if (max_n_blocks > 1 && n_candidate_pairs >= min_split_workgroups) {
     auto eval_interres = ([=] TMOL_DEVICE_FUNC(int cta) {
       eval(cta, TilePairModeTag<common::TilePairMode::Inter>{});
     });
@@ -504,6 +505,8 @@ class LKBallPoseScoreDispatch {
     int const max_n_interblock_bonds =
         block_type_atoms_forming_chemical_bonds.size(1);
     int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
+    int const n_block_pairs = score::common::checked_triangular_size(
+        max_n_blocks, true, "LK-ball block-pair dispatch");
 
     bool const use_shared_compact_block_neighbors =
         shared_compact_block_neighbors.size(0) != 0;
@@ -626,8 +629,8 @@ class LKBallPoseScoreDispatch {
 
       int const max_important_bond_separation = 4;
 
-      auto pair_indices =
-          lk_ball_pose_pair_indices<pair_mode>(cta, max_n_blocks);
+      auto pair_indices = lk_ball_pose_pair_indices<pair_mode>(
+          cta, max_n_blocks, n_block_pairs);
       int const pose_ind = common::get<0>(pair_indices);
       int const block_ind1 = common::get<1>(pair_indices);
       int const block_ind2 = common::get<2>(pair_indices);
@@ -862,6 +865,8 @@ class LKBallPoseScoreDispatch {
     int const max_n_interblock_bonds =
         block_type_atoms_forming_chemical_bonds.size(1);
     int const max_n_tiles = block_type_tile_pol_occ_inds.size(1);
+    int const n_block_pairs = score::common::checked_triangular_size(
+        max_n_blocks, true, "LK-ball derivative block-pair dispatch");
     bool const use_compact_block_neighbors =
         compact_block_neighbors.size(0) != 0;
 
@@ -886,8 +891,8 @@ class LKBallPoseScoreDispatch {
                             int cta) {
       constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
 #endif
-      auto pair_indices =
-          lk_ball_pose_pair_indices<pair_mode>(cta, max_n_blocks);
+      auto pair_indices = lk_ball_pose_pair_indices<pair_mode>(
+          cta, max_n_blocks, n_block_pairs);
       int const pose_ind = common::get<0>(pair_indices);
       int const block_ind1 = common::get<1>(pair_indices);
       int const block_ind2 = common::get<2>(pair_indices);
@@ -1106,9 +1111,10 @@ class LKBallPoseScoreDispatch {
           Int>(mgr, compact_block_neighbors, eval_compact);
       return {dV_d_pose_coords_t, dV_d_water_coords_t};
     }
-    int const n_pairs =
-        static_cast<int>((int64_t(max_n_blocks) * (max_n_blocks + 1)) / 2);
-    int const n_candidate_pairs = n_poses * n_pairs;
+    int const n_pairs = score::common::checked_triangular_size(
+        max_n_blocks, true, "LK-ball derivative block-pair dispatch");
+    int const n_candidate_pairs = score::common::checked_dispatch_product(
+        n_poses, n_pairs, "LK-ball derivative block-pair dispatch");
     constexpr int max_persistent_workgroups = 1 << 14;
     int const n_workgroups = n_candidate_pairs < max_persistent_workgroups
                                  ? n_candidate_pairs

--- a/tmol/tests/score/common/device_operations/test.pybind.cpp
+++ b/tmol/tests/score/common/device_operations/test.pybind.cpp
@@ -1,5 +1,6 @@
 #include <tmol/utility/tensor/pybind.h>
 #include <tmol/score/common/counting.hh>
+#include <tmol/score/common/upper_triangle_indices.hh>
 #include <tmol/tests/score/common/device_operations/test.hh>
 #include <moderngpu/meta.hxx>
 
@@ -25,6 +26,26 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       },
       "lhs"_a,
       "rhs"_a);
+  m.def(
+      "test_checked_triangular_size",
+      [](int64_t count, bool include_diagonal) {
+        return tmol::score::common::checked_triangular_size(
+            count, include_diagonal, "test triangular dispatch");
+      },
+      "count"_a,
+      "include_diagonal"_a);
+  m.def(
+      "test_upper_triangle_indices",
+      [](int linear_index, int dimension) {
+        auto result =
+            tmol::score::common::upper_triangle_inds_from_linear_index(
+                linear_index, dimension);
+        return std::make_pair(
+            tmol::score::common::get<0>(result),
+            tmol::score::common::get<1>(result));
+      },
+      "linear_index"_a,
+      "dimension"_a);
   m.def(
       "test_safe_div_up",
       [](int value, int divisor) { return mgpu::div_up(value, divisor); },

--- a/tmol/tests/score/common/device_operations/test_device_operations.py
+++ b/tmol/tests/score/common/device_operations/test_device_operations.py
@@ -141,6 +141,59 @@ def test_checked_dispatch_product_rejects_overflow(ext, lhs, rhs):
         ext.test_checked_dispatch_product(lhs, rhs)
 
 
+@pytest.mark.parametrize(
+    "count,include_diagonal,expected",
+    [
+        (0, True, 0),
+        (0, False, 0),
+        (1, True, 1),
+        (1, False, 0),
+        (2, True, 3),
+        (2, False, 1),
+        (65535, True, 2147450880),
+        (65536, False, 2147450880),
+    ],
+)
+def test_checked_triangular_size_accepts_int32_boundary(
+    ext, count, include_diagonal, expected
+):
+    assert ext.test_checked_triangular_size(count, include_diagonal) == expected
+
+
+@pytest.mark.parametrize(
+    "count,include_diagonal",
+    [
+        (-1, True),
+        (65536, True),
+        (65537, False),
+        (2**63 - 1, True),
+        (2**63 - 1, False),
+    ],
+)
+def test_checked_triangular_size_rejects_overflow(ext, count, include_diagonal):
+    with pytest.raises(OverflowError, match="(negative|signed (32|64)-bit)"):
+        ext.test_checked_triangular_size(count, include_diagonal)
+
+
+@pytest.mark.parametrize(
+    "linear_index,dimension,expected",
+    [
+        (0, 4, (0, 1)),
+        (2, 4, (0, 3)),
+        (3, 4, (1, 2)),
+        (5, 4, (2, 3)),
+        (0, 65536, (0, 1)),
+        (65534, 65536, (0, 65535)),
+        (65535, 65536, (1, 2)),
+        (2147450879, 65536, (65534, 65535)),
+    ],
+)
+def test_upper_triangle_indices_avoid_intermediate_overflow(
+    ext, linear_index, dimension, expected
+):
+    assert ext.test_upper_triangle_indices(linear_index, dimension) == expected
+
+
 def test_dispatch_ceiling_division_does_not_overflow(ext):
     assert ext.test_safe_div_up(2**31 - 1, 32) == 2**26
 


### PR DESCRIPTION
## Summary

- add one checked triangular-count helper that divides before multiplying and rejects negative, signed-64-bit, and native signed-32-bit overflow
- use checked triangular and pose-by-pair counts throughout LJ/LK, fused LJ/LK-electrostatics, electrostatics, hydrogen-bond, and LK-ball dispatch
- make compact-neighbor heuristics and allocations overflow-safe without changing their threshold policy
- evaluate inverse upper-triangle indices with safe 64-bit intermediates, including the 65,536-dimension off-diagonal boundary

The change fails oversized native launches before allocation with the existing actionable dispatch-limit error. Normal dispatch remains int32; this does not replace compact/chunked execution with a monolithic int64 table.

## Validation

- CPU pair-scoring suites: 136 passed, 71 skipped, 2 expected failures
- CUDA pair-scoring suites: 207 passed, 2 expected failures
- direct lower/upper boundary tests for triangular counts and inverse mapping
- clang-format and `git diff --check`

This is intentionally separate from the performance work merged in #469.
