### PR TITLE
Avoid CPU LKBall shared-memory staging copies

### DIFF
--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -682,26 +682,38 @@ void TMOL_DEVICE_FUNC lk_ball_load_block_coords_and_params_into_shared(
   // Note that TILE_SIZE is not explicitly passed in, but is "present"
   // in r_dat.coords allocation
 
-  DeviceDispatch<Dev>::template copy_contiguous_data<nt, 3>(
-      r_dat.pose_coords,
-      reinterpret_cast<Real*>(
-          &pose_coords[r_dat.rot_coord_offset + start_atom]),
-      n_atoms_to_load * 3);
-  DeviceDispatch<Dev>::template copy_contiguous_data<nt, MAX_N_WATER * 3>(
-      r_dat.water_coords,
-      reinterpret_cast<Real*>(
-          &water_coords[r_dat.rot_coord_offset + start_atom][0]),
-      n_atoms_to_load * MAX_N_WATER * 3);
+  if constexpr (Dev == tmol::Device::CPU) {
+    // CPU has no workgroup-shared memory to populate. Read immutable,
+    // contiguous coordinates and parameters in place instead of copying each
+    // rotamer pair through the CUDA-oriented staging arrays.
+    r_dat.pose_coords = reinterpret_cast<Real*>(
+        &pose_coords[r_dat.rot_coord_offset + start_atom]);
+    r_dat.water_coords = reinterpret_cast<Real*>(
+        &water_coords[r_dat.rot_coord_offset + start_atom][0]);
+    r_dat.lk_ball_params =
+        &block_type_tile_lk_ball_params[r_dat.block_type][tile_ind][0];
+  } else {
+    DeviceDispatch<Dev>::template copy_contiguous_data<nt, 3>(
+        r_dat.pose_coords,
+        reinterpret_cast<Real*>(
+            &pose_coords[r_dat.rot_coord_offset + start_atom]),
+        n_atoms_to_load * 3);
+    DeviceDispatch<Dev>::template copy_contiguous_data<nt, MAX_N_WATER * 3>(
+        r_dat.water_coords,
+        reinterpret_cast<Real*>(
+            &water_coords[r_dat.rot_coord_offset + start_atom][0]),
+        n_atoms_to_load * MAX_N_WATER * 3);
+    int const N_PARAMS = sizeof(LKBallTypeParams<Real>) / sizeof(Real);
+    DeviceDispatch<Dev>::template copy_contiguous_data<nt, N_PARAMS>(
+        reinterpret_cast<Real*>(r_dat.lk_ball_params),
+        reinterpret_cast<Real*>(
+            &block_type_tile_lk_ball_params[r_dat.block_type][tile_ind][0]),
+        r_dat.n_occluders * N_PARAMS);
+  }
   DeviceDispatch<Dev>::template copy_contiguous_data_and_cast<nt, 1>(
       r_dat.pol_occ_tile_inds,
       &block_type_tile_pol_occ_inds[r_dat.block_type][tile_ind][0],
       r_dat.n_occluders);
-  int const N_PARAMS = sizeof(LKBallTypeParams<Real>) / sizeof(Real);
-  DeviceDispatch<Dev>::template copy_contiguous_data<nt, N_PARAMS>(
-      reinterpret_cast<Real*>(r_dat.lk_ball_params),
-      reinterpret_cast<Real*>(
-          &block_type_tile_lk_ball_params[r_dat.block_type][tile_ind][0]),
-      r_dat.n_occluders * N_PARAMS);
 }
 
 template <
@@ -1155,7 +1167,12 @@ void TMOL_DEVICE_FUNC lk_ball_load_intrares2_tile_data_to_shared(
       start_atom2);
 }
 
