### PR TITLE
Differentiate fused rotamer pair scoring

### DIFF
--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1671,8 +1671,48 @@ class BlockPairScoringModule:
         )
 
 
+class _FusedLJLKAndElecRotamerFunction(torch.autograd.Function):
+    """Differentiate the compact fused table by one fused recomputation."""
+
+    @staticmethod
+    def forward(ctx, *args):
+        from tmol.score.ljlk.potentials import ljlk_elec_weighted_rotamer_scores
+
+        tensor_args = args[:-2]
+        max_dis, score_weights = args[-2:]
+        empty_gradients = score_weights.new_empty(0)
+        scores, indices, _ = ljlk_elec_weighted_rotamer_scores(
+            *tensor_args, max_dis, score_weights, empty_gradients
+        )
+        saved_tensors = []
+        ctx.scalar_args = {}
+        for index, arg in enumerate(args):
+            if isinstance(arg, torch.Tensor):
+                saved_tensors.append(arg)
+            else:
+                ctx.scalar_args[index] = arg
+        ctx.save_for_backward(*saved_tensors)
+        ctx.n_inputs = len(args)
+        ctx.mark_non_differentiable(indices)
+        return scores, indices
+
+    @staticmethod
+    def backward(ctx, score_gradients, _):
+        from tmol.score.ljlk.potentials import ljlk_elec_weighted_rotamer_scores
+
+        saved_tensors = iter(ctx.saved_tensors)
+        args = [
+            ctx.scalar_args[index] if index in ctx.scalar_args else next(saved_tensors)
+            for index in range(ctx.n_inputs)
+        ]
+        _, _, coord_gradients = ljlk_elec_weighted_rotamer_scores(
+            *args, score_gradients.reshape(-1)
+        )
+        return (coord_gradients,) + (None,) * (ctx.n_inputs - 1)
+
+
 class _FusedLJLKAndElecRotamerModule(torch.nn.Module):
-    """Internal packing-only group that emits one live-weighted sparse lane."""
+    """Internal group that emits one live-weighted sparse lane."""
 
     def __init__(self, ljlk_module, elec_module):
         super().__init__()
@@ -1712,9 +1752,13 @@ class _FusedLJLKAndElecRotamerModule(torch.nn.Module):
 
         if score_weights.dtype != coords.dtype:
             score_weights = score_weights.to(dtype=coords.dtype)
-        return ljlk_elec_weighted_rotamer_scores(
-            *self._native_arguments(coords), score_weights
+        args = (*self._native_arguments(coords), score_weights)
+        if torch.is_grad_enabled() and coords.requires_grad:
+            return _FusedLJLKAndElecRotamerFunction.apply(*args)
+        scores, indices, _ = ljlk_elec_weighted_rotamer_scores(
+            *args, score_weights.new_empty(0)
         )
+        return scores, indices
 
 
 def _fused_ljlk_elec_rotamer_module(term_modules):
@@ -1907,7 +1951,7 @@ class RotamerScoringModule:
         use_fused = (
             self._fused_ljlk_elec is not None
             and self._fused_ljlk_elec.is_compatible()
-            and not differentiable
+            and not self.weights.requires_grad
         )
         execution_terms = self._execution_terms(use_fused)
         parallel = self._cpu_term_workers >= 2 and not differentiable

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -1083,11 +1083,12 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
     Tensor block_type_elec_intra_repr_path_distance,
     Tensor elec_global_params,
     double max_dis,
-    Tensor score_weights) {
+    Tensor score_weights,
+    Tensor output_gradients) {
   TORCH_CHECK(
       !torch::GradMode::is_enabled()
           || (!rot_coords.requires_grad() && !score_weights.requires_grad()),
-      "weighted fused rotamer scoring is a packing-only forward path");
+      "weighted fused rotamer scoring requires the autograd module wrapper");
   TORCH_CHECK(
       score_weights.dim() == 1 && score_weights.size(0) == 4,
       "weighted fused rotamer scoring requires four score weights");
@@ -1095,8 +1096,14 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
       score_weights.scalar_type() == rot_coords.scalar_type()
           && score_weights.device() == rot_coords.device(),
       "fused rotamer weights must match coordinate dtype and device");
