### PR TITLE
Deduplicate CartBonded parameter tables

### DIFF
--- a/tmol/score/cartbonded/_cartbonded_energy_term.py
+++ b/tmol/score/cartbonded/_cartbonded_energy_term.py
@@ -362,44 +362,35 @@ class CartBondedEnergyTerm(AtomTypeDependentTerm):
                 if at not in cbet_atom_unique_id_index:
                     cbet_atom_unique_id_index[at] = len(cbet_atom_unique_id_index)
 
-        for bt in packed_block_types.active_block_types:
-            bt_params = bt.cartbonded_annotations[self.hash]
-
-            for key in bt_params.cartbonded_params:
+        block_param_sets = {
+            bt.base_name: bt.cartbonded_annotations[self.hash].cartbonded_params
+            for bt in packed_block_types.active_block_types
+        }
+        for params in block_param_sets.values():
+            for key in params:
                 for at in key:
                     if at not in cbet_atom_unique_id_index:
                         cbet_atom_unique_id_index[at] = len(cbet_atom_unique_id_index)
 
-        # Calculate the total number of params
-        n_total_params = sum(
-            [
-                len(bt.cartbonded_annotations[self.hash].cartbonded_params)
-                for bt in packed_block_types.active_block_types
-            ]
-        ) + len(wildcard_params)
-
-        # Construct the params hash with the given scaling factor
-        hash_keys, hash_values = make_hashtable_keys_values(n_total_params, 2, 5, 7)
-
-        # Fill the native hash table and a Python lookup with the same
-        # first-insert-wins behavior for setup-time subgraph resolution.
-        param_key_to_index = {}
-        cur_val = 0
+        # Collect each parameter key once. Residue variants with the same base
+        # name share parameter dictionaries, and hash lookup uses the first
+        # inserted value for duplicate keys.
         padded_key = self._padded_param_key
-        for bt in packed_block_types.active_block_types:
-
-            bt_params = bt.cartbonded_annotations[self.hash]
-            for key_w_str, value in bt_params.cartbonded_params.items():
+        unique_params = {}
+        for params in block_param_sets.values():
+            for key_w_str, value in params.items():
                 key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)
-                add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
-                param_key_to_index.setdefault(padded_key(key), cur_val)
-                cur_val += 1
+                unique_params.setdefault(padded_key(key), (key, value))
 
         for key_w_str, value in wildcard_params:
             key = tuple(cbet_atom_unique_id_index[at] for at in key_w_str)
+            unique_params.setdefault(padded_key(key), (key, value))
+
+        hash_keys, hash_values = make_hashtable_keys_values(len(unique_params), 2, 5, 7)
+        param_key_to_index = {}
+        for cur_val, (padded, (key, value)) in enumerate(unique_params.items()):
             add_to_hashtable(hash_keys, hash_values, cur_val, key, value)
-            param_key_to_index.setdefault(padded_key(key), cur_val)
-            cur_val += 1
+            param_key_to_index[padded] = cur_val
 
         # Intra-block topology and atom naming are fixed for a packed block
         # type. Resolve the exact/reversed/wildcard parameter search once here

--- a/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
+++ b/tmol/tests/score/cartbonded/test_cartbonded_energy_term.py
@@ -75,6 +75,12 @@ def test_annotate_restypes(
     assert cb_pbt_ann.cartbonded_params_hash_keys.device == torch_device
     assert cb_pbt_ann.cartbonded_params_hash_values.device == torch_device
 
+    hash_keys = cb_pbt_ann.cartbonded_params_hash_keys
+    parameter_keys = hash_keys[hash_keys[:, 0] != -1, :-1]
+    n_parameters = cb_pbt_ann.cartbonded_params_hash_values.shape[0]
+    assert parameter_keys.shape[0] == n_parameters
+    assert torch.unique(parameter_keys, dim=0).shape[0] == parameter_keys.shape[0]
+
     cartbonded_subgraphs = cb_pbt_ann.cartbonded_subgraphs
     cartbonded_energy.setup_packed_block_types(pbt)
     assert (


### PR DESCRIPTION
## Summary
- visit each cached base-residue parameter set once
- apply existing first-insert semantics before native hash-table allocation
- add a backend-parametrized invariant requiring one reachable row per unique key

## Performance
Isolated CartBonded setup improves 1.353x on one CPU thread and 1.340x on H200. The table shrinks from 10,408 to 2,192 rows and from 707,744 to 149,056 bytes. Complete cold 5UOI setup improves 1.091x CPU and 1.038x H200. Repeated pack-stage measurements improve 1.026x-1.036x across CPU/H200 and two proteins; four-process score/gradient measurements are neutral to 1.030x faster.

## Validation
The semantic parameter digest and per-backend energy-table checksums are exact. CPU scores and gradients are exact; CUDA remains inside the existing atomic-reassociation envelope with unchanged scratch allocation. The CartBonded suite passes 15 CPU tests and 26 combined CPU/H200 tests, and the new invariant passes on both backends. Benchmark and profiler artifacts remain external.