### PR TITLE
Accelerate packed scoring setup

### DIFF
--- a/tmol/score/_atom_type_dependent_term.py
+++ b/tmol/score/_atom_type_dependent_term.py
@@ -138,42 +138,28 @@ class AtomTypeDependentTerm(EnergyTerm):
                 atom_cross_ids[i, j] = atom_unique_id_index[atom_name]
 
         for i, restype in enumerate(packed_block_types.active_block_types):
-            atom_types[i, : packed_block_types.n_atoms[i]] = (
-                self.atom_type_index.get_indexer([x.atom_type for x in restype.atoms])
-            )
+            atom_types[i, : restype.n_atoms] = restype.atom_types
 
-        heavy_atom_inds = []
-        for restype in packed_block_types.active_block_types:
-            rt_heavy = [
-                j
-                for j, atype_ind in enumerate(
-                    self.atom_type_resolver.index.get_indexer(
-                        [restype.atoms[j].atom_type for j in range(len(restype.atoms))]
-                    )
-                )
-                if not self.atom_type_resolver.params.is_hydrogen[atype_ind]
-            ]
-            heavy_atom_inds.append(rt_heavy)
+        heavy_atom_inds = [
+            restype.heavy_atom_inds for restype in packed_block_types.active_block_types
+        ]
 
         n_heavy_atoms = numpy.array(
             [len(heavy_inds) for heavy_inds in heavy_atom_inds], dtype=numpy.int32
         )
-        max_n_heavy = numpy.max(n_heavy_atoms)
-
-        heavy_atom_inds_t = torch.full(
-            (packed_block_types.n_types, max_n_heavy), -1, dtype=torch.int32
+        max_n_heavy = int(numpy.max(n_heavy_atoms)) if n_heavy_atoms.size else 0
+        heavy_atom_inds_array = numpy.full(
+            (packed_block_types.n_types, max_n_heavy), -1, dtype=numpy.int32
         )
         for i, inds in enumerate(heavy_atom_inds):
-            heavy_atom_inds_t[i, : len(inds)] = torch.tensor(inds, dtype=torch.int32)
+            heavy_atom_inds_array[i, : len(inds)] = inds
 
-        atom_types = torch.tensor(atom_types, device=self.device)
-        heavy_atom_inds_t = heavy_atom_inds_t.to(self.device)
-        n_heavy_atoms = torch.tensor(
-            n_heavy_atoms, dtype=torch.int32, device=self.device
-        )
-        atom_unique_ids = torch.tensor(atom_unique_ids, device=self.device)
-        atom_wildcard_ids = torch.tensor(atom_wildcard_ids, device=self.device)
-        atom_cross_ids = torch.tensor(atom_cross_ids, device=self.device)
+        atom_types = torch.as_tensor(atom_types, device=self.device)
+        heavy_atom_inds_t = torch.as_tensor(heavy_atom_inds_array, device=self.device)
+        n_heavy_atoms = torch.as_tensor(n_heavy_atoms, device=self.device)
+        atom_unique_ids = torch.as_tensor(atom_unique_ids, device=self.device)
+        atom_wildcard_ids = torch.as_tensor(atom_wildcard_ids, device=self.device)
+        atom_cross_ids = torch.as_tensor(atom_cross_ids, device=self.device)
 
         setattr(packed_block_types, "atom_types", atom_types)
         setattr(packed_block_types, "n_heavy_atoms", n_heavy_atoms)

--- a/tmol/score/_bond_dependent_term.py
+++ b/tmol/score/_bond_dependent_term.py
@@ -54,45 +54,50 @@ class BondDependentTerm(EnergyTerm):
             dtype=numpy.int32,
         )
         for i, rt in enumerate(packed_block_types.active_block_types):
-            i_nats = packed_block_types.n_atoms[i]
+            i_nats = rt.n_atoms
             bond_separation[i, :i_nats, :i_nats] = rt.path_distance
-        bond_separation = torch.tensor(bond_separation, device=self.device)
 
-        n_all_bonds = torch.full(
-            (packed_block_types.n_types,),
-            -1,
-            dtype=torch.int32,
-            device=packed_block_types.device,
-        )
         max_n_all_bonds = max(
             bt.all_bonds.shape[0] for bt in packed_block_types.active_block_types
         )