+  TORCH_CHECK(
+      output_gradients.numel() == 0
+          || (output_gradients.dim() == 1
+              && output_gradients.scalar_type() == rot_coords.scalar_type()
+              && output_gradients.device() == rot_coords.device()),
+      "fused rotamer output gradients must be an empty or matching vector");
 
-  Tensor score, dispatch_indices;
+  Tensor score, dscore_dcoords, dispatch_indices;
   using Int = int32_t;
   TMOL_DISPATCH_FLOATING_DEVICE(
       rot_coords.options(), "ljlk_elec_weighted_rotamer_scores", ([&] {
@@ -1134,11 +1141,17 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
                     TCAST(block_type_elec_intra_repr_path_distance),
                     TCAST(elec_global_params),
                     (Real)max_dis,
-                    TCAST(score_weights));
+                    TCAST(score_weights),
+                    TCAST(output_gradients));
         score = std::get<0>(result).tensor.squeeze(1).squeeze(1);
+        dscore_dcoords = std::get<1>(result).tensor.squeeze(0);
         dispatch_indices = std::get<2>(result).tensor;
       }));
-  return {score, dispatch_indices};
+  TORCH_CHECK(
+      output_gradients.numel() == 0
+          || output_gradients.numel() == score.numel(),
+      "fused rotamer output gradients must match the score table");
+  return {score, dispatch_indices, dscore_dcoords};
 }
 
 // See https://stackoverflow.com/a/3221914

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
@@ -99,9 +99,9 @@ struct LJLKAndElecPoseScoreDispatch {
       -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
 
   /// Evaluate weighted LJ/LK + electrostatics for a prepared sparse rotamer
-  /// pair dispatch. Packing does not differentiate the energy table, so this
-  /// compact path emits one live-weighted value per dispatch entry without
-  /// allocating canonical score lanes or derivative scratch.
+  /// pair dispatch. An empty output-gradient vector selects the compact
+  /// packing path; a populated vector recomputes fused coordinate derivatives
+  /// without allocating canonical score lanes.
   static auto forward_weighted_rotamers(
       ContextManager& mgr,
       TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
@@ -133,7 +133,8 @@ struct LJLKAndElecPoseScoreDispatch {
       TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
           elec_global_params,
       Real max_dis,
-      TView<Real, 1, D> score_weights)
+      TView<Real, 1, D> score_weights,
+      TView<Real, 1, D> output_gradients)
       -> std::tuple<
           TPack<Real, 4, D>,
           TPack<LJLKExternalVec<Real, 3>, 2, D>,

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -115,7 +115,8 @@ TMOL_DEVICE_FUNC std::array<Real, 4> score_atom_pair(
     int ljlk_separation,
     int elec_separation,
     TView<Eigen::Matrix<Real, 3, 1>, 2, D> dV_dcoords,
-    TView<Real, 1, D> score_weights) {
+    TView<Real, 1, D> score_weights,
+    Real derivative_scale) {
   if (ljlk_separation < 4 && elec_separation < 4) {
     return {0, 0, 0, 0};
   }
@@ -205,10 +206,11 @@ TMOL_DEVICE_FUNC std::array<Real, 4> score_atom_pair(
     Real const radial_derivs[4] = {
         ljatr_deriv, ljrep_deriv, lk_deriv, elec_deriv};
     if constexpr (weighted) {
-      Real const weighted_deriv = score_weights[0] * radial_derivs[0]
-                                  + score_weights[1] * radial_derivs[1]
-                                  + score_weights[2] * radial_derivs[2]
-                                  + score_weights[3] * radial_derivs[3];
+      Real const weighted_deriv = derivative_scale
+                                  * (score_weights[0] * radial_derivs[0]
+                                     + score_weights[1] * radial_derivs[1]
+                                     + score_weights[2] * radial_derivs[2]
+                                     + score_weights[3] * radial_derivs[3]);
       Real3 const dxyz1 = weighted_deriv * unit_delta;
 #pragma unroll
       for (int axis = 0; axis < 3; ++axis) {
@@ -326,10 +328,12 @@ auto ljlk_elec_forward_impl(
         elec_global_params,
     TView<Int, 1, D> shared_compact_block_neighbors,
     TView<Int, 2, D> rotamer_dispatch_indices,
-    TView<Real, 1, D> score_weights)
+    TView<Real, 1, D> score_weights,
+    TView<Real, 1, D> output_gradients)
     -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
   using namespace ljlk_elec_detail;
   using Real3 = Eigen::Matrix<Real, 3, 1>;
+  static_assert(!require_gradient || !rotamer_pairs || weighted);
 
   int const n_atoms = rot_coords.size(0);
   int const n_poses = first_rot_for_block.size(0);
@@ -364,6 +368,10 @@ auto ljlk_elec_forward_impl(
   constexpr int score_nt = D == tmol::Device::CPU ? 1 : nt;
 
   auto eval_neighbor = ([=] TMOL_DEVICE_FUNC(int candidate) {
+    Real derivative_scale = 1;
+    if (require_gradient && rotamer_pairs) {
+      derivative_scale = output_gradients[candidate];
+    }
     int pose_ind;
     int rot_ind1;
     int rot_ind2;
@@ -608,7 +616,8 @@ auto ljlk_elec_forward_impl(
             lj_sep,
             elec_sep,
             dV_dcoords,
-            score_weights);
+            score_weights,
+            derivative_scale);
       });
       auto evaluate = ([&](int tid) {
         std::array<Real, 4> scores = {};
@@ -787,8 +796,15 @@ auto ljlk_elec_forward_impl(
   });
 
   if constexpr (rotamer_pairs) {
-    DeviceOperations<D>::template foreach_independent_workgroup<launch_t>(
-        mgr, n_outputs, eval_neighbor);
+    if constexpr (require_gradient) {
+      // Rotamer pairs share coordinate outputs. Keep CPU workgroups serial;
+      // CUDA accumulation is atomic, so its workgroups remain concurrent.
+      DeviceOperations<D>::template foreach_workgroup<launch_t>(
+          mgr, n_outputs, eval_neighbor);
+    } else {
+      DeviceOperations<D>::template foreach_independent_workgroup<launch_t>(
+          mgr, n_outputs, eval_neighbor);
+    }
   } else {
     common::sphere_overlap::
         launch_precomputed_block_neighbors<DeviceOperations, D, launch_t, Int>(
@@ -861,6 +877,7 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
         Int>(
         TMOL_LJLK_ELEC_FORWARD_ARGS,
         empty_rotamer_dispatch.view,
+        empty_weights.view,
         empty_weights.view);
   }
   return ljlk_elec_forward_impl<
@@ -873,6 +890,7 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       Int>(
       TMOL_LJLK_ELEC_FORWARD_ARGS,
       empty_rotamer_dispatch.view,
+      empty_weights.view,
       empty_weights.view);
 #undef TMOL_LJLK_ELEC_FORWARD_ARGS
 }
@@ -931,6 +949,7 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       block_type_elec_intra_repr_path_distance, elec_global_params,           \
       shared_compact_block_neighbors
   auto empty_rotamer_dispatch = TPack<Int, 2, D>::empty({0, 0});
+  auto empty_output_gradients = TPack<Real, 1, D>::empty({0});
   if (require_gradient) {
     return ljlk_elec_forward_impl<
         true,
@@ -942,7 +961,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
         Int>(
         TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
         empty_rotamer_dispatch.view,
-        score_weights);
+        score_weights,
+        empty_output_gradients.view);
   }
   return ljlk_elec_forward_impl<
       false,
@@ -954,7 +974,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       Int>(
       TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
       empty_rotamer_dispatch.view,
-      score_weights);
+      score_weights,
+      empty_output_gradients.view);
 #undef TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS
 }
 
@@ -995,7 +1016,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
         TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
             elec_global_params,
         Real max_dis,
-        TView<Real, 1, D> score_weights)
+        TView<Real, 1, D> score_weights,
+        TView<Real, 1, D> output_gradients)
         -> std::tuple<
             TPack<Real, 4, D>,
             TPack<LJLKExternalVec<Real, 3>, 2, D>,
