### PR TITLE
Reduce idle LBFGS mask work

### DIFF
--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -362,6 +362,7 @@ class LBFGS_Armijo(Optimizer):
             if state.get(name) is not None:
                 state[name].zero_()
         state["any_needs_reset"] = False
+        state["any_was_reset"] = False
         state["any_inactive"] = False
         self._last_loss_vec = None
         self._closure_fn = None
@@ -581,6 +582,7 @@ class LBFGS_Armijo(Optimizer):
             state["stalled"] = torch.zeros(self._n_segments, **flags)
             state["needs_reset"] = torch.zeros(self._n_segments, **flags)
             state["was_reset"] = torch.zeros(self._n_segments, **flags)
+            state["any_was_reset"] = False
 
         return SimpleNamespace(
             # config
@@ -617,6 +619,9 @@ class LBFGS_Armijo(Optimizer):
             # iteration. Reusing them avoids repeating identical device-to-host
             # checks at the start of the next iteration.
             any_needs_reset=state.get("any_needs_reset", False),
+            # Old state dictionaries lack this host mirror. Clear their mask
+            # once conservatively instead of trusting its contents.
+            any_was_reset=state.get("any_was_reset", "was_reset" in state),
             any_inactive=state.get("any_inactive", False),
             gtd_seg=None,
             # current eval
@@ -708,16 +713,19 @@ class LBFGS_Armijo(Optimizer):
         restarted, so a second failure retires it instead of searching again.
         """
         if not ctx.any_needs_reset:
-            ctx.was_reset = torch.zeros_like(ctx.needs_reset)
+            if ctx.any_was_reset:
+                ctx.was_reset.zero_()
+                ctx.any_was_reset = False
             return
-        ctx.was_reset = ctx.needs_reset.clone()
+        ctx.was_reset.copy_(ctx.needs_reset)
+        ctx.any_was_reset = True
         reset = ctx.needs_reset.nonzero(as_tuple=False).squeeze(-1)
         ctx.old_dirs_mat[:, reset, :] = 0.0
         ctx.old_stps_mat[:, reset, :] = 0.0
         reset_elem = self._per_element(ctx.needs_reset)
         ctx.d.copy_(torch.where(reset_elem, -ctx.flat_grad, ctx.d))
         ctx.x_ref = torch.where(reset_elem, ctx.x, ctx.x_ref)
-        ctx.needs_reset = torch.zeros_like(ctx.needs_reset)
+        ctx.needs_reset.zero_()
         ctx.any_needs_reset = False
 
     def _inactive(self, ctx):
@@ -943,6 +951,7 @@ class LBFGS_Armijo(Optimizer):
         ctx.state["needs_reset"] = ctx.needs_reset
         ctx.state["was_reset"] = ctx.was_reset
         ctx.state["any_needs_reset"] = ctx.any_needs_reset
+        ctx.state["any_was_reset"] = ctx.any_was_reset
         ctx.state["any_inactive"] = ctx.any_inactive
 
         return ctx.orig_loss

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -734,9 +734,9 @@ class LBFGS_Armijo(Optimizer):
 
     def _freeze_converged(self, ctx):
         """Hold converged or retired segments still by zeroing their direction."""
-        inactive = self._inactive(ctx)
         if not ctx.any_inactive:
             return
+        inactive = self._inactive(ctx)
         ctx.d.mul_(self._per_element((~inactive).to(ctx.d.dtype)))
 
     def _directional_derivative(self, ctx, correct=True):

--- a/tmol/tests/optimization/test_lbfgs_segments.py
+++ b/tmol/tests/optimization/test_lbfgs_segments.py
@@ -1,5 +1,7 @@
 """Per-segment L-BFGS: minimizing blocks together must match minimizing them alone."""
 
+from types import SimpleNamespace
+
 import torch
 
 from tmol.optimization import LBFGS_Armijo, lbfgs_two_loop
@@ -58,6 +60,30 @@ def test_equal_interleaved_segments_use_indexed_padding(torch_device):
     torch.testing.assert_close(
         optimizer._seg_sum(values), torch.tensor([6.0, 9.0], device=torch_device)
     )
+
+
+def test_idle_reset_mask_retains_storage(torch_device):
+    """The ordinary no-failure path does not allocate replacement masks."""
+    x = torch.nn.Parameter(torch.zeros(4, device=torch_device))
+    optimizer = LBFGS_Armijo([x])
+    was_reset = torch.zeros(1, dtype=torch.bool, device=torch_device)
+    ctx = SimpleNamespace(
+        any_needs_reset=False,
+        any_was_reset=False,
+        needs_reset=torch.zeros_like(was_reset),
+        was_reset=was_reset,
+    )
+    storage = was_reset.data_ptr()
+
+    optimizer._restart_failed_segments(ctx)
+    assert ctx.was_reset.data_ptr() == storage
+
+    ctx.was_reset.fill_(True)
+    ctx.any_was_reset = True
+    optimizer._restart_failed_segments(ctx)
+    assert ctx.was_reset.data_ptr() == storage
+    assert not ctx.was_reset.any()
+    assert not ctx.any_was_reset
 
 
 def test_batched_two_loop_matches_one_problem_at_a_time(torch_device):


### PR DESCRIPTION
## Summary

- reuse the existing per-segment LBFGS reset-mask tensors instead of allocating replacement masks on every ordinary iteration
- track whether the previous reset mask actually needs clearing, preserving the existing conservative migration behavior for older optimizer state dictionaries
- skip constructing the converged/stalled union when the existing host mirror proves that no segment is inactive

The change does not alter the optimizer API, line-search policy, score functions, tensor layouts, backend dispatch, or numerical operations on active/reset segments.

## Performance

For 12-iteration Cartesian minimization profiles on H200 (5uoi and hsp90, batch 1/4, eager/CUDA Graph):

- 24 fewer physical CUDA launches at every one of the 8 measured points versus current master
- 12 fewer `aten::empty_strided`, 12 fewer `aten::zero_`, and 12 fewer inactive-mask launches
- unchanged peak GPU memory (apart from an immaterial 512-byte profiler-level difference in the first step)
- the incremental inactive-mask guard measured 1.008x geomean; direct paired A/B timing is running in parallel because launch counts are the stable acceptance signal for this small change

CPU reversed-process A/B across 43/548 residues and 1/8 threads was neutral: 0.999x point geomean.

## Validation

- focused optimizer CPU suite: 30 passed, 21 skipped, 1 xfailed
- exact single-thread score and coordinate checksums; multithread deltas remain within existing reduction-order noise
- dedicated storage-reuse regression test added

Benchmark and profiler harnesses/results remain outside the repository.