### PR TITLE
Remove obsolete LJ/LK heavy-atom tile state

### DIFF
--- a/tmol/score/ljlk/potentials/ljlk.hh
+++ b/tmol/score/ljlk/potentials/ljlk.hh
@@ -20,10 +20,8 @@ class LJLKSingleResData {
   int rot_coord_offset;
   int n_atoms;
   int n_conn;
-  int n_heavy;
   Real* coords;
   LJLKTypeParams<Real>* params;
-  unsigned char* heavy_inds;
   unsigned char* path_dist;
 };
 
@@ -53,10 +51,6 @@ struct LJLKBlockPairSharedData {
   Real coords2[TILE_SIZE * 3];
   LJLKTypeParams<Real> params1[TILE_SIZE];  // 1536 bytes for params
   LJLKTypeParams<Real> params2[TILE_SIZE];
-  unsigned char n_heavy1;
-  unsigned char n_heavy2;
-  unsigned char heavy_inds1[TILE_SIZE];
-  unsigned char heavy_inds2[TILE_SIZE];
   unsigned char conn_ats1[MAX_N_CONN];  // 8 bytes
   unsigned char conn_ats2[MAX_N_CONN];
   unsigned char path_dist1[MAX_N_CONN * TILE_SIZE];  // 256 bytes
@@ -74,7 +68,6 @@ void TMOL_DEVICE_FUNC ljlk_load_block_coords_and_params_into_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
     int pose_ind,
     LJLKSingleResData<Real>& r_dat,
     int n_atoms_to_load,
@@ -94,11 +87,6 @@ void TMOL_DEVICE_FUNC ljlk_load_block_coords_and_params_into_shared(
         if (attype >= 0) {
           r_dat.params[count] = type_params[attype];
         }
-        // Note that we do NOT read from shared_m.n_heavy{1,2} here
-        // we instead read the full tile's worth of data
-        // this allows us to avoid a synchronize_workgroup call
-        r_dat.heavy_inds[count] =
-            block_type_heavy_atoms_in_tile[r_dat.block_type][atid];
       }
     }
   });
@@ -116,7 +104,6 @@ void TMOL_DEVICE_FUNC ljlk_load_block_into_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
     TView<Int, 3, D> block_type_path_distance,
     int pose_ind,
     LJLKSingleResData<Real>& r_dat,