@@ -1047,40 +1069,39 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
             rot_offset_for_block,
             scratch_rot_spheres_t.view,
             max_dis);
+  assert(
+      output_gradients.size(0) == 0
+      || output_gradients.size(0) == rotamer_dispatch_indices.view.size(1));
   auto empty_compact_block_neighbors = TPack<Int, 1, D>::empty({0});
+#define TMOL_LJLK_ELEC_WEIGHTED_ROTAMER_ARGS                                  \
+  mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
+      first_rot_block_type, block_ind_for_rot, pose_ind_for_rot,              \
+      block_type_ind_for_rot, n_rots_for_pose, rot_offset_for_pose,           \
+      n_rots_for_block, rot_offset_for_block, max_n_rots_per_pose,            \
+      pose_stack_min_bond_separation, pose_stack_inter_block_bondsep,         \
+      block_type_n_atoms, block_type_atom_types,                              \
+      block_type_n_interblock_bonds, block_type_atoms_forming_chemical_bonds, \
+      block_type_ljlk_path_distance, block_type_is_ligand_fragment,           \
+      ljlk_type_params, ljlk_global_params, block_type_partial_charge,        \
+      block_type_elec_inter_repr_path_distance,                               \
+      block_type_elec_intra_repr_path_distance, elec_global_params,           \
+      empty_compact_block_neighbors.view, rotamer_dispatch_indices.view,      \
+      score_weights, output_gradients
+  if (output_gradients.size(0) != 0) {
+    auto result = ljlk_elec_forward_impl<
+        true,
+        true,
+        true,
+        DeviceOperations,
+        D,
+        Real,
+        Int>(TMOL_LJLK_ELEC_WEIGHTED_ROTAMER_ARGS);
+    return {std::get<0>(result), std::get<1>(result), rotamer_dispatch_indices};
+  }
   auto result =
       ljlk_elec_forward_impl<false, true, true, DeviceOperations, D, Real, Int>(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          pose_ind_for_atom,
-          first_rot_for_block,
-          first_rot_block_type,
-          block_ind_for_rot,
-          pose_ind_for_rot,
-          block_type_ind_for_rot,
-          n_rots_for_pose,
-          rot_offset_for_pose,
-          n_rots_for_block,
-          rot_offset_for_block,
-          max_n_rots_per_pose,
-          pose_stack_min_bond_separation,
-          pose_stack_inter_block_bondsep,
-          block_type_n_atoms,
-          block_type_atom_types,
-          block_type_n_interblock_bonds,
-          block_type_atoms_forming_chemical_bonds,
-          block_type_ljlk_path_distance,
-          block_type_is_ligand_fragment,
-          ljlk_type_params,
-          ljlk_global_params,
-          block_type_partial_charge,
-          block_type_elec_inter_repr_path_distance,
-          block_type_elec_intra_repr_path_distance,
-          elec_global_params,
-          empty_compact_block_neighbors.view,
-          rotamer_dispatch_indices.view,
-          score_weights);
+          TMOL_LJLK_ELEC_WEIGHTED_ROTAMER_ARGS);
+#undef TMOL_LJLK_ELEC_WEIGHTED_ROTAMER_ARGS
   return {std::get<0>(result), std::get<1>(result), rotamer_dispatch_indices};
 }
 

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -489,6 +489,9 @@ def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
     # Weights are read at every call instead of being specialized into the
     # rendered module.
     weight_begin = scorer._fused_ljlk_elec_weight_offset
