### PR TITLE
Reduce hydrogen-bond work and harden bonded dispatch

### DIFF
--- a/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
+++ b/tmol/score/cartbonded/potentials/cartbonded_pose_score.impl.hh
@@ -194,6 +194,10 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   int const max_n_blocks = first_rot_for_block.size(1);
 
   int const max_n_conns = pose_stack_inter_block_connections.size(2);
+  int const workgroups_per_pose = score::common::checked_dispatch_product(
+      max_n_blocks,
+      int64_t(max_n_conns) + 1,
+      "Cartesian bonded per-pose dispatch");
   int const n_block_types = cart_subgraph_offsets.size(0);
   int const n_subgraphs = cart_subgraphs.size(0);
   int const n_max_atoms_per_block = atom_unique_ids.size(1);
@@ -272,8 +276,8 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
       CTA_REAL_REDUCE_T_VARIABLE;
     } shared;
 
-    int const pose_ind = cta / (max_n_blocks * (max_n_conns + 1));
-    int const block_conn = cta % (max_n_blocks * (max_n_conns + 1));
+    int const pose_ind = cta / workgroups_per_pose;
+    int const block_conn = cta % workgroups_per_pose;
     int const block_ind1 = block_conn / (max_n_conns + 1);
     int const conn_ind1 = block_conn % (max_n_conns + 1);
     int const block_type1 = first_rot_block_type[pose_ind][block_ind1];
@@ -590,10 +594,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     DeviceDispatch<D>::template for_each_in_workgroup<nt>(reduce_energies);
   });
   DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
-      mgr,
-      n_poses,
-      max_n_blocks * (max_n_conns + 1),
-      eval_subgraphs_for_interaction);
+      mgr, n_poses, workgroups_per_pose, eval_subgraphs_for_interaction);
 
   return {V_t, dV_dx_t};
 }
@@ -651,6 +652,10 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
   int const max_n_blocks = first_rot_for_block.size(1);
 
   int const max_n_conns = pose_stack_inter_block_connections.size(2);
+  int const workgroups_per_pose = score::common::checked_dispatch_product(
+      max_n_blocks,
+      int64_t(max_n_conns) + 1,
+      "Cartesian bonded derivative per-pose dispatch");
   int const n_block_types = cart_subgraph_offsets.size(0);
   int const n_subgraphs = cart_subgraphs.size(0);
   int const n_max_atoms_per_block = atom_unique_ids.size(1);
@@ -699,8 +704,8 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
   auto dV_dx = dV_dx_t.view;
 
   auto eval_subgraphs_for_interaction = ([=] TMOL_DEVICE_FUNC(int cta) {
-    int const pose_ind = cta / (max_n_blocks * (max_n_conns + 1));
-    int const block_conn = cta % (max_n_blocks * (max_n_conns + 1));
+    int const pose_ind = cta / workgroups_per_pose;
+    int const block_conn = cta % workgroups_per_pose;
     int const block_ind1 = block_conn / (max_n_conns + 1);
     int const conn_ind1 = block_conn % (max_n_conns + 1);
     int const block_type1 = first_rot_block_type[pose_ind][block_ind1];
@@ -950,10 +955,7 @@ auto CartBondedPoseScoreDispatch<DeviceDispatch, D, Real, Int>::backward(
     // a second time
   });
   DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(
-      mgr,
-      n_poses,
-      max_n_blocks * (max_n_conns + 1),
-      eval_subgraphs_for_interaction);
+      mgr, n_poses, workgroups_per_pose, eval_subgraphs_for_interaction);
 
   return dV_dx_t;
 

--- a/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
+++ b/tmol/score/genbonded/potentials/genbonded_pose_score.impl.hh
@@ -433,6 +433,10 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
   int const n_poses = first_rot_for_block.size(0);
   int const max_n_blocks = first_rot_for_block.size(1);
   int const max_n_conns = pose_stack_inter_block_connections.size(2);
+  int const workgroups_per_pose = score::common::checked_dispatch_product(
+      max_n_blocks,
+      int64_t(max_n_conns) + 1,
+      "generic bonded per-pose dispatch");
   int const n_block_types = gen_intra_subgraph_offsets.size(0);
   int const n_total_intra = gen_intra_subgraphs.size(0);
 
@@ -458,8 +462,8 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
     } shared;
 
     // Decode CTA index: (pose, block, connection).
-    int const pose_ind = cta / (max_n_blocks * (max_n_conns + 1));
-    int const block_conn = cta % (max_n_blocks * (max_n_conns + 1));
+    int const pose_ind = cta / workgroups_per_pose;
+    int const block_conn = cta % workgroups_per_pose;
     int const block_ind1 = block_conn / (max_n_conns + 1);
     int const conn_ind1 = block_conn % (max_n_conns + 1);
     int const block_type1 = first_rot_block_type[pose_ind][block_ind1];
@@ -687,10 +691,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::forward(
   });
 
   DeviceOps<D>::template foreach_pose_workgroup<launch_t>(
-      mgr,
-      n_poses,
-      max_n_blocks * (max_n_conns + 1),
-      eval_torsions_for_interaction);
+      mgr, n_poses, workgroups_per_pose, eval_torsions_for_interaction);
 
   return {V_t, dV_dx_t};
 }
