### PR TITLE
Document generalized chemistry, coupled packing and Rosetta comparisons

### DIFF
--- a/docs/_source_links.inc
+++ b/docs/_source_links.inc
@@ -1,0 +1,54 @@
+.. _CIF reader: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/io/_cif.py#L203
+.. _Biotite construction: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/io/_pose_stack_from_biotite.py#L147
+.. _Build context: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/io/_build_context.py#L9
+.. _Polymer preparation: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_preparation.py#L289
+.. _Polymer profiles: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_polymer_profile.py#L957
+.. _Polymer builder: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_polymer_builder.py#L746
+.. _Conjugation preparation: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_preparation.py#L874
+.. _Preparation boundary: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_preparation.py#L950
+.. _Charge preparation: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_openbabel_compat.py#L182
+.. _Chemical schema: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/database/chemical/__init__.py#L192
+.. _PoseStack: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pose/_pose_stack.py#L18
+.. _Packed block types: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pose/_packed_block_types.py#L29
+.. _Score function: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/score/_score_function.py#L27
+.. _Generic torsions: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/score/genbonded/_genbonded_energy_term.py#L185
+.. _Generic parameter database: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/database/scoring/_genbonded.py#L90
+.. _Cartesian bonded: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/score/cartbonded/_cartbonded_energy_term.py#L230
+.. _Dunbrack sampler: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/rotamer/dunbrack/_dunbrack_chi_sampler.py#L329
+.. _Dunbrack scoring: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/score/dunbrack/_dunbrack_energy_term.py#L132
+.. _NA sampler: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/rotamer/_na_chi_sampler.py#L56
+.. _Mirrored libraries: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/database/scoring/_mirrored_dunbrack.py#L99
+.. _Group discovery: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pose/_conjugated_groups.py#L50
+.. _tmol ligand fragmentation: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/ligand/_fragmentation.py#L396
+.. _Group packing: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/rotamer/_conjugated_groups.py#L214
+.. _Group sampler: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/rotamer/_conjugated_chi_sampler.py#L46
+.. _Chi budget: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/rotamer/_chi_budget.py#L29
+.. _Packer task: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/_packer_task.py#L344
+.. _Packing integration: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/pack/_pack_rotamers.py#L99
+.. _Fold forest: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/kinematics/_fold_forest.py#L283
+.. _Kinematic kernels: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/kinematics/compiled/compiled.impl.hh
+.. _LJLK kernel: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+.. _FastRelax: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/relax/_fast_relax.py#L157
+.. _Group packing tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/pack/test_conjugated_group_packing.py
+.. _Covalent component tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/test_covalent_components.py
+.. _Nucleic acid tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/ligand/test_nucleic_acids.py
+.. _Nonstandard backbone tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/ligand/test_nonstandard_backbones.py
+.. _Noncanonical scoring tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/score/test_noncanonical_scoring.py
+.. _Generic gradient tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/score/genbonded/test_genbonded_energy_term.py#L70
+.. _Mirror tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/score/test_mirror_image_scoring.py
+.. _Cyclic peptide tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/test_cyclic_peptide.py
+.. _Noncanonical rotamer tests: https://github.com/uw-ipd/tmol/blob/c03c1e745f3bc655948ea12dac44d6c74620358f/tmol/tests/pack/rotamer/test_noncanonical_rotamers.py
+.. _Rosetta generic bonded: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/scoring/GenericBondedPotential.cc#L2332
+.. _Residue params reader: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/chemical/residue_io.cc#L500
+.. _Rosetta residue cache: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/chemical/PoseResidueTypeSet.cc
+.. _Rosetta glycan sampler: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/protocols/carbohydrates/GlycanSampler.cc
+.. _Rosetta ligand fragmentation: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/scripts/python/public/molfile_to_params.py#L590
+.. _Rosetta chemical edges: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/kinematics/Edge.hh#L50
+.. _Rosetta score function: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/scoring/ScoreFunction.cc#L2044
+.. _Rosetta atom tree: https://github.com/RosettaCommons/rosetta/blob/de92a3c0dea8a010d372a22025e3e50bd4e2f33f/source/src/core/kinematics/AtomTree.cc#L1355
+.. _PR 503: https://github.com/uw-ipd/tmol/pull/503
+.. _Rosetta NCAA guide: https://docs.rosettacommons.org/docs/latest/rosetta_basics/non_protein_residues/Noncanonical-Amino-Acids
+.. _Rosetta D amino acid support: https://docs.rosettacommons.org/docs/latest/rosetta_basics/non_protein_residues/D-Amino-Acids
+.. _Rosetta GeneralizedKIC: https://docs.rosettacommons.org/docs/latest/scripting_documentation/RosettaScripts/composite_protocols/generalized_kic/GeneralizedKIC
+.. _GlycanTreeModeler paper: https://pmc.ncbi.nlm.nih.gov/articles/PMC11288642/
+.. _Rosetta small molecule force field paper: https://pmc.ncbi.nlm.nih.gov/articles/PMC8218654/

