### PR TITLE
Skip distant LJ/LK derivative work

### DIFF
--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -591,11 +591,13 @@ TMOL_DEVICE_FUNC void lj_atom_derivs(
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
   Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
-
-  auto dist_r = distance<Real>::V_dV(coord1, coord2);
-  auto& dist = dist_r.V;
-  auto& ddist_dat1 = dist_r.dV_dA;
-  auto& ddist_dat2 = dist_r.dV_dB;
+  Real3 const delta = coord1 - coord2;
+  Real const dist2 = delta.squaredNorm();
+  Real const max_dis = score_dat.global_params.max_dis;
+  if (dist2 >= max_dis * max_dis) return;
+  Real const dist = std::sqrt(dist2);
+  Real3 ddist_dat1({0.0, 0.0, 0.0});
+  if (dist != 0) ddist_dat1 = delta / dist;
 
   auto lj = lj_score<Real>::V_dV(
       dist,
@@ -620,7 +622,7 @@ TMOL_DEVICE_FUNC void lj_atom_derivs(
     }
   }
 
-  Vec<Real, 3> dxyz_at2 = weighted_dV_ddist * ddist_dat2;
+  Vec<Real, 3> dxyz_at2 = -dxyz_at1;
   for (int j = 0; j < 3; ++j) {
     if (dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(
@@ -736,11 +738,13 @@ TMOL_DEVICE_FUNC void lk_atom_derivs(
 
   Real3 coord1 = coord_from_shared(score_dat.r1.coords, atom_tile_ind1);
   Real3 coord2 = coord_from_shared(score_dat.r2.coords, atom_tile_ind2);
-
-  auto dist_r = distance<Real>::V_dV(coord1, coord2);
-  auto& dist = dist_r.V;
-  auto& ddist_dat1 = dist_r.dV_dA;
-  auto& ddist_dat2 = dist_r.dV_dB;
+  Real3 const delta = coord1 - coord2;
+  Real const dist2 = delta.squaredNorm();
+  Real const max_dis = score_dat.global_params.max_dis;
+  if (dist2 >= max_dis * max_dis) return;
+  Real const dist = std::sqrt(dist2);
+  Real3 ddist_dat1({0.0, 0.0, 0.0});
+  if (dist != 0) ddist_dat1 = delta / dist;
 
   auto lk = lk_isotropic_score<Real>::V_dV(
       dist,
@@ -763,7 +767,7 @@ TMOL_DEVICE_FUNC void lk_atom_derivs(
   }
 
   // all threads accumulate derivatives for atom 2 to global memory
-  Vec<Real, 3> lj_dxyz_at2 = dTdV_block * lk.dV_ddist * ddist_dat2;
+  Vec<Real, 3> lj_dxyz_at2 = -lj_dxyz_at1;
   for (int j = 0; j < 3; ++j) {
     if (lj_dxyz_at2[j] != 0) {
       accumulate<D, Real>::add(


### PR DESCRIPTION
## Summary

- reject LJ/LK derivative atom pairs at the existing maximum-distance boundary before normalization and spline work
- reuse the atom-1 radial derivative with the opposite sign for atom 2
- preserve CPU and CUDA behavior, layouts, score-term toggles, live weights, and autograd interfaces

## Performance

Clean direct source A/B on the first 43-residue rotamer workload:

- one-thread CPU independent LJ/LK gradient: 5.184 s -> 3.297 s (1.57x)
- H200 B1 independent LJ/LK gradient: 7.856 ms -> 5.981 ms (1.31x)
- H200 B4 independent LJ/LK gradient: measured in the attached benchmark matrix
- forward scoring and peak memory are unchanged controls

A second 548-residue CPU/H200 point and hosted validation are running. Benchmark harnesses and raw artifacts remain outside the repository.

## Correctness

The early return matches the existing V_dV cutoff exactly (`dist >= max_dis`), and the atom-2 distance derivative is exactly the negative of atom 1. CPU score and gradient checksums are exact in the completed A/B point; CUDA differences remain within normal atomic accumulation nondeterminism.