### PR TITLE
Use direct CPU loops for packed pair scoring

### DIFF
--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -611,33 +611,49 @@ auto ljlk_elec_forward_impl(
             score_weights);
       });
       auto evaluate = ([&](int tid) {
-        std::array<Real, 4> scores;
-        if (intra) {
-          scores = common::IntraResBlockEvaluation<
-              ScoringData,
-              common::AllAtomPairSelector,
-              D,
-              tile_size,
-              score_nt,
-              4,
-              Real,
-              Int>::
-              eval_intrares_atom_pairs(tid, start1, start2, pair_score, data);
+        std::array<Real, 4> scores = {};
+        if constexpr (D == tmol::Device::CPU) {
+          // The CPU workgroup has one lane. Traverse directly so GCC keeps
+          // score_atom_pair inline and avoids flattened-index division.
+          int const n_atoms1 =
+              min(int(tile_size), int(data.r1.n_atoms - start1));
+          int const n_atoms2 =
+              min(int(tile_size), int(data.r2.n_atoms - start2));
+          bool const same_tile = intra && start1 == start2;
+          for (int atom1 = 0; atom1 < n_atoms1; ++atom1) {
+            int const first_atom2 = same_tile ? atom1 + 1 : 0;
+            for (int atom2 = first_atom2; atom2 < n_atoms2; ++atom2) {
+              auto pair_scores = pair_score(start1, start2, atom1, atom2, data);
+              common::for_<4>([&](auto term) {
+                scores[term.value] += pair_scores[term.value];
+              });
+            }
+          }
         } else {
-          scores = common::InterResBlockEvaluation<
-              ScoringData,
-              common::AllAtomPairSelector,
-              D,
-              tile_size,
-              score_nt,
-              4,
-              Real,
-              Int>::
-              eval_interres_atom_pair(tid, start1, start2, pair_score, data);
+          if (intra) {
+            scores = common::IntraResBlockEvaluation<
+                ScoringData,
+                common::AllAtomPairSelector,
+                D,
+                tile_size,
+                score_nt,
+                4,
+                Real,
+                Int>::
+                eval_intrares_atom_pairs(tid, start1, start2, pair_score, data);
+          } else {
+            scores = common::InterResBlockEvaluation<
+                ScoringData,
+                common::AllAtomPairSelector,
+                D,
+                tile_size,
+                score_nt,
+                4,
+                Real,
+                Int>::
+                eval_interres_atom_pair(tid, start1, start2, pair_score, data);
+          }
         }
-        // Keep the per-pair accumulation in this hot lambda. In particular,
-        // GCC did not reliably inline the earlier helper through the CPU
-        // workgroup abstraction, erasing the compact path's CPU gain.
         if constexpr (weighted) {
           data.total_weighted +=
               score_weights[0] * scores[0] + score_weights[1] * scores[1]

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -1357,6 +1357,22 @@ void TMOL_DEVICE_FUNC eval_interres_pol_occ_pair_energies(
     int start_atom1,
     int start_atom2,
     Func f) {
+  if constexpr (Dev == tmol::Device::CPU) {
+    // CPU workgroup lanes run serially; direct loops avoid flattened-index
+    // division and modulo for every polar/occluder pair.
+    for (int pol_ind = 0; pol_ind < inter_dat.r1.n_polars; ++pol_ind) {
+      for (int occ_ind = 0; occ_ind < inter_dat.r2.n_occluders; ++occ_ind) {
+        f(start_atom1, start_atom2, pol_ind, occ_ind, inter_dat, true);
+      }
+    }
+    for (int pol_ind = 0; pol_ind < inter_dat.r2.n_polars; ++pol_ind) {
+      for (int occ_ind = 0; occ_ind < inter_dat.r1.n_occluders; ++occ_ind) {
+        f(start_atom2, start_atom1, pol_ind, occ_ind, inter_dat, false);
+      }
+    }
+    return;
+  }
+
   auto eval_scores_for_pol_occ_pairs = ([&](int tid) {
     int const n_pol_occ_pairs =
         inter_dat.r1.n_polars * inter_dat.r2.n_occluders
@@ -1394,6 +1410,29 @@ void TMOL_DEVICE_FUNC eval_intrares_pol_occ_pair_energies(
     int start_atom1,
     int start_atom2,
     Func f) {
+  if constexpr (Dev == tmol::Device::CPU) {
+    if (start_atom1 == start_atom2) {
+      for (int pol_ind = 0; pol_ind < intra_dat.r1.n_polars; ++pol_ind) {
+        for (int occ_ind = 0; occ_ind < intra_dat.r1.n_occluders; ++occ_ind) {
+          if (pol_ind == occ_ind) continue;
+          f(start_atom1, start_atom1, pol_ind, occ_ind, intra_dat, true);
+        }
+      }
+    } else {
+      for (int pol_ind = 0; pol_ind < intra_dat.r1.n_polars; ++pol_ind) {
+        for (int occ_ind = 0; occ_ind < intra_dat.r2.n_occluders; ++occ_ind) {
+          f(start_atom1, start_atom2, pol_ind, occ_ind, intra_dat, true);
+        }
+      }
+      for (int pol_ind = 0; pol_ind < intra_dat.r2.n_polars; ++pol_ind) {
+        for (int occ_ind = 0; occ_ind < intra_dat.r1.n_occluders; ++occ_ind) {
+          f(start_atom2, start_atom1, pol_ind, occ_ind, intra_dat, false);
+        }
+      }
+    }
+    return;
+  }
+
   auto eval_scores_for_pol_occ_pairs = ([&](int tid) {
     if (start_atom1 == start_atom2) {
       int const n_pol_occ_pairs =


### PR DESCRIPTION
## Summary

- traverse fused LJ/LK+electrostatics CPU atom tiles directly, keeping the hot pair scorer inline and avoiding flattened-index division
- traverse LKBall CPU polar/occluder pairs directly for the same reason
- retain the existing CUDA implementations and all independent-term, reweighting, cutoff, and decomposed-score fallbacks

## Performance

One-thread Xeon Platinum 8562Y+, 5UOI, reverse-order comparison against current `master`:

- fused raw rotamer table: 2.2367 s -> 2.1321 s (1.049x)
- fused table plus coalescing: 2.2595 s -> 2.1805 s (1.036x)
- complete packer energy-table/interaction-graph stage: 2.3240 s -> 2.2606 s (1.028x)
- rotamer score plus coordinate gradient: 6.6510 s -> 6.6339 s (1.003x)

The isolated LKBall traversal improved 1.034-1.038x on 5UOI and 1.033-1.034x on 5YZF. Benchmark harnesses and raw records remain outside the repository.

## Correctness and tests

- 5UOI raw sparse indices and values, coalesced indices and values, and all 66,408 coordinate-gradient values are bit-identical to `master`
- packer one-body and two-body table checksums match exactly
- 37 focused CPU tests passed, 24 expected CUDA tests skipped
- repository pre-commit formatting passed