+    original_fused_weights = scorer.weights[
+        weight_begin : weight_begin + 4, 0, 0, 0
+    ].clone()
     with torch.no_grad():
         scorer.weights[weight_begin : weight_begin + 4, 0, 0, 0] *= torch.tensor(
             [0.5, 1.25, 0.75, 0.0], device=torch_device
@@ -507,8 +510,8 @@ def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
 
     # Fusion remains the measured fast path when the term pool has four CPU
     # workers; each native operator can still use ATen's inner CPU parallelism.
+    original_forward = fused_group.forward
     if torch_device.type == "cpu":
-        original_forward = fused_group.forward
         fused_calls = []
 
         def record_fused_call(*args):
@@ -527,6 +530,11 @@ def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
         scorer._cpu_term_workers = 1
         fused_group.forward = original_forward
 
+    with torch.no_grad():
+        scorer.weights[weight_begin : weight_begin + 4, 0, 0, 0].copy_(
+            original_fused_weights
+        )
+
     # A caller that changes either dispatch cutoff must use the canonical
     # operators, since the fused traversal assumes the default compatible pair.
     original_cutoff = fused_group.ljlk_module.block_neighbor_cutoff
@@ -539,16 +547,43 @@ def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
     assert changed_cutoff._nnz() != 0
     fused_group.ljlk_module.block_neighbor_cutoff = original_cutoff
 
-    # Differentiable callers must retain the canonical independent operators.
-    fused_group.forward = lambda *_: pytest.fail(
-        "packing-only fusion used for a differentiable call"
+    # Coordinate derivatives use one fused recomputation with the live output
+    # gradient for every sparse entry.
+    fused_group.forward = original_forward
+    fused_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    fused_differentiable = scorer(fused_coords).coalesce()
+    upstream = torch.linspace(
+        0.25,
+        1.25,
+        fused_differentiable.values().numel(),
+        device=torch_device,
     )
-    coords = rotamer_set.coords.detach().clone().requires_grad_(True)
-    differentiable = scorer(coords).coalesce()
-    differentiable.values().sum().backward()
-    assert coords.grad is not None
-    assert torch.isfinite(coords.grad).all()
+    (fused_gradient,) = torch.autograd.grad(
+        (fused_differentiable.values() * upstream).sum(), fused_coords
+    )
+    scorer._fused_ljlk_elec = None
+    separate_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+    separate_differentiable = scorer(separate_coords).coalesce()
+    (separate_gradient,) = torch.autograd.grad(
+        (separate_differentiable.values() * upstream).sum(), separate_coords
+    )
+    scorer._fused_ljlk_elec = fused_group
+    assert torch.equal(
+        fused_differentiable.indices(), separate_differentiable.indices()
+    )
+    torch.testing.assert_close(
+        fused_differentiable.values(),
+        separate_differentiable.values(),
+        atol=2e-3,
+        rtol=2e-5,
+    )
+    torch.testing.assert_close(fused_gradient, separate_gradient, atol=2e-3, rtol=5e-5)
 
+    # Trainable score weights retain the canonical operators so their four
+    # independent parameter gradients remain available.
+    fused_group.forward = lambda *_: pytest.fail(
+        "weighted fusion used with trainable score weights"
+    )
     scorer.weights.requires_grad_(True)
     weight_differentiable = scorer(rotamer_set.coords.detach()).coalesce()
     weight_differentiable.values().sum().backward()


### PR DESCRIPTION
## Summary

- use the existing compact weighted LJ/LK + electrostatics rotamer traversal for coordinate derivatives
- recompute one fused weighted derivative in backward instead of traversing LJ/LK and electrostatics independently
- retain the canonical path for trainable score weights, trainable term parameters, or incompatible live cutoffs
- keep overlapping CPU derivative workgroups serial, matching the existing rotamer derivative convention; CUDA remains concurrent and atomic

## Performance

One-thread CPU, batch 1:

| Dataset | master | candidate | speedup |
| --- | ---: | ---: | ---: |
| 5UOI score + gradient | 6.464 s | 4.773 s | 1.354x |
| 5YZF score + gradient | 22.659 s | 16.518 s | 1.372x |

Score-only controls were neutral to slightly faster: 1.003-1.007x on 5UOI and 1.004x on the completed 5YZF pass.

H200, 5UOI score + gradient, batch 1:

| Order | master | candidate | speedup |
| --- | ---: | ---: | ---: |
| pass 1 | 19.599 ms | 17.107 ms | 1.146x |
| pass 2 | 19.575 ms | 17.045 ms | 1.148x |

Measured peak incremental H200 allocation was unchanged at 54,404,096 bytes; the peak is set outside this fused pair scratch.

## Correctness

- fresh 5UOI CPU raw and coalesced score-table indices and values are bit-identical to current master; checksum is 6,666,378.5 in both cases
- 5YZF CPU checksum is unchanged at 26,212,880
- H200 checksum is unchanged at 6,666,379; coordinate gradients remain within the existing atomic-reassociation envelope
- the focused test compares fused and canonical scores plus coordinate gradients using a nonuniform upstream gradient
- focused CPU test passes with one and 16 threads
- focused H200 test passes on both CPU and CUDA fixtures
- trainable weights and changed cutoffs are explicitly tested to retain the canonical path

Only production code and its regression test are included; benchmark drivers and results remain external.