--- a/docs/_static/chemistry_pipeline.svg
+++ b/docs/_static/chemistry_pipeline.svg
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="509.76pt" height="417.6pt" viewBox="0 0 509.76 417.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-11T12:49:50.720914</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 417.6
+L 509.76 417.6
+L 509.76 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="line2d_1">
+    <path d="M 245.500416 78.80112
+L 292.398336 78.80112
+" clip-path="url(#p5d35e56d77)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_2">
+    <path d="M 292.398336 78.80112
+L 329.916672 59.42448
+" clip-path="url(#p5d35e56d77)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_3">
+    <path d="M 292.398336 78.80112
+L 348.67584 93.3336
+" clip-path="url(#p5d35e56d77)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="patch_2">
+    <path d="M 20.3904 99.3888
+L 147.014784 99.3888
+L 147.014784 48.52512
+L 20.3904 48.52512
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #f1f6fa; stroke: #2875a7; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 20.3904 135.72
+L 147.014784 135.72
+L 147.014784 107.86608
+L 20.3904 107.86608
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #ffffff; stroke: #67747b; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 158.396918 73.95696
+Q 184.535622 73.95696 209.668095 73.95696
+" clip-path="url(#p5d35e56d77)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 206.468095 72.35696
+L 209.668095 73.95696
+L 206.468095 75.55696
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 158.074037 120.103172
+Q 184.531527 103.022949 210.143643 86.488475
+" clip-path="url(#p5d35e56d77)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 206.587404 86.879838
+L 210.143643 86.488475
+L 208.32299 89.568284
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 245.500416 82.43424
+C 249.231658 82.43424 252.810581 82.051432 255.448967 81.370124
+C 258.087354 80.688816 259.569792 79.764635 259.569792 78.80112
+C 259.569792 77.837605 258.087354 76.913424 255.448967 76.232116
+C 252.810581 75.550808 249.231658 75.168 245.500416 75.168
+C 241.769174 75.168 238.190251 75.550808 235.551865 76.232116
+C 232.913478 76.913424 231.43104 77.837605 231.43104 78.80112
+C 231.43104 79.764635 232.913478 80.688816 235.551865 81.370124
+C 238.190251 82.051432 241.769174 82.43424 245.500416 82.43424
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 292.398336 82.43424
+C 296.129578 82.43424 299.708501 82.051432 302.346887 81.370124
+C 304.985274 80.688816 306.467712 79.764635 306.467712 78.80112
+C 306.467712 77.837605 304.985274 76.913424 302.346887 76.232116
+C 299.708501 75.550808 296.129578 75.168 292.398336 75.168
+C 288.667094 75.168 285.088171 75.550808 282.449785 76.232116
+C 279.811398 76.913424 278.32896 77.837605 278.32896 78.80112
+C 278.32896 79.764635 279.811398 80.688816 282.449785 81.370124
+C 285.088171 82.051432 288.667094 82.43424 292.398336 82.43424
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 329.916672 63.0576
+C 333.647914 63.0576 337.226837 62.674792 339.865223 61.993484
+C 342.50361 61.312176 343.986048 60.387995 343.986048 59.42448
+C 343.986048 58.460965 342.50361 57.536784 339.865223 56.855476
+C 337.226837 56.174168 333.647914 55.79136 329.916672 55.79136
+C 326.18543 55.79136 322.606507 56.174168 319.968121 56.855476
+C 317.329734 57.536784 315.847296 58.460965 315.847296 59.42448
+C 315.847296 60.387995 317.329734 61.312176 319.968121 61.993484
+C 322.606507 62.674792 326.18543 63.0576 329.916672 63.0576
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #ffffff; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 348.67584 96.96672
+C 352.407082 96.96672 355.986005 96.583912 358.624391 95.902604
+C 361.262778 95.221296 362.745216 94.297115 362.745216 93.3336
+C 362.745216 92.370085 361.262778 91.445904 358.624391 90.764596
+C 355.986005 90.083288 352.407082 89.70048 348.67584 89.70048
+C 344.944598 89.70048 341.365675 90.083288 338.727289 90.764596
+C 336.088902 91.445904 334.606464 92.370085 334.606464 93.3336
+C 334.606464 94.297115 336.088902 95.221296 338.727289 95.902604
+C 341.365675 96.583912 344.944598 96.96672 348.67584 96.96672
+z
+" clip-path="url(#p5d35e56d77)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="19.766986" transform="rotate(-0 20.3904 19.766986)">a</text>
+   </g>
+   <g id="text_2">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="19.486361" transform="rotate(-0 39.149568 19.486361)">Chemical identity and observed coordinates</text>
+   </g>
+   <g id="text_3">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(47.498842 70.76446)">Component graph</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(41.278217 82.33946)">atoms + bond orders</text>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #67747b" x="83.702592" y="124.77554" transform="rotate(-0 83.702592 124.77554)">Observed coordinates</text>
+   </g>
+   <g id="text_5">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="245.500416" y="81.352839" transform="rotate(-0 245.500416 81.352839)">N</text>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="292.398336" y="81.349011" transform="rotate(-0 292.398336 81.349011)">C</text>
+   </g>
+   <g id="text_7">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #2875a7" x="329.916672" y="61.972371" transform="rotate(-0 329.916672 61.972371)">O</text>
+   </g>
+   <g id="text_8">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="348.67584" y="95.881491" transform="rotate(-0 348.67584 95.881491)">C</text>
+   </g>
+   <g id="text_9">
+    <text style="font-size: 7.6px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #18242b" x="306.467712" y="122.073605" transform="rotate(-0 306.467712 122.073605)">Unresolved atom stays in graph</text>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 7.6px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #67747b" x="376.814592" y="61.404636" transform="rotate(-0 376.814592 61.404636)">xyz = NaN</text>
+   </g>
+   <g id="text_11">
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(376.814592 76.908257)">Chemistry first;</text>
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(376.814592 86.898257)">geometry rebuilt</text>
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(376.814592 96.888258)">where supported.</text>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_10">
+    <path d="M 20.3904 233.60544
+L 137.6352 233.60544
+L 137.6352 190.75968
+L 20.3904 190.75968
+z
+" clip-path="url(#p5e97125490)" style="fill: #ffffff; stroke: #2875a7; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 144.326397 212.18256
+Q 161.085515 212.18256 176.838403 212.18256
+" clip-path="url(#p5e97125490)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 173.638403 210.58256
+L 176.838403 212.18256
+L 173.638403 213.78256
+z
+" clip-path="url(#p5e97125490)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 184.53312 233.60544
+L 320.537088 233.60544
+L 320.537088 190.75968
+L 184.53312 190.75968
+z
+" clip-path="url(#p5e97125490)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 327.228285 212.18256
+Q 343.987403 212.18256 359.740291 212.18256
+" clip-path="url(#p5e97125490)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 356.540291 210.58256
+L 359.740291 212.18256
+L 356.540291 213.78256
+z
+" clip-path="url(#p5e97125490)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 367.435008 233.60544
+L 489.3696 233.60544
+L 489.3696 190.75968
+L 367.435008 190.75968
+z
+" clip-path="url(#p5e97125490)" style="fill: #f0f7f5; stroke: #2c8074; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_12">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="158.407165" transform="rotate(-0 20.3904 158.407165)">b</text>
+   </g>
+   <g id="text_13">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="157.127321" transform="rotate(-0 39.149568 157.127321)">Cap, parameterize, then restore polymer connections</text>
+   </g>
+   <g id="text_14">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(50.589675 208.99006)">Open polymer</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(54.889675 220.56506)">connections</text>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #bd622e" transform="translate(217.716979 208.99006)">Capped molecule</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #bd622e" transform="translate(214.331979 219.79006)">shared preparation</text>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2c8074" transform="translate(398.610429 208.99006)">Prepared block</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2c8074" transform="translate(399.656054 220.56506)">+ connections</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="258.084637" transform="rotate(-0 20.3904 258.084637)">Alpha backbone + generic sidechain   |   generic backbone   |   modified nucleotide</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 7.5px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #bd622e" x="184.53312" y="179.298971" transform="rotate(-0 184.53312 179.298971)">Temporary caps are removed</text>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="line2d_4">
+    <path d="M 48.529152 325.01808
+L 100.116864 325.01808
+" clip-path="url(#pea4e96a0d4)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_5">
+    <path d="M 100.116864 325.01808
+L 151.704576 325.01808
+" clip-path="url(#pea4e96a0d4)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_6">
+    <path d="M 151.704576 325.01808
+L 203.292288 325.01808
+" clip-path="url(#pea4e96a0d4)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 48.529152 328.58856
+C 52.260394 328.58856 55.839317 328.212352 58.477703 327.542791
+C 61.11609 326.87323 62.598528 325.964982 62.598528 325.01808
+C 62.598528 324.071178 61.11609 323.16293 58.477703 322.493369
+C 55.839317 321.823808 52.260394 321.4476 48.529152 321.4476
+C 44.79791 321.4476 41.218987 321.823808 38.580601 322.493369
+C 35.942214 323.16293 34.459776 324.071178 34.459776 325.01808
+C 34.459776 325.964982 35.942214 326.87323 38.580601 327.542791
+C 41.218987 328.212352 44.79791 328.58856 48.529152 328.58856
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 100.116864 328.58856
+C 103.848106 328.58856 107.427029 328.212352 110.065415 327.542791
+C 112.703802 326.87323 114.18624 325.964982 114.18624 325.01808
+C 114.18624 324.071178 112.703802 323.16293 110.065415 322.493369
+C 107.427029 321.823808 103.848106 321.4476 100.116864 321.4476
+C 96.385622 321.4476 92.806699 321.823808 90.168313 322.493369
+C 87.529926 323.16293 86.047488 324.071178 86.047488 325.01808
+C 86.047488 325.964982 87.529926 326.87323 90.168313 327.542791
+C 92.806699 328.212352 96.385622 328.58856 100.116864 328.58856
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 151.704576 328.58856
+C 155.435818 328.58856 159.014741 328.212352 161.653127 327.542791
+C 164.291514 326.87323 165.773952 325.964982 165.773952 325.01808
+C 165.773952 324.071178 164.291514 323.16293 161.653127 322.493369
+C 159.014741 321.823808 155.435818 321.4476 151.704576 321.4476
+C 147.973334 321.4476 144.394411 321.823808 141.756025 322.493369
+C 139.117638 323.16293 137.6352 324.071178 137.6352 325.01808
+C 137.6352 325.964982 139.117638 326.87323 141.756025 327.542791
+C 144.394411 328.212352 147.973334 328.58856 151.704576 328.58856
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #bd622e; stroke: #bd622e; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 203.292288 328.58856
+C 207.02353 328.58856 210.602453 328.212352 213.240839 327.542791
+C 215.879226 326.87323 217.361664 325.964982 217.361664 325.01808
+C 217.361664 324.071178 215.879226 323.16293 213.240839 322.493369
+C 210.602453 321.823808 207.02353 321.4476 203.292288 321.4476
+C 199.561046 321.4476 195.982123 321.823808 193.343737 322.493369
+C 190.70535 323.16293 189.222912 324.071178 189.222912 325.01808
+C 189.222912 325.964982 190.70535 326.87323 193.343737 327.542791
+C 195.982123 328.212352 199.561046 328.58856 203.292288 328.58856
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #bd622e; stroke: #bd622e; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 264.259584 334.53936
+L 484.679808 334.53936
+L 484.679808 300.02472
+L 264.259584 300.02472
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #ffffff; stroke: #2875a7; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 264.259584 382.14576
+L 484.679808 382.14576
+L 484.679808 347.63112
+L 264.259584 347.63112
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #ffffff; stroke: #2c8074; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 372.1248 337.733266
+Q 372.1248 340.491775 372.1248 342.244054
+" clip-path="url(#pea4e96a0d4)" style="fill: none; stroke: #67747b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 373.7248 339.044054
+L 372.1248 342.244054
+L 370.5248 339.044054
+z
+" clip-path="url(#pea4e96a0d4)" style="fill: #67747b; stroke: #67747b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_19">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="284.901226" transform="rotate(-0 20.3904 284.901226)">c</text>
+   </g>
+   <g id="text_20">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="284.620601" transform="rotate(-0 39.149568 284.620601)">Assign torsion energies separately from sampling proposals</text>
+   </g>
+   <g id="text_21">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="48.529152" y="327.677533" transform="rotate(-0 48.529152 327.677533)">i</text>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="100.116864" y="326.949642" transform="rotate(-0 100.116864 326.949642)">j</text>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="151.704576" y="327.677533" transform="rotate(-0 151.704576 327.677533)">k</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="203.292288" y="327.677533" transform="rotate(-0 203.292288 327.677533)">l</text>
+   </g>
+   <g id="text_25">
+    <text style="font-size: 7.2px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="356.75883" transform="rotate(-0 20.3904 356.75883)">Blue: protein type   Orange: generic type</text>
+   </g>
+   <g id="text_26">
+    <text style="font-size: 7.2px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(20.3904 381.65283)">Mixed central bond: generic lookup</text>
+    <text style="font-size: 7.2px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(20.3904 391.37283)">except bonds owned by omega / NA terms</text>
+   </g>
+   <g id="text_27">
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #2875a7" x="374.469696" y="319.323977" transform="rotate(-0 374.469696 319.323977)">Sampling reference  →  candidate torsions</text>
+   </g>
+   <g id="text_28">
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #2c8074" x="374.469696" y="366.930377" transform="rotate(-0 374.469696 366.930377)">Energy ownership  →  candidate scores</text>
+   </g>
+   <g id="text_29">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #67747b" x="264.259584" y="400.739562" transform="rotate(-0 264.259584 400.739562)">Unmatched parameters require a separate audit.</text>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5d35e56d77">
+   <rect x="20.3904" y="14.616" width="468.9792" height="121.104"/>
+  </clipPath>
+  <clipPath id="p5e97125490">
+   <rect x="20.3904" y="152.424" width="468.9792" height="112.752"/>
+  </clipPath>
+  <clipPath id="pea4e96a0d4">
+   <rect x="20.3904" y="279.792" width="468.9792" height="119.016"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/_static/group_packing.svg
+++ b/docs/_static/group_packing.svg
@@ -1,0 +1,574 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="509.76pt" height="450pt" viewBox="0 0 509.76 450" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-11T12:49:51.507910</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 450
+L 509.76 450
+L 509.76 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="line2d_1">
+    <path d="M 62.598528 76.995
+L 118.876032 76.995
+" clip-path="url(#pb43fb2ec86)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_2">
+    <path d="M 118.876032 76.995
+L 170.463744 56.8125
+" clip-path="url(#pb43fb2ec86)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_3">
+    <path d="M 118.876032 76.995
+L 170.463744 97.1775
+" clip-path="url(#pb43fb2ec86)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="patch_2">
+    <path d="M 62.598528 83.205
+C 67.573518 83.205 72.345414 82.550675 75.863263 81.386133
+C 79.381112 80.221591 81.357696 78.641911 81.357696 76.995
+C 81.357696 75.348089 79.381112 73.768409 75.863263 72.603867
+C 72.345414 71.439325 67.573518 70.785 62.598528 70.785
+C 57.623538 70.785 52.851642 71.439325 49.333793 72.603867
+C 45.815944 73.768409 43.83936 75.348089 43.83936 76.995
+C 43.83936 78.641911 45.815944 80.221591 49.333793 81.386133
+C 52.851642 82.550675 57.623538 83.205 62.598528 83.205
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 118.876032 83.205
+C 123.851022 83.205 128.622918 82.550675 132.140767 81.386133
+C 135.658616 80.221591 137.6352 78.641911 137.6352 76.995
+C 137.6352 75.348089 135.658616 73.768409 132.140767 72.603867
+C 128.622918 71.439325 123.851022 70.785 118.876032 70.785
+C 113.901042 70.785 109.129146 71.439325 105.611297 72.603867
+C 102.093448 73.768409 100.116864 75.348089 100.116864 76.995
+C 100.116864 78.641911 102.093448 80.221591 105.611297 81.386133
+C 109.129146 82.550675 113.901042 83.205 118.876032 83.205
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #bd622e; stroke: #bd622e; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 170.463744 63.0225
+C 175.438734 63.0225 180.21063 62.368175 183.728479 61.203633
+C 187.246328 60.039091 189.222912 58.459411 189.222912 56.8125
+C 189.222912 55.165589 187.246328 53.585909 183.728479 52.421367
+C 180.21063 51.256825 175.438734 50.6025 170.463744 50.6025
+C 165.488754 50.6025 160.716858 51.256825 157.199009 52.421367
+C 153.68116 53.585909 151.704576 55.165589 151.704576 56.8125
+C 151.704576 58.459411 153.68116 60.039091 157.199009 61.203633
+C 160.716858 62.368175 165.488754 63.0225 170.463744 63.0225
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #bd622e; stroke: #bd622e; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 170.463744 103.3875
+C 175.438734 103.3875 180.21063 102.733175 183.728479 101.568633
+C 187.246328 100.404091 189.222912 98.824411 189.222912 97.1775
+C 189.222912 95.530589 187.246328 93.950909 183.728479 92.786367
+C 180.21063 91.621825 175.438734 90.9675 170.463744 90.9675
+C 165.488754 90.9675 160.716858 91.621825 157.199009 92.786367
+C 153.68116 93.950909 151.704576 95.530589 151.704576 97.1775
+C 151.704576 98.824411 153.68116 100.404091 157.199009 101.568633
+C 160.716858 102.733175 165.488754 103.3875 170.463744 103.3875
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #bd622e; stroke: #bd622e; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 205.29398 73.89
+Q 224.398417 73.89 242.496624 73.89
+" clip-path="url(#pb43fb2ec86)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 239.296624 72.29
+L 242.496624 73.89
+L 239.296624 75.49
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 250.190208 100.2825
+L 348.67584 100.2825
+L 348.67584 45.945
+L 250.190208 45.945
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #f0f7f5; stroke: #2c8074; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 355.367037 73.89
+Q 372.126155 73.89 387.879043 73.89
+" clip-path="url(#pb43fb2ec86)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 384.679043 72.29
+L 387.879043 73.89
+L 384.679043 75.49
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 395.57376 100.2825
+L 489.3696 100.2825
+L 489.3696 45.945
+L 395.57376 45.945
+z
+" clip-path="url(#pb43fb2ec86)" style="fill: #ffffff; stroke: #2875a7; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="23.833906" transform="rotate(-0 20.3904 23.833906)">a</text>
+   </g>
+   <g id="text_2">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="23.553281" transform="rotate(-0 39.149568 23.553281)">One group conformer, one packing decision</text>
+   </g>
+   <g id="text_3">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="62.598528" y="79.546719" transform="rotate(-0 62.598528 79.546719)">A</text>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="118.876032" y="79.546719" transform="rotate(-0 118.876032 79.546719)">B</text>
+   </g>
+   <g id="text_5">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="170.463744" y="59.360391" transform="rotate(-0 170.463744 59.360391)">C</text>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="170.463744" y="99.729219" transform="rotate(-0 170.463744 99.729219)">D</text>
+   </g>
+   <g id="text_7">
+    <text style="font-size: 7.7px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="37.948156" transform="rotate(-0 20.3904 37.948156)">Anchor + attached blocks</text>
+   </g>
+   <g id="text_8">
+    <!-- Allowed: $(A_k,B_k,C_k,D_k)$ -->
+    <g style="fill: #18242b" transform="translate(25.080192 127.5625)">
+     <text>
+      <tspan x="0" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">A</tspan>
+      <tspan x="5.472656" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">l</tspan>
+      <tspan x="7.695312" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">l</tspan>
+      <tspan x="9.917969" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">o</tspan>
+      <tspan x="14.8125" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">w</tspan>
+      <tspan x="21.355469" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">e</tspan>
+      <tspan x="26.277344" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">d</tspan>
+      <tspan x="31.355469" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">:</tspan>
+      <tspan x="34.050781" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b"> </tspan>
+      <tspan x="36.59375" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="48.649219" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="61.700781" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="74.85" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="88.573438" y="-0.921875" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="39.714844" y="-0.921875" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">A</tspan>
+      <tspan x="52.750781" y="-0.921875" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">B</tspan>
+      <tspan x="65.802344" y="-0.921875" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">C</tspan>
+      <tspan x="78.951563" y="-0.921875" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">D</tspan>
+      <tspan x="45.1875" y="0.278121" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="58.239063" y="0.278121" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="71.388281" y="0.278121" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="85.111719" y="0.278121" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+     </text>
+    </g>
+   </g>
+   <g id="text_9">
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #67747b" x="25.080192" y="148.899438" transform="rotate(-0 25.080192 148.899438)">No independent mixed-index choices</text>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2c8074" transform="translate(269.207399 69.92125)">Representative</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #2c8074" transform="translate(282.891774 81.49625)">choice k</text>
+   </g>
+   <g id="text_11">
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(424.494305 70.877562)">Write k to</text>
+    <text style="font-size: 7.4px; font-family: 'DejaVu Sans'; fill: #2875a7" transform="translate(415.210196 80.150688)">every member</text>
+   </g>
+   <g id="text_12">
+    <!-- $U_G(k)=\sum_i U_i(k)+\sum_{i&lt;h} V_{ih}(k,k)$ -->
+    <g style="fill: #18242b" transform="translate(250.190208 126.755)">
+     <text>
+      <tspan x="0" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">U</tspan>
+      <tspan x="13.534766" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="38.374609" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">U</tspan>
+      <tspan x="49.125781" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="78.679297" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">V</tspan>
+      <tspan x="92.596875" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="101.33125" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="5.855469" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">G</tspan>
+      <tspan x="34.108984" y="7.067187" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="44.230078" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="66.7" y="7.067187" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="75.130078" y="7.067187" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">h</tspan>
+      <tspan x="84.151953" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="85.707812" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">h</tspan>
+      <tspan x="10.413672" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="18.167578" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="22.847266" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">=</tspan>
+      <tspan x="46.004687" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="53.758594" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="58.438281" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">+</tspan>
+      <tspan x="89.475781" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="97.229687" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="105.964062" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="31.108984" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans Display'; fill: #18242b">∑</tspan>
+      <tspan x="68.7" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans Display'; fill: #18242b">∑</tspan>
+      <tspan x="69.346875" y="7.067187" style="font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">&lt;</tspan>
+     </text>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- $V_{Gj}(k,l)=\sum_{i\in G}V_{ij}(k,l)$ -->
+    <g style="fill: #18242b" transform="translate(250.190208 153.1075)">
+     <text>
+      <tspan x="0" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">V</tspan>
+      <tspan x="14.707812" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="23.442187" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">l</tspan>
+      <tspan x="51.561719" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">V</tspan>
+      <tspan x="63.485938" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">k</tspan>
+      <tspan x="72.220313" y="-0.859375" style="font-style: oblique; font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">l</tspan>
+      <tspan x="5.472656" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">G</tspan>
+      <tspan x="9.812109" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">j</tspan>
+      <tspan x="38.60625" y="7.067187" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="47.222266" y="7.067187" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">G</tspan>
+      <tspan x="57.034375" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">i</tspan>
+      <tspan x="58.590234" y="0.340621" style="font-style: oblique; font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">j</tspan>
+      <tspan x="11.586719" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="19.340625" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="25.664844" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="30.344531" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">=</tspan>
+      <tspan x="60.364844" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">(</tspan>
+      <tspan x="68.11875" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">,</tspan>
+      <tspan x="74.442969" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans'; fill: #18242b">)</tspan>
+      <tspan x="41.60625" y="-0.859375" style="font-size: 8px; font-family: 'DejaVu Sans Display'; fill: #18242b">∑</tspan>
+      <tspan x="41.253125" y="7.067187" style="font-size: 5.6px; font-family: 'DejaVu Sans'; fill: #18242b">∈</tspan>
+     </text>
+    </g>
+   </g>
+   <g id="text_14">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #67747b" x="250.190208" y="175.502578" transform="rotate(-0 250.190208 175.502578)">Sum and coalesce; retain chemical blocks.</text>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_10">
+    <path d="M 20.3904 261.54
+L 114.18624 261.54
+L 114.18624 227.88
+L 20.3904 227.88
+z
+" clip-path="url(#p4774d536fb)" style="fill: #ffffff; stroke: #2875a7; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 120.877437 244.71
+Q 137.636555 244.71 153.389443 244.71
+" clip-path="url(#p4774d536fb)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 150.189443 243.11
+L 153.389443 244.71
+L 150.189443 246.31
+z
+" clip-path="url(#p4774d536fb)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 161.08416 256.59
+L 184.53312 256.59
+L 184.53312 232.83
+L 161.08416 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 189.222912 256.59
+L 212.671872 256.59
+L 212.671872 232.83
+L 189.222912 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 217.361664 256.59
+L 240.810624 256.59
+L 240.810624 232.83
+L 217.361664 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 268.949376 256.59
+L 292.398336 256.59
+L 292.398336 232.83
+L 268.949376 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 297.088128 256.59
+L 320.537088 256.59
+L 320.537088 232.83
+L 297.088128 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 325.22688 256.59
+L 348.67584 256.59
+L 348.67584 232.83
+L 325.22688 232.83
+z
+" clip-path="url(#p4774d536fb)" style="fill: #fcf4ef; stroke: #bd622e; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 355.36532 244.71
+Q 369.780595 244.71 383.189639 244.71
+" clip-path="url(#p4774d536fb)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 379.989639 243.11
+L 383.189639 244.71
+L 379.989639 246.31
+z
+" clip-path="url(#p4774d536fb)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 390.883968 261.54
+L 489.3696 261.54
+L 489.3696 227.88
+L 390.883968 227.88
+z
+" clip-path="url(#p4774d536fb)" style="fill: #ffffff; stroke: #2c8074; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_15">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="196.958125" transform="rotate(-0 20.3904 196.958125)">b</text>
+   </g>
+   <g id="text_16">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="195.678281" transform="rotate(-0 39.149568 195.678281)">Fragmentation and grouping have different purposes</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #2875a7" x="67.28832" y="246.9175" transform="rotate(-0 67.28832 246.9175)">One ligand</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="283.354344" transform="rotate(-0 20.3904 283.354344)">Fragmentation: change scoring blocks</text>
+   </g>
+   <g id="text_19">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #2c8074" x="440.126784" y="247.6925" transform="rotate(-0 440.126784 247.6925)">One choice</text>
+   </g>
+   <g id="text_20">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="268.949376" y="283.354344" transform="rotate(-0 268.949376 283.354344)">Grouping: couple conformer indices</text>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="line2d_4">
+    <path d="M 48.529152 366.6375
+L 104.806656 339.4125
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_5">
+    <path d="M 104.806656 339.4125
+L 165.773952 366.6375
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_6">
+    <path d="M 165.773952 366.6375
+L 104.806656 393.8625
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_7">
+    <path d="M 104.806656 393.8625
+L 48.529152 366.6375
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #bd622e; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_8">
+    <path d="M 278.32896 366.6375
+L 334.606464 339.4125
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_9">
+    <path d="M 334.606464 339.4125
+L 395.57376 366.6375
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_10">
+    <path d="M 395.57376 366.6375
+L 334.606464 393.8625
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_11">
+    <path d="M 334.606464 393.8625
+L 278.32896 366.6375
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #bd622e; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 48.529152 370.35
+C 52.260394 370.35 55.839317 369.958828 58.477703 369.262634
+C 61.11609 368.56644 62.598528 367.622067 62.598528 366.6375
+C 62.598528 365.652933 61.11609 364.70856 58.477703 364.012366
+C 55.839317 363.316172 52.260394 362.925 48.529152 362.925
+C 44.79791 362.925 41.218987 363.316172 38.580601 364.012366
+C 35.942214 364.70856 34.459776 365.652933 34.459776 366.6375
+C 34.459776 367.622067 35.942214 368.56644 38.580601 369.262634
+C 41.218987 369.958828 44.79791 370.35 48.529152 370.35
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 104.806656 343.125
+C 108.537898 343.125 112.116821 342.733828 114.755207 342.037634
+C 117.393594 341.34144 118.876032 340.397067 118.876032 339.4125
+C 118.876032 338.427933 117.393594 337.48356 114.755207 336.787366
+C 112.116821 336.091172 108.537898 335.7 104.806656 335.7
+C 101.075414 335.7 97.496491 336.091172 94.858105 336.787366
+C 92.219718 337.48356 90.73728 338.427933 90.73728 339.4125
+C 90.73728 340.397067 92.219718 341.34144 94.858105 342.037634
+C 97.496491 342.733828 101.075414 343.125 104.806656 343.125
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 165.773952 370.35
+C 169.505194 370.35 173.084117 369.958828 175.722503 369.262634
+C 178.36089 368.56644 179.843328 367.622067 179.843328 366.6375
+C 179.843328 365.652933 178.36089 364.70856 175.722503 364.012366
+C 173.084117 363.316172 169.505194 362.925 165.773952 362.925
+C 162.04271 362.925 158.463787 363.316172 155.825401 364.012366
+C 153.187014 364.70856 151.704576 365.652933 151.704576 366.6375
+C 151.704576 367.622067 153.187014 368.56644 155.825401 369.262634
+C 158.463787 369.958828 162.04271 370.35 165.773952 370.35
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 104.806656 397.575
+C 108.537898 397.575 112.116821 397.183828 114.755207 396.487634
+C 117.393594 395.79144 118.876032 394.847067 118.876032 393.8625
+C 118.876032 392.877933 117.393594 391.93356 114.755207 391.237366
+C 112.116821 390.541172 108.537898 390.15 104.806656 390.15
+C 101.075414 390.15 97.496491 390.541172 94.858105 391.237366
+C 92.219718 391.93356 90.73728 392.877933 90.73728 393.8625
+C 90.73728 394.847067 92.219718 395.79144 94.858105 396.487634
+C 97.496491 397.183828 101.075414 397.575 104.806656 397.575
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 278.32896 370.35
+C 282.060202 370.35 285.639125 369.958828 288.277511 369.262634
+C 290.915898 368.56644 292.398336 367.622067 292.398336 366.6375
+C 292.398336 365.652933 290.915898 364.70856 288.277511 364.012366
+C 285.639125 363.316172 282.060202 362.925 278.32896 362.925
+C 274.597718 362.925 271.018795 363.316172 268.380409 364.012366
+C 265.742022 364.70856 264.259584 365.652933 264.259584 366.6375
+C 264.259584 367.622067 265.742022 368.56644 268.380409 369.262634
+C 271.018795 369.958828 274.597718 370.35 278.32896 370.35
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 334.606464 343.125
+C 338.337706 343.125 341.916629 342.733828 344.555015 342.037634
+C 347.193402 341.34144 348.67584 340.397067 348.67584 339.4125
+C 348.67584 338.427933 347.193402 337.48356 344.555015 336.787366
+C 341.916629 336.091172 338.337706 335.7 334.606464 335.7
+C 330.875222 335.7 327.296299 336.091172 324.657913 336.787366
+C 322.019526 337.48356 320.537088 338.427933 320.537088 339.4125
+C 320.537088 340.397067 322.019526 341.34144 324.657913 342.037634
+C 327.296299 342.733828 330.875222 343.125 334.606464 343.125
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 395.57376 370.35
+C 399.305002 370.35 402.883925 369.958828 405.522311 369.262634
+C 408.160698 368.56644 409.643136 367.622067 409.643136 366.6375
+C 409.643136 365.652933 408.160698 364.70856 405.522311 364.012366
+C 402.883925 363.316172 399.305002 362.925 395.57376 362.925
+C 391.842518 362.925 388.263595 363.316172 385.625209 364.012366
+C 382.986822 364.70856 381.504384 365.652933 381.504384 366.6375
+C 381.504384 367.622067 382.986822 368.56644 385.625209 369.262634
+C 388.263595 369.958828 391.842518 370.35 395.57376 370.35
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 334.606464 397.575
+C 338.337706 397.575 341.916629 397.183828 344.555015 396.487634
+C 347.193402 395.79144 348.67584 394.847067 348.67584 393.8625
+C 348.67584 392.877933 347.193402 391.93356 344.555015 391.237366
+C 341.916629 390.541172 338.337706 390.15 334.606464 390.15
+C 330.875222 390.15 327.296299 390.541172 324.657913 391.237366
+C 322.019526 391.93356 320.537088 392.877933 320.537088 393.8625
+C 320.537088 394.847067 322.019526 395.79144 324.657913 396.487634
+C 327.296299 397.183828 330.875222 397.575 334.606464 397.575
+z
+" clip-path="url(#p9c32131b52)" style="fill: #2875a7; stroke: #2875a7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 191.222314 366.6375
+Q 215.016168 366.6375 237.803791 366.6375
+" clip-path="url(#p9c32131b52)" style="fill: none; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 234.603791 365.0375
+L 237.803791 366.6375
+L 234.603791 368.2375
+z
+" clip-path="url(#p9c32131b52)" style="fill: #18242b; stroke: #18242b; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_21">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="311.203906" transform="rotate(-0 20.3904 311.203906)">c</text>
+   </g>
+   <g id="text_22">
+    <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="39.149568" y="310.923281" transform="rotate(-0 39.149568 310.923281)">Chemical connectivity is not the kinematic spanning tree</text>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="48.529152" y="369.185391" transform="rotate(-0 48.529152 369.185391)">0</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="104.806656" y="341.964219" transform="rotate(-0 104.806656 341.964219)">1</text>
+   </g>
+   <g id="text_25">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="165.773952" y="369.235156" transform="rotate(-0 165.773952 369.235156)">2</text>
+   </g>
+   <g id="text_26">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="104.806656" y="396.410391" transform="rotate(-0 104.806656 396.410391)">3</text>
+   </g>
+   <g id="text_27">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="278.32896" y="369.185391" transform="rotate(-0 278.32896 369.185391)">0</text>
+   </g>
+   <g id="text_28">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="334.606464" y="341.964219" transform="rotate(-0 334.606464 341.964219)">1</text>
+   </g>
+   <g id="text_29">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="395.57376" y="369.235156" transform="rotate(-0 395.57376 369.235156)">2</text>
+   </g>
+   <g id="text_30">
+    <text style="font-size: 7px; font-family: 'DejaVu Sans'; text-anchor: middle; fill: #ffffff" x="334.606464" y="396.410391" transform="rotate(-0 334.606464 396.410391)">3</text>
+   </g>
+   <g id="text_31">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="20.3904" y="420.626844" transform="rotate(-0 20.3904 420.626844)">All chemical bonds retained for scoring</text>
+   </g>
+   <g id="text_32">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; text-anchor: start; fill: #18242b" x="264.259584" y="420.626844" transform="rotate(-0 264.259584 420.626844)">Tree edge cut; closure still needs validation</text>
+   </g>
+   <g id="text_33">
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(414.332928 352.609344)">Segmented</text>
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(414.332928 362.442102)">scans</text>
+    <text style="font-size: 7.3px; font-family: 'DejaVu Sans'; fill: #18242b" transform="translate(414.332928 373.026531)">+ derivatives</text>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb43fb2ec86">
+   <rect x="20.3904" y="18" width="468.9792" height="155.25"/>
+  </clipPath>
+  <clipPath id="p4774d536fb">
+   <rect x="20.3904" y="191.25" width="468.9792" height="99"/>
+  </clipPath>
+  <clipPath id="p9c32131b52">
+   <rect x="20.3904" y="306" width="468.9792" height="123.75"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,116 +1,98 @@
 .. _architecture:
 
-============
 Architecture
 ============
 
-TMol is roughly divided into two core modules: a high-level description of
-polymeric molecules in `tmol.system` and a low-level, term-specific description
-used `tmol.score`.
+tmol expresses molecular modeling as batched tensor operations integrated with
+PyTorch. The principal representation is ``tmol.pose.PoseStack``. It replaces
+the historical ``tmol.system`` score-graph interface described in older versions
+of this page. Independent structures can have different sizes, sequences and
+chemistries; they do not interact simply because they share a batch.
 
+Representation and setup
+------------------------
 
-These components operate over a shared chemical vocabulary defined in
-`tmol.database.chemical`, with additional term-specific data given in
-`tmol.database.scoring`.
+``PoseStack.coords`` has shape ``[n_poses, max_n_atoms, 3]``. Block-type indices,
+atom offsets and inter-block connections encode each structure's layout.
+A block can represent a polymer residue, a non-polymer ligand, or a connected
+fragment of a larger component. ``PackedBlockTypes`` stores the active block
+types in a shared table indexed by each block occurrence. Chemistry-specific
+annotations are computed once where reusable, then packed into device tensors.
+See `PoseStack`_ and `Packed block types`_.
 
-.. aafig::
+``ParameterDatabase`` separates chemical definitions from score-term parameter
+tables. Preparation returns a new database instead of mutating the input.
+``PoseBuildContext`` groups compatible construction objects for reuse.
+The frozen chemical records coexist with derived caches on refined types and
+packed tables; immutable database does not mean every implementation object
+is immutable. Preserve database identity and configuration when reusing caches.
 
-  +--------+          +---------+
-  |        |          |         |
-  | system +----------o scoring |
-  |        |          |         |
-  +--+-----+          +--+----+-+
-     |                   |    |
-     | +-----------------v-+  |
-     | |                   |  |
-     | | database.scoring  |  |
-     | |                   |  |
-     | +---------+---------+  |
-     |           |            |
-     | +---------v---------+  |
-     | |                   |  |
-     +-> database.chemical <--+
-       |                   |
-       +-------------------+
+The repeated numerical path
+---------------------------
 
+A ``ScoreFunction`` owns weights and energy-term objects. Rendering performs
+block-type, packed-type and pose-topology setup before producing whole-pose,
+block-pair or rotamer scoring modules. Whole-pose scoring returns one weighted
+energy per pose by default; term-resolved and positional outputs support
+diagnostics. Compatible terms reuse low-level functions across these modes.
+Rosetta also shares energy methods between protocols; tmol's difference is the
+tensorized setup and execution contract. See `Score function`_.
 
-`tmol.system` and `tmol.score` are coupled via
-:py:func:`~functools.singledispatch` hooks registered in
-`tmol.system.score_support`.
+Compiled operators expose coordinate derivatives through PyTorch autograd.
+For a learned coordinate generator :math:`x=f_\theta(z)`, differentiable energy
+evaluation provides
 
-Scoring
-=======
+.. math::
 
-Scoring is managed via a "score graph" object, managing the initialization
-of a torch compute graph calculating a setup of score terms for
-a collection model states.
+   \frac{\partial E}{\partial\theta}
+   = \left(\frac{\partial f_\theta}{\partial\theta}\right)^T
+     \frac{\partial E}{\partial x}.
 
-A model is defined over of a set ``n`` of bonded atoms. Each atom is located at
-an atom index, and is defined by a type and coordinate. Atoms may be "null",
-defining no type and a nan coordinate at a given index.  Bonds are defined via
-a set of ``b``` sparse, undirected bonded inter-atom index pairs.
+The coordinate generator must preserve its autograd graph. Chemical typing,
+discrete rotamer selection and the entire FastRelax control flow are not
+thereby differentiable, and higher derivatives require separate validation.
+Coordinate-only changes can reuse a rendered module. Changes to layout,
+topology, active types or score configuration require appropriate setup and
+rerendering.
 
-A score graph operates over a "depth" of ``l`` layers, each containing a single
-model. Models must contain the same number of atoms ``n``, but may have
-differing atom types and null atoms. Bonds are strictly intra-layer, and form
-a disjoint set per-layer inter-atom graphs.
+The LJ/LK CUDA whole-pose kernel uses block-pair work units, bounding-sphere
+culling and 32-atom shared-memory tiles. A 32-thread warp processes a surviving
+block pair and reduces its interaction contributions. CPU and CUDA paths share
+low-level functional expressions with device-specific dispatch; other score
+terms can use different algorithms. This arrangement enables batching and data
+reuse but does not by itself establish a speedup on a particular workload.
+See `LJLK kernel`_.
 
+Kinematics and combinatorial optimization
+-----------------------------------------
 
-.. aafig::
+``FoldForest`` describes polymer, jump, root-jump and chemical edges and is
+expanded into an atom-level ``KinForest``. Dependency-ordered segmented scans
+compose local transforms and propagate derivative information. For transforms
+:math:`T_i`, the frame along a path is
+:math:`X_j=X_0\prod_{i=1}^{j}T_i`; associativity permits a prefix scan within
+each independent segment. Branches are scheduled after their dependencies.
 
-  +---------------------------------------+
-  |                                  --   |
-  | "[n] atom_types"                /  \  |
-  | "[n] coordinates"            +-+    + |
-  | "[b] (a,b) bond indices"    /   \  /  |
-  |                                  --   |
-  +----------------------------------+----+
-                                     |
-                                     |
-  +----------------------------------|----+
-  |                              +---o--+ |
-  |                              +------+ |
-  | "[l] layers"                 +------+ |
-  |                              +------+ |
-  |                              +------+ |
-  +---------------------------------------+
+The convenience ``reasonable_fold_forest`` constructor currently uses host
+NumPy arrays to discover edges, and conjugated-group discovery also walks
+host-side topology. The numerical kinematic operators and portions of schedule
+construction are tensorized/compiled. Do not describe the entire chemistry-to-
+coordinates pipeline as GPU-resident. Cyclic bonds excluded from the kinematic
+spanning tree remain distinct chemical constraints. See `Fold forest`_ and
+`Kinematic kernels`_.
 
-Score calculation is performed on an intra-layer and inter-layer basis.
-Intra-layer scoring is defined over across all interactions (bonded and
-non-bonded) within a layer, yielding ``l`` scores for a single score graph of
-depth ``l``. Inter-layer scoring is defined over all inter-layer non-bonded
-interactions, yielding a ``[i, j]`` pairwise score array for two score graphs
-of depth ``i`` and ``j``.
+Packing builds candidate coordinates and compatible one-/two-block energies
+into a sparse interaction graph. CPU and CUDA annealers search the discrete
+choices. Covalent-group packing adds a common conformer index and reduces the
+group to one representative choice without merging its chemical block records.
+FastRelax alternates packing with minimization under a repulsive-weight
+schedule. See :ref:`chemistry-workflows` for the necessary sampling configuration.
 
-.. note:: `tmol.score` currently only supports intra-layer scoring, and is
-   limited to models of depth 1.
+Related guides
+--------------
 
-The score graph implementation is partitioned into score component classes,
-each covering a logically distinct component of the score function. These
-components include score terms, derived model representations, or support data
-required for score evaluation. Component classes are combined as mixins into
-a `reactive` score graph. At minimum, a valid score graph will include an
-atomic representation, some number of score terms, and a total score property.
+* :ref:`noncanonical-chemistry`: chemical input, preparation and supported scope.
+* :ref:`chemistry-workflows`: API recipes and sampler choices.
+* :ref:`rosetta-comparison`: inherited methods, concrete differences and limits.
 
-.. aafig::
-
-  +------------------------------+
-  |                              |
-  |          +-------+           |
-  |          | Atoms |           |
-  |          ++-----++           |
-  |           |     |            |
-  |        +--+    ++------+     |
-  |        |       |Derived|     |
-  |        v       ++-----++     |
-  |    +----+       |     |      |
-  |    |Term|       v     v      |
-  |    +---++   +----+ +----+    |
-  |        |    |Term| |Term|    |
-  |        v    +--+-+ +--+-+    |
-  |      +-----+   |      |      |
-  |      |Total|<--+------+      |
-  |      +-----+                 |
-  |                              |
-  +------------------------------+
-
+.. include:: _source_links.inc

--- a/docs/chemistry_workflows.rst
+++ b/docs/chemistry_workflows.rst
@@ -1,0 +1,204 @@
+.. _chemistry-workflows:
+
+Scoring, packing and relaxing prepared chemistry
+================================================
+
+These examples target the feature commit identified in
+:ref:`noncanonical-chemistry`. Install that branch with its ``ligand`` extra
+in a supported tmol environment. CPU scoring is useful for small examples;
+large group-packing problems can require CUDA. The examples are supplied as
+source-checked recipes; the documentation build does not execute molecular
+modeling or establish numerical benchmark results.
+
+Prepare and score
+-----------------
+
+Use the same extended database for construction, scoring and sampling:
+
+.. code-block:: python
+
+   import torch
+   from tmol.io import pose_stack_from_cif
+   from tmol.score import beta2016_score_function
+
+   device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+   pose, context = pose_stack_from_cif(
+       "complex.cif",
+       device,
+       prepare_ligands=True,
+       strict_ligands=True,
+       ligand_seed=20250828,
+       return_context=True,
+   )
+   param_db = context.parameter_database
+   sfxn = beta2016_score_function(device, param_db=param_db)
+   scorer = sfxn.render_whole_pose_scoring_module(pose)
+   xyz = pose.coords.detach().clone().requires_grad_(True)
+   energy = scorer(xyz)
+   gradient, = torch.autograd.grad(energy.sum(), xyz)
+   if not torch.isfinite(energy).all() or not torch.isfinite(gradient).all():
+       raise RuntimeError("Non-finite energy or coordinate gradient")
+
+The keyword is ``prepare_ligands``, not ``process_ligands``. The latter spelling
+in the PR description is not the preparation flag in this commit. The build
+context's database attribute is ``parameter_database``, not ``param_db``.
+For an existing bonded AtomArray, use ``pose_stack_from_biotite`` with the same
+preparation options. Reuse the rendered scorer for changing coordinates with
+fixed layout; construct a new scorer after packing changes the layout.
+See `CIF reader`_, `Biotite construction`_, and `Build context`_.
+
+Cartesian minimization
+----------------------
+
+.. code-block:: python
+
+   from tmol.optimization import run_cart_min
+
+   minimized = run_cart_min(pose, sfxn, verbose=False)
+   final_scorer = sfxn.render_whole_pose_scoring_module(minimized)
+   print(final_scorer(minimized.coords))
+
+Minimization adjusts coordinates continuously. It does not search all ligand
+poses, sample chemical reactions, enumerate protonation states, or certify
+geometric quality. Retain and inspect all atoms, covalent bonds, stereocenters
+and any missing-coordinate reconstruction.
+
+.. _group-packing:
+
+Configure sampling explicitly
+-----------------------------
+
+The packer chooses among conformers supplied by samplers. ``PackerPalette``
+alone supplies a fallback that carries the input conformation for otherwise
+uncovered blocks. For broad repacking, add amino-acid and nucleic-acid
+samplers, then enable joint sampling of covalent groups:
+
+.. code-block:: python
+
+   from tmol.pack import PackerPalette, PackerTask, pack_rotamers
+   from tmol.pack.rotamer import (
+       FixedAAChiSampler, IncludeCurrentSampler, NaChiRotamerSampler,
+   )
+   from tmol.pack.rotamer.dunbrack import create_dunbrack_sampler_from_database
+   from tmol.pack.rotamer._conjugated_groups import add_conjugated_group_sampler
+
+   def configure_repacking(task):
+       task.restrict_to_repacking()
+       task.add_conformer_sampler(
+           create_dunbrack_sampler_from_database(param_db, device)
+       )
+       task.add_conformer_sampler(FixedAAChiSampler())
+       task.add_conformer_sampler(NaChiRotamerSampler.from_database(param_db, device))
+       task.add_conformer_sampler(IncludeCurrentSampler())
+       # Uses the fixed chemical connectivity of this repacking task.
+       # Add last so it can disable independent movement of group anchors.
+       add_conjugated_group_sampler(task, pose)
+
+   task = PackerTask(pose, PackerPalette())
+   configure_repacking(task)
+   packed = pack_rotamers(pose, sfxn, task, verbose=False)
+
+``add_conjugated_group_sampler`` is currently an internal import on the feature
+branch. It discovers an anchor plus attached blocks, builds conformers using
+one group kinematic forest, and disables samplers that would move the anchor
+independently. Each member's rotamer index then means the same group conformer.
+Scoring removes incompatible within-group index combinations; the interaction
+graph collapses the group to one representative choice and writes the selected
+coordinates back to every member. See `Group discovery`_, `Group packing`_
+and `Group sampler`_.
+
+.. figure:: _static/group_packing.svg
+   :alt: Separate scoring blocks share one group conformer index and one packing decision; chemical graph cycles remain distinct from the kinematic tree.
+   :width: 100%
+
+   Group packing couples choices while preserving block-level scoring.
+   User-defined fragmentation is a separate operation on the representation.
+
+A free ligand is not claimed by the conjugated-group sampler. The default
+amino-acid and nucleic-acid samplers also do not provide general free-ligand
+heavy-atom conformer search. Such a ligand may remain in its input conformer
+during packing and subsequently move under Cartesian minimization. Supply an
+appropriate conformer sampler when a free-ligand conformational search is
+required.
+
+Borrowed distributions and budgets
+----------------------------------
+
+``dunbrack_reference`` lets a noncanonical amino acid borrow candidate torsions
+from a structurally compatible canonical sidechain. Remaining heavy torsions
+can be enumerated from ``chi_samples``. This is a sampling proposal: the
+Dunbrack energy term resolves its own library by the residue's base name and
+does not automatically score the borrowed canonical probability. For modified
+nucleotides, ``na_base_reference`` can participate in both scoring and
+sampling. Their sampler holds the input sugar pucker fixed while sampling
+glycosidic chi and supported proton torsions. See `Dunbrack sampler`_,
+`Dunbrack scoring`_ and `NA sampler`_.
+
+The group and NA samplers have ``chi_sample_expanded_limit`` and
+``chi_sample_limit`` settings, defaulting to 100 and 1000. The budget removes
+extra-angle expansions, then freezes heavy chi from the tips of the relevant
+kinematic tree inward. Group budgeting accounts for the number of blocks and
+uses an estimate of the anchor-library contribution. Proton chi are not frozen.
+These are sampling-budget heuristics, not a universal hard bound on final
+rotamer count or GPU memory; the current group conformer is also offered when
+measurable. See `Chi budget`_.
+
+At the audited commit, ``PackerTask.set_chi_sample_budget`` stores values that
+are not propagated by ``SetPackerTask.from_packer_task``. For a custom group
+budget, construct the sampler with its settings before its first use:
+
+.. code-block:: python
+
+   from tmol.pack.rotamer._conjugated_chi_sampler import ConjugatedChiSampler
+
+   # Alternative group-sampler construction inside a task configuration.
+   # Use this instead of adding the default group sampler a second time.
+   library = create_dunbrack_sampler_from_database(param_db, device)
+   group_sampler = ConjugatedChiSampler(
+       library_sampler=library,
+       chi_sample_expanded_limit=100,
+       chi_sample_limit=1000,
+   )
+   # After adding the other samplers to a fresh task:
+   # add_conjugated_group_sampler(task, pose, sampler=group_sampler)
+
+Inspect actual generated counts and test budget changes on the intended system.
+Changing a setting after block annotations have been cached can leave old
+sampling data in use.
+
+FastRelax with the same sampling choices
+----------------------------------------
+
+Pass the explicit task configuration through every pack/minimize cycle:
+
+.. code-block:: python
+
+   from tmol.kinematics import CartesianMoveMap, FoldForest
+   from tmol.relax import fast_relax
+
+   relaxed = fast_relax(
+       pose,
+       sfxn,
+       PackerPalette(),
+       CartesianMoveMap(),
+       FoldForest.reasonable_fold_forest(pose),
+       task_operations=[configure_repacking],
+       num_repeats=2,
+       verbose=False,
+   )
+
+This uses the default Cartesian minimizer. The example restricts to repacking,
+so using the original pose's fixed connectivity to configure groups remains
+appropriate. A design task that changes identities or attachment topology
+needs its own lifecycle handling. FastRelax's default task operation installs
+amino-acid samplers and a current conformer; it does not install the NA or
+conjugated-group samplers. A successful default call therefore does not mean
+all these classes were sampled. See `FastRelax`_.
+
+Chemical edges in ``FoldForest`` propagate motion across non-polymeric covalent
+bonds. A cycle is cut in the spanning forest while its chemical bond remains
+in the pose's scoring topology. This is not an analytical ring-closure solver;
+especially for internal-coordinate minimization, inspect closure geometry and
+choose appropriate constraints or a validated closure protocol.
+
+.. include:: _source_links.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,12 +10,12 @@ TMol Documentation
 
 TMol is a tensor-based molecular modeling library for use on GPUs and CPUs.
 
-Ligand preparation (detecting, parameterizing, and scoring non-standard
-residues such as small-molecule ligands) is documented in the
-`ligand preparation guide
-<https://github.com/uw-ipd/tmol/blob/main/tmol/ligand/README.md>`_, which
-covers the CIF/SMILES/mol2 pipeline, the ``strict_ligands`` failure mode, and a
-protein-ligand ddG quickstart.
+Generalized preparation of noncanonical polymers, ligands and covalent
+attachments is described in :ref:`noncanonical-chemistry`. Start with
+:ref:`chemistry-workflows` for scoring, packing and relaxation recipes, and
+:ref:`rosetta-comparison` for inherited methods, implementation differences
+and validation boundaries. These guides identify the feature revision they
+describe; they do not imply that an unmerged feature is in every release.
 
 .. The toctree entry declares the document's location, and children, inside the
   table-of-contents entry. We want two captioned toc constructs on the front,
@@ -31,6 +31,9 @@ protein-ligand ddG quickstart.
   :caption: Notes
 
   architecture
+  noncanonical_chemistry
+  chemistry_workflows
+  rosetta_comparison
   datatypes
   apidoc
 
@@ -46,7 +49,12 @@ Packages
   :name: apidoc
   :hidden:
 
-  apidoc/tmol.system
+  apidoc/tmol.pose
+  apidoc/tmol.chemical
+  apidoc/tmol.ligand
+  apidoc/tmol.pack
+  apidoc/tmol.optimization
+  apidoc/tmol.relax
   apidoc/tmol.score
   apidoc/tmol.database
   apidoc/tmol.kinematics
@@ -54,13 +62,17 @@ Packages
   apidoc/tmol.types
   apidoc/tmol.utility
   apidoc/tmol.io
-  apidoc/tmol.viewer
   apidoc/tmol.support
   apidoc/tmol.extern
 
 .. autosummary::
 
-  tmol.system
+  tmol.pose
+  tmol.chemical
+  tmol.ligand
+  tmol.pack
+  tmol.optimization
+  tmol.relax
   tmol.score
   tmol.database
   tmol.kinematics
@@ -68,11 +80,10 @@ Packages
   tmol.types
   tmol.utility
   tmol.io
-  tmol.viewer
   tmol.support
   tmol.extern
 
-Indicies
+Indices
 ==================
 
 * :ref:`genindex`

--- a/docs/noncanonical_chemistry.rst
+++ b/docs/noncanonical_chemistry.rst
@@ -3,13 +3,16 @@
 Generalized chemistry from mmCIF
 ================================
 
+tmol is designed for scoring, packing and relaxation of arbitrary molecules
+through a shared chemical representation and tensor execution framework.
 The feature branch in `PR 503`_ extends the ligand preparation machinery to
 noncanonical amino acids, modified nucleic acids, peptide-like backbones, and
 covalently attached ligands and glycan trees. These components become ordinary
 blocks in a ``PoseStack`` and can participate in scoring, appropriately
 configured packing, and Cartesian relaxation. The contribution is a common
-construction and execution path across chemistry; it is not a claim that every
-deposited component has an accurate parameterization.
+construction and execution path across chemistry. Metal support is planned as
+an extension of this framework. The version-specific coverage below describes
+the audited implementation; parameter accuracy requires separate validation.
 
 This guide describes commit ``c03c1e745f3bc655948ea12dac44d6c74620358f`` on
 ``dimaio/noncanonicals_through_ligand_pipeline``. PR 503 was open at the time of
@@ -149,7 +152,7 @@ Scope and failure interpretation
      - Default samplers need not explore heavy-atom conformations
    * - Metal-containing unknown components
      - Automatic preparation rejects them
-     - No blanket metal-site claim follows from this pipeline
+     - Support is planned; use the implementing revision when available
 
 ``strict_ligands=True`` raises ``LigandPreparationError`` for detected
 unpreparable components; lenient mode can warn and drop them. Strict

--- a/docs/noncanonical_chemistry.rst
+++ b/docs/noncanonical_chemistry.rst
@@ -1,0 +1,170 @@
+.. _noncanonical-chemistry:
+
+Generalized chemistry from mmCIF
+================================
+
+The feature branch in `PR 503`_ extends the ligand preparation machinery to
+noncanonical amino acids, modified nucleic acids, peptide-like backbones, and
+covalently attached ligands and glycan trees. These components become ordinary
+blocks in a ``PoseStack`` and can participate in scoring, appropriately
+configured packing, and Cartesian relaxation. The contribution is a common
+construction and execution path across chemistry; it is not a claim that every
+deposited component has an accurate parameterization.
+
+This guide describes commit ``c03c1e745f3bc655948ea12dac44d6c74620358f`` on
+``dimaio/noncanonicals_through_ligand_pipeline``. PR 503 was open at the time of
+the audit. A release number alone does not identify this feature state.
+See :ref:`chemistry-workflows` for code and :ref:`rosetta-comparison` for the
+relationship to Rosetta.
+
+.. figure:: _static/chemistry_pipeline.svg
+   :alt: Observed coordinates and complete chemistry converge on prepared blocks, with explicit ownership of torsion terms.
+   :width: 100%
+
+   Chemical identity, coordinate availability, and scoring-term ownership are
+   separate decisions. The drawing is an implementation schematic, not a
+   measured coverage result.
+
+Chemical identity is more than the observed atoms
+-------------------------------------------------
+
+An unresolved sidechain atom is still part of a residue. Parameterizing only
+the resolved atoms can accidentally turn a missing sidechain tip into a
+different, protonated molecule. ``atom_array_from_cif`` combines observed
+``atom_site`` coordinates with component definitions from ``chem_comp_atom``
+and ``chem_comp_bond``, with a component-dictionary fallback when enabled.
+Declared but unresolved atoms enter the array at NaN, allowing preparation to
+recognize the complete chemistry and construction to rebuild supported missing
+coordinates. Atoms lost through polymerization are distinguished from atoms
+missing through unresolved density. See `CIF reader`_.
+
+This also accommodates bonded AtomWorks-style arrays that already mark missing
+atoms with NaN. Use ``pose_stack_from_biotite`` for such arrays; do not assume
+that every function whose name contains AtomWorks invokes chemical preparation.
+Unknown incomplete chemistry without a usable definition can still fail.
+If no definition describes an input at all, the reader can warn and treat the
+observed atom set as complete; that warning needs inspection in a corpus audit.
+
+Prefer mmCIF for generalized preparation of PDB-deposited structures. A PDB
+accession and the legacy ``.pdb`` text format are different things: coordinate
+records alone do not provide reliable ligand bond orders. ``pose_stack_from_pdb``
+uses the default chemical vocabulary and is not an equivalent automatic
+noncanonical-preparation entry point. Custom component codes can collide with
+the component dictionary; use ``use_ccd=False`` when their chemistry is defined
+locally and their names must not trigger dictionary lookup.
+
+Polymer residues use the ligand machinery without losing connections
+--------------------------------------------------------------------
+
+Preparation uses the bond graph, attachment sites, polymer-entity annotations,
+and declared component type to distinguish chain members from free molecules
+and sidechain conjugates. A supported polymer profile supplies its mainchain,
+connection atoms, and temporary chemical caps. The capped molecule passes
+through protonation, conformer generation, atom typing and charge assignment;
+the caps are then removed and the polymer connections and internal-coordinate
+records restored. Nonstandard backbones receive generated terminus patches
+and associated charge records. Canonical backbone aliases preserve supported
+input spellings. See `Polymer preparation`_ and `Polymer profiles`_.
+
+An unmodified alpha-amino-acid backbone can retain protein backbone types while
+its modified sidechain uses generic ligand types. A proline-like ring on the
+amide nitrogen is distinguished from N-methylation or a peptoid substituent.
+Beta-amino acids, gamma-linked peptides and other recognized nonstandard
+backbones use generic typing with explicit polymer connectivity. They are not
+forced into alpha-amino-acid statistical models merely because they are in a
+peptide chain. Modified RNA/DNA bases may use an explicit ``na_base_reference``;
+a fused dinucleotide can instead follow a generic path. See `Polymer builder`_
+and `Nucleic acid tests`_.
+
+Covalent attachments modify both sides of a connection
+------------------------------------------------------
+
+A conjugated ligand or glycan is not just placed near its anchor. Preparation
+creates named conjugation connections and variants, adjusts hydrogens, atom
+typing and charges, and transfers explicit covalent links into the canonical
+form and ``PoseStack``. Canonical anchors can acquire connection patches while
+retaining their other residue information. Tests cover lysine-biotin, an
+O-linked glycan and a branched N-linked glycan, including charge bookkeeping
+and connections on both partners. See `Conjugation preparation`_ and
+`Covalent component tests`_.
+
+Connected blocks remain separate scoring blocks. For packing, their selected
+conformations can be coupled as one group; see :ref:`group-packing`.
+Preparing the connections does not by itself install a group sampler in the
+packer or in FastRelax.
+
+Input routes and persistence
+----------------------------
+
+``pose_stack_from_cif(..., prepare_ligands=True, return_context=True)`` returns
+a pose and a ``PoseBuildContext`` holding the extended parameter database,
+canonical ordering, residue-type set and packed block types. Use
+``context.parameter_database`` for the score function and library samplers.
+Reusing a compatible context avoids repeating chemical setup; rerender scoring
+modules when the pose layout or topology changes.
+
+The low-level ``prepare_ligand_from_smiles`` and
+``prepare_ligand_from_mol2`` entry points still create free ligands, not
+polymer-aware residues. MOL2 with authoritative charges can bypass conformer
+generation. Derived-SMILES preparation uses Dimorphite-DL protonation, RDKit
+distance geometry, and OpenBabel charge assignment; install the ``ligand``
+extra for this path, including CIF inputs that route through it.
+MMFF94 is the intended charge model, but the implementation can warn and use
+another charge model if MMFF94 cannot parameterize the molecule. Some
+non-tetrahedral stereochemical descriptors are also stripped with a warning
+for OpenBabel compatibility. Preserve these warnings and inspect the resulting
+chemistry. See `Charge preparation`_.
+
+Prepared definitions can be saved with ``params_output`` and reloaded through
+``ligand_params_files``. The ``.tmol`` format carries prepared chemical and
+scoring records and supports inspection and manual correction. It should be
+archived with the source structure, preparation seed, pH, environment and
+commit. Reusing a prepared definition is not evidence that the original
+parameterization was accurate.
+
+Scope and failure interpretation
+--------------------------------
+
+.. list-table:: Different meanings of support
+   :header-rows: 1
+   :widths: 23 44 33
+
+   * - Chemistry
+     - Implemented route
+     - Boundary
+   * - Noncanonical amino acids
+     - Profile-based polymer preparation; shared score and rotamer machinery
+     - Backbone must be identifiable; rotamers are approximations
+   * - Modified RNA/DNA
+     - Polymer/base references and nucleic-acid scoring/sampling
+     - Base similarity is not a fitted potential for every modification
+   * - Native D residues and cyclic peptides
+     - Mirrored definitions/tables and chemical closure connections
+     - Closure in a chemical graph is not an exact loop-closure solver
+   * - Covalent ligand or glycan attachment
+     - Connections, variants and explicit joint group packing
+     - Configure the group sampler; inspect non-tree links
+   * - Free non-polymer ligands
+     - Preparation, scoring and Cartesian minimization
+     - Default samplers need not explore heavy-atom conformations
+   * - Metal-containing unknown components
+     - Automatic preparation rejects them
+     - No blanket metal-site claim follows from this pipeline
+
+``strict_ligands=True`` raises ``LigandPreparationError`` for detected
+unpreparable components; lenient mode can warn and drop them. Strict
+preparation is not a universal force-field-coverage check: generic torsions
+with no matching parameters can be omitted, and preparation can use the
+documented charge or geometry fallbacks. Inspect atom retention, connectivity,
+parameter coverage, nonzero term contributions, finite gradients and geometric
+quality separately. ``strict_atom_types`` concerns atom-type mappings and does
+not close all these gaps. See `Preparation boundary`_ and `Generic torsions`_.
+
+Keep construction success, actual conformational sampling, numerical
+correctness and scientific accuracy as separate outcomes. A static ligand
+carried through a packing run has not thereby been conformationally packed.
+The implementation tests are useful regression evidence; they do not provide
+a PDB-wide success fraction or establish superiority to Rosetta on all these
+chemistries.
+
+.. include:: _source_links.inc

--- a/docs/rosetta_comparison.rst
+++ b/docs/rosetta_comparison.rst
@@ -1,0 +1,161 @@
+.. _rosetta-comparison:
+
+Relationship to Rosetta
+=======================
+
+tmol inherits substantial scientific foundations from Rosetta: energy-function
+families, atom types and parameters, rotamer libraries, internal-coordinate
+modeling, packing and pack/minimize relaxation. Its contribution is to
+reorganize and extend these ideas around batched tensors, explicit chemical
+metadata, shared setup and PyTorch coordinate differentiation. Functional
+ancestry, implementation differences and scientific validation are different
+claims.
+
+This comparison uses tmol PR 503 commit
+``c03c1e745f3bc655948ea12dac44d6c74620358f`` and Rosetta commit
+``de92a3c0dea8a010d372a22025e3e50bd4e2f33f``. Source links are pinned to these
+revisions. Neither a newer tmol branch nor an old Rosetta tutorial alone
+establishes a feature's absence from current Rosetta.
+
+What is unified
+---------------
+
+.. list-table:: Implementation comparison
+   :header-rows: 1
+   :widths: 20 39 41
+
+   * - Concept
+     - Rosetta already provides
+     - tmol implementation and extension
+   * - Chemical vocabulary
+     - ResidueType, residue sets, patches, connections and caches
+     - Prepared blocks and a shared batch-local PackedBlockTypes table
+   * - Noncanonical setup
+     - Params, polymer tools, MakeRotLib, ROTAMER_AA and BACKBONE_AA
+     - Profile-driven preparation and explicit references in one database/context path
+   * - Mixed bonded scoring
+     - GenericBondedPotential with hybrid exclusions
+     - Packed type hierarchies and shared intra-/inter-block torsion gates
+   * - D amino acids
+     - Mirrored residues and scoring/sampling support
+     - Mirrored tables enter the same packed table and kernel paths as L types
+   * - Glycans and covalent links
+     - GlycanSampler/GlycanTreeModeler, linkage conformers and chemical FoldTree edges
+     - Generic anchor-plus-attachment conformers collapsed into one packer choice
+   * - Ligand fragments
+     - molfile_to_params can split ligands and create connections
+     - Fragment annotations, propagated parameters and identity-restoring export
+   * - Scoring and derivatives
+     - Shared EnergyMethods, analytical derivatives and caches
+     - Rendered tensor modules and coordinate derivatives in PyTorch autograd
+
+Rosetta's `Residue params reader`_ documents ``ROTAMER_AA``, ``BACKBONE_AA``
+and explicit Ramachandran-map settings. `Rosetta residue cache`_ shows shared
+and pose-local residue-type caching. Explicit metadata, reuse and support for
+noncanonical chemistry are not inventions of tmol. The practical advance is
+making preparation and execution more uniform within its batched differentiable
+framework. See also `Rosetta NCAA guide`_.
+
+Hybrid bonded scoring: explicit ownership
+-----------------------------------------
+
+At a protein-backbone/generic-sidechain boundary, parameter lookup must span
+both type vocabularies. tmol expands the generic hierarchy with Rosetta-type
+fallbacks. Proper torsions whose two central atoms are both Rosetta-typed are
+excluded from generic scoring; nucleic-acid torsion bonds and named omega
+connections are separately gated to avoid competing contributions. Generic
+impropers and Cartesian planarity terms use complementary typing logic.
+Intra-block resolution occurs during setup; inter-block lookup uses packed
+hierarchy and bond-type data. See `Generic torsions`_,
+`Generic parameter database`_, and `Cartesian bonded`_.
+
+This implements a Rosetta-inspired hybrid partition; it does not reproduce
+every exclusion rule in `Rosetta generic bonded`_. Rosetta also considers
+reference residues, changed atoms, backbone membership and the availability of
+rotamer/Ramachandran information. tmol keeps bond lengths and angles in its
+Cartesian bonded path while its generic term handles proper and improper
+torsions. Term names therefore need not define identical partitions. Compare
+matched physical contributions and parameter choices rather than assuming
+name-for-name numerical identity.
+
+The partition is intended to avoid double counting. It is not proof that each
+torsion has a valid restraint: unresolved generic parameter lookups can be
+omitted. Four-backbone-class scoring tests and finite-difference checks exercise
+important mixed boundaries; they are not a complete parameter-coverage proof.
+See `Noncanonical scoring tests`_ and `Generic gradient tests`_.
+
+Proposal distributions and scoring potentials
+---------------------------------------------
+
+The noncanonical amino-acid sampler can borrow a canonical library by chemical
+correspondence, while Dunbrack scoring only uses an actual library for the
+residue's base name. Generic torsions supply novel sidechain torsional energy.
+This allows useful proposals without treating the canonical sidechain's
+frequency as a measured probability for the modification. An alpha-backbone
+Ramachandran reference can still be borrowed (with an alanine fallback), and a
+nucleotide's base reference can influence its torsion energy. Disclose and
+validate these approximations rather than calling them newly fitted statistics.
+See `Polymer builder`_, `Dunbrack scoring`_ and `NA sampler`_.
+
+For native D residues, tmol reflects backbone table coordinates, reverses chi
+means and well labels, preserves appropriate unsigned quantities, and packs
+the resulting libraries through the normal machinery. This makes handedness
+explicit across preparation, scoring and sampling. Rosetta already has
+`Rosetta D amino acid support`_. tmol's mirror-image test uses symmetrized
+glycine tables and disables hydrogen optimization to preserve its controlled
+comparison; this is not an unconditional symmetry claim for every default
+protocol. See `Mirrored libraries`_ and `Mirror tests`_.
+
+Joint group packing and chemical kinematics
+-------------------------------------------
+
+The group representation changes the packer's decision variable. If blocks
+:math:`a,b,c` belong to one sampled group, it may select
+:math:`(a_k,b_k,c_k)` but not :math:`(a_k,b_l,c_m)` with unrelated indices.
+Within-group contributions map to the representative's self-energy;
+interactions with other blocks map to representative-partner energies. Sparse
+coalescing accumulates all contributions, and selected coordinates are written
+back to all members. Scoring remains decomposed by chemical block. This exposes
+attached-group conformations to the ordinary discrete optimizer without
+allowing inconsistent independent choices. See `Group packing`_.
+
+Rosetta's `Rosetta glycan sampler`_ composes linkage sampling, glycan branch
+minimization and packing; `GlycanTreeModeler paper`_ describes a validated,
+specialized glycan protocol. tmol's generic group-choice representation is a
+different integration strategy. It does not show that Rosetta cannot move
+bonded groups or that tmol replaces specialized glycan potentials and search
+protocols. Group sampling also differs from user-defined fragmentation, which
+subdivides one prepared ligand for representation and interaction analysis.
+Rosetta has `Rosetta ligand fragmentation`_ too.
+
+Rosetta's ``Edge::CHEMICAL`` also predates tmol's chemical FoldForest edge.
+tmol integrates this edge with tensor kinematics and derivative propagation.
+A spanning forest cannot retain every ring edge as a tree edge. Chemical
+closure remains in scoring, but exact closure under arbitrary
+internal-coordinate changes requires more than this representation. Rosetta
+provides `Rosetta GeneralizedKIC`_ for analytical closure of diverse covalently
+connected chains.
+
+What has to be measured
+-----------------------
+
+The new branch corrects Cartesian peptide-planarity records and generic type
+lookup, so old tmol energy goldens and speed/parity results cannot simply be
+reused. Report exact revisions, prepared parameters, term/weight alignment,
+charge model, termini, protonation, device and precision. Rosetta-derived
+functional forms do not establish agreement for automatically generated
+parameters. A within-tmol golden is a regression check, not an independent
+Rosetta comparison.
+
+Separate setup time, repeated scoring/backward time, packing time and
+end-to-end relaxation. Compare matched hardware budgets, candidate counts and
+output quality. Report every chemical-coverage attempt and distinguish
+construction, actual sampling, parameter coverage, finite derivatives,
+geometric validity and scientific accuracy. Keep unsupported chemistry and
+failed runs in the denominator.
+
+Source evidence supports integration and broader automated preparation within
+tmol. PDB-wide coverage, better physical accuracy, complete Rosetta replacement
+or universally higher speed require experiments.
+
+.. include:: _source_links.inc

--- a/tmol/ligand/README.md
+++ b/tmol/ligand/README.md
@@ -1,5 +1,9 @@
 # Generalized chemical preparation
 
+tmol targets scoring, packing and relaxation of arbitrary molecules through one
+chemical representation. Metal support is planned; the implementation details
+below describe the current PR #503 snapshot.
+
 PR #503 extends the ligand machinery to supported noncanonical polymer residues,
 modified nucleic acids, covalent ligands and glycan attachments. Use the
 [generalized chemistry guide](../../docs/noncanonical_chemistry.rst),

--- a/tmol/ligand/README.md
+++ b/tmol/ligand/README.md
@@ -1,330 +1,101 @@
-# Ligand Preparation Pipeline
+# Generalized chemical preparation
 
-Turns a non-standard (non-polymer) residue into a fully parameterized tmol
-residue type — protonated 3D coordinates, MMFF94 partial charges,
-Rosetta-compatible atom types, and cartbonded parameters — and injects it into
-a `ParameterDatabase` so the ligand can be scored and minimized like any other
-residue.
+PR #503 extends the ligand machinery to supported noncanonical polymer residues,
+modified nucleic acids, covalent ligands and glycan attachments. Use the
+[generalized chemistry guide](../../docs/noncanonical_chemistry.rst),
+[scoring/packing/relaxation recipes](../../docs/chemistry_workflows.rst), and
+[Rosetta comparison](../../docs/rosetta_comparison.rst). Those guides identify
+the feature revision and distinguish implementation from measured accuracy.
 
-## Quick Usage
-
-There are three ways to inject a ligand, one per input format. Each returns a
-new `(ParameterDatabase, CanonicalOrdering)`; the input database is never
-mutated.
+## Prepare a deposited structure
 
 ```python
-from tmol.ligand import (
-    prepare_ligand_from_mol2,
-    prepare_ligand_from_cif,
-    prepare_ligand_from_smiles,
-)
-
-# 1) MOL2 — richest input. With an authoritative charge model (MMFF94), atom
-#    names, coordinates, bond orders, and partial charges are read verbatim; no
-#    SMILES or 3D-generation step. A mol2 with a non-authoritative charge model
-#    (e.g. GASTEIGER) instead falls back to the derived-SMILES path below.
-param_db, co = prepare_ligand_from_mol2("ligand.mol2")
-
-# 2) CIF — the bond table drives a derived SMILES, which runs through the full
-#    prep pipeline (protonation, 3D conformer, MMFF94 charges).
-param_db, co = prepare_ligand_from_cif("ligand.cif")
-
-# 3) SMILES — no input geometry. Dimorphite-DL protonates at the target pH and
-#    a 3D conformer + MMFF94 charges are generated.
-param_db, co = prepare_ligand_from_smiles("c1ccccc1C(=O)O", res_name="BEN")
-```
-
-To detect and prepare **every** non-standard residue in a structure at once
-(the path used by IO), pass a biotite `AtomArray` to `prepare_ligands`, or let
-`pose_stack_from_biotite(..., prepare_ligands=True)` call it for you. The
-`AtomArray` is a biotite structure loaded from a CIF or PDB file:
-
-```python
-import biotite.structure.io
-from tmol.ligand import prepare_ligands
-
-atom_array = biotite.structure.io.load_structure("complex.cif")
-if hasattr(atom_array, "__len__") and len(atom_array) > 1:
-    atom_array = atom_array[0]  # first model of a multi-model file
-
-param_db, co = prepare_ligands(atom_array, ph=7.4)
-```
-
-**On PDB inputs:** tmol accepts PDB for structures generally, but PDB does not
-carry reliable bond orders. Deriving ligand parameters requires an input that
-describes bond geometry — a MOL2, a CIF with a bond table, or a SMILES. Load
-the ligand from one of those formats even when the rest of the complex is a PDB.
-
-- `calculate_block_pair_ddg` is a Python API in `tmol.score.score_utils` (no separate CLI wrapper).
-- The structure residue/atom naming must match the residue definition in your `.tmol`.
-- For multi-ligand systems, build an explicit mask instead of assuming the ligand is the last block.
-- Build the score function from the **ligand-extended** database
-  (`beta2016_score_function(device, param_db=context.parameter_database)`),
-  not the default database. A freshly prepared ligand block type has no
-  scoring parameters in the default database, so scoring against it silently
-  contributes nothing.
-
-## User-defined ligand fragmentation
-
-To score different parts of a ligand independently, add an integer
-`tmol_fragment_id` annotation to the input Biotite `AtomArray`. Assign every
-atom in one ligand residue to a fragment. tmol prepares the complete ligand
-first, then copies its atom types and scoring parameters into connected
-fragment block types.
-
-For a ligand named `XYZ`, fragment IDs `1`, `2`, and `3` produce block types
-named `XYZ.1`, `XYZ.2`, and `XYZ.3`.
-
-```python
-import biotite.structure as struc
-import biotite.structure.io
-import numpy as np
 import torch
-
-from tmol.database import ParameterDatabase
-from tmol.io.pose_stack_from_biotite import pose_stack_from_biotite
+from tmol.io import pose_stack_from_cif
 from tmol.score import beta2016_score_function
-from tmol.score.score_utils import calculate_fragment_interactions
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-structure = biotite.structure.io.load_structure("complex.cif")
-if isinstance(structure, struc.AtomArrayStack):
-    structure = structure[0]
-
-# Define the fragment assignment by atom name. This example assumes one XYZ
-# residue; use residue/chain IDs too when the structure contains duplicates.
-xyz_fragments = {
-    "C1": 1,
-    "C2": 1,
-    "O1": 1,
-    "C3": 2,
-    "C4": 2,
-    "N1": 2,
-}
-fragment_ids = np.zeros(structure.array_length(), dtype=np.int32)
-is_xyz = structure.res_name == "XYZ"
-for atom_name, fragment_id in xyz_fragments.items():
-    fragment_ids[is_xyz & (structure.atom_name == atom_name)] = fragment_id
-assert np.all(fragment_ids[is_xyz] > 0), "assign every XYZ atom to a fragment"
-structure.set_annotation("tmol_fragment_id", fragment_ids)
-
-pose, context = pose_stack_from_biotite(
-    structure,
-    device,
-    param_db=ParameterDatabase.get_default(),
-    prepare_ligands=True,
-    return_context=True,
+pose, context = pose_stack_from_cif(
+    "complex.cif", device,
+    prepare_ligands=True, strict_ligands=True,
+    ligand_seed=20250828, return_context=True,
 )
-
-# Select all non-fragment blocks as the interaction partner.
-mapping = pose.fragmented_ligand_mapping
-partner_mask = pose.block_type_ind >= 0
-for record in mapping.blocks:
-    partner_mask[record.pose_index, record.block_index] = False
-
-# The score function must use the ligand-extended database from the build context.
-sfxn = beta2016_score_function(
-    device,
-    param_db=context.parameter_database,
-)
-interactions = calculate_fragment_interactions(
-    pose,
-    partner_mask,
-    sfxn=sfxn,
-    sum_terms=True,
-)
-
-for index, record in enumerate(interactions.mapping):
-    print(record.fragment_name, interactions.scores[:, index])
+sfxn = beta2016_score_function(device, param_db=context.parameter_database)
+scorer = sfxn.render_whole_pose_scoring_module(pose)
+print(scorer(pose.coords))
 ```
 
-`interactions.scores` has shape `[n_poses, n_fragments]` when
-`sum_terms=True`, or `[n_score_terms, n_poses, n_fragments]` otherwise.
-`interactions.mapping` gives the fragment name, original residue identity,
-and pose block index for each score column. Summing the fragment interaction
-columns gives the fragmented ligand-versus-partner block-pair ddG.
+The keyword is `prepare_ligands=True`. Use the prepared database for both
+scoring and library samplers. Prefer mmCIF with reliable chemical definitions
+and bonds; the default PDB-text reader is not an equivalent automatic
+noncanonical-preparation route. A bonded AtomArray, including one with NaN
+coordinates for missing atoms, can use `pose_stack_from_biotite`.
 
-Fragment layouts currently have these correctness constraints:
+Install `tmol[ligand]` for preparation paths that invoke OpenBabel, including
+derived-SMILES preparation from CIF. The intended charge model is MMFF94, but
+warned fallback charge models and stereochemical compatibility transformations
+are possible. Retain preparation warnings and inspect the result.
 
-- each fragment is connected and contains at least three heavy atoms;
-- each fragment has at most four connections to other fragments;
-- no atom participates in more than one cut bond;
-- no four-atom bonded path contains more than one cut; and
-- cuts do not pass directly through hbond/lk_ball acceptor geometry.
+## Free-ligand entry points
 
-The cut-sharing rules prevent bonded angles, torsions, and impropers from
-spanning three or more blocks. The acceptor rule keeps hbond/lk_ball frame
-geometry local to a fragment. Current bonded scoring kernels evaluate terms
-within one block or across one connection between two blocks. tmol rejects
-unsupported layouts rather than silently omitting those energy and gradient
-terms. In practice, choose chemically meaningful fragments of roughly 3–8 heavy
-atoms and keep adjacent cut bonds separated.
+`prepare_ligand_from_mol2`, `prepare_ligand_from_cif` and
+`prepare_ligand_from_smiles` return an extended
+`(ParameterDatabase, CanonicalOrdering)` pair. SMILES and MOL2 entry points
+prepare free ligands; they do not infer polymer context. MOL2 with authoritative
+charges can preserve its input names, coordinates, bonds and charges instead of
+generating a new conformer.
 
-Additional requirements:
+## Persistence and reuse
 
-- Fragment IDs must be integers. Use `0` only outside fragmented residues; every
-  atom in a fragmented residue must have a positive fragment ID, and at least two
-  positive IDs must occur.
-- All instances of a residue name in one input must use the same fragment
-  layout.
-- Generated names such as `XYZ.1` must not already identify different
-  chemistry in the active parameter database.
-- The mapping is attached automatically as
-  `pose.fragmented_ligand_mapping`; users normally should not call the
-  lower-level fragmentation functions directly.
+For compatible chemistry, reuse `PoseBuildContext` through
+`pose_stack_from_biotite(structure, device, context=context)`. This avoids
+repeating parameter preparation and packed-type construction. Render a new
+scorer for a different pose layout or topology.
 
-### Recombining and dumping fragments
+For persistence, `prepare_ligands(..., params_output="prepared.tmol")` writes
+prepared records. Reuse them through `params_files` at the preparation layer or
+`ligand_params_files` at the pose-construction layer. `inject_params_file`
+extends a database directly. Preserve the `.tmol` file with input chemistry,
+seed, pH, environment and source commit; edit deliberately when correcting
+parameters.
 
-Fragmentation only changes the in-memory block layout used for scoring.
-`write_pose_stack_pdb()` and `biotite_from_pose_stack()` restore each
-fragmented ligand's original residue name, number, chain, and insertion code by
-default, so dumped coordinates contain the original ligand residue:
+## Fragmentation is separate from group packing
 
-```python
-from tmol import write_pose_stack_pdb
-from tmol.io.pose_stack_from_biotite import biotite_from_pose_stack
+An integer `tmol_fragment_id` annotation partitions one ligand into connected
+scoring blocks. Every atom in that residue must have a positive fragment ID;
+zero is reserved for atoms outside fragmented residues. Repeated instances of
+one residue name must have the same layout. Generated fragment names must not
+collide with other chemistry.
 
-write_pose_stack_pdb(pose, "scored_complex.pdb")
-restored = biotite_from_pose_stack(pose, context.canonical_ordering)
-```
+Current restrictions require connected fragments with at least three heavy
+atoms and at most four connections. An atom cannot participate in multiple cut
+bonds, a four-atom bonded path cannot cross multiple cuts, and cuts cannot
+break supported hbond/LK-ball acceptor-frame geometry. These restrictions keep
+terms within supported one-/two-block scoring paths.
 
-Pass `merge_fragments=False` to either function to inspect the separate
-fragment residues. `tmol.ligand.recombine_fragmented_ligands()` provides the
-same residue-identity restoration for an already exported Biotite structure.
-This export operation does not rebuild a new single-block scoring pose; the
-original pose remains fragmented so per-fragment interactions can still be
-calculated.
+`calculate_fragment_interactions` is exported from `tmol.score`. The pose's
+`fragmented_ligand_mapping` records the original component and fragment blocks.
+Select partners explicitly, rather than assuming the ligand is the last block.
+`write_pose_stack_pdb` and `biotite_from_pose_stack` restore the original residue
+identity by default; `merge_fragments=False` exports separate blocks.
 
-## Troubleshooting
+Group packing instead couples an anchor and attached blocks to one common
+conformer choice. It requires the explicit group sampler described in the
+workflow guide. It does not automatically sample free ligands, and merely
+carrying a free ligand through the fallback sampler is not conformer search.
 
-### Reuse the context (preferred)
+## Failure interpretation
 
-When scoring many poses that share the same ligand(s), build the expensive,
-structure-independent `PoseBuildContext` **once** and reuse it. This is
-the preferred reuse path: it skips rebuilding the parameter database, canonical
-ordering, and packed block types on every structure.
+With `strict_ligands=True`, detected unpreparable components raise
+`LigandPreparationError`. `strict_ligands=False` can warn and drop them. Covalent
+attachments are now supported by the preparation machinery; they are no longer
+a blanket rejection category. Automatic preparation still rejects
+metal-containing unknown components and unsupported elements, and requires
+identifiable polymer profiles and adequate chemical definitions.
 
-```python
-from tmol.io.pose_stack_from_biotite import (
-    build_context_from_biotite,
-    pose_stack_from_biotite,
-)
-
-context = build_context_from_biotite(struct0, device, prepare_ligands=True)
-for struct in structures:
-    pose_stack = pose_stack_from_biotite(struct, device, context=context)
-```
-
-### Persist to `.tmol` (for manual edits or cold reuse)
-
-Preparation (SMILES → 3D → typing) is expensive and, for edge-case
-chemistries, sometimes wrong. Write prepared ligands to a `.tmol` params file,
-hand-edit if needed, then inject that file instead of re-preparing. This is the
-path to take when you want to inspect or manually correct a ligand definition.
-
-```python
-from tmol.database import ParameterDatabase
-from tmol.ligand import prepare_ligands
-
-# Write once
-param_db, co = prepare_ligands(
-    atom_array, ph=7.4, params_output="my_ligands.tmol"
-)
-
-# Reuse later (optionally after editing the file by hand)
-param_db, co = prepare_ligands(
-    atom_array,
-    param_db=ParameterDatabase.get_default(),
-    params_files=["my_ligands.tmol"],
-)
-```
-
-The same files can be passed through IO:
-`pose_stack_from_biotite(..., prepare_ligands=True, ligand_params_files=[...])`.
-For a `.tmol` you already have, `inject_params_file(param_db, "my_ligand.tmol")`
-extends a database directly. Prefer context reuse over file round-trips when the
-ligand topology is fixed within a run; use `.tmol` when you need persistence
-across runs or manual control.
-
-## Pipeline Overview
-
-All three input modes converge on a single typing/build/inject core.
-
-```mermaid
-flowchart TD
-    M2["MOL2 file"] -->|authoritative MMFF94 charges:\nnames, coords, bonds, charges verbatim| CORE
-    M2 -->|non-authoritative charges:\nSMILES from bond table| SM
-    CIF["CIF file"] -->|SMILES from bond table| SM
-    SMI["SMILES string"] --> SM
-
-    SM["Dimorphite-DL protonation\n+ 3D conformer (RDKit distance geometry)\n+ MMFF94 charges (OpenBabel)"] --> CORE
-
-    subgraph CORE [Typing / build / inject]
-        T["assign Rosetta atom types (RDKit)"] --> B["build RawResidueType"]
-        B --> INJ["inject into ParameterDatabase\n(residues + elec charges + cartbonded)"]
-    end
-
-    INJ --> DB["New frozen ParameterDatabase\n(+ rebuilt CanonicalOrdering)"]
-
-    TMOL[".tmol params file"] -->|inject_params_file| DB
-```
-
-The `.tmol` path bypasses typing/build entirely — it injects already-prepared
-residue, charge, and cartbonded records straight into the database.
-
-## Troubleshooting
-
-A ligand that "scores as 0" or goes missing almost always means it never made
-it into the pose. Failure modes, in order of likelihood:
-
-- **Ligand dropped during preparation.** With `prepare_ligands=True`,
-  preparation is **strict by default** (`strict_ligands=True`): an unpreparable
-  residue raises `LigandPreparationError` rather than silently disappearing. A
-  residue is dropped when it is *skipped* (contains metal atoms, or is
-  covalently linked to another residue) or when preparation *fails* (no
-  derivable SMILES, atom-typing failure, or residue-build error). Pass
-  `strict_ligands=False` to restore warn-and-drop behavior. (A successful but
-  imperfect atom-name match only warns — the ligand still loads.)
-
-- **`Unrecognized 3lc <NAME>`.** Emitted by pose construction, not prep: the
-  3-letter code is not in the active `CanonicalOrdering`, so the residue is
-  stripped from the structure. Causes: `prepare_ligands=False` (ligands are
-  never registered), or `prepare_ligands=True, strict_ligands=False` with a
-  ligand that was skipped/failed (see the preceding warning for why). Under the
-  strict default this surfaces earlier as a `LigandPreparationError`.
-
-- **Scoring against the default database.** A freshly prepared ligand block type
-  has no scoring parameters in the *default* database. Always build the score
-  function from the **ligand-extended** database returned by preparation
-  (`beta2016_score_function(device, param_db=param_db)`), or scoring silently
-  contributes nothing.
-
-- **Ligand wrongly flagged "covalently linked."** Historically, tight
-  binding-pocket contacts in unminimized models could be misread as covalent
-  links. Covalent detection now trusts the explicit bond table and only applies
-  the spatial-proximity fallback to polymer-linking residue types (modified
-  amino acids/nucleotides, glycans); genuine non-polymer ligands are no longer
-  flagged by proximity alone.
-
-## File Inventory
-
-| File | Role |
-|------|------|
-| `preparation.py` | `prepare_ligands`, single-ligand `from_{mol2,cif,smiles}` helpers, CIF rename |
-| `detect.py` | `NonStandardResidueInfo`, non-standard residue detection, mol2/SMILES readers |
-| `structure_to_smiles.py` | SMILES from an AtomArray bond table (no geometry perception, no CCD lookup) |
-| `fragmentation.py` | Fragment annotations, fragment block types/connections, pose mapping |
-| `dimorphite_dl.py` | pKa-based protonation-state enumeration on SMILES |
-| `conformer_generation.py` | 3D coordinates via RDKit distance geometry (replaces OpenBabel `make3D`) |
-| `generated_geometry.py` | Corrections to known systematic errors in generated conformers |
-| `openbabel_compat.py` | SMILES→mol2 (conformer + MMFF94 charges), mol2 read fallbacks |
-| `mol3d.py` | OpenBabel MMFF94 charges by atom index |
-| `rdkit_mol.py` | AtomArray → RDKit `Mol` |
-| `mol2_names.py` | Rosetta-style disambiguation of duplicate Tripos atom names |
-| `atom_typing.py` | Rosetta `generic_potential` atom-type assignment (RDKit) |
-| `chi_topology.py` | Rotatable bonds / `PROTON_CHI` |
-| `chemistry_tables.py` | DB-backed atom-class and hbond lookup tables from the chemical DB |
-| `residue_builder.py` | `RawResidueType` from a `Chem.Mol` (atom tree, ICs, bond order) |
-| `registry.py` | `ParameterDatabase` injection, cartbonded params |
-| `params_file.py` | Load/inject `.tmol` YAML params |
-| `params_io.py` | Write `.params`/`.tmol`; read Rosetta `.params` |
+Strict preparation does not verify every force-field parameter: unmatched
+generic torsions can be omitted, and warned preparation fallbacks remain
+possible. Validate atom retention, connectivity, parameter coverage, actual
+sampling, finite derivatives and resulting geometry independently. The
+[workflow guide](../../docs/chemistry_workflows.rst) documents sampler selection,
+budget limitations and the FastRelax task configuration.


### PR DESCRIPTION
PR #503 broadens chemical preparation to noncanonical polymers and covalent attachments, while the existing architecture page and ligand README describe older interfaces and restrictions. This change explains how prepared chemistry reaches scoring, configured packing and relaxation, and distinguishes inherited Rosetta methods from tmol's tensor representation and execution.

This PR branches from and targets `dimaio/noncanonicals_through_ligand_pipeline`, frozen at `c03c1e745f3bc655948ea12dac44d6c74620358f`. The feature remains unmerged.

- Add generalized chemistry and Rosetta-comparison guides covering complete chemical graphs versus missing coordinates, cap/prepare/reconnect, mixed bonded-term ownership, statistical references, D residues, chemical kinematic edges and the setup/evaluation lifecycle.
- Add source-checked scoring, Cartesian minimization, packing and FastRelax recipes using `prepare_ligands=True` and `context.parameter_database`. Explain explicit NA and conjugated-group sampler installation, shared group indices and energy regrouping.
- Replace the outdated architecture page and ligand quickstart, update package navigation, and add two editable SVG diagrams plus links pinned to the audited tmol and Rosetta revisions.
- Document current boundaries: free-ligand fallback is not heavy-atom conformer search; metal-containing unknown components are rejected; strict preparation is not a parameter-coverage certificate; ring closure and sampling budgets need separate validation. The guides also identify the current task-budget propagation limitation.

Validation: a focused Sphinx HTML build of all four narrative guides passes with warnings treated as errors; five Python snippets parse and fifteen tmol imports resolve by static source inspection; SVG figures were visually inspected; `git diff --check` passes. Molecular examples and CPU/CUDA numerical tests were not executed. The full existing autodoc build stops at `git describe --tags` in the shallow, tagless checkout, so the focused build does not establish that the full documentation site builds.

The Rosetta comparison acknowledges existing noncanonical/D-residue, glycan, covalent-link, generic bonded and kinematic capabilities. No new accuracy, coverage fraction or speedup is claimed by this documentation.
