### PR TITLE
Reuse electrostatic dielectric exponentials

### DIFF
--- a/tmol/score/elec/potentials/potentials.hh
+++ b/tmol/score/elec/potentials/potentials.hh
@@ -54,6 +54,16 @@ def deps_ddist(Real dist, Real D, Real D0, Real S) -> Real {
   return Real(0.5) * (D - D0) * dist * dist * S * S * S * std::exp(-dist * S);
 }
 
+def eps_deps_ddist(Real dist, Real D, Real D0, Real S) -> tuple<Real, Real> {
+  Real const exp_term = std::exp(-dist * S);
+  return {
+      D
+          - Real(0.5) * (D - D0)
+                * (Real(2) + Real(2) * dist * S + dist * dist * S * S)
+                * exp_term,
+      Real(0.5) * (D - D0) * dist * dist * S * S * S * exp_term};
+}
+
 def elec_delec_ddist(
     Real dist,
     Real e_i,
@@ -98,8 +108,10 @@ def elec_delec_ddist(
 
   } else if (dist < hi_poly_start) {
     // Coulombic part
-    Real eps_elec = eps(dist, params.D, params.D0, params.S);
-    Real deps_elec_d_dist = deps_ddist(dist, params.D, params.D0, params.S);
+    Real eps_elec;
+    Real deps_elec_d_dist;
+    tie(eps_elec, deps_elec_d_dist) =
+        eps_deps_ddist(dist, params.D, params.D0, params.S);
 
     elecE = eiej * (Real(322.0637) / (dist * eps_elec) - params.cutoff_offset);
     delec_ddist = -Real(322.0637) * eiej * (eps_elec + dist * deps_elec_d_dist)
@@ -161,7 +173,6 @@ def elec(
   } else if (dist < hi_poly_start) {
     // Coulombic part
     Real eps_elec = eps(dist, params.D, params.D0, params.S);
-    Real deps_elec_d_dist = deps_ddist(dist, params.D, params.D0, params.S);
 
     elecE = eiej * (Real(322.0637) / (dist * eps_elec) - params.cutoff_offset);
 


### PR DESCRIPTION
## Summary

- evaluate the sigmoidal dielectric value and derivative from one shared exponential
- remove the derivative calculation from score-only electrostatics
- retain the existing score formulas, term interfaces, weights, and shared CPU/CUDA implementation

The generated fused CPU object drops from 49 to 39 `exp` call sites across its specializations.

## Performance

Reverse-order 5UOI A/B:

- isolated one-thread CPU Elec gradient: 1.042x
- isolated CPU Elec gradient in the 16-thread process configuration: 1.044x
- isolated CPU Elec score: neutral at 0.999x
- complete one-thread score + gradient: neutral at 1.000x
- complete raw score table: 1.002x
- complete score + sparse coalescing: 1.007x
- isolated H200 Elec score and gradient: neutral at 1.000x
- complete H200 score + gradient: 1.005x

The complete H200 difference is within run noise; the accepted benefit is the repeatable 4.2--4.4% CPU Elec gradient reduction with no backend regression.

## Validation

- focused CPU electrostatics/fused-rotamer suite: 15 passed, 14 skipped
- CPU scores and coordinate-gradient checksums are bit-identical
- H200 scores are identical; coordinate gradients remain within the existing atomic-reassociation envelope
- peak H200 allocation is unchanged
- clang-format and `git diff --check` pass

Benchmark scripts and results are external to the repository.