-        all_bonds = torch.full(
+        n_all_bonds = numpy.full((packed_block_types.n_types,), -1, dtype=numpy.int32)
+        all_bonds = numpy.full(
             (packed_block_types.n_types, max_n_all_bonds, 3),
             -1,
-            dtype=torch.int32,
-            device=packed_block_types.device,
+            dtype=numpy.int32,
         )
-        atom_all_bond_ranges = torch.full(
+        atom_all_bond_ranges = numpy.full(
             (packed_block_types.n_types, packed_block_types.max_n_atoms, 2),
             -1,
-            dtype=torch.int32,
-            device=packed_block_types.device,
+            dtype=numpy.int32,
         )
-
-        def _t(arr):
-            return torch.tensor(arr, dtype=torch.int32, device=self.device)
 
         for i, bt in enumerate(packed_block_types.active_block_types):
             i_n_bonds = bt.all_bonds.shape[0]
             n_all_bonds[i] = i_n_bonds
-            all_bonds[i, :i_n_bonds, :] = _t(bt.all_bonds)
-            atom_all_bond_ranges[i, : bt.n_atoms] = _t(bt.atom_all_bond_ranges)
+            all_bonds[i, :i_n_bonds, :] = bt.all_bonds
+            atom_all_bond_ranges[i, : bt.n_atoms] = bt.atom_all_bond_ranges
 
-        setattr(packed_block_types, "bond_separation", bond_separation)
-        setattr(packed_block_types, "n_all_bonds", n_all_bonds)
-        setattr(packed_block_types, "all_bonds", all_bonds)
-        setattr(packed_block_types, "atom_all_bond_ranges", atom_all_bond_ranges)
+        setattr(
+            packed_block_types,
+            "bond_separation",
+            torch.as_tensor(bond_separation, device=self.device),
+        )
+        setattr(
+            packed_block_types,
+            "n_all_bonds",
+            torch.as_tensor(n_all_bonds, device=self.device),
+        )
+        setattr(
+            packed_block_types,
+            "all_bonds",
+            torch.as_tensor(all_bonds, device=self.device),
+        )
+        setattr(
+            packed_block_types,
+            "atom_all_bond_ranges",
+            torch.as_tensor(atom_all_bond_ranges, device=self.device),
+        )
 
     def setup_poses(self, pose_stack: PoseStack):
         super(BondDependentTerm, self).setup_poses(pose_stack)

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -359,6 +359,8 @@ class ScoreFunction:
         self._options_version = 0
         self._prepared_packed_block_types = None
         self._prepared_versions = None
+        self._prepared_block_type_ids = None
+        self._prepared_packed_annotation_names = ()
         self._setup_token = object()
 
         self.term_options = {}
@@ -589,7 +591,9 @@ class ScoreFunction:
         """Prepare active energy terms for a pose topology.
 
         Repeated calls reuse topology-dependent setup when neither the terms,
-        their options, nor the packed block types have changed.
+        their options, nor the packed block types have changed. A newly built
+        PackedBlockTypes with the same ordered residue-type objects can reuse
+        the previous packed annotations.
 
         Args:
             pose_stack: Poses whose topology will be scored.
@@ -602,17 +606,46 @@ class ScoreFunction:
 
         packed_block_types = pose_stack.packed_block_types
         versions = (self._terms_version, self._options_version)
-        if not (
+        same_object = (
             packed_block_types is self._prepared_packed_block_types
             and versions == self._prepared_versions
             and getattr(packed_block_types, "_score_setup_token", None)
             is self._setup_token
-        ):
-            for block_type in packed_block_types.active_block_types:
-                for energy_term in terms:
-                    energy_term.setup_block_type(block_type)
+        )
+        if not same_object:
+            block_type_ids = tuple(
+                id(block_type) for block_type in packed_block_types.active_block_types
+            )
+            previous = self._prepared_packed_block_types
+            same_block_types = (
+                previous is not None
+                and versions == self._prepared_versions
+                and block_type_ids == self._prepared_block_type_ids
+                and getattr(previous, "_score_setup_token", None) is self._setup_token
+            )
+            if same_block_types:
+                for name in self._prepared_packed_annotation_names:
+                    setattr(packed_block_types, name, getattr(previous, name))
+            else:
+                for block_type in packed_block_types.active_block_types:
+                    for energy_term in terms:
+                        energy_term.setup_block_type(block_type)
+
+            attributes_before = dict(vars(packed_block_types))
             for energy_term in terms:
                 energy_term.setup_packed_block_types(packed_block_types)
+            annotations = {
+                name
+                for name, value in vars(packed_block_types).items()
+                if name not in attributes_before or attributes_before[name] is not value
+            }
+            annotations.update(
+                name
+                for name in self._prepared_packed_annotation_names
+                if hasattr(packed_block_types, name)
+            )
+            self._prepared_packed_annotation_names = tuple(sorted(annotations))
+            self._prepared_block_type_ids = block_type_ids
             self._prepared_packed_block_types = packed_block_types
             self._prepared_versions = versions
             # Packed-block annotations can be score-function-specific (for

--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -14,7 +14,6 @@ from tmol.pose import (
     PoseStack,
 )
 from tmol.score.common import make_hashtable_keys_values, add_to_hashtable
-from tmol.score.common._hash_util import hash_fun
 
 debug = False
 
@@ -64,6 +63,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         self.cart_database = param_db.scoring.cartbonded
         self.hash = self.cart_database.hash
         self.device = device
+        self._params_for_res_cache = {}
 
     @classmethod
     def class_name(cls):
@@ -156,6 +156,10 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         return atoms, params
 
     def get_params_for_res(self, res: str):
+        cached = self._params_for_res_cache.get(res)
+        if cached is not None:
+            return cached
+
         params_by_atom_unique_id = {}
 
         # Fetch the raw params from the DB
@@ -183,6 +187,7 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
 
             params_by_atom_unique_id[key] = params
 
+        self._params_for_res_cache[res] = params_by_atom_unique_id
         return params_by_atom_unique_id
 
     def setup_block_type(self, block_type: RefinedResidueType):
@@ -228,18 +233,21 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         block_type.cartbonded_annotations[self.hash] = cb_block_ann
 
     @staticmethod
-    def _lookup_param_index(key, hash_keys):
-        hash_index = hash_fun(key, hash_keys.shape[0])
-        padded_key = numpy.full(4, -1, dtype=numpy.int32)
-        padded_key[: len(key)] = key
-        while hash_keys[hash_index, 0] != -1:
-            if numpy.array_equal(hash_keys[hash_index, :4], padded_key):
-                return hash_keys[hash_index, 4]
-            hash_index = (hash_index + 1) % hash_keys.shape[0]
-        return -1
+    def _padded_param_key(key):
+        padded = [-1, -1, -1, -1]
+        padded[: len(key)] = key
+        return tuple(padded)
+
+    @staticmethod
+    def _lookup_param_index(key, param_key_to_index):
+        return param_key_to_index.get(CartBondedEnergyTerm._padded_param_key(key), -1)
 
     def _precompute_subgraph_param_indices(
-        self, packed_block_types, subgraph_offsets, total_subgraphs, hash_keys
+        self,
+        packed_block_types,
+        subgraph_offsets,
+        total_subgraphs,
+        param_key_to_index,
     ):
         """Resolve invariant intra-block parameter searches once during setup."""
         atom_unique_ids = packed_block_types.atom_unique_ids.cpu().numpy()
@@ -251,20 +259,35 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         ):
             block_params = block_type.cartbonded_annotations[self.hash]
             block_offset = subgraph_offsets[block_type_index]
-            for local_index, subgraph in enumerate(block_params.cartbonded_subgraphs):
-                atoms = [int(atom) for atom in subgraph if atom != -1]
-                for atom_ids in (
-                    atom_unique_ids[block_type_index],
-                    atom_wildcard_ids[block_type_index],
-                ):
-                    for oriented_atoms in (atoms, atoms[::-1]):
-                        key = [int(atom_ids[atom]) for atom in oriented_atoms]
-                        param_index = self._lookup_param_index(key, hash_keys)
-                        if param_index != -1:
-                            param_indices[block_offset + local_index] = param_index
-                            break
-                    if param_indices[block_offset + local_index] != -1:
+            unique_ids = atom_unique_ids[block_type_index]
+            wildcard_ids = atom_wildcard_ids[block_type_index]
+            subgraphs = numpy.asarray(
+                block_params.cartbonded_subgraphs, dtype=numpy.int32
+            )
+            for local_index, subgraph in enumerate(subgraphs):
+                n_atoms = 4
+                while n_atoms > 0 and subgraph[n_atoms - 1] == -1:
+                    n_atoms -= 1
+                if n_atoms == 0:
+                    continue
+                found = -1
+                for atom_ids in (unique_ids, wildcard_ids):
+                    found = self._lookup_param_index(
+                        [int(atom_ids[subgraph[i]]) for i in range(n_atoms)],
+                        param_key_to_index,
+                    )
+                    if found != -1:
                         break
+                    found = self._lookup_param_index(
+                        [
+                            int(atom_ids[subgraph[n_atoms - 1 - i]])
+                            for i in range(n_atoms)
+                        ],
+                        param_key_to_index,
+                    )
+                    if found != -1:
+                        break
+                param_indices[block_offset + local_index] = found
         return param_indices
 
     def setup_packed_block_types(
@@ -273,12 +296,14 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         super(CartBondedEnergyTerm, self).setup_packed_block_types(packed_block_types)
 
         if not hasattr(packed_block_types, "cartbonded_is_fragment"):
-            packed_block_types.cartbonded_is_fragment = torch.tensor(
-                [
-                    block_type.is_ligand_fragment
-                    for block_type in packed_block_types.active_block_types
-                ],
-                dtype=torch.int32,
+            packed_block_types.cartbonded_is_fragment = torch.as_tensor(
+                numpy.asarray(
+                    [
+                        block_type.is_ligand_fragment
+                        for block_type in packed_block_types.active_block_types
+                    ],
+                    dtype=numpy.int32,
+                ),
                 device=self.device,
             )
         if (
@@ -356,26 +381,34 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
         # Construct the params hash with the given scaling factor
         hash_keys, hash_values = make_hashtable_keys_values(n_total_params, 2, 5, 7)
 
-        # Fill the hash table
+        # Fill the native hash table and a Python lookup with the same
+        # first-insert-wins behavior for setup-time subgraph resolution.
+        param_key_to_index = {}
         cur_val = 0
+        padded_key = self._padded_param_key
         for bt in packed_block_types.active_block_types:
 
             bt_params = bt.cartbonded_annotations[self.hash]
             for key_w_str, value in bt_params.cartbonded_params.items():
                 key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)
                 add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
+                param_key_to_index.setdefault(padded_key(key), cur_val)
                 cur_val += 1
 
         for key_w_str, value in wildcard_params:
             key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)
             add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
+            param_key_to_index.setdefault(padded_key(key), cur_val)
             cur_val += 1
 
         # Intra-block topology and atom naming are fixed for a packed block
         # type. Resolve the exact/reversed/wildcard parameter search once here
         # instead of repeating four hash probes in every scoring invocation.
         subgraph_param_indices = self._precompute_subgraph_param_indices(
-            packed_block_types, subgraph_offsets, total_subgraphs, hash_keys
+            packed_block_types,
+            subgraph_offsets,
+            total_subgraphs,
+            param_key_to_index,
         )
 
         subgraphs = torch.from_numpy(subgraphs).to(device=self.device)

--- a/tmol/score/dunbrack/_dunbrack_energy_term.py
+++ b/tmol/score/dunbrack/_dunbrack_energy_term.py
@@ -218,7 +218,6 @@ class DunbrackEnergyTerm(EnergyTerm):
         self, active_block_types, field_getter, device, default_fill=-1
     ):
         max_size = None
-        dtype = None
         for bt in active_block_types:
             bt_data = field_getter(bt)
             if bt_data is None:
@@ -226,41 +225,25 @@ class DunbrackEnergyTerm(EnergyTerm):
             cur = numpy.shape(bt_data)
             if max_size is None:
                 max_size = cur
-                dtype = bt_data.dtype if not isinstance(bt_data, int) else int
             max_size = numpy.maximum(max_size, cur)
 
         n_block_types = (len(active_block_types),)
         size = n_block_types + tuple(max_size)
 
-        dtype_conversion = {
-            numpy.dtype(numpy.int32): torch.int32,
-            numpy.dtype(numpy.int64): torch.int32,
-            int: torch.int32,
-            torch.int32: torch.int32,
-            torch.int64: torch.int32,
-        }
-
-        tensor = torch.full(
-            size, default_fill, dtype=dtype_conversion[dtype], device=device
-        )
-
-        def dim_slices(dim):
-            return slice(0, dim)
-
+        packed = numpy.full(size, default_fill, dtype=numpy.int32)
         for i, bt in enumerate(active_block_types):
             bt_data = field_getter(bt)
             if bt_data is None:
                 continue
-            slices = [i] + (
-                [*map(dim_slices, bt_data.shape)]
-                if not isinstance(bt_data, int)
-                else []
-            )
-            tensor[tuple(slices)] = torch.tensor(
-                bt_data, dtype=dtype_conversion[dtype], device=device
-            )
+            if isinstance(bt_data, (int, numpy.integer)) or (
+                isinstance(bt_data, numpy.ndarray) and bt_data.ndim == 0
+            ):
+                packed[i] = int(bt_data)
+            else:
+                slices = (i,) + tuple(slice(0, dim) for dim in numpy.shape(bt_data))
+                packed[slices] = bt_data
 
-        return tensor
+        return torch.as_tensor(packed, dtype=torch.int32, device=device)
 
     def setup_poses(self, poses: PoseStack):
         super(DunbrackEnergyTerm, self).setup_poses(poses)

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -1,5 +1,6 @@
 import math
 
+import numpy
 import torch
 
 from .._atom_type_dependent_term import AtomTypeDependentTerm
@@ -99,55 +100,57 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             assert hasattr(packed_block_types, "elec_is_ligand_fragment")
             return
 
-        def _ti(arr):
-            return torch.tensor(arr, dtype=torch.int32, device=self.device)
-
-        def _tf(arr):
-            return torch.tensor(arr, dtype=torch.float32, device=self.device)
-
         pbt = packed_block_types
-        elec_partial_charge = torch.zeros(
-            (pbt.n_types, pbt.max_n_atoms), dtype=torch.float32, device=self.device
+        elec_partial_charge = numpy.zeros(
+            (pbt.n_types, pbt.max_n_atoms), dtype=numpy.float32
         )
-        elec_inter_repr_path_distance = torch.zeros(
+        elec_inter_repr_path_distance = numpy.zeros(
             (pbt.n_types, pbt.max_n_atoms, pbt.max_n_atoms),
-            dtype=torch.int32,
-            device=self.device,
+            dtype=numpy.int32,
         )
-        elec_intra_repr_path_distance = torch.zeros(
+        elec_intra_repr_path_distance = numpy.zeros(
             (pbt.n_types, pbt.max_n_atoms, pbt.max_n_atoms),
-            dtype=torch.int32,
-            device=self.device,
+            dtype=numpy.int32,
         )
 
         for i, bt in enumerate(packed_block_types.active_block_types):
-            elec_partial_charge[i, : bt.n_atoms] = _tf(bt.elec_partial_charge)
-            elec_inter_repr_path_distance[i, : bt.n_atoms, : bt.n_atoms] = _ti(
+            n_atoms = bt.n_atoms
+            elec_partial_charge[i, :n_atoms] = bt.elec_partial_charge
+            elec_inter_repr_path_distance[i, :n_atoms, :n_atoms] = (
                 bt.elec_inter_repr_path_distance
             )
-            elec_intra_repr_path_distance[i, : bt.n_atoms, : bt.n_atoms] = _ti(
+            elec_intra_repr_path_distance[i, :n_atoms, :n_atoms] = (
                 bt.elec_intra_repr_path_distance
             )
 
-        setattr(packed_block_types, "elec_partial_charge", elec_partial_charge)
+        setattr(
+            packed_block_types,
+            "elec_partial_charge",
+            torch.as_tensor(elec_partial_charge, device=self.device),
+        )
         setattr(
             packed_block_types,
             "elec_is_ligand_fragment",
-            torch.tensor(
-                [bt.is_ligand_fragment for bt in packed_block_types.active_block_types],
-                dtype=torch.int32,
+            torch.as_tensor(
+                numpy.asarray(
+                    [
+                        bt.is_ligand_fragment
+                        for bt in packed_block_types.active_block_types
+                    ],
+                    dtype=numpy.int32,
+                ),
                 device=self.device,
             ),
         )
         setattr(
             packed_block_types,
             "elec_inter_repr_path_distance",
-            elec_inter_repr_path_distance,
+            torch.as_tensor(elec_inter_repr_path_distance, device=self.device),
         )
         setattr(
             packed_block_types,
             "elec_intra_repr_path_distance",
-            elec_intra_repr_path_distance,
+            torch.as_tensor(elec_intra_repr_path_distance, device=self.device),
         )
 
     def setup_poses(self, poses: PoseStack):

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -1,3 +1,4 @@
+import numpy
 import torch
 
 from .._atom_type_dependent_term import AtomTypeDependentTerm
@@ -67,30 +68,33 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
             assert hasattr(packed_block_types, "ljlk_is_ligand_fragment")
             return
         max_n_tiles = (packed_block_types.max_n_atoms - 1) // self.tile_size + 1
-        heavy_atoms_in_tile = torch.full(
+        heavy_atoms_in_tile = numpy.full(
             (packed_block_types.n_types, max_n_tiles * self.tile_size),
             -1,
-            dtype=torch.int32,
-            device=self.device,
+            dtype=numpy.int32,
         )
-        n_heavy_ats_in_tile = torch.full(
+        n_heavy_ats_in_tile = numpy.full(
             (packed_block_types.n_types, max_n_tiles),
             0,
-            dtype=torch.int32,
-            device=self.device,
+            dtype=numpy.int32,
         )
-
-        def _t(arr):
-            return torch.tensor(arr, dtype=torch.int32, device=self.device)
 
         for i, rt in enumerate(packed_block_types.active_block_types):
             i_n_tiles = rt.ljlk_n_heavy_atoms_in_tile.shape[0]
             i_n_tile_ats = i_n_tiles * self.tile_size
-            heavy_atoms_in_tile[i, :i_n_tile_ats] = _t(rt.ljlk_heavy_atoms_in_tile)
-            n_heavy_ats_in_tile[i, :i_n_tiles] = _t(rt.ljlk_n_heavy_atoms_in_tile)
+            heavy_atoms_in_tile[i, :i_n_tile_ats] = rt.ljlk_heavy_atoms_in_tile
+            n_heavy_ats_in_tile[i, :i_n_tiles] = rt.ljlk_n_heavy_atoms_in_tile
 
-        setattr(packed_block_types, "ljlk_heavy_atoms_in_tile", heavy_atoms_in_tile)
-        setattr(packed_block_types, "ljlk_n_heavy_atoms_in_tile", n_heavy_ats_in_tile)
+        setattr(
+            packed_block_types,
+            "ljlk_heavy_atoms_in_tile",
+            torch.as_tensor(heavy_atoms_in_tile, device=self.device),
+        )
+        setattr(
+            packed_block_types,
+            "ljlk_n_heavy_atoms_in_tile",
+            torch.as_tensor(n_heavy_ats_in_tile, device=self.device),
+        )
 
         # Ligands (non-polymer) use CP_CROSSOVER_3FULL: 1-4 pairs get full
         # weight (1.0). Build a modified bond_separation where path_dist=4 is
@@ -99,16 +103,21 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         ljlk_bond_separation = packed_block_types.bond_separation.clone()
         for i, bt in enumerate(packed_block_types.active_block_types):
             if not bt.properties.polymer.is_polymer:
-                n = packed_block_types.n_atoms[i]
+                n = bt.n_atoms
                 slab = ljlk_bond_separation[i, :n, :n]
                 slab[(slab == 3) | (slab == 4)] = 5
         setattr(packed_block_types, "ljlk_bond_separation", ljlk_bond_separation)
         setattr(
             packed_block_types,
             "ljlk_is_ligand_fragment",
-            torch.tensor(
-                [bt.is_ligand_fragment for bt in packed_block_types.active_block_types],
-                dtype=torch.int32,
+            torch.as_tensor(
+                numpy.asarray(
+                    [
+                        bt.is_ligand_fragment
+                        for bt in packed_block_types.active_block_types
+                    ],
+                    dtype=numpy.int32,
+                ),
                 device=self.device,
             ),
         )

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -2,6 +2,7 @@ import torch
 import numpy
 import os
 import threading
+import attr
 import pytest
 
 from tmol.score import _score_function as score_function_module
@@ -21,6 +22,7 @@ from tmol.score.ljlk.potentials import build_compact_block_neighbors
 from tmol.pose import (
     DEFAULT_ATOM_B_FACTOR,
     DEFAULT_ATOM_OCCUPANCY,
+    PackedBlockTypes,
     PoseStackBuilder,
 )
 from tmol import (
@@ -470,6 +472,77 @@ def test_packed_block_setup_is_reused_and_cross_score_function_safe(
     other.pre_work_initialization(pose)
     sfxn.pre_work_initialization(pose)
     assert calls == 2 * first_calls
+
+
+def test_packed_block_setup_reuses_annotations_for_identical_types(
+    ubq_pdb, default_database, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    original_pbt = pose.packed_block_types
+    packed_block_types = [
+        PackedBlockTypes.from_restype_list(
+            original_pbt.chem_db,
+            original_pbt.restype_set,
+            list(original_pbt.active_block_types),
+            torch_device,
+        )
+        for _ in range(2)
+    ]
+    packed_block_types[0].unrelated_annotation = object()
+    poses = [attr.evolve(pose, packed_block_types=pbt) for pbt in packed_block_types]
+    score_function = ScoreFunction(default_database, torch_device)
+    score_function.set_weight(ScoreType.ref, 1.0)
+
+    score_function.pre_work_initialization(poses[0])
+    first_weights = packed_block_types[0].ref_weights
+    score_function.pre_work_initialization(poses[1])
+
+    assert packed_block_types[1].ref_weights is first_weights
+    assert (
+        packed_block_types[1]._ref_weights_src is packed_block_types[0]._ref_weights_src
+    )
+    assert not hasattr(packed_block_types[1], "unrelated_annotation")
+
+    reversed_pbt = PackedBlockTypes.from_restype_list(
+        original_pbt.chem_db,
+        original_pbt.restype_set,
+        list(reversed(original_pbt.active_block_types)),
+        torch_device,
+    )
+    reversed_pose = attr.evolve(pose, packed_block_types=reversed_pbt)
+    score_function.pre_work_initialization(reversed_pose)
+    assert reversed_pbt.ref_weights is not first_weights
+
+
+def test_packed_block_annotation_reuse_survives_option_changes(
+    ubq_pdb, default_database, torch_device
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    original_pbt = pose.packed_block_types
+
+    def equivalent_pose():
+        pbt = PackedBlockTypes.from_restype_list(
+            original_pbt.chem_db,
+            original_pbt.restype_set,
+            list(original_pbt.active_block_types),
+            torch_device,
+        )
+        return attr.evolve(pose, packed_block_types=pbt)
+
+    score_function = ScoreFunction(default_database, torch_device)
+    score_function.set_weight(ScoreType.ref, 1.0)
+    first_pose = equivalent_pose()
+    score_function.pre_work_initialization(first_pose)
+
+    override = dict(default_database.scoring.ref.weights)
+    override[original_pbt.active_block_types[0].base_name] = 123.0
+    score_function.set_option("ref_weights", override)
+    score_function.pre_work_initialization(first_pose)
+    overridden_weights = first_pose.packed_block_types.ref_weights
+
+    second_pose = equivalent_pose()
+    score_function.pre_work_initialization(second_pose)
+    assert second_pose.packed_block_types.ref_weights is overridden_weights
 
 
 def test_no_grad_scoring_detaches_coordinates():


### PR DESCRIPTION
## Summary

- assemble static packed scoring tables on the host and transfer each completed tensor once
- replace repeated CartBonded Python hash probing with an equivalent first-insert lookup and cache residue parameter maps
- reuse only ScoreFunction-created annotations when a new PackedBlockTypes has the same ordered residue-type objects
- preserve term/option invalidation, cross-score-function safety, and arbitrary score-term enable/disable behavior

## Performance

On one-thread CPU with the standard 80-residue sequence and all beta2016 terms:

- fresh PackedBlockTypes scoring setup: 481.38 ms to 84.25 ms median (5.71x faster)
- another PackedBlockTypes over the same residue-type objects after initial setup: about 1.3 ms

This addresses first-pack setup overhead; steady-state native pair scoring is unchanged by this PR.

## Validation

- 88 passed, 72 skipped in the focused CPU scoring suite
- cache tests cover identical and reordered residue types, option changes, cross-score-function invalidation, and unrelated annotations
- Black, Flake8, and git diff checks pass
- CUDA and end-to-end 5UOI A/B validation are running