### PR TITLE
Keep atom-type annotation parameters on CPU

### DIFF
--- a/tmol/score/_atom_type_dependent_term.py
+++ b/tmol/score/_atom_type_dependent_term.py
@@ -25,7 +25,7 @@ class AtomTypeDependentTerm(EnergyTerm):
 
     def __init__(self, param_db: ParameterDatabase, device: torch.device):
         atom_type_resolver = AtomTypeParamResolver.from_database(
-            param_db.chemical, device=device
+            param_db.chemical, device=torch.device("cpu")
         )
         super(AtomTypeDependentTerm, self).__init__(param_db=param_db, device=device)
         self.atom_type_resolver = atom_type_resolver


### PR DESCRIPTION
## Summary

- construct the common atom-type resolver on CPU because it is used only for host-side residue annotation
- avoid creating six sets of transient CUDA metadata and synchronizing their flags back to the host
- preserve scoring tensors, arithmetic, weights, term controls, and public interfaces

## Performance

Post-#489 5UOI, 142 active block types, alternating fresh-process H200 runs:

- LKBall constructor + block-type + packed setup: 376.0 ms -> 345.7 ms median (1.088x, three runs)
- repeated block-type phase: 270.0 ms -> 243.2 ms median (1.110x, three runs)
- complete cold score-function construction and rendering: 1511.7 ms -> 1462.8 ms median (1.033x, six runs)
- allocated H200 peak: 41,300,480 -> 41,282,048 bytes

The CPU resolver was already on CPU for CPU scoring, so that path retains the same effective placement. Generated LKBall setup tensors have identical checksums, and complete scores remain within the existing CUDA atomic-reassociation envelope.

## Validation

- focused CPU and H200 LKBall suite: 18 passed
- full hosted CPU, CUDA, lint, docs, and coverage gates requested by this PR
- benchmark harness and results remain external to the repository