### PR TITLE
Use direct atom-type indices during setup

### DIFF
--- a/tmol/score/_atom_type_dependent_term.py
+++ b/tmol/score/_atom_type_dependent_term.py
@@ -30,6 +30,9 @@ class AtomTypeDependentTerm(EnergyTerm):
         super(AtomTypeDependentTerm, self).__init__(param_db=param_db, device=device)
         self.atom_type_resolver = atom_type_resolver
         self.atom_type_index = atom_type_resolver.index
+        self._atom_type_indices = {
+            name: index for index, name in enumerate(self.atom_type_index)
+        }
         self.np_is_hydrogen = atom_type_resolver.params.is_hydrogen.cpu().numpy()
         self.np_is_heavyatom = numpy.logical_not(self.np_is_hydrogen)
 
@@ -71,8 +74,9 @@ class AtomTypeDependentTerm(EnergyTerm):
             self._create_uniq_and_wildcard_names_for_bt(block_type)
         )
 
-        atom_types = self.atom_type_index.get_indexer(
-            [x.atom_type for x in block_type.atoms]
+        atom_types = numpy.asarray(
+            [self._atom_type_indices.get(x.atom_type, -1) for x in block_type.atoms],
+            dtype=numpy.intp,
         )
         heavy_inds = numpy.nonzero(self.np_is_heavyatom[atom_types])[0]
 

--- a/tmol/score/hbond/_hbond_dependent_term.py
+++ b/tmol/score/hbond/_hbond_dependent_term.py
@@ -110,6 +110,9 @@ class HBondDependentTerm(BondDependentTerm):
         self.atom_type_resolver = AtomTypeParamResolver.from_database(
             param_db.chemical, torch.device("cpu")
         )
+        self._atom_type_indices = {
+            name: index for index, name in enumerate(self.atom_type_resolver.index)
+        }
         self.hbond_database = param_db.scoring.hbond
         self.hbond_resolver = HBondParamResolver.from_database(
             param_db.chemical, self.hbond_database, device
@@ -142,8 +145,10 @@ class HBondDependentTerm(BondDependentTerm):
         if hasattr(block_type, "hbbt_params"):
             return
 
-        atom_types = [x.atom_type for x in block_type.atoms]
-        atom_type_idx = self.atom_type_resolver.index.get_indexer(atom_types)
+        atom_type_idx = numpy.asarray(
+            [self._atom_type_indices.get(x.atom_type, -1) for x in block_type.atoms],
+            dtype=numpy.intp,
+        )
         acc_type = self._acceptor_type_for_atom_type[atom_type_idx]
         don_type = self._donor_type_for_atom_type[atom_type_idx]
         is_acc = acc_type != -1


### PR DESCRIPTION
## Summary

- build compact name-to-index maps once per atom-type-dependent term
- use direct dictionary lookups while annotating block types
- preserve unknown atom types as `-1` and retain a single shared CPU/CUDA path

## Performance

Across isolated 142-block setup, median time improved 1.116x on CPU and 1.128x on H200. Combined cold 5UOI setup improved 1.039x on CPU (six independent processes) and 1.055x on H200. H200 peak memory was unchanged.

## Validation

- annotation digests are exact across 12 isolated CPU/H200 runs
- CPU 5UOI scores are exact; CUDA stays within the existing atomic-reassociation tolerance
- 34 H-bond tests passed on H200, with 2 expected xfails
- Black and Flake8 pass

Benchmark drivers and profiler output remain external to the repository.