-template <int TILE_SIZE, int MAX_N_WATER, int MAX_N_CONN, typename Real>
+template <
+    tmol::Device Dev,
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    int MAX_N_CONN,
+    typename Real>
 void TMOL_DEVICE_FUNC lk_ball_load_intrares_data_from_shared(
     int tile_ind1,
     int tile_ind2,
@@ -1167,18 +1184,26 @@ void TMOL_DEVICE_FUNC lk_ball_load_intrares_data_from_shared(
   // then only the "1" shared-memory arrays will be loaded with data;
   // we will point the "2" memory pointers at the "1" arrays
   bool same_tile = tile_ind1 == tile_ind2;
-  intra_dat.r1.pose_coords = shared_m.pose_coords1;
-  intra_dat.r2.pose_coords =
-      (same_tile ? shared_m.pose_coords1 : shared_m.pose_coords2);
-  intra_dat.r1.water_coords = shared_m.water_coords1;
-  intra_dat.r2.water_coords =
-      (same_tile ? shared_m.water_coords1 : shared_m.water_coords2);
+  if constexpr (Dev == tmol::Device::CPU) {
+    if (same_tile) {
+      intra_dat.r2.pose_coords = intra_dat.r1.pose_coords;
+      intra_dat.r2.water_coords = intra_dat.r1.water_coords;
+      intra_dat.r2.lk_ball_params = intra_dat.r1.lk_ball_params;
+    }
+  } else {
+    intra_dat.r1.pose_coords = shared_m.pose_coords1;
+    intra_dat.r2.pose_coords =
+        (same_tile ? shared_m.pose_coords1 : shared_m.pose_coords2);
+    intra_dat.r1.water_coords = shared_m.water_coords1;
+    intra_dat.r2.water_coords =
+        (same_tile ? shared_m.water_coords1 : shared_m.water_coords2);
+    intra_dat.r1.lk_ball_params = shared_m.lk_ball_params1;
+    intra_dat.r2.lk_ball_params =
+        (same_tile ? shared_m.lk_ball_params1 : shared_m.lk_ball_params2);
+  }
   intra_dat.r1.pol_occ_tile_inds = shared_m.pol_occ_tile_inds1;
   intra_dat.r2.pol_occ_tile_inds =
       (same_tile ? shared_m.pol_occ_tile_inds1 : shared_m.pol_occ_tile_inds2);
-  intra_dat.r1.lk_ball_params = shared_m.lk_ball_params1;
-  intra_dat.r2.lk_ball_params =
-      (same_tile ? shared_m.lk_ball_params1 : shared_m.lk_ball_params2);
   if (same_tile) {
     intra_dat.r2.n_polars = intra_dat.r1.n_polars;
     intra_dat.r2.n_occluders = intra_dat.r1.n_occluders;

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -309,7 +309,7 @@
       int tile_ind2,                                \
       shared_mem_union& shared,                     \
       LKBallScoringData<Real>& intra_dat) {         \
-    lk_ball_load_intrares_data_from_shared(         \
+    lk_ball_load_intrares_data_from_shared<Dev>(    \
         tile_ind1, tile_ind2, shared.m, intra_dat); \
   }
 


### PR DESCRIPTION
## Summary

- read immutable CPU LKBall coordinates, water coordinates, and type parameters directly from their contiguous input tensors
- retain the existing compact index and count-pair staging
- preserve the CUDA shared-memory path behind a compile-time device branch

This does not change traversal, arithmetic, score weights, term toggles, trainable parameters, or public interfaces.

## Performance

Clean 5UOI ABBA measurements on one Intel Xeon Platinum 8562Y+ node:

- isolated LKBall: 1.016x score and 1.018x score+gradient
- full one-thread rotamer table: 1.001x raw score, 1.009x score plus coalescing, and 1.006x score+gradient
- full 16-thread score+gradient: 1.018x
- standard B1 score+gradient microbenchmark: 1.004x
- FastRelax: neutral within one-sample ABBA noise (0.995x)

All benchmark and profiler code remains outside the repository.

## Validation

- 123 passed, 78 skipped in the broad CPU score and pack suite
- 27 passed in the full H200 LKBall suite
- 2 passed in the selected H200 pack-dispatch integration gate
- exact CPU score and coordinate-gradient checksums in one- and 16-thread ABBA runs
- exact B1 validation score and gradient norm
- exact 5UOI FastRelax final score
- H200 score+gradient is neutral at 1.003x, with an identical score checksum and gradient variation inside the existing atomic-reassociation envelope

All local pre-merge gates are complete.
