### PR TITLE
Reuse fused rotamer dispatch in backward

### DIFF
--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1678,11 +1678,15 @@ class _FusedLJLKAndElecRotamerFunction(torch.autograd.Function):
     def forward(ctx, *args):
         from tmol.score.ljlk.potentials import ljlk_elec_weighted_rotamer_scores
 
-        tensor_args = args[:-2]
-        max_dis, score_weights = args[-2:]
+        tensor_args = args[:-3]
+        max_dis, score_weights, empty_dispatch = args[-3:]
         empty_gradients = score_weights.new_empty(0)
         scores, indices, _ = ljlk_elec_weighted_rotamer_scores(
-            *tensor_args, max_dis, score_weights, empty_gradients
+            *tensor_args,
+            max_dis,
+            score_weights,
+            empty_gradients,
+            empty_dispatch,
         )
         saved_tensors = []
         ctx.scalar_args = {}
@@ -1691,7 +1695,7 @@ class _FusedLJLKAndElecRotamerFunction(torch.autograd.Function):
                 saved_tensors.append(arg)
             else:
                 ctx.scalar_args[index] = arg
-        ctx.save_for_backward(*saved_tensors)
+        ctx.save_for_backward(*saved_tensors, indices)
         ctx.n_inputs = len(args)
         ctx.mark_non_differentiable(indices)
         return scores, indices
@@ -1700,13 +1704,14 @@ class _FusedLJLKAndElecRotamerFunction(torch.autograd.Function):
     def backward(ctx, score_gradients, _):
         from tmol.score.ljlk.potentials import ljlk_elec_weighted_rotamer_scores
 
-        saved_tensors = iter(ctx.saved_tensors)
+        saved_tensors = iter(ctx.saved_tensors[:-1])
+        dispatch_indices = ctx.saved_tensors[-1]
         args = [
             ctx.scalar_args[index] if index in ctx.scalar_args else next(saved_tensors)
             for index in range(ctx.n_inputs)
         ]
         _, _, coord_gradients = ljlk_elec_weighted_rotamer_scores(
-            *args, score_gradients.reshape(-1)
+            *args[:-1], score_gradients.reshape(-1), dispatch_indices
         )
         return (coord_gradients,) + (None,) * (ctx.n_inputs - 1)
 
@@ -1752,11 +1757,15 @@ class _FusedLJLKAndElecRotamerModule(torch.nn.Module):
 
         if score_weights.dtype != coords.dtype:
             score_weights = score_weights.to(dtype=coords.dtype)
-        args = (*self._native_arguments(coords), score_weights)
+        args = (
+            *self._native_arguments(coords),
+            score_weights,
+            self.ljlk_module._empty_dispatch_indices,
+        )
         if torch.is_grad_enabled() and coords.requires_grad:
             return _FusedLJLKAndElecRotamerFunction.apply(*args)
         scores, indices, _ = ljlk_elec_weighted_rotamer_scores(
-            *args, score_weights.new_empty(0)
+            *args[:-1], score_weights.new_empty(0), args[-1]
         )
         return scores, indices
 

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -1084,7 +1084,8 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
     Tensor elec_global_params,
     double max_dis,
     Tensor score_weights,
-    Tensor output_gradients) {
+    Tensor output_gradients,
+    Tensor shared_dispatch_indices) {
   TORCH_CHECK(
       !torch::GradMode::is_enabled()
           || (!rot_coords.requires_grad() && !score_weights.requires_grad()),
@@ -1102,6 +1103,23 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
               && output_gradients.scalar_type() == rot_coords.scalar_type()
               && output_gradients.device() == rot_coords.device()),
       "fused rotamer output gradients must be an empty or matching vector");
+  TORCH_CHECK(
+      shared_dispatch_indices.dim() == 2
+          && (shared_dispatch_indices.size(0) == 3
+              || (shared_dispatch_indices.size(0) == 0
+                  && shared_dispatch_indices.size(1) == 0)),
+      "shared rotamer dispatch indices must have shape [3, nnz] or [0, 0]");
+  TORCH_CHECK(
+      shared_dispatch_indices.scalar_type() == torch::kInt32,
+      "shared rotamer dispatch indices must have dtype int32");
+  TORCH_CHECK(
+      shared_dispatch_indices.device() == rot_coords.device(),
+      "shared rotamer dispatch indices must be on the coordinate device");
+  TORCH_CHECK(
+      (shared_dispatch_indices.size(0) == 0 && output_gradients.numel() == 0)
+          || (shared_dispatch_indices.size(0) == 3
+              && output_gradients.numel() == shared_dispatch_indices.size(1)),
+      "fused rotamer output gradients require the matching forward dispatch");
 
   Tensor score, dscore_dcoords, dispatch_indices;
   using Int = int32_t;
