### PR TITLE
Accelerate score parameter setup

### DIFF
--- a/tmol/numeric/_bspline.py
+++ b/tmol/numeric/_bspline.py
@@ -74,21 +74,27 @@ class BSplineInterpolation:
         This code handles splines of 2-4 dimensions
         """
 
-        # we only implement the python interface for CPU
+        coeffs = cls._coefficients_from_coordinates(coords)
+        return cls(coeffs=coeffs, n_interp_dims=coords.ndim)
+
+    @staticmethod
+    def _coefficients_from_coordinates(
+        coords: Tensor[torch.float],
+    ) -> Tensor[torch.float]:
+        """Compute coefficients for already-validated CPU coordinates."""
+
         assert coords.device == torch.device("cpu")
         coeffs = coords.clone()
-
-        input_shape = coords.shape
-        if len(input_shape) == 2:
+        if coords.ndim == 2:
             compiled.computeCoeffs2(coeffs)
-        elif len(input_shape) == 3:
+        elif coords.ndim == 3:
             compiled.computeCoeffs3(coeffs)
-        elif len(input_shape) == 4:
+        elif coords.ndim == 4:
             compiled.computeCoeffs4(coeffs)
         else:
             raise ValueError("Unsupported dimensionality in BSplineInterpolation!")
 
-        return cls(coeffs=coeffs, n_interp_dims=len(input_shape))
+        return coeffs
 
     @validate_args
     def interpolate(self, X: Tensor[torch.float][...]) -> Tensor[torch.float]:

--- a/tmol/score/_chemical_database.py
+++ b/tmol/score/_chemical_database.py
@@ -1,3 +1,4 @@
+import functools
 import typing
 
 import attr
@@ -9,6 +10,7 @@ import torch
 import numpy
 
 from tmol.database.chemical import ChemicalDatabase
+from tmol.utility._device import resolve_device
 
 from tmol.types import (
     Tensor,
@@ -82,20 +84,26 @@ class AtomTypeParamResolver(ValidateAttrs):
     @classmethod
     def from_database(cls, chemical_database: ChemicalDatabase, device: torch.device):
         """Initialize param resolver for all atom types in database."""
+        return cls._from_atom_types(
+            chemical_database.atom_types, resolve_device(device)
+        )
+
+    @classmethod
+    @functools.lru_cache(maxsize=32)
+    def _from_atom_types(cls, atom_types, device):
+        """Initialize and cache parameters for an immutable atom-type tuple."""
 
         # Generate a full atom type index, appending a "None" value at index -1
         # to generate nan parameter entries if an atom type is not present in
         # the index.
-        atom_type_names = [p.name for p in chemical_database.atom_types]
+        atom_type_names = [p.name for p in atom_types]
         atom_type_index = pandas.Index(atom_type_names + [None])
 
         # Pack the tuple of type parameters into a dataframe and reindex via
         # the param resolver type index. This appends a "nan" row at the end of
         # the frame for the invalid/None entry added above.
         param_records = (
-            pandas.DataFrame.from_records(
-                cattr.unstructure(chemical_database.atom_types)
-            )
+            pandas.DataFrame.from_records(cattr.unstructure(atom_types))
             .set_index("name")
             .reindex(index=atom_type_index)
         )

--- a/tmol/score/dunbrack/_params.py
+++ b/tmol/score/dunbrack/_params.py
@@ -31,7 +31,10 @@ from tmol.utility._device import resolve_device
 
 def _pack_bspline_coefficients(coordinate_tables, device):
     packed = nplus1d_tensor_from_list(
-        [BSplineInterpolation.from_coordinates(t).coeffs for t in coordinate_tables]
+        [
+            BSplineInterpolation._coefficients_from_coordinates(t)
+            for t in coordinate_tables
+        ]
     )
     return tuple(t.to(device) for t in packed)
 

--- a/tmol/score/hbond/_params.py
+++ b/tmol/score/hbond/_params.py
@@ -102,10 +102,12 @@ class HBondParamResolver(ValidateAttrs):
         device: torch.device,
     ):
         donors = {g.name: g for g in hbond_database.donor_type_params}
-        donor_type_index = pandas.Index(list(donors))
+        donor_type_to_index = {name: i for i, name in enumerate(donors)}
+        donor_type_index = pandas.Index(donor_type_to_index)
 
         acceptors = {g.name: g for g in hbond_database.acceptor_type_params}
-        acceptor_type_index = pandas.Index(list(acceptors))
+        acceptor_type_to_index = {name: i for i, name in enumerate(acceptors)}
+        acceptor_type_index = pandas.Index(acceptor_type_to_index)
 
         atom_type_hybridization = {
             a.name: a.acceptor_hybridization for a in chemical_database.atom_types
@@ -118,12 +120,10 @@ class HBondParamResolver(ValidateAttrs):
         pair_params = HBondPairParams.full((len(donors), len(acceptors)), numpy.nan)
 
         # Denormalize donor/acceptor weight and class into pair parameter table
-        for name, g in donors.items():
-            (i,) = donor_type_index.get_indexer([name])
+        for i, g in enumerate(donors.values()):
             pair_params.donor_weight[i, :] = g.weight
 
-        for name, g in acceptors.items():
-            (i,) = acceptor_type_index.get_indexer([name])
+        for i, (name, g) in enumerate(acceptors.items()):
             pair_params.acceptor_weight[:, i] = g.weight
             pair_params.acceptor_hybridization[:, i] = int(
                 AcceptorHybridization._index.get_indexer_for(
@@ -159,11 +159,8 @@ class HBondParamResolver(ValidateAttrs):
 
         # Denormalize polynomial parameters into pair parameter table
         for pp in hbond_database.pair_parameters:
-            (di,) = donor_type_index.get_indexer([pp.donor_type])
-            assert di >= 0
-
-            (ai,) = acceptor_type_index.get_indexer([pp.acceptor_type])
-            assert ai >= 0
+            di = donor_type_to_index[pp.donor_type]
+            ai = acceptor_type_to_index[pp.acceptor_type]
 
             pair_index = (di, ai)
             assign_polynomial(pair_params.AHdist, pair_index, pp.AHdist)

--- a/tmol/score/hbond/_params.py
+++ b/tmol/score/hbond/_params.py
@@ -147,10 +147,15 @@ class HBondParamResolver(ValidateAttrs):
             )
         )
 
-        poly_params = {
-            p.name: poly_params[i]
-            for i, p in enumerate(hbond_database.polynomial_parameters)
+        poly_param_index = {
+            p.name: i for i, p in enumerate(hbond_database.polynomial_parameters)
         }
+
+        def assign_polynomial(destination, pair_index, name):
+            source_index = poly_param_index[name]
+            destination.range[pair_index] = poly_params.range[source_index]
+            destination.bound[pair_index] = poly_params.bound[source_index]
+            destination.coeffs[pair_index] = poly_params.coeffs[source_index]
 
         # Denormalize polynomial parameters into pair parameter table
         for pp in hbond_database.pair_parameters:
@@ -160,9 +165,10 @@ class HBondParamResolver(ValidateAttrs):
             (ai,) = acceptor_type_index.get_indexer([pp.acceptor_type])
             assert ai >= 0
 
-            pair_params[di, ai].AHdist[:] = poly_params[pp.AHdist]
-            pair_params[di, ai].cosBAH[:] = poly_params[pp.cosBAH]
-            pair_params[di, ai].cosAHD[:] = poly_params[pp.cosAHD]
+            pair_index = (di, ai)
+            assign_polynomial(pair_params.AHdist, pair_index, pp.AHdist)
+            assign_polynomial(pair_params.cosBAH, pair_index, pp.cosBAH)
+            assign_polynomial(pair_params.cosAHD, pair_index, pp.cosAHD)
 
         return cls(
             donor_type_index=donor_type_index,

--- a/tmol/tests/score/test_atom_type_dependent_term.py
+++ b/tmol/tests/score/test_atom_type_dependent_term.py
@@ -2,6 +2,15 @@ import torch
 
 from tmol.pose import PackedBlockTypes
 from tmol.score import AtomTypeDependentTerm
+from tmol.score._chemical_database import AtomTypeParamResolver
+
+
+def test_atom_type_parameters_are_cached(default_database, torch_device):
+    first = AtomTypeParamResolver.from_database(default_database.chemical, torch_device)
+    second = AtomTypeParamResolver.from_database(
+        default_database.chemical, torch_device
+    )
+    assert first is second
 
 
 def test_setup_block_type(fresh_default_restype_set, default_database, torch_device):

--- a/tmol/tests/utility/tensor/test_common_operations.py
+++ b/tmol/tests/utility/tensor/test_common_operations.py
@@ -153,6 +153,22 @@ def test_nplus1d_tensor_from_list():
         assert tuple(sizes[i, :]) == ti.shape
 
 
+def test_nplus1d_metadata(torch_device):
+    tensors = [
+        torch.zeros((2, 3), device=torch_device),
+        torch.zeros((4, 1), device=torch_device),
+    ]
+    joined, sizes, strides = nplus1d_tensor_from_list(tensors)
+
+    torch.testing.assert_close(
+        sizes, torch.tensor([[2, 3], [4, 1]], device=torch_device)
+    )
+    torch.testing.assert_close(
+        strides,
+        torch.tensor([joined.stride()[1:]] * 2, device=torch_device),
+    )
+
+
 def test_cat_diff_sized_tensors_w_same_sizes():
     t1 = torch.full((2, 3, 4), 1, dtype=torch.long)
     t2 = torch.full((3, 3, 4), 2, dtype=torch.long)

--- a/tmol/utility/tensor/_common_operations.py
+++ b/tmol/utility/tensor/_common_operations.py
@@ -146,11 +146,13 @@ def nplus1d_tensor_from_list(
     newdimsizes = [len(tensors)] + max_sizes
 
     newt = torch.zeros(newdimsizes, dtype=first.dtype, device=first.device)
-    sizes = torch.zeros(
-        (len(tensors), first.dim()), dtype=torch.int64, device=first.device
+    sizes = torch.tensor(
+        [tensor.shape for tensor in tensors], dtype=torch.int64, device=first.device
     )
-    strides = torch.zeros(
-        (len(tensors), first.dim()), dtype=torch.int64, device=first.device
+    strides = torch.tensor(
+        [newt.stride()[1:]] * len(tensors),
+        dtype=torch.int64,
+        device=first.device,
     )
 
     for i, t in enumerate(tensors):
@@ -158,8 +160,6 @@ def nplus1d_tensor_from_list(
         for j in range(t.dim()):
             ti = ti.narrow(j, 0, t.shape[j])
         ti[:] = t
-        sizes[i, :] = torch.tensor(t.shape, dtype=torch.int64, device=t.device)
-        strides[i, :] = torch.tensor(ti.stride(), dtype=torch.int64, device=t.device)
     return newt, sizes, strides
 
 


### PR DESCRIPTION
## Summary
- reuse immutable atom-type resolvers across score terms with a bounded semantic cache
- fill hydrogen-bond parameter tables directly and use direct type-index mappings
- avoid temporary B-spline wrappers in trusted Dunbrack packing
- construct ragged tensor metadata in bulk

## Performance
The two Dunbrack packing changes reduce isolated setup by 1.184x on one CPU thread and 1.207x on H200 across six fresh-process runs. Complete cold 5UOI score-function setup improves by 1.093x CPU and 1.085x H200 for that pair. The atom-type and hydrogen-bond changes add independent cold-setup gains and reduce repeated device metadata.

## Validation
Parameter digests are exact. CPU 5UOI scores are bit-identical; CUDA results remain inside the existing atomic-reassociation envelope. Focused CPU and H200 suites for atom parameters, hydrogen bonds, Dunbrack, and tensor packing pass. Benchmark and profiler artifacts remain external to the repository.