### PR TITLE
Skip excluded CUDA LJ/LK atom pairs

### DIFF
--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -530,12 +530,16 @@ TMOL_DEVICE_FUNC std::array<Real, 2> lj_atom_energy(
 
 // Fused LJ/LK energy for pose scoring. Heavy-atom pairs reuse the coordinate
 // loads, distance, and count-pair separation for both potentials.
-template <typename Real>
+template <typename Real, tmol::Device D>
 TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy(
     int atom_tile_ind1,
     int atom_tile_ind2,
     LJLKScoringData<Real> const& score_dat,
     int cp_separation) {
+  if constexpr (D == Device::CUDA) {
+    if (cp_separation < 4) return {0.0, 0.0, 0.0};
+  }
+
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
@@ -579,6 +583,10 @@ TMOL_DEVICE_FUNC void lj_atom_derivs(
     Real dTdV_atr,
     Real dTdV_rep,
     TView<Eigen::Matrix<Real, 3, 1>, 1, D> dV_dcoords) {
+  if constexpr (D == Device::CUDA) {
+    if (cp_separation < 4) return;
+  }
+
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
@@ -720,6 +728,10 @@ TMOL_DEVICE_FUNC void lk_atom_derivs(
     int cp_separation,
     Real dTdV,
     TView<Eigen::Matrix<Real, 3, 1>, 1, D> dV_dcoords) {
+  if constexpr (D == Device::CUDA) {
+    if (cp_separation < 4) return;
+  }
+
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
@@ -819,6 +831,10 @@ TMOL_DEVICE_FUNC std::array<Real, 3> ljlk_atom_energy_and_derivs_full(
     LJLKScoringData<Real> const& score_dat,
     int cp_separation,
     TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords) {
+  if constexpr (D == Device::CUDA) {
+    if (cp_separation < 4) return {0.0, 0.0, 0.0};
+  }
+
   using Real3 = Eigen::Matrix<Real, 3, 1>;
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -974,7 +974,7 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
                                   int,
                                   LJLKScoringData<Real> const& score_dat,
                                   int cp_separation) {
-      return ljlk_atom_energy(
+      return ljlk_atom_energy<Real, D>(
           atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
     });
 
@@ -1846,7 +1846,7 @@ auto LJLKRotamerScoreDispatch<DeviceOperations, D, Real, Int>::forward(
                                   int,
                                   LJLKScoringData<Real> const& score_dat,
                                   int cp_separation) {
-      return ljlk_atom_energy(
+      return ljlk_atom_energy<Real, D>(
           atom_tile_ind1, atom_tile_ind2, score_dat, cp_separation);
     });
 


### PR DESCRIPTION
## Summary

- return before coordinate, distance, and parameter work for CUDA LJ/LK atom pairs excluded by count-pair separation
- cover fused energy-only, weighted derivative, and full energy/derivative helpers used by pose and rotamer scoring
- specialize at compile time so CPU keeps the established path; no score-term, weight, layout, or public-API policy changes

The default fused LJ/LK-electrostatics traversal already has the equivalent joint shortcut. This change targets independent LJ/LK scoring used by term toggles, block-pair outputs, rotamer scoring, and general fallback paths.

## Performance

A three-repeat reversed-order H200 matrix over 5uoi and 5yzf at B1/B4 found all 24 paired LJ/LK measurements faster. Point medians improve by 10.47-12.37% for score-only and 2.61-3.15% for score plus gradient, with unchanged measured peak allocation. Exact score checksums match; CUDA gradient totals stay inside the baseline atomic-reduction repeat envelope.

The broad portable experiment was rejected: CPU LJ/LK regressed (0.983x geometric mean) and electrostatics was neutral on CUDA. This PR retains only the measured CUDA LJ/LK specialization. Benchmark harnesses and raw artifacts remain outside the repository.

## Validation

- corrected source compiled for CPU and CUDA against current master
- 62 focused LJ/LK tests passed in the broad semantic gate
- current-master repeated A/B, full focused tests, and hosted CI are running in parallel; this PR will not be merged until all finish cleanly