### PR TITLE
Cache backbone torsion table mappings

### DIFF
--- a/tmol/score/backbone_torsion/_bb_torsion_energy_term.py
+++ b/tmol/score/backbone_torsion/_bb_torsion_energy_term.py
@@ -73,6 +73,13 @@ class BackboneTorsionEnergyTerm(EnergyTerm):
             dim=1,
         )
 
+        def table_ids(lookup):
+            ids = lookup["table_id"]
+            return ids.to_dict(), int(ids.iloc[-1])
+
+        self._rama_table_ids = table_ids(self.param_resolver.rama_lookup)
+        self._omega_table_ids = table_ids(self.param_resolver.omega_lookup)
+
     @classmethod
     def class_name(cls):
         return "BackboneTorsion"
@@ -100,15 +107,16 @@ class BackboneTorsionEnergyTerm(EnergyTerm):
             return
 
         rname = block_type.name
-        lookups = numpy.array([[rname, "_"], [rname, "PRO"]], dtype=object)
-        rama_table_inds = self.param_resolver.rama_lookup.index.get_indexer(lookups)
-        rama_table_inds = self.param_resolver.rama_lookup.iloc[rama_table_inds, :][
-            "table_id"
-        ].values
-        omega_table_inds = self.param_resolver.omega_lookup.index.get_indexer(lookups)
-        omega_table_inds = self.param_resolver.omega_lookup.iloc[omega_table_inds, :][
-            "table_id"
-        ].values
+
+        def table_ids_for_residue(table_ids):
+            ids, default = table_ids
+            return numpy.array(
+                [ids.get((rname, following), default) for following in ("_", "PRO")],
+                dtype=numpy.int32,
+            )
+
+        rama_table_inds = table_ids_for_residue(self._rama_table_ids)
+        omega_table_inds = table_ids_for_residue(self._omega_table_ids)
 
         backbone_torsion_atoms = numpy.full((3, 4), -1, dtype=uaid_t)
         if rama_table_inds[0] != -1 or rama_table_inds[1] != -1:


### PR DESCRIPTION
## Summary

- convert immutable Ramachandran and omega table-id series to dictionaries once per energy term
- replace per-residue NumPy object-array construction and pandas dataframe lookups with two direct tuple-key lookups
- preserve the existing missing-key fallback and documented `int32` output

This is temporarily stacked on #491 to start validation early and must merge after it. Once #491 merges, this PR's production diff is one backbone-torsion file with 17 additions and 9 deletions. It does not change scoring arithmetic, weights, term controls, public interfaces, or native CPU/CUDA kernels.

## Performance

Fresh-process 5UOI measurements relative to #491:

- isolated setup: 143.17 ms to 16.27 ms on H200 (8.802x), 126.13 ms to 7.45 ms on one CPU thread (16.93x)
- repeated block annotation: 129.24 ms to 2.17 ms on H200 (59.65x), 120.50 ms to 1.91 ms on CPU (63.13x)
- complete cold score construction/rendering: 1318.1 ms to 1186.5 ms on H200 (1.111x), 1125.3 ms to 990.2 ms on CPU (1.137x)
- H200 peak allocation: unchanged

Benchmark and profiler code and results remain outside the repository.

## Validation

- generated setup checksum is identical
- focused backbone-torsion CPU/H200 suite: 18 passed
- `git diff --check` and formatting checks pass