@@ -1142,7 +1160,8 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
                     TCAST(elec_global_params),
                     (Real)max_dis,
                     TCAST(score_weights),
-                    TCAST(output_gradients));
+                    TCAST(output_gradients),
+                    TCAST(shared_dispatch_indices));
         score = std::get<0>(result).tensor.squeeze(1).squeeze(1);
         dscore_dcoords = std::get<1>(result).tensor.squeeze(0);
         dispatch_indices = std::get<2>(result).tensor;

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
@@ -99,9 +99,9 @@ struct LJLKAndElecPoseScoreDispatch {
       -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
 
   /// Evaluate weighted LJ/LK + electrostatics for a prepared sparse rotamer
-  /// pair dispatch. An empty output-gradient vector selects the compact
-  /// packing path; a populated vector recomputes fused coordinate derivatives
-  /// without allocating canonical score lanes.
+  /// pair dispatch. An empty dispatch selects the compact score path; a
+  /// prepared dispatch recomputes fused coordinate derivatives with its
+  /// matching output-gradient vector.
   static auto forward_weighted_rotamers(
       ContextManager& mgr,
       TView<LJLKExternalVec<Real, 3>, 1, D> rot_coords,
@@ -134,7 +134,8 @@ struct LJLKAndElecPoseScoreDispatch {
           elec_global_params,
       Real max_dis,
       TView<Real, 1, D> score_weights,
-      TView<Real, 1, D> output_gradients)
+      TView<Real, 1, D> output_gradients,
+      TPack<Int, 2, D> shared_dispatch_indices)
       -> std::tuple<
           TPack<Real, 4, D>,
           TPack<LJLKExternalVec<Real, 3>, 2, D>,

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -1017,7 +1017,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
             elec_global_params,
         Real max_dis,
         TView<Real, 1, D> score_weights,
-        TView<Real, 1, D> output_gradients)
+        TView<Real, 1, D> output_gradients,
+        TPack<Int, 2, D> shared_dispatch_indices)
         -> std::tuple<
             TPack<Real, 4, D>,
             TPack<LJLKExternalVec<Real, 3>, 2, D>,
@@ -1025,50 +1026,55 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
   int const n_rots = rot_coord_offset.size(0);
   int const n_poses = first_rot_for_block.size(0);
   int const max_n_blocks = first_rot_for_block.size(1);
-  auto scratch_rot_spheres_t = D == Device::CPU
-                                   ? TPack<Real, 2, D>::zeros({n_rots, 4})
-                                   : TPack<Real, 2, D>::empty({n_rots, 4});
-  auto scratch_block_spheres_t =
-      D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
-                       : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
-  auto scratch_block_neighbors_t =
-      D == Device::CPU
-          ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
-          : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
-  score::common::sphere_overlap::
-      compute_rot_spheres<DeviceOperations, D, Real, Int>::f(
-          mgr,
-          rot_coords,
-          rot_coord_offset,
-          block_type_ind_for_rot,
-          block_type_n_atoms,
-          scratch_rot_spheres_t.view);
-  score::common::sphere_overlap::
-      compute_block_spheres_from_rot_spheres<DeviceOperations, D, Real, Int>::f(
-          mgr,
-          scratch_rot_spheres_t.view,
-          n_rots_for_block,
-          rot_offset_for_block,
-          scratch_block_spheres_t.view);
-  score::common::sphere_overlap::
-      detect_block_neighbors<DeviceOperations, D, Real, Int>::f(
-          mgr,
-          first_rot_block_type,
-          scratch_block_spheres_t.view,
-          scratch_block_neighbors_t.view,
-          max_dis);
-  auto rotamer_dispatch_indices =
-      score::common::sphere_overlap::rot_neighbor_indices_from_block_neighbors<
-          DeviceOperations,
-          D,
-          Real,
-          Int>::
-          f(mgr,
+  TPack<Int, 2, D> rotamer_dispatch_indices;
+  if (shared_dispatch_indices.size(0) == 3) {
+    rotamer_dispatch_indices = shared_dispatch_indices;
+  } else {
+    auto scratch_rot_spheres_t = D == Device::CPU
+                                     ? TPack<Real, 2, D>::zeros({n_rots, 4})
+                                     : TPack<Real, 2, D>::empty({n_rots, 4});
+    auto scratch_block_spheres_t =
+        D == Device::CPU ? TPack<Real, 3, D>::zeros({n_poses, max_n_blocks, 4})
+                         : TPack<Real, 3, D>::empty({n_poses, max_n_blocks, 4});
+    auto scratch_block_neighbors_t =
+        D == Device::CPU
+            ? TPack<Int, 3, D>::zeros({n_poses, max_n_blocks, max_n_blocks})
+            : TPack<Int, 3, D>::empty({n_poses, max_n_blocks, max_n_blocks});
+    score::common::sphere_overlap::
+        compute_rot_spheres<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            rot_coords,
+            rot_coord_offset,
+            block_type_ind_for_rot,
+            block_type_n_atoms,
+            scratch_rot_spheres_t.view);
+    score::common::sphere_overlap::
+        compute_block_spheres_from_rot_spheres<DeviceOperations, D, Real, Int>::
+            f(mgr,
+              scratch_rot_spheres_t.view,
+              n_rots_for_block,
+              rot_offset_for_block,
+              scratch_block_spheres_t.view);
+    score::common::sphere_overlap::
+        detect_block_neighbors<DeviceOperations, D, Real, Int>::f(
+            mgr,
+            first_rot_block_type,
+            scratch_block_spheres_t.view,
             scratch_block_neighbors_t.view,
-            n_rots_for_block,
-            rot_offset_for_block,
-            scratch_rot_spheres_t.view,
             max_dis);
+    rotamer_dispatch_indices = score::common::sphere_overlap::
+        rot_neighbor_indices_from_block_neighbors<
+            DeviceOperations,
+            D,
+            Real,
+            Int>::
+            f(mgr,
+              scratch_block_neighbors_t.view,
+              n_rots_for_block,
+              rot_offset_for_block,
+              scratch_rot_spheres_t.view,
+              max_dis);
+  }
   assert(
       output_gradients.size(0) == 0
       || output_gradients.size(0) == rotamer_dispatch_indices.view.size(1));
