### PR TITLE
Reuse LKBall host type parameters

### DIFF
--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -30,6 +30,9 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         self.ljlk_param_resolver = LJLKParamResolver.from_database(
             param_db.chemical, param_db.scoring.ljlk, device=device
         )
+        self._ljlk_type_params_cpu = self.ljlk_param_resolver.type_params.to(
+            torch.device("cpu")
+        )
         self.tile_size = LKBallEnergyTerm.tile_size
 
         # Precompute the stacked lk-ball global-parameter tensors
@@ -149,7 +152,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         # needed for LKBallTypeParams (see properties/params.hh)
         assert hasattr(block_type, "atom_types")
         at = block_type.atom_types
-        type_params = self.ljlk_param_resolver.type_params.to(torch.device("cpu"))
+        type_params = self._ljlk_type_params_cpu
         bt_lj_radius = type_params.lj_radius[at].numpy()
         bt_lk_dgfree = type_params.lk_dgfree[at].numpy()
         bt_lk_lambda = type_params.lk_lambda[at].numpy()


### PR DESCRIPTION
## Summary

- transfer the immutable LJ/LK type table to the host once per LKBall energy term
- reuse that host view while annotating residue types
- leave score arithmetic, term selection, weights, and public interfaces unchanged

## Performance

5UOI, 142 active block types, alternating fresh-process runs:

- H200 LKBall constructor + block-type + packed setup: 390.5 ms -> 366.6 ms median (1.065x, three runs)
- H200 block-type phase: 290.2 ms -> 264.9 ms median (1.095x, three runs)
- one-thread CPU total setup: 310.0 ms -> 309.5 ms median (neutral, 1.002x, three runs)
- H200 full cold score-function setup: 1517.8 ms -> 1485.8 ms median (1.022x, six runs)
- H200 allocated peak: unchanged at 41,300,480 bytes

All generated LKBall setup tensors have the same checksum. The full score remains within the existing CUDA atomic-reassociation envelope.

## Validation

- focused CPU and H200 LKBall suite: 18 passed
- full hosted CPU, CUDA, lint, docs, and coverage gates requested by this PR
- benchmark harness and results remain external to the repository