@@ -128,7 +115,6 @@ void TMOL_DEVICE_FUNC ljlk_load_block_into_shared(
       coords,
       block_type_atom_types,
       type_params,
-      block_type_heavy_atoms_in_tile,
       pose_ind,
       r_dat,
       n_atoms_to_load,
@@ -201,8 +187,6 @@ void TMOL_DEVICE_FUNC ljlk_load_tile_invariant_interres_data(
   inter_dat.r2.coords = shared_m.coords2;
   inter_dat.r1.params = shared_m.params1;
   inter_dat.r2.params = shared_m.params2;
-  inter_dat.r1.heavy_inds = shared_m.heavy_inds1;
-  inter_dat.r2.heavy_inds = shared_m.heavy_inds2;
   inter_dat.r1.path_dist = shared_m.path_dist1;
   inter_dat.r2.path_dist = shared_m.path_dist2;
   inter_dat.conn_seps = shared_m.conn_seps;
@@ -260,27 +244,16 @@ void TMOL_DEVICE_FUNC ljlk_load_interres1_tile_data_to_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
     TView<Int, 3, D> block_type_path_distance,
-    TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
-    int tile_ind,
+    int,
     int start_atom1,
     int n_atoms_to_load1,
     LJLKScoringData<Real>& inter_dat,
     LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN>& shared_m) {
-  auto store_n_heavy1 = ([&](int tid) {
-    if (tid == 0) {
-      shared_m.n_heavy1 =
-          block_type_n_heavy_atoms_in_tile[inter_dat.r1.block_type][tile_ind];
-    }
-  });
-  DeviceDispatch<D>::template for_each_in_workgroup<nt>(store_n_heavy1);
-
   ljlk_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
       coords,
       block_type_atom_types,
       type_params,
-      block_type_heavy_atoms_in_tile,
       block_type_path_distance,
       inter_dat.pose_ind,
       inter_dat.r1,
@@ -302,27 +275,16 @@ void TMOL_DEVICE_FUNC ljlk_load_interres2_tile_data_to_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
     TView<Int, 3, D> block_type_path_distance,
-    TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
-    int tile_ind,
+    int,
     int start_atom2,
     int n_atoms_to_load2,
     LJLKScoringData<Real>& inter_dat,
     LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN>& shared_m) {
-  auto store_n_heavy2 = ([&](int tid) {
-    if (tid == 0) {
-      shared_m.n_heavy2 =
-          block_type_n_heavy_atoms_in_tile[inter_dat.r2.block_type][tile_ind];
-    }
-  });
-  DeviceDispatch<D>::template for_each_in_workgroup<nt>(store_n_heavy2);
-
   ljlk_load_block_into_shared<DeviceDispatch, D, nt, TILE_SIZE>(
       coords,
       block_type_atom_types,
       type_params,
-      block_type_heavy_atoms_in_tile,
       block_type_path_distance,
       inter_dat.pose_ind,
       inter_dat.r2,
@@ -330,14 +292,6 @@ void TMOL_DEVICE_FUNC ljlk_load_interres2_tile_data_to_shared(
       start_atom2,
       inter_dat.in_count_pair_striking_dist,
       shared_m.conn_ats2);
-}
-
-template <int TILE_SIZE, int MAX_N_CONN, typename Real>
-void TMOL_DEVICE_FUNC ljlk_load_interres_data_from_shared(
-    LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN>& shared_m,
-    LJLKScoringData<Real>& inter_dat) {
-  inter_dat.r1.n_heavy = shared_m.n_heavy1;
-  inter_dat.r2.n_heavy = shared_m.n_heavy2;
 }
 
 template <
@@ -385,12 +339,10 @@ void TMOL_DEVICE_FUNC ljlk_load_tile_invariant_intrares_data(
   // shared-memory arrays. Note that these arrays will be reset
   // later because which shared memory arrays we will use depends on
   // which tile pair we are evaluating!
-  intra_dat.r1.coords = shared_m.coords1;          // depends on tile pair!
-  intra_dat.r2.coords = shared_m.coords2;          // depends on tile pair!
-  intra_dat.r1.params = shared_m.params1;          // depends on tile pair!
-  intra_dat.r2.params = shared_m.params2;          // depends on tile pair!
-  intra_dat.r1.heavy_inds = shared_m.heavy_inds1;  // depends on tile pair!
-  intra_dat.r2.heavy_inds = shared_m.heavy_inds2;
+  intra_dat.r1.coords = shared_m.coords1;  // depends on tile pair!
+  intra_dat.r2.coords = shared_m.coords2;  // depends on tile pair!
+  intra_dat.r1.params = shared_m.params1;  // depends on tile pair!
+  intra_dat.r2.params = shared_m.params2;  // depends on tile pair!
 
   // these count pair arrays are not going to be used
   intra_dat.r1.path_dist = 0;
@@ -416,26 +368,15 @@ void TMOL_DEVICE_FUNC ljlk_load_intrares1_tile_data_to_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
-    int tile_ind,
+    int,
     int start_atom1,
     int n_atoms_to_load1,
     LJLKScoringData<Real>& intra_dat,
     LJLKBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN>& shared_m) {
-  auto store_n_heavy1 = ([&](int tid) {
-    if (tid == 0) {
-      shared_m.n_heavy1 =
-          block_type_n_heavy_atoms_in_tile[intra_dat.r1.block_type][tile_ind];
-    }
-  });
-  DeviceDispatch<D>::template for_each_in_workgroup<nt>(store_n_heavy1);
-
   ljlk_load_block_coords_and_params_into_shared<DeviceDispatch, D, nt>(
       coords,
       block_type_atom_types,
       type_params,
-      block_type_heavy_atoms_in_tile,
       intra_dat.pose_ind,
       intra_dat.r1,
       n_atoms_to_load1,
@@ -454,9 +395,7 @@ void TMOL_DEVICE_FUNC ljlk_load_intrares2_tile_data_to_shared(
     TView<Vec<Real, 3>, 1, D> coords,
     TView<Int, 2, D> block_type_atom_types,
     TView<LJLKTypeParams<Real>, 1, D> type_params,
-    TView<Int, 2, D> block_type_n_heavy_atoms_in_tile,
-    TView<Int, 2, D> block_type_heavy_atoms_in_tile,
-    int tile_ind,
+    int,
     int start_atom2,
     int n_atoms_to_load2,
     LJLKScoringData<Real>& intra_dat,
@@ -466,19 +405,10 @@ void TMOL_DEVICE_FUNC ljlk_load_intrares2_tile_data_to_shared(
   // the "2" arrays so the load below writes to the correct destination.
   intra_dat.r2.coords = shared_m.coords2;
   intra_dat.r2.params = shared_m.params2;
-  intra_dat.r2.heavy_inds = shared_m.heavy_inds2;
-  auto store_n_heavy2 = ([&](int tid) {
-    if (tid == 0) {
-      shared_m.n_heavy2 =
-          block_type_n_heavy_atoms_in_tile[intra_dat.r2.block_type][tile_ind];
-    }
-  });
-  DeviceDispatch<D>::template for_each_in_workgroup<nt>(store_n_heavy2);
   ljlk_load_block_coords_and_params_into_shared<DeviceDispatch, D, nt>(
       coords,
       block_type_atom_types,
       type_params,
-      block_type_heavy_atoms_in_tile,
       intra_dat.pose_ind,
       intra_dat.r2,
       n_atoms_to_load2,
@@ -496,15 +426,10 @@ void TMOL_DEVICE_FUNC ljlk_load_intrares_data_from_shared(
   // then only the "1" shared-memory arrays will be loaded with data;
   // we will point the "2" memory pointers at the "1" arrays
   bool same_tile = tile_ind1 == tile_ind2;
-  intra_dat.r1.n_heavy = shared_m.n_heavy1;
-  intra_dat.r2.n_heavy = same_tile ? intra_dat.r1.n_heavy : shared_m.n_heavy2;
   intra_dat.r1.coords = shared_m.coords1;
   intra_dat.r2.coords = (same_tile ? shared_m.coords1 : shared_m.coords2);
   intra_dat.r1.params = shared_m.params1;
   intra_dat.r2.params = (same_tile ? shared_m.params1 : shared_m.params2);
-  intra_dat.r1.heavy_inds = shared_m.heavy_inds1;
-  intra_dat.r2.heavy_inds =
-      (same_tile ? shared_m.heavy_inds1 : shared_m.heavy_inds2);
 }
 
 // Fused LJ/LK energy for pose scoring. Heavy-atom pairs reuse the coordinate

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -133,84 +133,10 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         separation);                                                         \
   }
 
-// SCORE_INTER_LK_ATOM_PAIR
-// input argument:  a function with signature (
-//     int atom_tile_idx1
-//     int atom_tile_idx2
-//     int start_atom1
-//     int start_atom2
-//     LJLKScoringData<Real> const &score_dat
-//     int cp_separation)
-//   ->Real
-// captures:
-//    None
-#define SCORE_INTER_LK_ATOM_PAIR(atom_pair_func)                              \
-  TMOL_DEVICE_FUNC(                                                           \
-      int start_atom1,                                                        \
-      int start_atom2,                                                        \
-      int atom_heavy_tile_ind1,                                               \
-      int atom_heavy_tile_ind2,                                               \
-      LJLKScoringData<Real> const& inter_dat)                                 \
-      ->std::array<Real, 1> {                                                 \
-    int const atom_tile_ind1 = inter_dat.r1.heavy_inds[atom_heavy_tile_ind1]; \
-    int const atom_tile_ind2 = inter_dat.r2.heavy_inds[atom_heavy_tile_ind2]; \
-    int separation = interres_count_pair_separation<TILE_SIZE>(               \
-        inter_dat,                                                            \
-        atom_tile_ind1,                                                       \
-        atom_tile_ind2,                                                       \
-        block_type_is_ligand_fragment[inter_dat.r1.block_type]                \
-            && block_type_is_ligand_fragment[inter_dat.r2.block_type]);       \
-    Real lk = atom_pair_func(                                                 \
-        atom_tile_ind1,                                                       \
-        atom_tile_ind2,                                                       \
-        start_atom1,                                                          \
-        start_atom2,                                                          \
-        inter_dat,                                                            \
-        separation);                                                          \
-    return {lk};                                                              \
-  }
-
-// SCORE_INTRA_LK_ATOM_PAIR
-// input argument:  a function with signature (
-//     int atom_tile_idx1
-//     int atom_tile_idx2
-//     int start_atom1
-//     int start_atom2
-//     LJLKScoringData<Real> const &score_dat
-//     int cp_separation)
-//   ->Real
-// captures:
-//    block_type_path_distance
-#define SCORE_INTRA_LK_ATOM_PAIR(atom_pair_func)                              \
-  TMOL_DEVICE_FUNC(                                                           \
-      int start_atom1,                                                        \
-      int start_atom2,                                                        \
-      int atom_heavy_tile_ind1,                                               \
-      int atom_heavy_tile_ind2,                                               \
-      LJLKScoringData<Real> const& intra_dat)                                 \
-      ->std::array<Real, 1> {                                                 \
-    int const atom_tile_ind1 = intra_dat.r1.heavy_inds[atom_heavy_tile_ind1]; \
-    int const atom_tile_ind2 = intra_dat.r2.heavy_inds[atom_heavy_tile_ind2]; \
-    int const atom_ind1 = start_atom1 + atom_tile_ind1;                       \
-    int const atom_ind2 = start_atom2 + atom_tile_ind2;                       \
-    int const separation = block_type_path_distance[intra_dat.r1.block_type]  \
-                                                   [atom_ind1][atom_ind2];    \
-    Real lk = atom_pair_func(                                                 \
-        atom_tile_ind1,                                                       \
-        atom_tile_ind2,                                                       \
-        start_atom1,                                                          \
-        start_atom2,                                                          \
-        intra_dat,                                                            \
-        separation);                                                          \
-    return {lk};                                                              \
-  }
-
-// SCORE_INTRA_LK_ATOM_PAIR
 // captures:
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 #define LOAD_BLOCK_COORDS_AND_PARAMS_INTO_SHARED                            \
   TMOL_DEVICE_FUNC(                                                         \
       int pose_ind,                                                         \
@@ -221,7 +147,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                         \
         block_type_atom_types,                                              \
         type_params,                                                        \
-        block_type_heavy_atoms_in_tile,                                     \
         pose_ind,                                                           \
         r_dat,                                                              \
         n_atoms_to_load,                                                    \
@@ -233,7 +158,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 //    block_type_path_distance (TView<Int, 3, D>)
 #define LOAD_BLOCK_INTO_SHARED                                       \
   TMOL_DEVICE_FUNC(                                                  \
@@ -247,7 +171,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                  \
         block_type_atom_types,                                       \
         type_params,                                                 \
-        block_type_heavy_atoms_in_tile,                              \
         block_type_path_distance,                                    \
         pose_ind,                                                    \
         r_dat,                                                       \
@@ -305,9 +228,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 //    block_type_path_distance (TView<Int, 3, D>)
-//    block_type_n_heavy_atoms_in_tile (TView<Int, 2, D>)
 #define LOAD_INTERRES1_TILE_DATA_TO_SHARED                            \
   TMOL_DEVICE_FUNC(                                                   \
       int tile_ind,                                                   \
@@ -319,9 +240,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                   \
         block_type_atom_types,                                        \
         type_params,                                                  \
-        block_type_heavy_atoms_in_tile,                               \
         block_type_path_distance,                                     \
-        block_type_n_heavy_atoms_in_tile,                             \
         tile_ind,                                                     \
         start_atom1,                                                  \
         n_atoms_to_load1,                                             \
@@ -335,9 +254,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 //    block_type_path_distance (TView<Int, 3, D>)
-//    block_type_n_heavy_atoms_in_tile (TView<Int, 2, D>)
 #define LOAD_INTERRES2_TILE_DATA_TO_SHARED                            \
   TMOL_DEVICE_FUNC(                                                   \
       int tile_ind,                                                   \
@@ -349,9 +266,7 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                   \
         block_type_atom_types,                                        \
         type_params,                                                  \
-        block_type_heavy_atoms_in_tile,                               \
         block_type_path_distance,                                     \
-        block_type_n_heavy_atoms_in_tile,                             \
         tile_ind,                                                     \
         start_atom2,                                                  \
         n_atoms_to_load2,                                             \
@@ -362,11 +277,8 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 // LOAD_INTERRES_DATA_FROM_SHARED
 // captures:
 //    nothing
-#define LOAD_INTERRES_DATA_FROM_SHARED                                        \
-  TMOL_DEVICE_FUNC(                                                           \
-      int, int, shared_mem_union& shared, LJLKScoringData<Real>& inter_dat) { \
-    ljlk_load_interres_data_from_shared(shared.m, inter_dat);                 \
-  }
+#define LOAD_INTERRES_DATA_FROM_SHARED \
+  TMOL_DEVICE_FUNC(int, int, shared_mem_union&, LJLKScoringData<Real>&) {}
 
 // Fused LJ/LK traversal: LJ is evaluated for every atom pair and LK for the
 // heavy subset inside the pair function, reusing geometry and count-pair work.
@@ -493,8 +405,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_n_heavy_atoms_in_tile (TView<Int, 2, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 #define LOAD_INTRARES1_TILE_DATA_TO_SHARED                            \
   TMOL_DEVICE_FUNC(                                                   \
       int tile_ind,                                                   \
@@ -506,8 +416,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                   \
         block_type_atom_types,                                        \
         type_params,                                                  \
-        block_type_n_heavy_atoms_in_tile,                             \
-        block_type_heavy_atoms_in_tile,                               \
         tile_ind,                                                     \
         start_atom1,                                                  \
         n_atoms_to_load1,                                             \
@@ -521,8 +429,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
 //    coords (TView<Vec<Real, 3>, 2, D>)
 //    block_type_atom_types (TView<Int, 2, D>)
 //    type_params (TView<LJLKTypeParams<Real>, 1, D>)
-//    block_type_n_heavy_atoms_in_tile (TView<Int, 2, D>)
-//    block_type_heavy_atoms_in_tile (TView<Int, 2, D>)
 #define LOAD_INTRARES2_TILE_DATA_TO_SHARED                            \
   TMOL_DEVICE_FUNC(                                                   \
       int tile_ind,                                                   \
@@ -534,8 +440,6 @@ EIGEN_DEVICE_FUNC int interres_count_pair_separation(
         rot_coords,                                                   \
         block_type_atom_types,                                        \
         type_params,                                                  \
-        block_type_n_heavy_atoms_in_tile,                             \
-        block_type_heavy_atoms_in_tile,                               \
         tile_ind,                                                     \
         start_atom2,                                                  \
         n_atoms_to_load2,                                             \


### PR DESCRIPTION
## Summary

- remove the heavy-atom index/count fields that became dead after the fused LJ/LK traversal in #476
- stop loading and round-tripping that obsolete state through per-residue shared tile data
- delete the superseded standalone LK pair-dispatch macros

This is a deletion-only simplification of the hot traversal: 10 insertions and 181 deletions. It does not change score-term APIs, weighting, dispatch selection, or differentiable/custom-weight fallbacks.

## Performance

Three-repeat, alternating-order A/B measurements on 5uoi and 5yzf:

- CPU single-thread forward: 1.014-1.025x
- CPU single-thread gradients: 1.013-1.015x
- H200 batch-1 forward/gradients: 1.096-1.122x
- H200 batch-4 forward/gradients: 1.108-1.127x
- all-point geometric mean: 1.080x

CUDA allocator peaks, entry counts, and score checksums are unchanged. Resource inspection shows lower shared memory and register pressure; for example, the float rotamer backward kernel drops from 120 to 94 registers and shared memory drops from 5,468 to 5,400 bytes.

## Validation

- 77 passed, 3 skipped in focused CPU and CUDA LJ/LK scoring/dispatch tests
- 36/36 final A/B records completed across two proteins, CPU/H200, forward/gradient, and batch 1/4 CUDA
- benchmark harness and raw results remain outside the repository