@@ -1087,7 +1093,7 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       block_type_elec_intra_repr_path_distance, elec_global_params,           \
       empty_compact_block_neighbors.view, rotamer_dispatch_indices.view,      \
       score_weights, output_gradients
-  if (output_gradients.size(0) != 0) {
+  if (shared_dispatch_indices.size(0) == 3) {
     auto result = ljlk_elec_forward_impl<
         true,
         true,

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -592,6 +592,38 @@ def test_weighted_fused_ljlk_elec_rotamer_scores_match_fallback(
     assert torch.count_nonzero(scorer.weights.grad[:4]) != 0
 
 
+def test_fused_ljlk_elec_empty_table_gradient(monkeypatch):
+    from tmol.score import _score_function
+    from tmol.score.ljlk import potentials
+
+    calls = []
+
+    def empty_scores(coords, _max_dis, _weights, output_gradients, dispatch):
+        calls.append((output_gradients.shape, dispatch.shape))
+        indices = torch.empty((3, 0), dtype=torch.int32, device=coords.device)
+        coord_gradients = (
+            torch.zeros_like(coords)
+            if dispatch.shape[0] == 3
+            else coords.new_empty((0, 3))
+        )
+        return coords.new_empty((1, 0)), indices, coord_gradients
+
+    monkeypatch.setattr(potentials, "ljlk_elec_weighted_rotamer_scores", empty_scores)
+    coords = torch.empty((0, 3), requires_grad=True)
+    weights = torch.ones(4)
+    empty_dispatch = torch.empty((0, 0), dtype=torch.int32)
+    scores, _ = _score_function._FusedLJLKAndElecRotamerFunction.apply(
+        coords, 6.0, weights, empty_dispatch
+    )
+    scores.sum().backward()
+
+    assert coords.grad.shape == coords.shape
+    assert calls == [
+        (torch.Size([0]), torch.Size([0, 0])),
+        (torch.Size([0]), torch.Size([3, 0])),
+    ]
+
+
 def test_pack_rotamers_optH(default_database, ubq_pdb, torch_device):
     n_poses = 4
     p = pose_stack_from_pdb(ubq_pdb, torch_device, residue_start=0, residue_end=76)


### PR DESCRIPTION
The fused weighted LJ/LK + electrostatics autograd path now saves its compact forward dispatch and reuses it in backward. This removes redundant sphere construction, neighbor detection, and compact-dispatch construction while keeping live weights and the existing fallback behavior unchanged.

It also distinguishes score mode from derivative mode by dispatch shape, fixing the zero-entry gradient case where an empty upstream vector previously selected the score-only path.

Performance (5UOI):
- H200 score+gradient: 2.0% and 3.8% faster in reverse-order passes (2.9% geometric mean)
- CUDA events: 215 -> 206 per score+gradient evaluation
- H200 score-only and allocator peak: neutral
- one-thread CPU: approximately neutral/slightly negative (-0.4% score+gradient geometric mean)
- CPU values/gradients: bit-identical; CUDA scores identical and gradients within the existing atomic tolerance

Validation:
- 105 passed, 69 skipped in broad local CPU scoring tests
- focused 16-thread CPU test passed
- 3 focused CPU/CUDA H200 tests passed
- clang-format, Black, and flake8 passed

Benchmark and profiler scripts/results remain outside the repository.