### PR TITLE
Reuse GenBonded parameter lookups

### DIFF
--- a/tmol/score/genbonded/_genbonded_energy_term.py
+++ b/tmol/score/genbonded/_genbonded_energy_term.py
@@ -82,6 +82,8 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
         # regardless of which block types are later loaded.
         self._type_to_idx = self.gen_database.make_type_to_idx()
         self._all_type_names = self.gen_database.all_type_names()
+        self._torsion_params_cache = {}
+        self._improper_params_cache = {}
 
     @classmethod
     def class_name(cls):
@@ -191,6 +193,7 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
         """
         kept = []
         rows = []
+        cache = self._torsion_params_cache
 
         for i, j, k, l in torsions:
             t1 = self.get_atom_chem_type(block_type, i)
@@ -206,9 +209,12 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
 
             # find_torsion_params tries both forward and reversed directions
             # internally and returns the most specific match.
-            entry = self.gen_database.find_torsion_params(
-                t1, t2, t3, t4, bond_type_int, is_ring
-            )
+            key = (t1, t2, t3, t4, bond_type_int, is_ring)
+            try:
+                entry = cache[key]
+            except KeyError:
+                entry = self.gen_database.find_torsion_params(*key)
+                cache[key] = entry
             if entry is not None:
                 kept.append((i, j, k, l))
                 # Rosetta's calculate_offset() zeros the minimum when the
@@ -239,6 +245,7 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
         """
         kept = []
         rows = []
+        cache = self._improper_params_cache
 
         for quad in impropers:
             center, n1, n2, n3 = quad
@@ -247,7 +254,12 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
             t2 = self.get_atom_chem_type(block_type, n2)
             t3 = self.get_atom_chem_type(block_type, n3)
 
-            entry = self.gen_database.find_improper_params(tc, t1, t2, t3)
+            key = (tc, t1, t2, t3)
+            try:
+                entry = cache[key]
+            except KeyError:
+                entry = self.gen_database.find_improper_params(*key)
+                cache[key] = entry
             if entry is not None:
                 kept.append(quad)
                 rows.append([entry.k, entry.delta])

--- a/tmol/tests/score/genbonded/test_genbonded_energy_term.py
+++ b/tmol/tests/score/genbonded/test_genbonded_energy_term.py
@@ -1,0 +1,60 @@
+import numpy
+import torch
+
+from tmol.database.scoring._genbonded import GenBondedDatabase
+from tmol.score.genbonded import GenBondedEnergyTerm
+
+
+def test_genbonded_parameter_lookups_are_reused(
+    fresh_default_packed_block_types, default_database, monkeypatch
+):
+    calls = {"torsion": 0, "improper": 0}
+    original_torsion = GenBondedDatabase.find_torsion_params
+    original_improper = GenBondedDatabase.find_improper_params
+
+    def counted_torsion(database, *args):
+        calls["torsion"] += 1
+        return original_torsion(database, *args)
+
+    def counted_improper(database, *args):
+        calls["improper"] += 1
+        return original_improper(database, *args)
+
+    monkeypatch.setattr(GenBondedDatabase, "find_torsion_params", counted_torsion)
+    monkeypatch.setattr(GenBondedDatabase, "find_improper_params", counted_improper)
+
+    term = GenBondedEnergyTerm(default_database, torch.device("cpu"))
+    blocks = fresh_default_packed_block_types.active_block_types
+    torsion_block, torsions = next(
+        (block, subgraphs)
+        for block in blocks
+        if (subgraphs := term.find_torsion_subgraphs(block.bond_indices))
+    )
+    improper_block, impropers = next(
+        (block, subgraphs)
+        for block in blocks
+        if (subgraphs := term.find_improper_subgraphs(block.bond_indices))
+    )
+
+    first_torsions, first_torsion_params = term.resolve_torsion_params(
+        torsion_block, torsions
+    )
+    first_impropers, first_improper_params = term.resolve_improper_params(
+        improper_block, impropers
+    )
+    first_call_counts = calls.copy()
+
+    second_torsions, second_torsion_params = term.resolve_torsion_params(
+        torsion_block, torsions
+    )
+    second_impropers, second_improper_params = term.resolve_improper_params(
+        improper_block, impropers
+    )
+
+    assert first_call_counts["torsion"] > 0
+    assert first_call_counts["improper"] > 0
+    assert calls == first_call_counts
+    assert second_torsions == first_torsions
+    assert second_impropers == first_impropers
+    numpy.testing.assert_array_equal(second_torsion_params, first_torsion_params)
+    numpy.testing.assert_array_equal(second_improper_params, first_improper_params)


### PR DESCRIPTION
## Summary

- reuse immutable GenBonded torsion and improper database lookup results across residue types
- cache both matching entries and misses for the lifetime of one energy term
- preserve lookup ordering, offset calculation, output assembly, and all device paths

The default 142 residue types issue 7,574 torsion queries with only 359 unique keys and 562 improper queries with only 47 unique keys. The two small per-term dictionaries remove those repeated hierarchy and permutation searches without global state, device branches, or changes to score-term controls.

## Performance

Exact post-#499, alternating three-process medians:

- one-thread CPU block annotation: 28.05 ms to 18.49 ms (1.517x)
- one-thread CPU complete GenBonded setup: 42.52 ms to 32.53 ms (1.307x)
- H200 block annotation: 30.23 ms to 18.98 ms (1.593x)
- H200 complete GenBonded setup: 47.55 ms to 36.94 ms (1.287x)
- complete cold one-thread CPU setup: 682.10 ms to 662.39 ms (1.030x)
- complete cold H200 setup: 747.36 ms to 711.67 ms (1.050x)

H200 peak allocation is unchanged at 41,096,192 bytes.

A follow-up that also cached assembled parameter rows was rejected: it improved CPU complete term setup by only 0.3% and regressed the noisy H200 median. This PR retains the smaller lookup-only cache.

## Validation

- all packed GenBonded parameter SHA-256 digests are identical
- the focused reuse test passes on CPU- and CUDA-backed fixture variants
- the complete score-function directory passes 69 tests with 8 device skips
- Black, Flake8, and diff checks pass

Benchmark drivers, profiles, and outputs remain external to the repository.
