### PR TITLE
Simplify clamped LKBall ramp evaluation

### DIFF
--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -80,14 +80,8 @@ struct lk_fraction {
     if (wted_d2_delta <= std::exp(-ramp_width_A2)) return Real(0);
     wted_d2_delta = -std::log(wted_d2_delta);
 
-    Real frac = 0;
-    if (wted_d2_delta < 0) {
-      frac = 1;
-    } else if (wted_d2_delta < ramp_width_A2) {
-      frac = square(1 - square(wted_d2_delta / ramp_width_A2));
-    }
-
-    return frac;
+    // The clamps above imply 0 < wted_d2_delta < ramp_width_A2.
+    return square(1 - square(wted_d2_delta / ramp_width_A2));
   }
 
   static def V_dV(WatersMat WI, Real3 J, Real lj_radius_j) -> V_dV_t {
@@ -118,21 +112,12 @@ struct lk_fraction {
     }
     wted_d2_delta = -std::log(wted_d2_delta);
 
-    Real frac = 0;
-    Real dfrac_dwted_d2 = 0;
-    if (wted_d2_delta < 0) {
-      frac = 1;
-    } else if (wted_d2_delta < ramp_width_A2) {
-      frac = square(1 - square(wted_d2_delta / ramp_width_A2));
-      if (wted_d2_delta > 0) {
-        dfrac_dwted_d2 = Real(-4) * wted_d2_delta
-                         * (square(ramp_width_A2) - square(wted_d2_delta))
-                         / square(square(ramp_width_A2));
-      }
-    }
-
-    Real const derivative_scale =
-        exp_sum != 0 ? 2 * dfrac_dwted_d2 / exp_sum : Real(0);
+    // The clamps above imply 0 < wted_d2_delta < ramp_width_A2.
+    Real frac = square(1 - square(wted_d2_delta / ramp_width_A2));
+    Real dfrac_dwted_d2 = Real(-4) * wted_d2_delta
+                          * (square(ramp_width_A2) - square(wted_d2_delta))
+                          / square(square(ramp_width_A2));
+    Real const derivative_scale = 2 * dfrac_dwted_d2 / exp_sum;
     return V_dV_t{
         frac,
         dV_t{


### PR DESCRIPTION
## Summary

- remove branches that are unreachable after LKBall's existing exponential-sum clamps
- evaluate the interior ramp and derivative directly
- keep the same shared CPU/CUDA implementation, traversal, term weights, and public interfaces

After the guards, the exponential sum is strictly between `exp(-ramp_width_A2)` and 1, so its negative logarithm is strictly between 0 and `ramp_width_A2`. The deleted checks therefore cannot select another result for finite scoring inputs.

## Performance

One-thread 5UOI reverse-order A/B:

- isolated LKBall score: 1.010x
- isolated LKBall score + gradient: 1.009x
- complete score + gradient: 1.003x
- complete raw score table: 1.004x
- complete score + sparse coalescing: 1.000x

A warm, uncontended H200 reverse-order rerun is neutral at 0.999x. The patch removes 14 net lines and adds no backend policy.

## Validation

- focused CPU LKBall suite: 18 passed, 9 skipped
- CPU score and coordinate-gradient checksums are bit-identical
- H200 score checksum is identical; coordinate gradients remain within the existing atomic-reassociation envelope
- `git diff --check` passes

Benchmark scripts and results are external to the repository.
