### PR TITLE
Avoid unused math errno checks in native kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,7 @@ endfunction()
 # Common compile options for CUDA extensions
 function(tmol_set_cuda_flags TARGET)
   target_compile_options(${TARGET} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-O3 -w -DWITH_CUDA -DWITH_NVTX>
+    $<$<COMPILE_LANGUAGE:CXX>:-O3 -w -fno-math-errno -DWITH_CUDA -DWITH_NVTX>
     $<$<COMPILE_LANGUAGE:CUDA>:
       -O3 -w
       --expt-extended-lambda
@@ -362,7 +362,7 @@ endfunction()
 # Common compile options for CPU-only extensions
 function(tmol_set_cpp_flags TARGET)
   target_compile_options(${TARGET} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-O3 -w -DWITH_NVTX>
+    $<$<COMPILE_LANGUAGE:CXX>:-O3 -w -fno-math-errno -DWITH_NVTX>
   )
   target_include_directories(${TARGET} PRIVATE ${TMOL_INCLUDE_DIRS})
   tmol_set_portable_link_flags(${TARGET})

--- a/tmol/tests/utility/test_cpp_extension.py
+++ b/tmol/tests/utility/test_cpp_extension.py
@@ -13,6 +13,7 @@ def test_active_torch_cxx_standard_flags_match():
     )
 
     assert f"--std=c++{expected}" in _cpp_extension._required_flags
+    assert "-fno-math-errno" in _cpp_extension._required_flags
     assert f"-std=c++{expected}" in _cpp_extension._required_cuda_flags
 
 

--- a/tmol/utility/_cpp_extension.py
+++ b/tmol/utility/_cpp_extension.py
@@ -72,7 +72,12 @@ def _required_cxx_standard(torch_major, torch_minor):
 
 
 _cxx_standard = _required_cxx_standard(torch_major, torch_minor)
-_required_flags = [f"--std=c++{_cxx_standard}", "-DWITH_NVTX", "-w"]
+_required_flags = [
+    f"--std=c++{_cxx_standard}",
+    "-fno-math-errno",
+    "-DWITH_NVTX",
+    "-w",
+]
 
 _required_cuda_flags = [
     f"-std=c++{_cxx_standard}",


### PR DESCRIPTION
## Summary

- compile host C++ score kernels with `-fno-math-errno`
- apply the same flag to both CMake-built and Torch JIT extensions
- leave CUDA compiler flags, score formulas, term dispatch, and public interfaces unchanged

TMol score kernels do not consume the C math `errno` side channel. Keeping IEEE floating-point behavior while dropping that unused requirement lets GCC and Clang emit direct hardware math instructions instead of preserving a scalar libm fallback.

## Validation

- GCC assembly for a representative `sqrt` changes from a guarded `sqrt@PLT` fallback to a direct `sqrtsd`
- the active JIT flag is covered by the focused utility test
- the local compiler accepts the flag
- `git diff --check` passes

Full CPU/CUDA, platform, lint, and documentation validation is delegated to the existing PR CI matrix.