@@ -738,6 +739,10 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
   int const n_poses = first_rot_for_block.size(0);
   int const max_n_blocks = first_rot_for_block.size(1);
   int const max_n_conns = pose_stack_inter_block_connections.size(2);
+  int const workgroups_per_pose = score::common::checked_dispatch_product(
+      max_n_blocks,
+      int64_t(max_n_conns) + 1,
+      "generic bonded derivative per-pose dispatch");
   int const n_block_types = gen_intra_subgraph_offsets.size(0);
   int const n_total_intra = gen_intra_subgraphs.size(0);
 
@@ -748,8 +753,8 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
   CTA_REAL_REDUCE_T_TYPEDEF;
 
   auto eval_torsions_for_interaction = ([=] TMOL_DEVICE_FUNC(int cta) {
-    int const pose_ind = cta / (max_n_blocks * (max_n_conns + 1));
-    int const block_conn = cta % (max_n_blocks * (max_n_conns + 1));
+    int const pose_ind = cta / workgroups_per_pose;
+    int const block_conn = cta % workgroups_per_pose;
     int const block_ind1 = block_conn / (max_n_conns + 1);
     int const conn_ind1 = block_conn % (max_n_conns + 1);
     int const block_type1 = first_rot_block_type[pose_ind][block_ind1];
@@ -944,10 +949,7 @@ auto GenBondedPoseScoreDispatch<DeviceOps, D, Real, Int>::backward(
   });
 
   DeviceOps<D>::template foreach_pose_workgroup<launch_t>(
-      mgr,
-      n_poses,
-      max_n_blocks * (max_n_conns + 1),
-      eval_torsions_for_interaction);
+      mgr, n_poses, workgroups_per_pose, eval_torsions_for_interaction);
 
   return dV_dx_t;
 }

--- a/tmol/score/hbond/potentials/hbond.hh
+++ b/tmol/score/hbond/potentials/hbond.hh
@@ -654,8 +654,8 @@ TMOL_DEVICE_FUNC Real hbond_atom_energy_full(
   Real3 Hxyz = coord_from_shared(don_dat.coords, don_h_atom_tile_ind);
   Real3 Axyz = coord_from_shared(acc_dat.coords, acc_atom_tile_ind);
 
-  Real const dist = distance<Real>::V(Hxyz, Axyz);
-  if (dist < respair_dat.global_params.max_ha_dis) {
+  Real const max_ha_dis = respair_dat.global_params.max_ha_dis;
+  if ((Hxyz - Axyz).squaredNorm() < max_ha_dis * max_ha_dis) {
     int const H_pose_atom_ind =
         don_dat.rot_coord_offset + don_start + don_h_atom_tile_ind;
     int const A_pose_atom_ind =
@@ -701,8 +701,8 @@ TMOL_DEVICE_FUNC Real hbond_atom_derivs(
   Real3 Hxyz = coord_from_shared(don_dat.coords, don_h_atom_tile_ind);
   Real3 Axyz = coord_from_shared(acc_dat.coords, acc_atom_tile_ind);
 
-  auto const dist_r = distance<Real>::V_dV(Hxyz, Axyz);
-  if (dist_r.V < respair_dat.global_params.max_ha_dis) {
+  Real const max_ha_dis = respair_dat.global_params.max_ha_dis;
+  if ((Hxyz - Axyz).squaredNorm() < max_ha_dis * max_ha_dis) {
     int const H_pose_atom_ind =
         don_dat.rot_coord_offset + don_start + don_h_atom_tile_ind;
     int const A_pose_atom_ind =
@@ -773,8 +773,8 @@ TMOL_DEVICE_FUNC Real hbond_atom_energy_and_derivs_full(
   Real3 Hxyz = coord_from_shared(don_dat.coords, don_h_atom_tile_ind);
   Real3 Axyz = coord_from_shared(acc_dat.coords, acc_atom_tile_ind);
 
-  auto const dist_r = distance<Real>::V_dV(Hxyz, Axyz);
-  if (dist_r.V < respair_dat.global_params.max_ha_dis) {
+  Real const max_ha_dis = respair_dat.global_params.max_ha_dis;
+  if ((Hxyz - Axyz).squaredNorm() < max_ha_dis * max_ha_dis) {
     int const H_pose_atom_ind =
         don_dat.rot_coord_offset + don_start + don_h_atom_tile_ind;
     int const A_pose_atom_ind =


### PR DESCRIPTION
## Summary

- replace the redundant hydrogen-bond cutoff square root and derivative evaluation with the equivalent squared-distance comparison
- compute CartBonded and GenBonded per-pose workgroup counts through the shared checked dispatch helper before both launch sizing and CTA decoding
- preserve score lanes, weights, term enablement, and CPU/CUDA behavior without adding backend-specific paths

## Performance

A process-isolated 48-record A/B across four structures, batches 1 and 4, and three repeats measured a 1.0295x CPU geometric-mean speedup and a 1.0069x H200 geometric-mean speedup. All checksums match. Benchmark code and results remain outside this repository.

## Validation

The hydrogen-bond suite passed 34 tests with the two existing expected failures. Exact-commit focused CPU and H200 suites for common dispatch, hydrogen bonding, CartBonded, and GenBonded are running; the hosted full matrix is the merge gate.