### PR TITLE
Reduce scoring retention and simplify L-BFGS and annealing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ set(_C_SOURCES
 
 if(TMOL_HAS_CUDA)
   list(APPEND _C_SOURCES
+    tmol/score/common/whole_pose_scoring.cuda.cu
     tmol/optimization/armijo_compiled.cuda.cu
     tmol/io/details/compiled/gen_pose_leaf_atoms.cuda.cu
     tmol/io/details/compiled/resolve_his_taut.cuda.cu
@@ -601,6 +602,19 @@ if(TMOL_BUILD_TESTS)
     test_in_place_heap "tmol/tests/utility/datastructures" "_in_place_heap"
     tmol/tests/utility/datastructures/in_place_heap.cpp
   )
+
+  if(TMOL_HAS_CUDA)
+    tmol_add_pybind_cuda_ext(
+      test_whole_pose_gradients "tmol/tests/score/common" "_whole_pose_gradients"
+      tmol/tests/score/common/whole_pose_gradients.pybind.cpp
+      tmol/score/common/whole_pose_scoring.cuda.cu
+    )
+  else()
+    tmol_add_pybind_cpp_ext(
+      test_whole_pose_gradients "tmol/tests/score/common" "_whole_pose_gradients"
+      tmol/tests/score/common/whole_pose_gradients.pybind.cpp
+    )
+  endif()
 
   # --- mixed-backend and CUDA-only test extensions ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,12 @@ if(TMOL_BUILD_TESTS)
 
   if(TMOL_HAS_CUDA)
     tmol_add_pybind_cuda_ext(
+      test_torch_context "tmol/tests/utility/tensor" "_torch_context"
+      tmol/tests/utility/tensor/torch_context.pybind.cpp
+      tmol/tests/utility/tensor/torch_context.cuda.cu
+    )
+
+    tmol_add_pybind_cuda_ext(
       test_geom_cuda "tmol/tests/score/common/geom" "_ext_cuda"
       tmol/tests/score/common/geom/geom.cu
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,11 @@ if(TMOL_BUILD_TESTS)
   )
 
   tmol_add_pybind_cpp_ext(
+    test_dunbrack_dihedral "tmol/tests/score/dunbrack" "_dihedral"
+    tmol/tests/score/dunbrack/dihedral.pybind.cpp
+  )
+
+  tmol_add_pybind_cpp_ext(
     test_lkball_ext "tmol/tests/score/lk_ball/potentials" "_ext"
     tmol/tests/score/lk_ball/potentials/compiled.pybind.cpp
   )

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -40,16 +40,31 @@ def lbfgs_two_loop(grad, dirs, stps):
     S = stps.double()
     Y = dirs.double()
     g = -grad.double()
-    # FastRelax supplies float32 coordinates. Preserve the common einsum path
-    # for float64, where callers may compare independently minimized segments
-    # with a batched minimization at tight double-precision tolerances.
+    # Explicit batched products avoid einsum's repeated layout planning. Keep
+    # the single-segment, broadcast, and differentiable paths: their reduction
+    # layouts can differ at tight double-precision tolerances.
     single_segment = grad.shape[0] == 1 and out_dtype == torch.float32
+    use_bmm = (
+        g.shape[0] > 1
+        and S.shape[1] == Y.shape[1] == g.shape[0]
+        and S.shape[2] == Y.shape[2] == g.shape[1]
+        and not (
+            torch.is_grad_enabled()
+            and (grad.requires_grad or dirs.requires_grad or stps.requires_grad)
+        )
+    )
     if single_segment:
         S_one, Y_one, g_one = S[:, 0], Y[:, 0], g[0]
         a = torch.mv(S_one, g_one).unsqueeze(0)  # a_i = s_i . g
         b = torch.mv(Y_one, g_one).unsqueeze(0)  # b_i = y_i . g
         SY = torch.mm(S_one, Y_one.T).unsqueeze(0)  # SY_ij = s_i . y_j
         YY = torch.mm(Y_one, Y_one.T).unsqueeze(0)  # YY_ij = y_i . y_j
+    elif use_bmm:
+        S_by_pose, Y_by_pose = S.transpose(0, 1), Y.transpose(0, 1)
+        a = torch.bmm(S_by_pose, g.unsqueeze(-1)).squeeze(-1)
+        b = torch.bmm(Y_by_pose, g.unsqueeze(-1)).squeeze(-1)
+        SY = torch.bmm(S_by_pose, Y_by_pose.transpose(-2, -1))
+        YY = torch.bmm(Y_by_pose, Y_by_pose.transpose(-2, -1))
     else:
         a = torch.einsum("ipk,pk->pi", S, g)
         b = torch.einsum("ipk,pk->pi", Y, g)
@@ -67,6 +82,8 @@ def lbfgs_two_loop(grad, dirs, stps):
     # v = (D + Y^T Y) u - b
     if single_segment:
         v = (torch.mv(YY[0], u[0]) + D[0] * u[0] - b[0]).unsqueeze(0)
+    elif use_bmm:
+        v = torch.bmm(YY, u.unsqueeze(-1)).squeeze(-1) + D * u - b
     else:
         v = torch.einsum("pij,pj->pi", YY, u) + D * u - b
     # p1 = R^-T v
@@ -80,6 +97,9 @@ def lbfgs_two_loop(grad, dirs, stps):
         result = (
             g[0] + torch.mv(S[:, 0].T, p1[0]) + torch.mv(Y[:, 0].T, p2[0])
         ).unsqueeze(0)
+    elif use_bmm:
+        result = g + torch.bmm(p1.unsqueeze(1), S_by_pose).squeeze(1)
+        result += torch.bmm(p2.unsqueeze(1), Y_by_pose).squeeze(1)
     else:
         result = g + torch.einsum("pi,ipk->pk", p1, S)
         result += torch.einsum("pi,ipk->pk", p2, Y)

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -189,10 +189,9 @@ def armijo_linesearch_segmented(
         sigma_decrease,
     )
 
-    while True:
-        if not _any_true(active):
-            break
-
+    combine_cuda_checks = searching.is_cuda and searching.numel() > 1
+    any_active = _any_true(active)
+    while any_active:
         trial = armijo_trial(status, alpha, accepted, factor)
         phi_trial = func(trial)
         n_evals += 1
@@ -209,7 +208,13 @@ def armijo_linesearch_segmented(
             sigma_decrease,
             minstep,
         )
-        if _any_true(failed):
+        if combine_cuda_checks:
+            # Transfer both decisions together and reuse the active flag on
+            # the next iteration instead of synchronizing its mask again.
+            any_failed, any_active = torch.stack((failed, active)).any(dim=1).tolist()
+        else:
+            any_failed = _any_true(failed)
+        if any_failed:
             for p in failed.nonzero(as_tuple=False).flatten().tolist():
                 step = float(trial[p])
                 finite = (
@@ -230,6 +235,8 @@ def armijo_linesearch_segmented(
 
         alpha = trial
         phi = phi_trial
+        if not combine_cuda_checks:
+            any_active = _any_true(active)
 
     return accepted, phi_accepted, n_evals, status, bool(torch.equal(alpha, accepted))
 

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -707,16 +707,13 @@ class LBFGS_Armijo(Optimizer):
                     old_stps_view = ctx.old_stps_mat[: ctx.history_count]
                 else:
                     # Buffer full, need to reorder: [start:end] + [0:start]
-                    indices = torch.cat(
-                        [
-                            torch.arange(
-                                ctx.history_start, ctx.history_size, device=x.device
-                            ),
-                            torch.arange(0, ctx.history_start, device=x.device),
-                        ]
+                    start = ctx.history_start
+                    old_dirs_view = torch.cat(
+                        (ctx.old_dirs_mat[start:], ctx.old_dirs_mat[:start])
                     )
-                    old_dirs_view = ctx.old_dirs_mat[indices]
-                    old_stps_view = ctx.old_stps_mat[indices]
+                    old_stps_view = torch.cat(
+                        (ctx.old_stps_mat[start:], ctx.old_stps_mat[:start])
+                    )
 
                 grad_pad = self._pad(flat_grad, out=ctx.state["grad_pad"])
                 d.copy_(

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -595,10 +595,10 @@ class LBFGS_Armijo(Optimizer):
                 hist_shape = (history_size, L)
             else:
                 hist_shape = (history_size, self._n_segments, self._segment_size)
-                # scratch for the padded gradient handed to the two-loop
-                state["grad_pad"] = torch.zeros(
-                    hist_shape[1:], device=x.device, dtype=x.dtype
-                )
+                if not self._segments_are_dense:
+                    state["grad_pad"] = torch.zeros(
+                        hist_shape[1:], device=x.device, dtype=x.dtype
+                    )
             # Only ``history_count`` written slots are consumed. Non-dense
             # segmented writes explicitly zero their own padding.
             state["old_dirs_mat"] = torch.empty(
@@ -741,7 +741,12 @@ class LBFGS_Armijo(Optimizer):
                         (ctx.old_stps_mat[start:], ctx.old_stps_mat[:start])
                     )
 
-                grad_pad = self._pad(flat_grad, out=ctx.state["grad_pad"])
+                # Dense gradients already have the layout consumed by the
+                # two-loop calculation; only scattered segments need a copy.
+                grad_pad = self._pad(
+                    flat_grad,
+                    out=None if self._segments_are_dense else ctx.state["grad_pad"],
+                )
                 d.copy_(
                     self._unpad(lbfgs_two_loop(grad_pad, old_dirs_view, old_stps_view))
                 )

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -491,6 +491,15 @@ class LBFGS_Armijo(Optimizer):
         """Broadcast per-segment values to parameters without indexing one segment."""
         if self._n_segments == 1:
             return segment_values[0]
+        # Repeated CPU copies avoid reading an index for every parameter.
+        # Keep differentiable broadcasts on their original reduction path.
+        if (
+            self._segments_are_dense
+            and segment_values.device.type == "cpu"
+            and segment_values.shape == (self._n_segments,)
+            and not (torch.is_grad_enabled() and segment_values.requires_grad)
+        ):
+            return segment_values.repeat_interleave(self._segment_size)
         return segment_values[self._segment_ids]
 
     def _wrap_closure(self, closure):

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -14,7 +14,7 @@ from tmol.optimization._armijo_compiled import (
 
 
 def lbfgs_two_loop(grad, dirs, stps):
-    """L-BFGS search direction H_k @ grad via the compact
+    """L-BFGS search direction -H_k @ grad via the compact
     representation of Byrd, Nocedal & Schnabel, (Math. Prog. 63 (1994)):
         H_0 = I
         M = [[ R^-T (D + Y^T Y) R^-1, -R^-T ], [ -R^-1, 0 ]]
@@ -83,17 +83,17 @@ def lbfgs_two_loop(grad, dirs, stps):
     else:
         q = q - torch.einsum("pi,ipk->pk", u, Y)
         v = D * u - torch.einsum("ipk,pk->pi", Y, q)
-    # p1 = R^-T v
-    p1 = torch.linalg.solve_triangular(
+    # p = R^-T v
+    p = torch.linalg.solve_triangular(
         R.transpose(-2, -1), v.unsqueeze(-1), upper=False
     ).squeeze(-1)
-    # result = q + S p1
+    # result = q + S p
     if single_segment:
-        result = (q[0] + torch.mv(S_one.T, p1[0])).unsqueeze(0)
+        result = (q[0] + torch.mv(S_one.T, p[0])).unsqueeze(0)
     elif use_bmm:
-        result = q + torch.bmm(p1.unsqueeze(1), S_by_pose).squeeze(1)
+        result = q + torch.bmm(p.unsqueeze(1), S_by_pose).squeeze(1)
     else:
-        result = q + torch.einsum("pi,ipk->pk", p1, S)
+        result = q + torch.einsum("pi,ipk->pk", p, S)
     result = result.to(out_dtype)
     return result.squeeze(0) if unbatched else result
 

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -827,13 +827,13 @@ class LBFGS_Armijo(Optimizer):
         )
         ctx.ls_evals = ls_evals
 
-        torch.addcmul(
-            ctx.x_backup,
-            ctx.d,
-            self._per_element(accepted),
-            out=ctx.x,
-        )
         if not trial_is_accepted:
+            torch.addcmul(
+                ctx.x_backup,
+                ctx.d,
+                self._per_element(accepted),
+                out=ctx.x,
+            )
             ctx.closure()
         ctx.loss_vec = self._last_loss_vec
         # Keep the normal optimization path asynchronous. The scalar total is

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -385,7 +385,6 @@ class LBFGS_Armijo(Optimizer):
         state["any_was_reset"] = False
         state["any_inactive"] = False
         self._last_loss_vec = None
-        self._closure_fn = None
 
     def _init_segments(self, segment_ids):
         """Set up the mapping from parameter elements to independent blocks.
@@ -605,6 +604,9 @@ class LBFGS_Armijo(Optimizer):
             state["any_was_reset"] = False
 
         return SimpleNamespace(
+            # Keep the wrapped closure local to this step. Storing it on the
+            # optimizer creates a cycle through the wrapper's self reference.
+            closure=closure,
             # config
             max_iter=max_iter,
             lr=lr,
@@ -811,7 +813,7 @@ class LBFGS_Armijo(Optimizer):
             out=ctx.x,
         )
         if not trial_is_accepted:
-            self._closure_fn()
+            ctx.closure()
         ctx.loss_vec = self._last_loss_vec
         # Keep the normal optimization path asynchronous. The scalar total is
         # only needed for human-readable progress output.
@@ -892,7 +894,6 @@ class LBFGS_Armijo(Optimizer):
             The initial loss, matching the ``Optimizer.step`` convention.
         """
         closure = self._wrap_closure(closure)
-        self._closure_fn = closure
         ctx = self._step_setup(closure)
 
         x = ctx.x

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -688,12 +688,20 @@ class LBFGS_Armijo(Optimizer):
                 else:
                     keep_elem = self._per_element(keep)
                     zero = torch.zeros((), dtype=y.dtype, device=y.device)
-                    self._pad(
-                        torch.where(keep_elem, y, zero), out=ctx.old_dirs_mat[idx]
-                    )
-                    self._pad(
-                        torch.where(keep_elem, s, zero), out=ctx.old_stps_mat[idx]
-                    )
+                    if self._segments_are_dense:
+                        torch.where(
+                            keep_elem, y, zero, out=ctx.old_dirs_mat[idx].view(-1)
+                        )
+                        torch.where(
+                            keep_elem, s, zero, out=ctx.old_stps_mat[idx].view(-1)
+                        )
+                    else:
+                        self._pad(
+                            torch.where(keep_elem, y, zero), out=ctx.old_dirs_mat[idx]
+                        )
+                        self._pad(
+                            torch.where(keep_elem, s, zero), out=ctx.old_stps_mat[idx]
+                        )
                     ctx.x_ref = torch.where(keep_elem, x, ctx.x_ref)
 
             # compute the approximate (L-BFGS) inverse Hessian

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -39,37 +39,31 @@ def lbfgs_two_loop(grad, dirs, stps):
     # promote to float64
     S = stps.double()
     Y = dirs.double()
-    g = -grad.double()
+    q = -grad.double()
     # Explicit batched products avoid einsum's repeated layout planning. Keep
     # the single-segment, broadcast, and differentiable paths: their reduction
     # layouts can differ at tight double-precision tolerances.
     single_segment = grad.shape[0] == 1 and out_dtype == torch.float32
     use_bmm = (
-        g.shape[0] > 1
-        and S.shape[1] == Y.shape[1] == g.shape[0]
-        and S.shape[2] == Y.shape[2] == g.shape[1]
+        q.shape[0] > 1
+        and S.shape[1] == Y.shape[1] == q.shape[0]
+        and S.shape[2] == Y.shape[2] == q.shape[1]
         and not (
             torch.is_grad_enabled()
             and (grad.requires_grad or dirs.requires_grad or stps.requires_grad)
         )
     )
     if single_segment:
-        S_one, Y_one, g_one = S[:, 0], Y[:, 0], g[0]
-        a = torch.mv(S_one, g_one).unsqueeze(0)  # a_i = s_i . g
-        b = torch.mv(Y_one, g_one).unsqueeze(0)  # b_i = y_i . g
+        S_one, Y_one = S[:, 0], Y[:, 0]
+        a = torch.mv(S_one, q[0]).unsqueeze(0)  # a_i = s_i . g
         SY = torch.mm(S_one, Y_one.T).unsqueeze(0)  # SY_ij = s_i . y_j
-        YY = torch.mm(Y_one, Y_one.T).unsqueeze(0)  # YY_ij = y_i . y_j
     elif use_bmm:
         S_by_pose, Y_by_pose = S.transpose(0, 1), Y.transpose(0, 1)
-        a = torch.bmm(S_by_pose, g.unsqueeze(-1)).squeeze(-1)
-        b = torch.bmm(Y_by_pose, g.unsqueeze(-1)).squeeze(-1)
+        a = torch.bmm(S_by_pose, q.unsqueeze(-1)).squeeze(-1)
         SY = torch.bmm(S_by_pose, Y_by_pose.transpose(-2, -1))
-        YY = torch.bmm(Y_by_pose, Y_by_pose.transpose(-2, -1))
     else:
-        a = torch.einsum("ipk,pk->pi", S, g)
-        b = torch.einsum("ipk,pk->pi", Y, g)
+        a = torch.einsum("ipk,pk->pi", S, q)
         SY = torch.einsum("ipk,jpk->pij", S, Y)
-        YY = torch.einsum("ipk,jpk->pij", Y, Y)
     R = torch.triu(SY)  # upper-triangular incl. diagonal
     D = SY.diagonal(dim1=-2, dim2=-1)  # D_i = s_i . y_i
 
@@ -79,30 +73,27 @@ def lbfgs_two_loop(grad, dirs, stps):
 
     # u = R^-1 a
     u = torch.linalg.solve_triangular(R, a.unsqueeze(-1), upper=True).squeeze(-1)
-    # v = (D + Y^T Y) u - b
+    # q = g - Y u; v = D u - Y^T q avoids forming Y^T Y.
     if single_segment:
-        v = (torch.mv(YY[0], u[0]) + D[0] * u[0] - b[0]).unsqueeze(0)
+        q = (q[0] - torch.mv(Y[:, 0].T, u[0])).unsqueeze(0)
+        v = (D[0] * u[0] - torch.mv(Y[:, 0], q[0])).unsqueeze(0)
     elif use_bmm:
-        v = torch.bmm(YY, u.unsqueeze(-1)).squeeze(-1) + D * u - b
+        q = q - torch.bmm(u.unsqueeze(1), Y_by_pose).squeeze(1)
+        v = D * u - torch.bmm(Y_by_pose, q.unsqueeze(-1)).squeeze(-1)
     else:
-        v = torch.einsum("pij,pj->pi", YY, u) + D * u - b
+        q = q - torch.einsum("pi,ipk->pk", u, Y)
+        v = D * u - torch.einsum("ipk,pk->pi", Y, q)
     # p1 = R^-T v
     p1 = torch.linalg.solve_triangular(
         R.transpose(-2, -1), v.unsqueeze(-1), upper=False
     ).squeeze(-1)
-    p2 = -u
-
-    # result = g + S p1 + Y p2
+    # result = q + S p1
     if single_segment:
-        result = (
-            g[0] + torch.mv(S[:, 0].T, p1[0]) + torch.mv(Y[:, 0].T, p2[0])
-        ).unsqueeze(0)
+        result = (q[0] + torch.mv(S[:, 0].T, p1[0])).unsqueeze(0)
     elif use_bmm:
-        result = g + torch.bmm(p1.unsqueeze(1), S_by_pose).squeeze(1)
-        result += torch.bmm(p2.unsqueeze(1), Y_by_pose).squeeze(1)
+        result = q + torch.bmm(p1.unsqueeze(1), S_by_pose).squeeze(1)
     else:
-        result = g + torch.einsum("pi,ipk->pk", p1, S)
-        result += torch.einsum("pi,ipk->pk", p2, Y)
+        result = q + torch.einsum("pi,ipk->pk", p1, S)
     result = result.to(out_dtype)
     return result.squeeze(0) if unbatched else result
 

--- a/tmol/optimization/_lbfgs_armijo.py
+++ b/tmol/optimization/_lbfgs_armijo.py
@@ -75,8 +75,8 @@ def lbfgs_two_loop(grad, dirs, stps):
     u = torch.linalg.solve_triangular(R, a.unsqueeze(-1), upper=True).squeeze(-1)
     # q = g - Y u; v = D u - Y^T q avoids forming Y^T Y.
     if single_segment:
-        q = (q[0] - torch.mv(Y[:, 0].T, u[0])).unsqueeze(0)
-        v = (D[0] * u[0] - torch.mv(Y[:, 0], q[0])).unsqueeze(0)
+        q = (q[0] - torch.mv(Y_one.T, u[0])).unsqueeze(0)
+        v = (D[0] * u[0] - torch.mv(Y_one, q[0])).unsqueeze(0)
     elif use_bmm:
         q = q - torch.bmm(u.unsqueeze(1), Y_by_pose).squeeze(1)
         v = D * u - torch.bmm(Y_by_pose, q.unsqueeze(-1)).squeeze(-1)
@@ -89,7 +89,7 @@ def lbfgs_two_loop(grad, dirs, stps):
     ).squeeze(-1)
     # result = q + S p1
     if single_segment:
-        result = (q[0] + torch.mv(S[:, 0].T, p1[0])).unsqueeze(0)
+        result = (q[0] + torch.mv(S_one.T, p1[0])).unsqueeze(0)
     elif use_bmm:
         result = q + torch.bmm(p1.unsqueeze(1), S_by_pose).squeeze(1)
     else:

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -233,7 +233,6 @@ MGPU_DEVICE float warp_wide_sim_annealing(
     float lo_temp,
     int n_outer_iterations,
     int n_inner_iterations,
-    int n_quench_iterations,
     bool quench_on_last_iteration,
     bool quench_lite) {
   float const cooling_factor = 0.35f;
@@ -280,7 +279,7 @@ MGPU_DEVICE float warp_wide_sim_annealing(
     int i_n_inner_iterations = n_inner_iterations;
 
     if (i == n_outer_iterations - 1 && quench_on_last_iteration) {
-      i_n_inner_iterations = n_quench_iterations;
+      i_n_inner_iterations = n_rotamers;
       quench = true;
       temperature = 0.0f;
       // Recover the lowest-energy assignment before quenching. Ranking phases
@@ -709,7 +708,6 @@ struct Annealer {
           low_temp_initial,
           n_outer_iterations_hitemp,
           pose_inner_iterations,
-          n_rotamers,
           false,
           false);
 
@@ -735,7 +733,6 @@ struct Annealer {
               low_temp_initial,
               1,  // quench on the (only) iteration
               n_inner_iterations_hitemp,
-              n_rotamers,
               true,
               true);
       if (g.thread_rank() == 0) {
@@ -801,7 +798,6 @@ struct Annealer {
           low_temp_later,
           n_outer_iterations_lotemp,
           pose_inner_iterations,
-          n_rotamers,
           false,
           false);
 
@@ -823,7 +819,6 @@ struct Annealer {
               low_temp_later,
               1,  // quench on the (only) iteration
               n_inner_iterations_lotemp,
-              n_rotamers,
               true,
               true);
       if (g.thread_rank() == 0) {
@@ -847,7 +842,6 @@ struct Annealer {
       int const source_traj = sorted_lotemp_traj[pose][traj_id];
 
       int const n_res = ig.n_res(pose);
-      int const n_rotamers = ig.n_rotamers(pose);
 
       if (g.thread_rank() == 0) {
         sorted_fullquench_traj[pose][traj_id] = traj_id;
@@ -876,7 +870,6 @@ struct Annealer {
           low_temp_later,
           1,  // quench on the (only) iteration
           n_inner_iterations_lotemp,
-          n_rotamers,
           true,
           false);
       // A greedy quench only accepts improvements, so current is also best.

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -275,7 +275,6 @@ MGPU_DEVICE float warp_wide_sim_annealing(
 
   for (int i = 0; i < n_outer_iterations; ++i) {
     bool quench = false;
-    int quench_period = n_rotamers;
     int i_n_inner_iterations = n_inner_iterations;
 
     if (i == n_outer_iterations - 1 && quench_on_last_iteration) {
@@ -302,26 +301,26 @@ MGPU_DEVICE float warp_wide_sim_annealing(
 
       if (quench) {
         if (g.thread_rank() == 0) {
-          if (j % quench_period == 0) {
+          // A quench visits its shuffled order once.
+          if (j == 0) {
             if (quench_lite) {
-              quench_period = set_quench_32_order(
+              i_n_inner_iterations = set_quench_32_order(
                   n_res,
                   ig.n_rotamers_for_res_[pose],
                   ig.oneb_offsets_[pose],
                   quench_order,
                   state);
-              i_n_inner_iterations = quench_period;
             } else {
               set_quench_order(
                   quench_order, n_rotamers, pose_rotamer_offset, state);
             }
           }
-          int global_ran_rot = quench_order[j % quench_period];
+          int global_ran_rot = quench_order[j];
           ran_res = ig.res_for_rot()[global_ran_rot];
           global_new_rot = global_ran_rot;
           local_new_rot = global_ran_rot - ig.oneb_offsets_[pose][ran_res];
         }
-        if (j % quench_period == 0 && quench_lite) {
+        if (j == 0 && quench_lite) {
           i_n_inner_iterations = g.shfl(i_n_inner_iterations, 0);
         }
       } else {

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -135,14 +135,18 @@ struct InteractionGraph {
   }
 };
 
-/// @brief Return a uniformly-distributed integer in the range
-/// between 0 and n-1.
-/// Note that curand_uniform() returns a random number in the range
-/// (0,1], unlike unlike rand() returns a random number in the range
-/// [0,1). Take care with curand_uniform().
+// Preserve the existing mapping, including cuRAND's inclusive upper endpoint.
+// Most products already lie in range and need no integer division. Keep the
+// remainder fallback for the endpoint and any float-to-int boundary cases.
+MGPU_DEVICE
+int curand_in_range(float uniform, int n) {
+  int const index = int(uniform * n);
+  return index >= 0 && index < n ? index : index % n;
+}
+
 MGPU_DEVICE
 int curand_in_range(curandStatePhilox4_32_10_t* state, int n) {
-  return int(curand_uniform(state) * n) % n;
+  return curand_in_range(curand_uniform(state), n);
 }
 
 template <tmol::Device D>
@@ -325,11 +329,11 @@ MGPU_DEVICE float warp_wide_sim_annealing(
         if (g.thread_rank() == 0) {
           float4 rands = curand_uniform4(state);
           int global_ran_rot =
-              int(rands.x * n_rotamers) % n_rotamers + pose_rotamer_offset;
+              curand_in_range(rands.x, n_rotamers) + pose_rotamer_offset;
           ran_res = ig.res_for_rot()[global_ran_rot];
           int const ran_res_n_rots = ig.n_rotamers_for_res_[pose][ran_res];
           int const ran_res_offset = ig.oneb_offsets_[pose][ran_res];
-          local_new_rot = int(rands.y * ran_res_n_rots) % ran_res_n_rots;
+          local_new_rot = curand_in_range(rands.y, ran_res_n_rots);
           global_new_rot = local_new_rot + ran_res_offset;
           accept_rand = rands.z;
         }
@@ -679,7 +683,7 @@ struct Annealer {
       // Random initial assignment
       for (int i = g.thread_rank(); i < n_res; i += 32) {
         int const i_n_rots = ig.n_rotamers_for_res()[pose][i];
-        int chosen = int(curand_uniform(&state) * i_n_rots) % i_n_rots;
+        int chosen = curand_in_range(&state, i_n_rots);
         current_rotamer_assignments_hitemp[pose][traj_id][i] = chosen;
         best_rotamer_assignments_hitemp[pose][traj_id][i] = chosen;
       }

--- a/tmol/pack/compiled/compiled.cuda.cu
+++ b/tmol/pack/compiled/compiled.cuda.cu
@@ -16,6 +16,8 @@
 #include <moderngpu/transform.hxx>
 #include <cooperative_groups.h>
 
+#include <type_traits>
+
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
@@ -210,6 +212,7 @@ template <
     bool ReturnFinalScore,
     bool EntryAssignmentIsBest,
     bool TrackBestAssignment,
+    bool CacheAssignments = false,
     tmol::Device D,
     uint n_threads,
     typename Int,
@@ -235,6 +238,27 @@ MGPU_DEVICE float warp_wide_sim_annealing(
   int const n_res = ig.n_res(pose);
   int const n_rotamers = ig.n_rotamers(pose);
   int const pose_rotamer_offset = ig.pose_rotamer_offset_[pose];
+
+  auto original_current = current_rotamer_assignment;
+  auto original_best = best_rotamer_assignment;
+  int64_t const assignment_size = n_res;
+  int64_t const assignment_stride = 1;
+  // Each warp owns one trajectory; cache its frequently read assignments.
+  // The host enables this only when all residues fit and the CTA has 4 warps.
+  if constexpr (CacheAssignments) {
+    __shared__ Int current_cache[4][128];
+    __shared__ Int best_cache[4][128];
+    int const warp = threadIdx.x / 32;
+    for (int k = g.thread_rank(); k < n_res; k += 32) {
+      current_cache[warp][k] = current_rotamer_assignment[k];
+      best_cache[warp][k] = best_rotamer_assignment[k];
+    }
+    g.sync();
+    current_rotamer_assignment = TensorAccessor<Int, 1, D>(
+        current_cache[warp], &assignment_size, &assignment_stride);
+    best_rotamer_assignment = TensorAccessor<Int, 1, D>(
+        best_cache[warp], &assignment_size, &assignment_stride);
+  }
 
   float temperature = hi_temp;
   float best_energy = 0.0f;
@@ -402,8 +426,17 @@ MGPU_DEVICE float warp_wide_sim_annealing(
       accept = g.shfl(accept, 0);
 
       if (accept) {
+        if constexpr (CacheAssignments) {
+          // Shuffles do not order shared-memory accesses. Complete reads from
+          // this proposal and the preceding best-assignment copy before
+          // writing.
+          g.sync();
+        }
         if (g.thread_rank() == 0) {
           current_rotamer_assignment[ran_res] = local_new_rot;
+        }
+        if constexpr (CacheAssignments) {
+          g.sync();
         }
         if constexpr (TrackBestAssignment) {
           if (g.thread_rank() == 0) {
@@ -435,6 +468,17 @@ MGPU_DEVICE float warp_wide_sim_annealing(
     temperature = cooling_factor * (temperature - lo_temp) + lo_temp;
 
   }  // end outer loop
+
+  if constexpr (CacheAssignments) {
+    g.sync();
+    for (int k = g.thread_rank(); k < n_res; k += 32) {
+      original_current[k] = current_rotamer_assignment[k];
+      if constexpr (TrackBestAssignment) {
+        original_best[k] = best_rotamer_assignment[k];
+      }
+    }
+    g.sync();
+  }
 
   // Transition phases consume only the assignments; avoid their otherwise
   // unused exact rescore while retaining it for ranking phases.
@@ -601,7 +645,8 @@ struct Annealer {
     }
 
     // Phase 1: run full SA, then score via quench-lite.
-    auto hitemp_simulated_annealing = [=] MGPU_DEVICE(int thread_id) {
+    auto hitemp_simulated_annealing = [=] MGPU_DEVICE(
+                                          int thread_id, auto cache_tag) {
       auto seeds = at::cuda::philox::unpack(hitemp_philox_state);
       curandStatePhilox4_32_10_t state;
       curand_init(std::get<0>(seeds), thread_id, std::get<1>(seeds), &state);
@@ -643,7 +688,12 @@ struct Annealer {
       // Match the CPU annealer's per-pose work: a large neighbor in a jagged
       // batch must not inflate this pose's trajectory length.
       int const pose_inner_iterations = n_rotamers + n_rotamers / 2;
-      warp_wide_sim_annealing<ChunkSize, false, false, true>(
+      warp_wide_sim_annealing<
+          ChunkSize,
+          false,
+          false,
+          true,
+          decltype(cache_tag)::value>(
           pose,
           &state,
           g,
@@ -691,7 +741,8 @@ struct Annealer {
 
     // Phase 2: low-temp SA seeded from top hitemp trajectories (each seeds
     // n_lotemp_expansions independent lotemp runs).
-    auto lotemp_simulated_annealing = [=] MGPU_DEVICE(int thread_id) {
+    auto lotemp_simulated_annealing = [=] MGPU_DEVICE(
+                                          int thread_id, auto cache_tag) {
       cooperative_groups::thread_block_tile<32> g =
           cooperative_groups::tiled_partition<32>(
               cooperative_groups::this_thread_block());
@@ -729,7 +780,12 @@ struct Annealer {
 
       // Low-temperature cooling trajectory
       int const pose_inner_iterations = n_rotamers / 2;
-      warp_wide_sim_annealing<ChunkSize, false, false, true>(
+      warp_wide_sim_annealing<
+          ChunkSize,
+          false,
+          false,
+          true,
+          decltype(cache_tag)::value>(
           pose,
           &state,
           g,
@@ -856,12 +912,27 @@ struct Annealer {
     // traffic and benefit from extra latency hiding. Short and older-GPU
     // workloads retain the unconstrained kernel.
     using HitempLaunch = mgpu::launch_params_t<annealer_cta_threads, 1, 1, 6>;
-    if (max_n_rotamers >= 128 && context->ptx_version() >= 80) {
-      mgpu::transform<HitempLaunch>(
-          hitemp_simulated_annealing, n_hitemp_simA_threads, *context);
+    auto launch_hitemp = [&](auto cache_tag) {
+      if (max_n_rotamers >= 128 && context->ptx_version() >= 80) {
+        mgpu::transform<HitempLaunch>(
+            hitemp_simulated_annealing,
+            n_hitemp_simA_threads,
+            *context,
+            cache_tag);
+      } else {
+        mgpu::transform<annealer_cta_threads, 1>(
+            hitemp_simulated_annealing,
+            n_hitemp_simA_threads,
+            *context,
+            cache_tag);
+      }
+    };
+    bool const cache_assignments =
+        max_n_res <= 128 && context->ptx_version() == 90;
+    if (cache_assignments) {
+      launch_hitemp(std::true_type{});
     } else {
-      mgpu::transform<annealer_cta_threads, 1>(
-          hitemp_simulated_annealing, n_hitemp_simA_threads, *context);
+      launch_hitemp(std::false_type{});
     }
 
     mgpu::segmented_sort(
@@ -873,8 +944,19 @@ struct Annealer {
         mgpu::less_t<float>(),
         *context);
 
-    mgpu::transform<annealer_cta_threads, 1>(
-        lotemp_simulated_annealing, n_lotemp_simA_threads, *context);
+    if (cache_assignments) {
+      mgpu::transform<annealer_cta_threads, 1>(
+          lotemp_simulated_annealing,
+          n_lotemp_simA_threads,
+          *context,
+          std::true_type{});
+    } else {
+      mgpu::transform<annealer_cta_threads, 1>(
+          lotemp_simulated_annealing,
+          n_lotemp_simA_threads,
+          *context,
+          std::false_type{});
+    }
 
     mgpu::segmented_sort(
         scores_lotemp.data(),

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -126,6 +126,14 @@ class EnergyTerm:
         """Maximum whole-pose block-neighbor reach, or ``None`` if unused."""
         return None
 
+    def supports_score_only_in_no_grad(self):
+        """Whether whole-pose scoring may detach coordinates when grad is disabled.
+
+        Native terms can opt in to avoid calculating discarded derivatives.
+        Custom scoring functions keep their original input by default.
+        """
+        return False
+
     def get_rotamer_score_term_attributes(
         self, pose_stack: PoseStack, rotamer_set: RotamerSet
     ):
@@ -169,6 +177,7 @@ class EnergyTerm:
             term_attributes,
             f,
             self.get_block_neighbor_cutoff(),
+            score_only_in_no_grad=self.supports_score_only_in_no_grad(),
         )
 
     def render_block_pair_scoring_module(

--- a/tmol/score/_energy_term.py
+++ b/tmol/score/_energy_term.py
@@ -107,7 +107,9 @@ class EnergyTerm:
 
         Subclasses may override this method to extract configuration values
         that affect scoring behavior, such as boolean flags, numeric
-        parameters, or other settings. The base implementation is a no-op.
+        parameters, or other settings. This dictionary replaces the previous
+        options; omitted keys must restore their defaults. The base
+        implementation is a no-op.
         """
         pass
 

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1902,6 +1902,9 @@ class RotamerScoringModule:
             if dispatch_key is not None and cutoff is not None:
                 dispatch_by_key.setdefault(dispatch_key, []).append((cutoff, result[1]))
             yield term, result, already_weighted
+            # The consumer has retained the weighted values. Release the raw
+            # lanes before the next native call allocates another score table.
+            del result
 
     @staticmethod
     def _matching_layout(indices, all_indices, layouts_by_nnz):
@@ -2046,6 +2049,11 @@ class RotamerScoringModule:
             if n_poses is None:
                 n_poses = term.n_poses
                 n_rots = term.n_rots
+            # Loop locals otherwise keep the previous raw table (and, after
+            # merging layouts, its temporary weighted values) alive during
+            # the next call to the result generator. Autograd retains any
+            # tensors it still needs for differentiable scoring.
+            del scores, weighted_values
 
         return all_indices, all_values, n_poses, n_rots
 

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -813,6 +813,14 @@ class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
             ljlk_module.block_neighbor_cutoff, elec_module.block_neighbor_cutoff
         )
         self.n_score_types = ljlk_module.n_score_types + elec_module.n_score_types
+        # Topology is fixed at render time; count once, before graph capture.
+        # Native rotamer arrays include padding on jagged pose stacks.
+        self.n_valid_rots = -1
+        block_types = ljlk_module.common_parameters[3]
+        # Below the native gradient threshold, even all-valid storage cannot
+        # benefit from specialization; avoid a device synchronization there.
+        if block_types.is_cuda and block_types.numel() >= 1024:
+            self.n_valid_rots = int((block_types >= 0).sum().item())
 
     def build_compact_block_neighbors(self, coords, reach):
         return self.ljlk_module.build_compact_block_neighbors(coords, reach)
@@ -834,7 +842,7 @@ class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
         # composite selects arguments from each child's dtype-adjusted static
         # tail rather than bypassing it and reading raw float32 parameters.
         (scores,) = ljlk_elec_pose_scores(
-            *self._native_arguments(coords, shared_block_neighbors)
+            *self._native_arguments(coords, shared_block_neighbors), self.n_valid_rots
         )
         return scores
 
@@ -845,7 +853,9 @@ class _FusedLJLKAndElecWholePoseModule(torch.nn.Module):
         if score_weights.dtype != coords.dtype:
             score_weights = score_weights.to(dtype=coords.dtype)
         (scores,) = ljlk_elec_weighted_pose_scores(
-            *self._native_arguments(coords, shared_block_neighbors), score_weights
+            *self._native_arguments(coords, shared_block_neighbors),
+            score_weights,
+            self.n_valid_rots,
         )
         return scores
 

--- a/tmol/score/_score_function.py
+++ b/tmol/score/_score_function.py
@@ -1386,6 +1386,8 @@ class WholePoseScoringModule:
         if mode in ("forward_backward", "both") and not hasattr(
             self, "_cuda_graphed_autograd"
         ):
+            from tmol.score.common._cuda_graph import CapturedScoringGraph
+
             graph_module = _DefaultWholePoseScoringModule(
                 self.weights,
                 self._execution_modules,
@@ -1397,16 +1399,13 @@ class WholePoseScoringModule:
                 torch.enable_grad(),
                 warnings.catch_warnings(),
             ):
-                # PyTorch's backward-capture warmup retains the sample leaf's
-                # default-stream AccumulateGrad node. Capture and replay are
-                # valid; suppress only that known internal warning.
+                # Scoring parameters may retain an AccumulateGrad node on
+                # another stream. Suppress only that known warmup warning.
                 warnings.filterwarnings(
                     "ignore",
                     message="The AccumulateGrad node's stream does not match",
                 )
-                self._cuda_graphed_autograd = torch.cuda.make_graphed_callables(
-                    graph_module, (sample,), allow_unused_input=True
-                )
+                self._cuda_graphed_autograd = CapturedScoringGraph(graph_module, sample)
         return self
 
 

--- a/tmol/score/backbone_torsion/potentials/_compiled.py
+++ b/tmol/score/backbone_torsion/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "backbone_torsion_pose_score.cpu.cpp",
         "backbone_torsion_pose_score.cuda.cu",
     ],

--- a/tmol/score/cartbonded/potentials/_compiled.py
+++ b/tmol/score/cartbonded/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "cartbonded_pose_score.cpu.cpp",
         "cartbonded_pose_score.cuda.cu",
     ],

--- a/tmol/score/common/_cuda_graph.py
+++ b/tmol/score/common/_cuda_graph.py
@@ -1,0 +1,106 @@
+"""CUDA scoring capture with ownership that follows its pending backwards."""
+
+import torch
+
+
+class _ReplayScoringGraph(torch.autograd.Function):
+    # A module-level Function keeps per-capture tensors out of the reference
+    # cycle between dynamically created forward and backward Function classes.
+    @staticmethod
+    def forward(ctx, capture, coords, *parameters):
+        ctx.capture = capture
+        if capture._coords.data_ptr() != coords.data_ptr():
+            capture._coords.copy_(coords)
+        capture._forward_graph.replay()
+        # The stored capture output must never acquire this Function's context:
+        # that would create a new cycle through ctx.capture.
+        return capture._output.detach()
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_output):
+        capture = ctx.capture
+        if capture._backward_graph is None:
+            return (None,) * (2 + len(capture._parameters_for_capture))
+        if capture._grad_output.data_ptr() != grad_output.data_ptr():
+            capture._grad_output.copy_(grad_output)
+        capture._backward_graph.replay()
+        return (None,) + tuple(
+            grad.detach() if grad is not None else None for grad in capture._grad_inputs
+        )
+
+
+class CapturedScoringGraph(torch.nn.Module):
+    """Capture one coordinate-input, tensor-output scoring module.
+
+    The capture owns the unmodified module so native kernels retain all their
+    parameter storage, including tensors held in ordinary Python containers.
+    Outstanding autograd outputs retain the capture until backward is finished
+    and the outputs are released. No cyclic garbage collection is required.
+    """
+
+    def __init__(self, module: torch.nn.Module, example_coords: torch.Tensor):
+        super().__init__()
+        if torch.is_autocast_enabled() and torch.is_autocast_cache_enabled():
+            raise RuntimeError("Captured scoring requires autocast cache_enabled=False")
+        if module._backward_hooks or module._forward_hooks or module._forward_pre_hooks:
+            raise AssertionError("Scoring modules must not have hooks before capture")
+        if any(buffer.requires_grad for buffer in module.buffers()):
+            raise AssertionError(
+                "Captured scoring buffers must have requires_grad=False"
+            )
+        self.module = module
+        self.training = module.training
+        self._graph_training_state = module.training
+        self._coords = example_coords
+        self._parameters_for_capture = tuple(module.parameters())
+        inputs = (example_coords,) + self._parameters_for_capture
+        differentiable = tuple(value for value in inputs if value.requires_grad)
+
+        with torch.cuda.device(example_coords.device), torch.enable_grad():
+            torch.cuda.synchronize()
+            # Torch's default graph-capture stream may belong to another
+            # device. Warm and capture on the same explicit device stream.
+            stream = torch.cuda.Stream(device=example_coords.device)
+            with torch.cuda.stream(stream):
+                for _ in range(3):
+                    output = module(example_coords)
+                    if output.requires_grad:
+                        gradients = torch.autograd.grad(
+                            output,
+                            differentiable,
+                            torch.empty_like(output),
+                            allow_unused=True,
+                        )
+                        del gradients
+                    del output
+            torch.cuda.synchronize()
+
+            # Forward and backward run in this order and can share a pool.
+            pool = torch.cuda.graph_pool_handle()
+            self._forward_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(self._forward_graph, pool=pool, stream=stream):
+                self._output = module(example_coords)
+
+            self._backward_graph = None
+            gradients = ()
+            if self._output.requires_grad:
+                self._grad_output = torch.empty_like(self._output)
+                self._backward_graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(self._backward_graph, pool=pool, stream=stream):
+                    gradients = torch.autograd.grad(
+                        self._output,
+                        differentiable,
+                        self._grad_output,
+                        allow_unused=True,
+                    )
+            gradient_iter = iter(gradients)
+            self._grad_inputs = tuple(
+                next(gradient_iter) if value.requires_grad and gradients else None
+                for value in inputs
+            )
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        if self.module.training != self._graph_training_state:
+            return self.module(coords)
+        return _ReplayScoringGraph.apply(self, coords, *self._parameters_for_capture)

--- a/tmol/score/common/_scoring_module.py
+++ b/tmol/score/common/_scoring_module.py
@@ -148,11 +148,13 @@ class TermWholePoseScoringModule(TermPoseScoringModule):
         term_parameters,
         term_score_poses,
         block_neighbor_cutoff=None,
+        score_only_in_no_grad=False,
     ):
         super(TermWholePoseScoringModule, self).__init__(
             classname, pose_stack, term_parameters, term_score_poses
         )
         self.block_neighbor_cutoff = block_neighbor_cutoff
+        self.score_only_in_no_grad = score_only_in_no_grad
         self._neighbor_block_type_n_atoms = pose_stack.packed_block_types.n_atoms
         self.register_buffer(
             "_empty_block_neighbors",
@@ -166,6 +168,12 @@ class TermWholePoseScoringModule(TermPoseScoringModule):
         shared_block_neighbors=None,
     ):
         flat = coords.flatten(start_dim=0, end_dim=-2)
+        if (
+            self.score_only_in_no_grad
+            and not torch.is_grad_enabled()
+            and flat.requires_grad
+        ):
+            flat = flat.detach()
         tail = self._static_tail_for_coords(coords)
         if self.block_neighbor_cutoff is not None:
             if shared_block_neighbors is None:

--- a/tmol/score/common/launch_box_macros.hh
+++ b/tmol/score/common/launch_box_macros.hh
@@ -1,88 +1,37 @@
 #pragma once
 
-// Common macros for working with MGPU launch_box
+// Common macros for MGPU launches. Uniform configurations need no per-GPU list.
 #ifdef __NVCC__
 #include <moderngpu/launch_box.hxx>
-#endif
 
-#ifndef __NVCC__
-// A stub for a CPU launch_t mimicing the
-// one provided by mgpu::launch_box
+#define LAUNCH_BOX_32   \
+  using namespace mgpu; \
+  typedef launch_box_t<arch_20_cta<32, 1>> launch_t;
+#define LAUNCH_BOX_64   \
+  using namespace mgpu; \
+  typedef launch_box_t<arch_20_cta<64, 1>> launch_t;
+#define LAUNCH_BOX_128  \
+  using namespace mgpu; \
+  typedef launch_box_t<arch_20_cta<128, 1>> launch_t;
+
+// Apply the requested occupancy on Volta and newer; older GPUs inherit the
+// unconstrained configuration. MGPU propagates each setting to newer targets.
+#define LAUNCH_BOX_32_OCC_AS(name, occ) \
+  using namespace mgpu;                 \
+  typedef launch_box_t<arch_20_cta<32, 1>, arch_70_cta<32, 1, 1, occ>> name;
+#else
+// CPU workgroups traverse their lanes serially, so one lane is sufficient.
 template <int NT, int VT>
 struct launch_t_cpu {
   struct sm_ptx {
     enum { nt = NT, vt = VT, vt0 = VT };
   };
 };
-#endif
 
-#ifdef __NVCC__
-// Create a launch box that sets nt to 32 for all (supported) architectures
-#define LAUNCH_BOX_32     \
-  using namespace mgpu;   \
-  typedef launch_box_t<   \
-      arch_20_cta<32, 1>, \
-      arch_35_cta<32, 1>, \
-      arch_52_cta<32, 1>, \
-      arch_70_cta<32, 1>, \
-      arch_75_cta<32, 1>> \
-      launch_t;
-
-// Create a one-warp launch box with a requested minimum number of resident
-// blocks per SM on Volta and newer. This lets register-heavy kernels trade
-// registers for latency hiding without changing their warp-cooperative
-// algorithm or imposing modern occupancy targets on legacy architectures.
-#define LAUNCH_BOX_32_OCC_AS(name, occ) \
-  using namespace mgpu;                 \
-  typedef launch_box_t<                 \
-      arch_20_cta<32, 1>,               \
-      arch_35_cta<32, 1>,               \
-      arch_52_cta<32, 1>,               \
-      arch_70_cta<32, 1, 1, occ>,       \
-      arch_75_cta<32, 1, 1, occ>>       \
-      name;
-#define LAUNCH_BOX_32_OCC(occ) LAUNCH_BOX_32_OCC_AS(launch_t, occ)
-
-#else
-// On the CPU, an "ntreads" of 1 is faster because there
-// is only one set of threads
 #define LAUNCH_BOX_32 typedef launch_t_cpu<1, 1> launch_t;
-#define LAUNCH_BOX_32_OCC_AS(name, occ) typedef launch_t_cpu<1, 1> name;
-#define LAUNCH_BOX_32_OCC(occ) typedef launch_t_cpu<1, 1> launch_t;
-#endif
-
-#ifdef __NVCC__
-// Create a launch box that sets nt to 64 for all (supported) architectures
-#define LAUNCH_BOX_64     \
-  using namespace mgpu;   \
-  typedef launch_box_t<   \
-      arch_20_cta<64, 1>, \
-      arch_35_cta<64, 1>, \
-      arch_52_cta<64, 1>, \
-      arch_70_cta<64, 1>, \
-      arch_75_cta<64, 1>> \
-      launch_t;
-
-#else
-// On the CPU, an "ntreads" of 1 is faster because there
-// is only one set of threads
 #define LAUNCH_BOX_64 typedef launch_t_cpu<1, 1> launch_t;
-#endif
-
-#ifdef __NVCC__
-// Create a launch box that sets nt to 64 for all (supported) architectures
-#define LAUNCH_BOX_128     \
-  using namespace mgpu;    \
-  typedef launch_box_t<    \
-      arch_20_cta<128, 1>, \
-      arch_35_cta<128, 1>, \
-      arch_52_cta<128, 1>, \
-      arch_70_cta<128, 1>, \
-      arch_75_cta<128, 1>> \
-      launch_t;
-
-#else
-// On the CPU, an "ntreads" of 1 is faster because there
-// is only one set of threads
 #define LAUNCH_BOX_128 typedef launch_t_cpu<1, 1> launch_t;
+#define LAUNCH_BOX_32_OCC_AS(name, occ) typedef launch_t_cpu<1, 1> name;
 #endif
+
+#define LAUNCH_BOX_32_OCC(occ) LAUNCH_BOX_32_OCC_AS(launch_t, occ)

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -787,7 +787,11 @@ template <
     typename Int,
     typename Eval>
 void launch_precomputed_block_neighbors(
-    ContextManager& mgr, TView<Int, 1, D> neighbor_indices, Eval eval) {
+    ContextManager& mgr,
+    TView<Int, 1, D> neighbor_indices,
+    int n_poses,
+    int max_n_blocks,
+    Eval eval) {
   int const n_candidates = neighbor_indices.size(0) - 1;
   if (n_candidates <= 0) return;
 #ifdef __NVCC__
@@ -804,10 +808,48 @@ void launch_precomputed_block_neighbors(
       mgr, n_workgroups, eval_compact);
 #else
   int const n_neighbors = neighbor_indices[0];
-  auto eval_compact =
-      ([=] TMOL_DEVICE_FUNC(int index) { eval(neighbor_indices[index + 1]); });
-  DeviceDispatch<D>::template foreach_workgroup<Launch>(
-      mgr, n_neighbors, eval_compact);
+  bool ordered = n_poses > 1;
+  for (int index = 2; ordered && index <= n_neighbors; ++index) {
+    ordered = neighbor_indices[index - 1] <= neighbor_indices[index];
+  }
+  if (ordered) {
+    int const pairs_per_pose = common::checked_triangular_size(
+        max_n_blocks, true, "compact CPU block-pair dispatch");
+    common::checked_dispatch_product(
+        n_poses, pairs_per_pose, "compact CPU block-pair dispatch");
+    // CPU neighbor construction retains ascending candidate IDs. Partition
+    // this list by pose: coordinate/energy outputs are disjoint across poses,
+    // while each pose keeps the original pair accumulation order. Explicit
+    // caller-provided lists with another order retain the serial fallback.
+    auto lower_bound = ([=](int candidate) {
+      int first = 1;
+      int last = n_neighbors + 1;
+      while (first < last) {
+        int const middle = first + (last - first) / 2;
+        if (neighbor_indices[middle] < candidate) {
+          first = middle + 1;
+        } else {
+          last = middle;
+        }
+      }
+      return first;
+    });
+    auto eval_pose = ([=](int pose) {
+      int const first = lower_bound(pose * pairs_per_pose);
+      int const last = lower_bound((pose + 1) * pairs_per_pose);
+      for (int index = first; index < last; ++index) {
+        eval(neighbor_indices[index]);
+      }
+    });
+    DeviceDispatch<D>::template foreach_pose_workgroup<Launch>(
+        mgr, n_poses, 1, eval_pose);
+  } else {
+    auto eval_compact = ([=] TMOL_DEVICE_FUNC(int index) {
+      eval(neighbor_indices[index + 1]);
+    });
+    DeviceDispatch<D>::template foreach_workgroup<Launch>(
+        mgr, n_neighbors, eval_compact);
+  }
 #endif
 }
 

--- a/tmol/score/common/sphere_overlap.impl.hh
+++ b/tmol/score/common/sphere_overlap.impl.hh
@@ -600,39 +600,59 @@ struct detect_compact_block_neighbors {
         return;
       }
 
-      auto detect_neighbors = ([=] TMOL_DEVICE_FUNC(int candidate) {
-        // CPU candidates run concurrently. Classify into disjoint slots;
-        // compact them deterministically after the parallel loop instead of
-        // racing on the intentionally non-atomic CPU accumulator.
-        neighbor_indices[candidate + 1] = -1;
-        int const pose_ind = candidate / n_pairs;
+      auto detect_neighbors =
+          ([=] TMOL_DEVICE_FUNC(
+               int candidate, int pose_ind, int block_ind1, int block_ind2) {
+            // CPU candidates run concurrently. Classify into disjoint slots;
+            // compact them deterministically after the parallel loop instead of
+            // racing on the intentionally non-atomic CPU accumulator.
+            neighbor_indices[candidate + 1] = -1;
+            int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
+            if (block_type1 < 0) return;
+            int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
+            if (block_type2 < 0) return;
+
+            Vec<Real, 4> sphere1(0, 0, 0, 0);
+            Vec<Real, 4> sphere2(0, 0, 0, 0);
+            for (int i = 0; i < 4; ++i) {
+              sphere1[i] = block_spheres[pose_ind][block_ind1][i];
+              sphere2[i] = block_spheres[pose_ind][block_ind2][i];
+            }
+            Real const d2 =
+                ((sphere1[0] - sphere2[0]) * (sphere1[0] - sphere2[0])
+                 + (sphere1[1] - sphere2[1]) * (sphere1[1] - sphere2[1])
+                 + (sphere1[2] - sphere2[2]) * (sphere1[2] - sphere2[2]));
+            Real const threshold = sphere1[3] + sphere2[3] + reach;
+            if (d2 >= threshold * threshold) return;
+
+            neighbor_indices[candidate + 1] = candidate;
+          });
+      // Decode one triangular index per chunk, then advance through adjacent
+      // pairs. Chunks own disjoint output slots and retain canonical ordering.
+      constexpr int chunk_size = 128;
+      int const n_chunks =
+          int((int64_t(n_candidates) + chunk_size - 1) / chunk_size);
+      auto detect_chunk = ([=] TMOL_DEVICE_FUNC(int chunk) {
+        int const first = chunk * chunk_size;
+        int const end = first + min(chunk_size, n_candidates - first);
+        int pose = first / n_pairs;
         auto pair = common::upper_triangle_inds_from_linear_index(
-            candidate % n_pairs, max_n_blocks + 1);
-        int const block_ind1 = common::get<0>(pair);
-        int const block_ind2 = common::get<1>(pair) - 1;
-
-        int const block_type1 = pose_stack_block_type[pose_ind][block_ind1];
-        if (block_type1 < 0) return;
-        int const block_type2 = pose_stack_block_type[pose_ind][block_ind2];
-        if (block_type2 < 0) return;
-
-        Vec<Real, 4> sphere1(0, 0, 0, 0);
-        Vec<Real, 4> sphere2(0, 0, 0, 0);
-        for (int i = 0; i < 4; ++i) {
-          sphere1[i] = block_spheres[pose_ind][block_ind1][i];
-          sphere2[i] = block_spheres[pose_ind][block_ind2][i];
+            first % n_pairs, max_n_blocks + 1);
+        int block1 = common::get<0>(pair);
+        int block2 = common::get<1>(pair) - 1;
+        for (int candidate = first; candidate < end; ++candidate) {
+          detect_neighbors(candidate, pose, block1, block2);
+          if (++block2 == max_n_blocks) {
+            if (++block1 == max_n_blocks) {
+              ++pose;
+              block1 = 0;
+            }
+            block2 = block1;
+          }
         }
-        Real const d2 =
-            ((sphere1[0] - sphere2[0]) * (sphere1[0] - sphere2[0])
-             + (sphere1[1] - sphere2[1]) * (sphere1[1] - sphere2[1])
-             + (sphere1[2] - sphere2[2]) * (sphere1[2] - sphere2[2]));
-        Real const threshold = sphere1[3] + sphere2[3] + reach;
-        if (d2 >= threshold * threshold) return;
-
-        neighbor_indices[candidate + 1] = candidate;
       });
-      DeviceDispatch<D>::template forall_independent<launch_t>(
-          mgr, n_candidates, detect_neighbors);
+      DeviceDispatch<D>::template foreach_independent_workgroup<launch_t>(
+          mgr, n_chunks, detect_chunk);
       Int n_neighbors = 0;
       for (int candidate = 0; candidate < n_candidates; ++candidate) {
         Int const value = neighbor_indices[candidate + 1];

--- a/tmol/score/common/whole_pose_scoring.cuda.cu
+++ b/tmol/score/common/whole_pose_scoring.cuda.cu
@@ -1,0 +1,111 @@
+#include <algorithm>
+#include <type_traits>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+namespace tmol {
+namespace score {
+namespace common {
+namespace {
+
+template <typename Real>
+__device__ Real rounded_product(Real a, Real b);
+template <>
+__device__ float rounded_product(float a, float b) {
+  return __fmul_rn(a, b);
+}
+template <>
+__device__ double rounded_product(double a, double b) {
+  return __dmul_rn(a, b);
+}
+template <typename Real>
+__device__ Real rounded_sum(Real a, Real b);
+template <>
+__device__ float rounded_sum(float a, float b) {
+  return __fadd_rn(a, b);
+}
+template <>
+__device__ double rounded_sum(double a, double b) {
+  return __dadd_rn(a, b);
+}
+
+template <typename Real, int NScoreTypes>
+__global__ void weighted_gradient_sum(
+    Real const* derivatives,
+    Real const* weights,
+    Real* output,
+    int64_t n_values,
+    int64_t values_per_pose,
+    int64_t weight_type_stride,
+    int64_t weight_pose_stride) {
+  for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < n_values;
+       i += int64_t(blockDim.x) * gridDim.x) {
+    int64_t const pose = i / values_per_pose;
+    // Match Torch's four-accumulator reduction for this short, strided axis.
+    // Explicit rounding prevents contraction of the separate multiply and sum.
+    Real partial[4] = {0, 0, 0, 0};
+#pragma unroll
+    for (int channel = 0; channel < NScoreTypes; ++channel) {
+      Real const product = rounded_product(
+          derivatives[channel * n_values + i],
+          weights[channel * weight_type_stride + pose * weight_pose_stride]);
+      partial[channel % 4] = rounded_sum(partial[channel % 4], product);
+    }
+    output[i] = rounded_sum(
+        rounded_sum(rounded_sum(partial[0], partial[1]), partial[2]),
+        partial[3]);
+  }
+}
+
+}  // namespace
+
+at::Tensor accumulate_whole_pose_gradients_cuda(
+    at::Tensor const& saved_grad, at::Tensor const& score_grad) {
+  c10::cuda::CUDAGuard guard(saved_grad.device());
+  auto result =
+      at::empty({saved_grad.size(1), saved_grad.size(2)}, saved_grad.options());
+  int64_t const n_values = result.numel();
+  int64_t const values_per_pose = n_values / score_grad.size(1);
+  int const blocks =
+      static_cast<int>(std::min<int64_t>((n_values + 255) / 256, 65535));
+  auto stream = at::cuda::getCurrentCUDAStream();
+  AT_DISPATCH_FLOATING_TYPES(
+      saved_grad.scalar_type(), "whole_pose_gradients", [&] {
+        auto launch = [&](auto channels) {
+          weighted_gradient_sum<scalar_t, decltype(channels)::value>
+              <<<blocks, 256, 0, stream>>>(
+                  saved_grad.data_ptr<scalar_t>(),
+                  score_grad.data_ptr<scalar_t>(),
+                  result.data_ptr<scalar_t>(),
+                  n_values,
+                  values_per_pose,
+                  score_grad.stride(0),
+                  score_grad.stride(1));
+        };
+        switch (saved_grad.size(0)) {
+          case 2:
+            launch(std::integral_constant<int, 2>{});
+            break;
+          case 3:
+            launch(std::integral_constant<int, 3>{});
+            break;
+          case 4:
+            launch(std::integral_constant<int, 4>{});
+            break;
+          case 5:
+            launch(std::integral_constant<int, 5>{});
+            break;
+          default:
+            TORCH_INTERNAL_ASSERT(false, "unsupported score channel count");
+        }
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return result;
+}
+
+}  // namespace common
+}  // namespace score
+}  // namespace tmol

--- a/tmol/score/common/whole_pose_scoring.hh
+++ b/tmol/score/common/whole_pose_scoring.hh
@@ -6,6 +6,12 @@ namespace tmol {
 namespace score {
 namespace common {
 
+#ifdef WITH_CUDA
+// Defined in a separate CUDA translation unit so callers remain ordinary C++.
+torch::Tensor accumulate_whole_pose_gradients_cuda(
+    torch::Tensor const& saved_grad, torch::Tensor const& score_grad);
+#endif
+
 /// Apply per-score-type, per-pose upstream gradients to saved coordinate
 /// derivatives from a whole-pose score kernel.
 ///
@@ -23,6 +29,22 @@ inline torch::Tensor accumulate_whole_pose_gradients(
   int64_t const n_poses = score_grad.size(1);
   int64_t const n_atoms = saved_grad.size(1);
   TORCH_INTERNAL_ASSERT(n_poses > 0 && n_atoms % n_poses == 0);
+
+#ifdef WITH_CUDA
+  // Keep Torch operations when constructing a derivative graph. The fused
+  // kernel otherwise avoids materializing one weighted tensor per score type.
+  // A scalar output uses a different Torch reduction order; lazy negative
+  // views also require Torch to resolve their logical values.
+  if (saved_grad.is_cuda() && !torch::GradMode::is_enabled()
+      && saved_grad.is_contiguous() && n_score_types >= 2 && n_score_types <= 5
+      && saved_grad.numel() > n_score_types && !saved_grad.is_neg()
+      && !score_grad.is_neg() && saved_grad.device() == score_grad.device()
+      && saved_grad.scalar_type() == score_grad.scalar_type()
+      && (saved_grad.scalar_type() == torch::kFloat32
+          || saved_grad.scalar_type() == torch::kFloat64)) {
+    return accumulate_whole_pose_gradients_cuda(saved_grad, score_grad);
+  }
+#endif
 
   auto derivatives_by_pose = saved_grad.reshape(
       {n_score_types, n_poses, n_atoms / n_poses, saved_grad.size(2)});

--- a/tmol/score/disulfide/_disulfide_energy_term.py
+++ b/tmol/score/disulfide/_disulfide_energy_term.py
@@ -72,6 +72,10 @@ class DisulfideEnergyTerm(EnergyTerm):
     def setup_poses(self, poses: PoseStack):
         super(DisulfideEnergyTerm, self).setup_poses(poses)
 
+    def supports_score_only_in_no_grad(self):
+        # Tiny CPU disulfide calls do not amortize the per-call mode check.
+        return self.device.type == "cuda"
+
     def get_pose_score_term_function(self):
         from tmol.score.disulfide.potentials import disulfide_pose_scores
 

--- a/tmol/score/disulfide/potentials/_compiled.py
+++ b/tmol/score/disulfide/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "disulfide_pose_score.cpu.cpp",
         "disulfide_pose_score.cuda.cu",
     ],

--- a/tmol/score/dunbrack/_dunbrack_energy_term.py
+++ b/tmol/score/dunbrack/_dunbrack_energy_term.py
@@ -236,6 +236,9 @@ class DunbrackEnergyTerm(EnergyTerm):
 
         return dunbrack_pose_scores
 
+    def supports_score_only_in_no_grad(self):
+        return True
+
     def get_rotamer_score_term_function(self):
         from tmol.score.dunbrack.potentials import dunbrack_rotamer_scores
 

--- a/tmol/score/dunbrack/potentials/_compiled.py
+++ b/tmol/score/dunbrack/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "dunbrack_pose_score.cpu.cpp",
         "dunbrack_pose_score.cuda.cu",
     ],

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -193,23 +193,13 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto semirotameric_rottable_assignment =
       semirotameric_rottable_assignment_t.view;
 
-  auto dneglnprob_rot_dbb_xyz_t =
-      D == Device::CPU && accumulate_derivs
-          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 2})
-          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 2});
-  auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
-
-  auto drotchi_devpen_dtor_xyz_t =
+  // These three terms consume their derivatives sequentially within each
+  // rotamer's thread. Reuse one buffer after each contribution is accumulated.
+  auto dterm_dtor_xyz_t =
       D == Device::CPU && accumulate_derivs
           ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 3})
           : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 3});
-  auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
-
-  auto dneglnprob_nonrot_dtor_xyz_t =
-      D == Device::CPU && accumulate_derivs
-          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 3})
-          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 3});
-  auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
+  auto dterm_dtor_xyz = dterm_dtor_xyz_t.view;
 
   auto V = V_t.view;
   auto dV_dx = dV_dx_t.view;
@@ -317,7 +307,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           block_rotamer_table_set[block_type_index],
           dihedral_values[rotamer_index],
           rotameric_rottable_assignment[rotamer_index],
-          calc_derivs ? dneglnprob_rot_dbb_xyz[rotamer_index]
+          calc_derivs ? dterm_dtor_xyz[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
           calc_derivs ? dihedral_deriv[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
@@ -339,12 +329,10 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         for (int j = 0; j < DIH_N_ATOMS; ++j) {
           if (phi_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[0][phi_ats[j]],
-                dneglnprob_rot_dbb_xyz[rotamer_index][0].row(j));
+                dV_dx[0][phi_ats[j]], dterm_dtor_xyz[rotamer_index][0].row(j));
           if (psi_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[0][psi_ats[j]],
-                dneglnprob_rot_dbb_xyz[rotamer_index][1].row(j));
+                dV_dx[0][psi_ats[j]], dterm_dtor_xyz[rotamer_index][1].row(j));
         }
       }
     }
@@ -370,7 +358,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           ii,
           rotameric_rottable_assignment[rotamer_index],
           // Out
-          calc_derivs ? drotchi_devpen_dtor_xyz[rotamer_index]
+          calc_derivs ? dterm_dtor_xyz[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
           calc_derivs ? dihedral_deriv[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
@@ -385,16 +373,13 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         for (int j = 0; j < DIH_N_ATOMS; ++j) {
           if (tor0_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[1][tor0_ats[j]],
-                drotchi_devpen_dtor_xyz[rotamer_index][0].row(j));
+                dV_dx[1][tor0_ats[j]], dterm_dtor_xyz[rotamer_index][0].row(j));
           if (tor1_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[1][tor1_ats[j]],
-                drotchi_devpen_dtor_xyz[rotamer_index][1].row(j));
+                dV_dx[1][tor1_ats[j]], dterm_dtor_xyz[rotamer_index][1].row(j));
           if (tor2_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[1][tor2_ats[j]],
-                drotchi_devpen_dtor_xyz[rotamer_index][2].row(j));
+                dV_dx[1][tor2_ats[j]], dterm_dtor_xyz[rotamer_index][2].row(j));
         }
       }
     }
@@ -425,7 +410,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           dihedral_values[rotamer_index],
           semirotameric_rottable_assignment[rotamer_index],
 
-          calc_derivs ? dneglnprob_nonrot_dtor_xyz[rotamer_index]
+          calc_derivs ? dterm_dtor_xyz[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
           calc_derivs ? dihedral_deriv[rotamer_index]
                       : TensorAccessor<CoordQuad, 1, D>(),
@@ -446,16 +431,13 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         for (int j = 0; j < DIH_N_ATOMS; ++j) {
           if (tor0_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[2][tor0_ats[j]],
-                dneglnprob_nonrot_dtor_xyz[rotamer_index][0].row(j));
+                dV_dx[2][tor0_ats[j]], dterm_dtor_xyz[rotamer_index][0].row(j));
           if (tor1_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[2][tor1_ats[j]],
-                dneglnprob_nonrot_dtor_xyz[rotamer_index][1].row(j));
+                dV_dx[2][tor1_ats[j]], dterm_dtor_xyz[rotamer_index][1].row(j));
           if (tor2_ats[j] != -1)
             accumulate<D, Vec<Real, 3>>::add(
-                dV_dx[2][tor2_ats[j]],
-                dneglnprob_nonrot_dtor_xyz[rotamer_index][2].row(j));
+                dV_dx[2][tor2_ats[j]], dterm_dtor_xyz[rotamer_index][2].row(j));
         }
       }
     }

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <type_traits>
 
 #include <tmol/utility/tensor/TensorAccessor.h>
 #include <tmol/utility/tensor/TensorPack.h>
@@ -174,15 +175,12 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                                ? TPack<Real, 2, D>::zeros({n_rots, max_n_dih})
                                : TPack<Real, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
+  // Score-only and block-pair forward calls never consume derivative scratch.
+  int const n_deriv_rots = accumulate_derivs ? n_rots : 0;
   auto dihedral_deriv_t =
-      accumulate_derivs
-          ? (D == Device::CPU
-                 ? TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::zeros(
-                       {n_rots, max_n_dih})
-                 : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
-                       {n_rots, max_n_dih}))
-          : TPack<Eigen::Matrix<Real, DIH_N_ATOMS, 3>, 2, D>::empty(
-                {n_rots, max_n_dih});
+      D == Device::CPU && accumulate_derivs
+          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, max_n_dih})
+          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, max_n_dih});
   auto dihedral_deriv = dihedral_deriv_t.view;
 
   auto rotameric_rottable_assignment_t =
@@ -199,24 +197,21 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
       semirotameric_rottable_assignment_t.view;
 
   auto dneglnprob_rot_dbb_xyz_t =
-      accumulate_derivs
-          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 2})
-                              : TPack<CoordQuad, 2, D>::empty({n_rots, 2}))
-          : TPack<CoordQuad, 2, D>::empty({n_rots, 2});
+      D == Device::CPU && accumulate_derivs
+          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 2})
+          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 2});
   auto dneglnprob_rot_dbb_xyz = dneglnprob_rot_dbb_xyz_t.view;
 
   auto drotchi_devpen_dtor_xyz_t =
-      accumulate_derivs
-          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                              : TPack<CoordQuad, 2, D>::empty({n_rots, 3}))
-          : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      D == Device::CPU && accumulate_derivs
+          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 3})
+          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 3});
   auto drotchi_devpen_dtor_xyz = drotchi_devpen_dtor_xyz_t.view;
 
   auto dneglnprob_nonrot_dtor_xyz_t =
-      accumulate_derivs
-          ? (D == Device::CPU ? TPack<CoordQuad, 2, D>::zeros({n_rots, 3})
-                              : TPack<CoordQuad, 2, D>::empty({n_rots, 3}))
-          : TPack<CoordQuad, 2, D>::empty({n_rots, 3});
+      D == Device::CPU && accumulate_derivs
+          ? TPack<CoordQuad, 2, D>::zeros({n_deriv_rots, 3})
+          : TPack<CoordQuad, 2, D>::empty({n_deriv_rots, 3});
   auto dneglnprob_nonrot_dtor_xyz = dneglnprob_nonrot_dtor_xyz_t.view;
 
   auto V = V_t.view;
@@ -227,7 +222,8 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   // Define nt and reduce_t
   CTA_REAL_REDUCE_T_TYPEDEF;
 
-  auto func = ([=] TMOL_DEVICE_FUNC(int ind) {
+  auto func = ([=] TMOL_DEVICE_FUNC(int ind, auto deriv_tag) {
+    constexpr bool calc_derivs = decltype(deriv_tag)::value;
     int const pose_index = ind / max_n_blocks;
     int const block_index = ind % max_n_blocks;
     int const block_type_index = first_rot_block_type[pose_index][block_index];
@@ -286,7 +282,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                          : (ii == 1) ? PSI_DEFAULT
                                      : 0.0;
 
-      if (accumulate_derivs) {
+      if (calc_derivs) {
         measure_dihedral_V_dV(
             TensorAccessor<Vec<Real, 3>, 1, D>(rot_coords),
             dihedral_atom_inds[rotamer_index][ii],
@@ -324,9 +320,11 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           block_rotamer_table_set[block_type_index],
           dihedral_values[rotamer_index],
           rotameric_rottable_assignment[rotamer_index],
-          dneglnprob_rot_dbb_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index],
-          accumulate_derivs);
+          calc_derivs ? dneglnprob_rot_dbb_xyz[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs ? dihedral_deriv[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs);
 
       if (output_block_pair_energies) {
         V[0][pose_index][block_index][block_index] = prob;
@@ -334,7 +332,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         common::accumulate<D, Real>::add(V[0][pose_index][0][0], prob);
       }
 
-      if (accumulate_derivs) {
+      if (calc_derivs) {
         // Note that we will accumulate all of the dV_dx derivatives
         // into the phi and psi definiing atoms of the _first rotamers_
         // of residues i+1 and i-1 respectively. This is dedicedly weird
@@ -375,12 +373,14 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           ii,
           rotameric_rottable_assignment[rotamer_index],
           // Out
-          drotchi_devpen_dtor_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index],
-          accumulate_derivs);
+          calc_derivs ? drotchi_devpen_dtor_xyz[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs ? dihedral_deriv[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs);
       rotameric_chi_dev_penalty += Erotdev;
 
-      if (accumulate_derivs) {
+      if (calc_derivs) {
         Vec<Int, DIH_N_ATOMS> tor0_ats = dihedral_atom_inds[rotamer_index][0];
         Vec<Int, DIH_N_ATOMS> tor1_ats = dihedral_atom_inds[rotamer_index][1];
         Vec<Int, DIH_N_ATOMS> tor2_ats =
@@ -428,9 +428,11 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
           dihedral_values[rotamer_index],
           semirotameric_rottable_assignment[rotamer_index],
 
-          dneglnprob_nonrot_dtor_xyz[rotamer_index],
-          dihedral_deriv[rotamer_index],
-          accumulate_derivs);
+          calc_derivs ? dneglnprob_nonrot_dtor_xyz[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs ? dihedral_deriv[rotamer_index]
+                      : TensorAccessor<CoordQuad, 1, D>(),
+          calc_derivs);
 
       if (output_block_pair_energies) {
         V[2][pose_index][block_index][block_index] = Esemi;
@@ -438,7 +440,7 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
         common::accumulate<D, Real>::add(V[2][pose_index][0][0], Esemi);
       }
 
-      if (accumulate_derivs) {
+      if (calc_derivs) {
         int last = block_n_chi[block_type_index] + 1;  // = +2 - 1
         Vec<Int, DIH_N_ATOMS> tor0_ats = dihedral_atom_inds[rotamer_index][0];
         Vec<Int, DIH_N_ATOMS> tor1_ats = dihedral_atom_inds[rotamer_index][1];
@@ -462,8 +464,19 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     }
   });
 
-  DeviceDispatch<D>::template forall_grouped<launch_t>(
-      mgr, n_poses, max_n_blocks, func);
+  // Specialize the two paths so unused derivative scratch and arithmetic
+  // disappear from score-only kernels without adding per-residue branches.
+  if (accumulate_derivs) {
+    auto eval =
+        ([=] TMOL_DEVICE_FUNC(int ind) { func(ind, std::true_type{}); });
+    DeviceDispatch<D>::template forall_grouped<launch_t>(
+        mgr, n_poses, max_n_blocks, eval);
+  } else {
+    auto eval =
+        ([=] TMOL_DEVICE_FUNC(int ind) { func(ind, std::false_type{}); });
+    DeviceDispatch<D>::template forall_grouped<launch_t>(
+        mgr, n_poses, max_n_blocks, eval);
+  }
 
   return {V_t, dV_dx_t};
 }

--- a/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
+++ b/tmol/score/dunbrack/potentials/dunbrack_pose_score.impl.hh
@@ -163,15 +163,14 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
                      ? TPack<Vec<Real, 3>, 2, D>::zeros({3, n_atoms})
                      : TPack<Vec<Real, 3>, 2, D>::empty({3, 0});
 
-  // The derivative-enabled CUDA kernel fully writes every scratch element it
-  // consumes.  Skip separate initialization launches there, while retaining
-  // the established CPU and inference allocation paths.
+  // Both CUDA modes fully write every scratch element they consume.
+  // Keep CPU initialization while avoiding separate CUDA memset launches.
   auto dihedral_atom_inds_t =
-      D == Device::CPU || !accumulate_derivs
+      D == Device::CPU
           ? TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::zeros({n_rots, max_n_dih})
           : TPack<Vec<Int, DIH_N_ATOMS>, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_atom_inds = dihedral_atom_inds_t.view;
-  auto dihedral_values_t = D == Device::CPU || !accumulate_derivs
+  auto dihedral_values_t = D == Device::CPU
                                ? TPack<Real, 2, D>::zeros({n_rots, max_n_dih})
                                : TPack<Real, 2, D>::empty({n_rots, max_n_dih});
   auto dihedral_values = dihedral_values_t.view;
@@ -184,15 +183,13 @@ auto DunbrackPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
   auto dihedral_deriv = dihedral_deriv_t.view;
 
   auto rotameric_rottable_assignment_t =
-      D == Device::CPU || !accumulate_derivs
-          ? TPack<Int, 1, D>::zeros({n_rots})
-          : TPack<Int, 1, D>::empty({n_rots});
+      D == Device::CPU ? TPack<Int, 1, D>::zeros({n_rots})
+                       : TPack<Int, 1, D>::empty({n_rots});
   auto rotameric_rottable_assignment = rotameric_rottable_assignment_t.view;
 
   auto semirotameric_rottable_assignment_t =
-      D == Device::CPU || !accumulate_derivs
-          ? TPack<Int, 1, D>::zeros({n_rots})
-          : TPack<Int, 1, D>::empty({n_rots});
+      D == Device::CPU ? TPack<Int, 1, D>::zeros({n_rots})
+                       : TPack<Int, 1, D>::empty({n_rots});
   auto semirotameric_rottable_assignment =
       semirotameric_rottable_assignment_t.view;
 

--- a/tmol/score/dunbrack/potentials/potentials.hh
+++ b/tmol/score/dunbrack/potentials/potentials.hh
@@ -54,6 +54,9 @@ def measure_dihedral_V_dV(
   } else if (at1 == -1) {
     // -1 is sentinel value for undefined dihedral
     dihedral = dih_default;
+    // Default angles are constant. Downstream derivative helpers consume
+    // this scratch even though unresolved atom indices prevent accumulation.
+    ddihe_dxyz.setZero();
   }
 }
 

--- a/tmol/score/elec/_elec_energy_term.py
+++ b/tmol/score/elec/_elec_energy_term.py
@@ -156,6 +156,9 @@ class ElecEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
     def setup_poses(self, poses: PoseStack):
         super(ElecEnergyTerm, self).setup_poses(poses)
 
+    def supports_score_only_in_no_grad(self):
+        return True
+
     def get_pose_score_term_function(self):
         from tmol.score.elec.potentials import elec_pose_scores
 

--- a/tmol/score/elec/potentials/_compiled.py
+++ b/tmol/score/elec/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "elec_pose_score.cpu.cpp",
         "elec_pose_score.cuda.cu",
     ],

--- a/tmol/score/elec/potentials/compiled.ops.cpp
+++ b/tmol/score/elec/potentials/compiled.ops.cpp
@@ -149,10 +149,17 @@ class ElecPoseScoreOp
       ctx->save_for_backward({dscore_dcoords, pose_ind_for_atom});
     }
 
+    // The integer neighbor output has no derivative. Do not allocate an
+    // unused zero gradient for it when differentiating the score.
+    ctx->set_materialize_grads(false);
     return {score, block_neighbors};
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    tensor_list gradients(26);
+    if (!grad_outputs[0].defined()) {
+      return gradients;
+    }
     auto saved = ctx->get_saved_variables();
 
     at::Tensor dV_d_pose_coords;
@@ -253,19 +260,8 @@ class ElecPoseScoreOp
           }));
     }
 
-    return {
-        dV_d_pose_coords, torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-
-        torch::Tensor(),  torch::Tensor(),
-
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-        torch::Tensor(),
-
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-    };
+    gradients[0] = dV_d_pose_coords;
+    return gradients;
   }
 };
 

--- a/tmol/score/elec/potentials/elec_pose_score.impl.hh
+++ b/tmol/score/elec/potentials/elec_pose_score.impl.hh
@@ -849,11 +849,19 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
     if (compute_derivs) {
       score::common::sphere_overlap::
           launch_precomputed_block_neighbors<DeviceDispatch, D, launch_t, Int>(
-              mgr, shared_compact_block_neighbors, eval_energies);
+              mgr,
+              shared_compact_block_neighbors,
+              n_poses,
+              max_n_blocks,
+              eval_energies);
     } else {
       score::common::sphere_overlap::
           launch_precomputed_block_neighbors<DeviceDispatch, D, launch_t, Int>(
-              mgr, shared_compact_block_neighbors, eval_energies_by_block);
+              mgr,
+              shared_compact_block_neighbors,
+              n_poses,
+              max_n_blocks,
+              eval_energies_by_block);
     }
   } else if (
       !output_block_pair_energies
@@ -877,13 +885,23 @@ auto ElecPoseScoreDispatch<DeviceDispatch, D, Real, Int>::forward(
             DeviceDispatch,
             D,
             launch_t,
-            Int>(mgr, shared_compact_block_neighbors, eval_energies);
+            Int>(
+            mgr,
+            shared_compact_block_neighbors,
+            n_poses,
+            max_n_blocks,
+            eval_energies);
       } else {
         score::common::sphere_overlap::launch_precomputed_block_neighbors<
             DeviceDispatch,
             D,
             launch_t,
-            Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+            Int>(
+            mgr,
+            shared_compact_block_neighbors,
+            n_poses,
+            max_n_blocks,
+            eval_energies_by_block);
       }
     } else if (output_block_pair_energies || !compute_derivs) {
       DeviceDispatch<D>::template foreach_pose_workgroup<launch_t>(

--- a/tmol/score/genbonded/_genbonded_energy_term.py
+++ b/tmol/score/genbonded/_genbonded_energy_term.py
@@ -608,6 +608,9 @@ class GenBondedEnergyTerm(AtomTypeDependentTerm):
     # Scoring
     # ------------------------------------------------------------------
 
+    def supports_score_only_in_no_grad(self):
+        return True
+
     def get_pose_score_term_function(self):
         return genbonded_pose_scores
 

--- a/tmol/score/genbonded/potentials/_compiled.py
+++ b/tmol/score/genbonded/potentials/_compiled.py
@@ -12,6 +12,7 @@ if ensure_compiled_or_jit():
                 __file__,
                 [
                     "compiled.ops.cpp",
+                    "../../common/whole_pose_scoring.cuda.cu",
                     "genbonded_pose_score.cpu.cpp",
                     "genbonded_pose_score.cuda.cu",
                 ],

--- a/tmol/score/hbond/_hbond_energy_term.py
+++ b/tmol/score/hbond/_hbond_energy_term.py
@@ -219,6 +219,9 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             score_args += (shared_dispatch_indices,)
         return score_op(*score_args)
 
+    def supports_score_only_in_no_grad(self):
+        return True
+
     def get_pose_score_term_function(self):
         return self.pose_score_hbond
 

--- a/tmol/score/hbond/_hbond_energy_term.py
+++ b/tmol/score/hbond/_hbond_energy_term.py
@@ -62,6 +62,13 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     def setup_poses(self, poses: PoseStack):
         super(HBondEnergyTerm, self).setup_poses(poses)
+        # Count actual residues once, before scoring or CUDA Graph capture.
+        # Padded stack size alone can overestimate work in jagged batches.
+        poses._hbond_allow_split_pairs = (
+            poses.device.type == "cuda"
+            and poses.block_type_ind.numel() >= 4096
+            and int((poses.block_type_ind >= 0).sum()) >= 2048
+        )
 
     def pose_score_hbond(self, *args):
         from tmol.score.hbond.potentials import (
@@ -73,6 +80,7 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         pose_stack = args[-3]
         block_pair_scoring = args[-2]
         shared_block_neighbors = args[-1]
+        allow_split_pairs = getattr(pose_stack, "_hbond_allow_split_pairs", False)
         coords_dtype = common_args[0].dtype
         pair_param_table, pair_poly_table, global_param_table = self._param_tables(
             coords_dtype
@@ -132,6 +140,7 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             derived_atom_inds,
             block_pair_scoring,
             shared_block_neighbors,
+            allow_split_pairs,
         )
 
     def rotamer_score_hbond(self, *args):

--- a/tmol/score/hbond/_hbond_energy_term.py
+++ b/tmol/score/hbond/_hbond_energy_term.py
@@ -220,7 +220,9 @@ class HBondEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
         return score_op(*score_args)
 
     def supports_score_only_in_no_grad(self):
-        return True
+        # CPU compilers can round score-only and derivative paths differently
+        # (including float64 on ARM). Preserve tracked-input values there.
+        return self.device.type == "cuda"
 
     def get_pose_score_term_function(self):
         return self.pose_score_hbond

--- a/tmol/score/hbond/potentials/_compiled.py
+++ b/tmol/score/hbond/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "hbond_pose_score.cpu.cpp",
         "hbond_pose_score.cuda.cu",
         "gen_hbond_bases.cpu.cpp",

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -81,7 +81,8 @@ class HBondPoseScoresOp
       Tensor derived_atom_inds,
 
       bool output_block_pair_energies,
-      Tensor shared_compact_block_neighbors
+      Tensor shared_compact_block_neighbors,
+      bool allow_split_pairs
 
   ) {
     at::Tensor score;
@@ -148,7 +149,8 @@ class HBondPoseScoresOp
 
                   TCAST(shared_compact_block_neighbors),
                   output_block_pair_energies,
-                  rot_coords.requires_grad());
+                  rot_coords.requires_grad(),
+                  allow_split_pairs);
 
           score = std::get<0>(result).tensor;
           dscore_dcoords = std::get<1>(result).tensor;
@@ -359,16 +361,9 @@ class HBondPoseScoresOp
           }));
     }
 
-    return {dV_d_pose_coords, torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor()};
+    tensor_list gradients(39);
+    gradients[0] = dV_d_pose_coords;
+    return gradients;
   }
 };
 
@@ -771,7 +766,8 @@ std::vector<Tensor> hbond_pose_scores_op(
     Tensor derived_atom_inds,
 
     bool output_block_pair_energies,
-    Tensor shared_compact_block_neighbors) {
+    Tensor shared_compact_block_neighbors,
+    bool allow_split_pairs = false) {
   return HBondPoseScoresOp<DispatchMethod>::apply(
       // common params
       rot_coords,
@@ -822,7 +818,8 @@ std::vector<Tensor> hbond_pose_scores_op(
       derived_atom_inds,
 
       output_block_pair_energies,
-      shared_compact_block_neighbors);
+      shared_compact_block_neighbors,
+      allow_split_pairs);
 }
 
 template <template <tmol::Device> class DispatchMethod>
@@ -1092,7 +1089,17 @@ std::vector<Tensor> gen_hbond_bases_op(
 
 // See https://stackoverflow.com/a/3221914
 TORCH_LIBRARY(tmol_hbond, m) {
-  m.def("hbond_pose_scores", &hbond_pose_scores_op<common::DeviceOperations>);
+  // Preserve the inferred positional argument names for existing callers.
+  m.def(
+      "hbond_pose_scores(Tensor _0, Tensor _1, Tensor _2, Tensor _3, Tensor "
+      "_4, Tensor _5, Tensor _6, Tensor _7, Tensor _8, Tensor _9, Tensor _10, "
+      "Tensor _11, int _12, Tensor _13, Tensor _14, Tensor _15, Tensor _16, "
+      "Tensor _17, Tensor _18, Tensor _19, Tensor _20, Tensor _21, Tensor _22, "
+      "Tensor _23, Tensor _24, Tensor _25, Tensor _26, Tensor _27, Tensor _28, "
+      "Tensor _29, Tensor _30, Tensor _31, Tensor _32, Tensor _33, Tensor _34, "
+      "Tensor _35, bool _36, Tensor _37, bool allow_split_pairs=False) -> "
+      "Tensor[] _0",
+      &hbond_pose_scores_op<common::DeviceOperations>);
   m.def(
       "hbond_rotamer_scores",
       &hbond_rotamer_scores_op<common::DeviceOperations>);

--- a/tmol/score/hbond/potentials/compiled.ops.cpp
+++ b/tmol/score/hbond/potentials/compiled.ops.cpp
@@ -220,10 +220,17 @@ class HBondPoseScoresOp
       ctx->save_for_backward({dscore_dcoords, pose_ind_for_atom});
     }
 
+    // The integer neighbor output has no derivative. Do not allocate an
+    // unused zero gradient for it when differentiating the score.
+    ctx->set_materialize_grads(false);
     return {score, block_neighbors};
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    tensor_list gradients(39);
+    if (!grad_outputs[0].defined()) {
+      return gradients;
+    }
     auto saved = ctx->get_saved_variables();
 
     at::Tensor dV_d_pose_coords;
@@ -361,7 +368,6 @@ class HBondPoseScoresOp
           }));
     }
 
-    tensor_list gradients(39);
     gradients[0] = dV_d_pose_coords;
     return gradients;
   }

--- a/tmol/score/hbond/potentials/hbond_pose_score.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.hh
@@ -112,7 +112,8 @@ struct HBondPoseScoreDispatch {
 
       TView<Int, 1, Dev> shared_compact_block_neighbors,
       bool output_block_pair_energies,
-      bool compute_derivs)
+      bool compute_derivs,
+      bool allow_split_pairs = false)
       -> std::tuple<
           TPack<Real, 4, Dev>,
           TPack<Vec<Real, 3>, 2, Dev>,

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -31,6 +31,7 @@
 #include <moderngpu/operators.hxx>
 
 #include <chrono>
+#include <type_traits>
 
 // The maximum number of inter-residue chemical bonds
 #define MAX_N_CONN 4
@@ -498,7 +499,8 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
 
     TView<Int, 1, Dev> shared_compact_block_neighbors,
     bool output_block_pair_energies,
-    bool compute_derivs
+    bool compute_derivs,
+    bool allow_split_pairs
 
     )
     -> std::tuple<
@@ -657,130 +659,139 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   int const max_n_upper_triangle_inds = score::common::checked_triangular_size(
       max_n_blocks, true, "hydrogen-bond block-pair dispatch");
 
+#ifdef __NVCC__
+  auto eval_energies_impl =
+      ([=] TMOL_DEVICE_FUNC(int cta, auto derivative_tag, auto pair_mode_tag) {
+        bool const accumulate_derivs = static_cast<bool>(derivative_tag);
+        constexpr auto PairMode = decltype(pair_mode_tag)::value;
+#else
   auto eval_energies = ([=] TMOL_DEVICE_FUNC(int cta) {
-    auto hbond_atom_energy = ([=] HBOND_ATOM_ENERGY);
+#endif
+        auto hbond_atom_energy = ([=] HBOND_ATOM_ENERGY);
 
-    auto score_inter_hbond_atom_pair = ([=] SCORE_INTER_HBOND_ATOM_PAIR);
+        auto score_inter_hbond_atom_pair = ([=] SCORE_INTER_HBOND_ATOM_PAIR);
 
-    auto score_intra_hbond_atom_pair = ([=] SCORE_INTRA_HBOND_ATOM_PAIR);
+        auto score_intra_hbond_atom_pair = ([=] SCORE_INTRA_HBOND_ATOM_PAIR);
 
-    SHARED_MEMORY union shared_mem_union {
-      shared_mem_union() {}
-      HBondBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> m;
-      CTA_REAL_REDUCE_T_VARIABLE;
+        SHARED_MEMORY union shared_mem_union {
+          shared_mem_union() {}
+          HBondBlockPairSharedData<Real, TILE_SIZE, MAX_N_CONN> m;
+          CTA_REAL_REDUCE_T_VARIABLE;
 
-    } shared;
+        } shared;
 
-    int const max_important_bond_separation = 4;
+        int const max_important_bond_separation = 4;
 
-    int const pose_ind = cta / (max_n_upper_triangle_inds);
-    int const block_ind_pair = cta % (max_n_upper_triangle_inds);
+        int const pose_ind = cta / (max_n_upper_triangle_inds);
+        int const block_ind_pair = cta % (max_n_upper_triangle_inds);
 
-    // We do not have to kill half of our thread blocks simply because they
-    // represent the lower triangle now that we're using upper-triangle indices
-    auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
-        block_ind_pair, max_n_blocks + 1);
+        // We do not have to kill half of our thread blocks simply because they
+        // represent the lower triangle now that we're using upper-triangle
+        // indices
+        auto upper_triangle_ind = common::upper_triangle_inds_from_linear_index(
+            block_ind_pair, max_n_blocks + 1);
 
-    int const block_ind1 = common::get<0>(upper_triangle_ind);
-    int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
-
-    // We still kill CTAs targetting non-neighboring block pairs, though,
-    // and that can be a lot
-    if (!use_shared_compact_block_neighbors
-        && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
-      return;
-    }
-    int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
-    int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
-
-    int const block_type1 = block_type_ind_for_rot[rot_ind1];
-    int const block_type2 = block_type_ind_for_rot[rot_ind2];
-
-    if (block_type1 < 0 || block_type2 < 0) {
-      return;
-    }
-
-    int const n_atoms1 = block_type_n_atoms[block_type1];
-    int const n_atoms2 = block_type_n_atoms[block_type2];
-
-    auto load_tile_invariant_interres_data =
-        ([=] LOAD_TILE_INVARIANT_INTERRES_DATA);
-
-    auto load_interres1_tile_data_to_shared =
-        ([=] LOAD_INTERRES1_TILE_DATA_TO_SHARED);
-
-    auto load_interres2_tile_data_to_shared =
-        ([=] LOAD_INTERRES2_TILE_DATA_TO_SHARED);
-
-    auto load_interres_data_from_shared = ([=] LOAD_INTERRES_DATA_FROM_SHARED);
-
-    auto eval_interres_atom_pair_scores = ([=] EVAL_INTERRES_ATOM_PAIR_SCORES);
-
-    auto store_calculated_energies = ([=] STORE_POSE_CALCULATED_ENERGIES);
-
-    auto load_tile_invariant_intrares_data =
-        ([=] LOAD_TILE_INVARIANT_INTRARES_DATA);
-
-    auto load_intrares1_tile_data_to_shared =
-        ([=] LOAD_INTRARES1_TILE_DATA_TO_SHARED);
-
-    auto load_intrares2_tile_data_to_shared =
-        ([=] LOAD_INTRARES2_TILE_DATA_TO_SHARED);
-
-    auto load_intrares_data_from_shared = ([=] LOAD_INTRARES_DATA_FROM_SHARED);
-
-    auto eval_intrares_atom_pair_scores = ([=] EVAL_INTRARES_ATOM_PAIR_SCORES);
-
-    tmol::score::common::tile_evaluate_rot_pair<
-        DeviceDispatch,
-        Dev,
-        HBondScoringData<Dev, Real, Int>,
-        HBondScoringData<Dev, Real, Int>,
-        Real,
-        TILE_SIZE>(
-        shared,
-        pose_ind,
-        rot_ind1,
-        rot_ind2,
-        block_ind1,
-        block_ind2,
-        block_type1,
-        block_type2,
-        n_atoms1,
-        n_atoms2,
-        load_tile_invariant_interres_data,
-        load_interres1_tile_data_to_shared,
-        load_interres2_tile_data_to_shared,
-        load_interres_data_from_shared,
-        eval_interres_atom_pair_scores,
-        store_calculated_energies,
-        load_tile_invariant_intrares_data,
-        load_intrares1_tile_data_to_shared,
-        load_intrares2_tile_data_to_shared,
-        load_intrares_data_from_shared,
-        eval_intrares_atom_pair_scores,
-        store_calculated_energies);
-  });
+        int const block_ind1 = common::get<0>(upper_triangle_ind);
+        int const block_ind2 = common::get<1>(upper_triangle_ind) - 1;
 
 #ifdef __NVCC__
-  if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
-    score::common::sphere_overlap::
-        launch_precomputed_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
-            mgr,
-            shared_compact_block_neighbors,
-            n_poses,
-            max_n_blocks,
-            eval_energies);
-  } else if (
-      !output_block_pair_energies
-      && score::common::sphere_overlap::should_compact_block_neighbors(
-          n_poses, max_n_blocks, compute_derivs)) {
-    score::common::sphere_overlap::
-        launch_compact_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
-            mgr, scratch_rot_neighbors, eval_energies);
-  } else
+        if constexpr (PairMode == common::TilePairMode::Inter) {
+          if (block_ind1 == block_ind2) return;
+        } else if constexpr (PairMode == common::TilePairMode::Intra) {
+          if (block_ind1 != block_ind2) return;
+        }
 #endif
-  {
+
+        // We still kill CTAs targetting non-neighboring block pairs, though,
+        // and that can be a lot
+        if (!use_shared_compact_block_neighbors
+            && scratch_rot_neighbors[pose_ind][block_ind1][block_ind2] == 0) {
+          return;
+        }
+        int const rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
+        int const rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
+
+        int const block_type1 = block_type_ind_for_rot[rot_ind1];
+        int const block_type2 = block_type_ind_for_rot[rot_ind2];
+
+        if (block_type1 < 0 || block_type2 < 0) {
+          return;
+        }
+
+        int const n_atoms1 = block_type_n_atoms[block_type1];
+        int const n_atoms2 = block_type_n_atoms[block_type2];
+
+        auto load_tile_invariant_interres_data =
+            ([=] LOAD_TILE_INVARIANT_INTERRES_DATA);
+
+        auto load_interres1_tile_data_to_shared =
+            ([=] LOAD_INTERRES1_TILE_DATA_TO_SHARED);
+
+        auto load_interres2_tile_data_to_shared =
+            ([=] LOAD_INTERRES2_TILE_DATA_TO_SHARED);
+
+        auto load_interres_data_from_shared =
+            ([=] LOAD_INTERRES_DATA_FROM_SHARED);
+
+        auto eval_interres_atom_pair_scores =
+            ([=] EVAL_INTERRES_ATOM_PAIR_SCORES);
+
+        auto store_calculated_energies = ([=] STORE_POSE_CALCULATED_ENERGIES);
+
+        auto load_tile_invariant_intrares_data =
+            ([=] LOAD_TILE_INVARIANT_INTRARES_DATA);
+
+        auto load_intrares1_tile_data_to_shared =
+            ([=] LOAD_INTRARES1_TILE_DATA_TO_SHARED);
+
+        auto load_intrares2_tile_data_to_shared =
+            ([=] LOAD_INTRARES2_TILE_DATA_TO_SHARED);
+
+        auto load_intrares_data_from_shared =
+            ([=] LOAD_INTRARES_DATA_FROM_SHARED);
+
+        auto eval_intrares_atom_pair_scores =
+            ([=] EVAL_INTRARES_ATOM_PAIR_SCORES);
+
+        tmol::score::common::tile_evaluate_rot_pair<
+            DeviceDispatch,
+            Dev,
+            HBondScoringData<Dev, Real, Int>,
+            HBondScoringData<Dev, Real, Int>,
+            Real,
+            TILE_SIZE
+#ifdef __NVCC__
+            ,
+            PairMode
+#endif
+            >(
+            shared,
+            pose_ind,
+            rot_ind1,
+            rot_ind2,
+            block_ind1,
+            block_ind2,
+            block_type1,
+            block_type2,
+            n_atoms1,
+            n_atoms2,
+            load_tile_invariant_interres_data,
+            load_interres1_tile_data_to_shared,
+            load_interres2_tile_data_to_shared,
+            load_interres_data_from_shared,
+            eval_interres_atom_pair_scores,
+            store_calculated_energies,
+            load_tile_invariant_intrares_data,
+            load_intrares1_tile_data_to_shared,
+            load_intrares2_tile_data_to_shared,
+            load_intrares_data_from_shared,
+            eval_intrares_atom_pair_scores,
+            store_calculated_energies);
+      });
+
+#ifdef __NVCC__
+  auto launch_energies = [&](auto eval_energies) {
+#endif
     if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
       score::common::sphere_overlap::launch_precomputed_block_neighbors<
           DeviceDispatch,
@@ -792,11 +803,67 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
           n_poses,
           max_n_blocks,
           eval_energies);
-    } else {
+    }
+#ifdef __NVCC__
+    else if (
+        !output_block_pair_energies
+        && score::common::sphere_overlap::should_compact_block_neighbors(
+            n_poses, max_n_blocks, compute_derivs)) {
+      score::common::sphere_overlap::
+          launch_compact_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
+              mgr, scratch_rot_neighbors, eval_energies);
+    }
+#endif
+    else {
       DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
           mgr, n_poses, max_n_upper_triangle_inds, eval_energies);
     }
+
+#ifdef __NVCC__
+  };
+  // Split derivative evaluation only when the stack is large enough to
+  // amortize the second pass. Both passes preserve the original candidate IDs.
+  bool const split_pairs =
+      allow_split_pairs && !output_block_pair_energies
+      && use_shared_compact_block_neighbors && max_n_blocks > 1
+      && int64_t(n_poses) * max_n_blocks >= 4096
+      && shared_compact_block_neighbors.size(0) - 1 >= (1 << 15);
+  using PairMode = common::TilePairMode;
+  if (accumulate_derivs) {
+    if (split_pairs) {
+      auto eval_inter = ([=] TMOL_DEVICE_FUNC(int cta) {
+        eval_energies_impl(
+            cta,
+            std::true_type{},
+            std::integral_constant<PairMode, PairMode::Inter>{});
+      });
+      launch_energies(eval_inter);
+      auto eval_intra = ([=] TMOL_DEVICE_FUNC(int cta) {
+        eval_energies_impl(
+            cta,
+            std::true_type{},
+            std::integral_constant<PairMode, PairMode::Intra>{});
+      });
+      launch_energies(eval_intra);
+    } else {
+      auto eval = ([=] TMOL_DEVICE_FUNC(int cta) {
+        eval_energies_impl(
+            cta,
+            accumulate_derivs,
+            std::integral_constant<PairMode, PairMode::InterAndIntra>{});
+      });
+      launch_energies(eval);
+    }
+  } else {
+    auto eval = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval_energies_impl(
+          cta,
+          std::false_type{},
+          std::integral_constant<PairMode, PairMode::InterAndIntra>{});
+    });
+    launch_energies(eval);
   }
+#endif
 
   // DeviceDispatch<Dev>::synchronize_device();
   return {output_t, dV_dcoords_t, scratch_rot_neighbors_t};

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -766,7 +766,11 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
   if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
     score::common::sphere_overlap::
         launch_precomputed_block_neighbors<DeviceDispatch, Dev, launch_t, Int>(
-            mgr, shared_compact_block_neighbors, eval_energies);
+            mgr,
+            shared_compact_block_neighbors,
+            n_poses,
+            max_n_blocks,
+            eval_energies);
   } else if (
       !output_block_pair_energies
       && score::common::sphere_overlap::should_compact_block_neighbors(
@@ -782,7 +786,12 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
           DeviceDispatch,
           Dev,
           launch_t,
-          Int>(mgr, shared_compact_block_neighbors, eval_energies);
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_energies);
     } else {
       DeviceDispatch<Dev>::template foreach_pose_workgroup<launch_t>(
           mgr, n_poses, max_n_upper_triangle_inds, eval_energies);

--- a/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
+++ b/tmol/score/hbond/potentials/hbond_pose_score.impl.hh
@@ -829,8 +829,10 @@ auto HBondPoseScoreDispatch<DeviceDispatch, Dev, Real, Int>::forward(
       && int64_t(n_poses) * max_n_blocks >= 4096
       && shared_compact_block_neighbors.size(0) - 1 >= (1 << 15);
   using PairMode = common::TilePairMode;
-  if (accumulate_derivs) {
-    if (split_pairs) {
+  // Keep the combined latency path for small stacks. Specializing only the
+  // HBond score kernel can slow subsequent terms in this workload range.
+  if (accumulate_derivs || n_rots < 512) {
+    if (accumulate_derivs && split_pairs) {
       auto eval_inter = ([=] TMOL_DEVICE_FUNC(int cta) {
         eval_energies_impl(
             cta,

--- a/tmol/score/ljlk/_ljlk_energy_term.py
+++ b/tmol/score/ljlk/_ljlk_energy_term.py
@@ -46,8 +46,7 @@ class LJLKEnergyTerm(AtomTypeDependentTerm, BondDependentTerm):
         return 2
 
     def set_options(self, options: dict):
-        if "soft_rep" in options:
-            self.soft_repulsive = options["soft_rep"]
+        self.soft_repulsive = options.get("soft_rep", False)
 
     def setup_block_type(self, block_type: RefinedResidueType):
         super(LJLKEnergyTerm, self).setup_block_type(block_type)

--- a/tmol/score/ljlk/potentials/_compiled.py
+++ b/tmol/score/ljlk/potentials/_compiled.py
@@ -5,6 +5,7 @@ _ops = load_ops(
     __file__,
     [
         "compiled.ops.cpp",
+        "../../common/whole_pose_scoring.cuda.cu",
         "ljlk_pose_score.cpu.cpp",
         "ljlk_pose_score.cuda.cu",
         "ljlk_elec_pose_score.cpu.cpp",

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -159,10 +159,17 @@ class LJLKPoseScoreOp
       score = score.squeeze(-1).squeeze(-1);  // remove final 2 "dummy" dims
       ctx->save_for_backward({dscore_dcoords, pose_ind_for_atom});
     }
+    // The integer neighbor output has no derivative. Do not allocate an
+    // unused zero gradient for it when differentiating the score.
+    ctx->set_materialize_grads(false);
     return {score, block_neighbors};
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    tensor_list gradients(28);
+    if (!grad_outputs[0].defined()) {
+      return gradients;
+    }
     auto saved = ctx->get_saved_variables();
 
     at::Tensor dV_d_pose_coords;
@@ -262,22 +269,8 @@ class LJLKPoseScoreOp
           }));
     }
 
-    return {dV_d_pose_coords, torch::Tensor(),
-
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(),
-
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(),
-
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(),
-
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(),
-
-            torch::Tensor(),  torch::Tensor(), torch::Tensor(),
-            torch::Tensor(),  torch::Tensor(), torch::Tensor()};
+    gradients[0] = dV_d_pose_coords;
+    return gradients;
   }
 };
 

--- a/tmol/score/ljlk/potentials/compiled.ops.cpp
+++ b/tmol/score/ljlk/potentials/compiled.ops.cpp
@@ -316,10 +316,14 @@ class LJLKAndElecPoseScoreOp
       Tensor block_type_elec_intra_repr_path_distance,
       Tensor elec_global_params,
       Tensor shared_compact_block_neighbors,
-      Tensor score_weights) {
+      Tensor score_weights,
+      int64_t n_valid_rots) {
     TORCH_CHECK(
         shared_compact_block_neighbors.numel() != 0,
         "fused LJ/LK + electrostatics requires compact block neighbors");
+    TORCH_CHECK(
+        n_valid_rots >= -1 && n_valid_rots <= rot_coord_offset.numel(),
+        "valid rotamer count must be -1 or within the rotamer storage size");
     if constexpr (weighted) {
       TORCH_CHECK(
           score_weights.dim() == 1 && score_weights.size(0) == 4,
@@ -363,14 +367,18 @@ class LJLKAndElecPoseScoreOp
                   forward_weighted(
                       TMOL_FUSED_SCORE_ARGS,
                       TCAST(score_weights),
-                      rot_coords.requires_grad());
+                      rot_coords.requires_grad(),
+                      n_valid_rots);
             } else {
               return LJLKAndElecPoseScoreDispatch<
                   DispatchMethod,
                   Dev,
                   Real,
                   Int>::
-                  forward(TMOL_FUSED_SCORE_ARGS, rot_coords.requires_grad());
+                  forward(
+                      TMOL_FUSED_SCORE_ARGS,
+                      rot_coords.requires_grad(),
+                      n_valid_rots);
             }
           }();
           score = std::get<0>(result).tensor.squeeze(-1).squeeze(-1);
@@ -383,7 +391,7 @@ class LJLKAndElecPoseScoreOp
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
     auto const saved = ctx->get_saved_variables();
-    tensor_list gradients(29);
+    tensor_list gradients(30);
     gradients[0] =
         common::accumulate_whole_pose_gradients(saved[0], grad_outputs[0]);
     return gradients;
@@ -823,7 +831,8 @@ std::vector<Tensor> ljlk_elec_pose_scores_op(
     Tensor block_type_elec_inter_repr_path_distance,
     Tensor block_type_elec_intra_repr_path_distance,
     Tensor elec_global_params,
-    Tensor shared_compact_block_neighbors) {
+    Tensor shared_compact_block_neighbors,
+    int64_t n_valid_rots) {
   return LJLKAndElecPoseScoreOp<DispatchMethod, false>::apply(
       rot_coords,
       rot_coord_offset,
@@ -853,7 +862,8 @@ std::vector<Tensor> ljlk_elec_pose_scores_op(
       block_type_elec_intra_repr_path_distance,
       elec_global_params,
       shared_compact_block_neighbors,
-      torch::empty({0}, rot_coords.options()));
+      torch::empty({0}, rot_coords.options()),
+      n_valid_rots);
 }
 
 template <template <tmol::Device> class DispatchMethod>
@@ -886,7 +896,8 @@ std::vector<Tensor> ljlk_elec_weighted_pose_scores_op(
     Tensor block_type_elec_intra_repr_path_distance,
     Tensor elec_global_params,
     Tensor shared_compact_block_neighbors,
-    Tensor score_weights) {
+    Tensor score_weights,
+    int64_t n_valid_rots) {
   return LJLKAndElecPoseScoreOp<DispatchMethod, true>::apply(
       rot_coords,
       rot_coord_offset,
@@ -916,7 +927,8 @@ std::vector<Tensor> ljlk_elec_weighted_pose_scores_op(
       block_type_elec_intra_repr_path_distance,
       elec_global_params,
       shared_compact_block_neighbors,
-      score_weights);
+      score_weights,
+      n_valid_rots);
 }
 
 template <template <tmol::Device> class DispatchMethod>
@@ -1175,9 +1187,33 @@ std::vector<Tensor> ljlk_elec_weighted_rotamer_scores_op(
 // See https://stackoverflow.com/a/3221914
 TORCH_LIBRARY(tmol_ljlk, m) {
   m.def("ljlk_pose_scores", &ljlk_pose_scores_op<DeviceOperations>);
-  m.def("ljlk_elec_pose_scores", &ljlk_elec_pose_scores_op<DeviceOperations>);
+  // Preserve the inferred argument names for existing callers while adding
+  // an optional topology hint used only to choose the CUDA launch strategy.
   m.def(
-      "ljlk_elec_weighted_pose_scores",
+      "ljlk_elec_pose_scores("
+      "Tensor _0, Tensor _1, Tensor _2, "
+      "Tensor _3, Tensor _4, Tensor _5, "
+      "Tensor _6, Tensor _7, Tensor _8, "
+      "Tensor _9, Tensor _10, Tensor _11, "
+      "int _12, Tensor _13, Tensor _14, "
+      "Tensor _15, Tensor _16, Tensor _17, "
+      "Tensor _18, Tensor _19, Tensor _20, "
+      "Tensor _21, Tensor _22, Tensor _23, "
+      "Tensor _24, Tensor _25, Tensor _26, "
+      "Tensor _27, int n_valid_rots=-1) -> Tensor[] _0",
+      &ljlk_elec_pose_scores_op<DeviceOperations>);
+  m.def(
+      "ljlk_elec_weighted_pose_scores("
+      "Tensor _0, Tensor _1, Tensor _2, "
+      "Tensor _3, Tensor _4, Tensor _5, "
+      "Tensor _6, Tensor _7, Tensor _8, "
+      "Tensor _9, Tensor _10, Tensor _11, "
+      "int _12, Tensor _13, Tensor _14, "
+      "Tensor _15, Tensor _16, Tensor _17, "
+      "Tensor _18, Tensor _19, Tensor _20, "
+      "Tensor _21, Tensor _22, Tensor _23, "
+      "Tensor _24, Tensor _25, Tensor _26, "
+      "Tensor _27, Tensor _28, int n_valid_rots=-1) -> Tensor[] _0",
       &ljlk_elec_weighted_pose_scores_op<DeviceOperations>);
   m.def(
       "weighted_fused_score_sum",

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.hh
@@ -57,7 +57,8 @@ struct LJLKAndElecPoseScoreDispatch {
       TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
           elec_global_params,
       TView<Int, 1, D> shared_compact_block_neighbors,
-      bool require_gradient)
+      bool require_gradient,
+      Int n_valid_rots = -1)
       -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
 
   /// Evaluate the same four potentials while reducing them with live score
@@ -95,7 +96,8 @@ struct LJLKAndElecPoseScoreDispatch {
           elec_global_params,
       TView<Int, 1, D> shared_compact_block_neighbors,
       TView<Real, 1, D> score_weights,
-      bool require_gradient)
+      bool require_gradient,
+      Int n_valid_rots = -1)
       -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>>;
 
   /// Evaluate weighted LJ/LK + electrostatics for a prepared sparse rotamer

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 #include <moderngpu/operators.hxx>
 
@@ -338,7 +339,8 @@ auto ljlk_elec_forward_impl(
     TView<Int, 1, D> shared_compact_block_neighbors,
     TView<Int, 2, D> rotamer_dispatch_indices,
     TView<Real, 1, D> score_weights,
-    TView<Real, 1, D> output_gradients)
+    TView<Real, 1, D> output_gradients,
+    Int n_valid_rots = -1)
     -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
   using namespace ljlk_elec_detail;
   using Real3 = Eigen::Matrix<Real, 3, 1>;
@@ -381,7 +383,13 @@ auto ljlk_elec_forward_impl(
   // CPU workgroup lanes run serially; one lane traverses each tile directly.
   constexpr int score_nt = D == tmol::Device::CPU ? 1 : nt;
 
+#ifdef __NVCC__
+  auto eval_pair = ([=] TMOL_DEVICE_FUNC(int candidate, auto pair_mode_tag) {
+    constexpr auto pair_mode = decltype(pair_mode_tag)::value;
+#else
   auto eval_neighbor = ([=] TMOL_DEVICE_FUNC(int candidate) {
+    constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
+#endif
     Real derivative_scale = 1;
     if (require_gradient && rotamer_pairs) {
       derivative_scale = output_gradients[candidate];
@@ -408,6 +416,11 @@ auto ljlk_elec_forward_impl(
       block_ind2 = common::get<1>(pair) - 1;
       rot_ind1 = rot_offset_for_block[pose_ind][block_ind1];
       rot_ind2 = rot_offset_for_block[pose_ind][block_ind2];
+    }
+    if constexpr (pair_mode == common::TilePairMode::Inter) {
+      if (block_ind1 == block_ind2) return;
+    } else if constexpr (pair_mode == common::TilePairMode::Intra) {
+      if (block_ind1 != block_ind2) return;
     }
     if (rot_ind1 < 0 || rot_ind2 < 0) {
       if (rotamer_pairs) output[0][0][0][candidate] = 0;
@@ -796,7 +809,8 @@ auto ljlk_elec_forward_impl(
         ScoringData<Real>,
         ScoringData<Real>,
         Real,
-        tile_size>(
+        tile_size,
+        pair_mode>(
         shared,
         pose_ind,
         rot_ind1,
@@ -820,6 +834,51 @@ auto ljlk_elec_forward_impl(
         eval_intra,
         store_energies);
   });
+
+#ifdef __NVCC__
+  using PairMode = common::TilePairMode;
+  auto eval_neighbor = ([=] TMOL_DEVICE_FUNC(int candidate) {
+    eval_pair(
+        candidate, std::integral_constant<PairMode, PairMode::InterAndIntra>{});
+  });
+  if constexpr (!rotamer_pairs) {
+    // Specialization amortizes the second launch only on larger stacks.
+    // Derivative evaluation has enough work to benefit at a smaller size.
+    constexpr int min_split_rots = require_gradient ? 1024 : 2048;
+    if (max_n_blocks > 1 && n_valid_rots >= min_split_rots
+        && shared_compact_block_neighbors.size(0) - 1 >= (1 << 15)) {
+      auto eval_inter = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        eval_pair(
+            candidate, std::integral_constant<PairMode, PairMode::Inter>{});
+      });
+      auto eval_intra = ([=] TMOL_DEVICE_FUNC(int candidate) {
+        eval_pair(
+            candidate, std::integral_constant<PairMode, PairMode::Intra>{});
+      });
+      common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceOperations,
+          D,
+          launch_t,
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_inter);
+      common::sphere_overlap::launch_precomputed_block_neighbors<
+          DeviceOperations,
+          D,
+          launch_t,
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_intra);
+      return {output_t, dV_dcoords_t};
+    }
+  }
+#endif
 
   if constexpr (rotamer_pairs) {
     if constexpr (require_gradient) {
@@ -879,7 +938,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
     TView<tmol::score::elec::potentials::ElecGlobalParams<Real>, 1, D>
         elec_global_params,
     TView<Int, 1, D> shared_compact_block_neighbors,
-    bool require_gradient)
+    bool require_gradient,
+    Int n_valid_rots)
     -> std::tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
 #define TMOL_LJLK_ELEC_FORWARD_ARGS                                           \
   mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
@@ -908,7 +968,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
         TMOL_LJLK_ELEC_FORWARD_ARGS,
         empty_rotamer_dispatch.view,
         empty_weights.view,
-        empty_weights.view);
+        empty_weights.view,
+        n_valid_rots);
   }
   return ljlk_elec_forward_impl<
       false,
@@ -921,7 +982,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
       TMOL_LJLK_ELEC_FORWARD_ARGS,
       empty_rotamer_dispatch.view,
       empty_weights.view,
-      empty_weights.view);
+      empty_weights.view,
+      n_valid_rots);
 #undef TMOL_LJLK_ELEC_FORWARD_ARGS
 }
 
@@ -963,7 +1025,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
             elec_global_params,
         TView<Int, 1, D> shared_compact_block_neighbors,
         TView<Real, 1, D> score_weights,
-        bool require_gradient) -> std::
+        bool require_gradient,
+        Int n_valid_rots) -> std::
         tuple<TPack<Real, 4, D>, TPack<LJLKExternalVec<Real, 3>, 2, D>> {
 #define TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS                                  \
   mgr, rot_coords, rot_coord_offset, pose_ind_for_atom, first_rot_for_block,  \
@@ -992,7 +1055,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
         TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
         empty_rotamer_dispatch.view,
         score_weights,
-        empty_output_gradients.view);
+        empty_output_gradients.view,
+        n_valid_rots);
   }
   return ljlk_elec_forward_impl<
       false,
@@ -1005,7 +1069,8 @@ auto LJLKAndElecPoseScoreDispatch<DeviceOperations, D, Real, Int>::
       TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS,
       empty_rotamer_dispatch.view,
       score_weights,
-      empty_output_gradients.view);
+      empty_output_gradients.view,
+      n_valid_rots);
 #undef TMOL_LJLK_ELEC_WEIGHTED_FORWARD_ARGS
 }
 

--- a/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_elec_pose_score.impl.hh
@@ -834,7 +834,11 @@ auto ljlk_elec_forward_impl(
   } else {
     common::sphere_overlap::
         launch_precomputed_block_neighbors<DeviceOperations, D, launch_t, Int>(
-            mgr, shared_compact_block_neighbors, eval_neighbor);
+            mgr,
+            shared_compact_block_neighbors,
+            n_poses,
+            max_n_blocks,
+            eval_neighbor);
   }
   return {output_t, dV_dcoords_t};
 }

--- a/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
+++ b/tmol/score/ljlk/potentials/ljlk_pose_score.impl.hh
@@ -1072,13 +1072,23 @@ auto LJLKPoseScoreDispatch<DeviceOperations, D, Real, Int>::forward(
           DeviceOperations,
           D,
           launch_t_high_occupancy,
-          Int>(mgr, shared_compact_block_neighbors, eval_energies);
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_energies);
     } else {
       score::common::sphere_overlap::launch_precomputed_block_neighbors<
           DeviceOperations,
           D,
           launch_t_high_occupancy,
-          Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_energies_by_block);
     }
   } else if (output_block_pair_energies) {
     DeviceOperations<D>::template foreach_pose_workgroup<launch_t>(

--- a/tmol/score/ljlk/potentials/lk_isotropic.hh
+++ b/tmol/score/ljlk/potentials/lk_isotropic.hh
@@ -108,15 +108,6 @@ struct lk_isotropic_pair {
     if (bonded_path_length < Real(4)) {
       return 0.0;
     }
-    Real d_min = lj_sigma_ij * .89;
-    if (is_cc_pair)
-      d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
-
-    // close-spline knots lie on etable bins spaced 1/20 A^2 apart
-    Real const n = std::floor(Real(20) * d_min * d_min);
-    Real cpoly_close_dmin = std::sqrt(std::max(Real(0), n - 29) / 20);
-    Real cpoly_close_dmax = std::sqrt(std::min(n + 21, Real(405)) / 20);
-
     Real cpoly_far_dmax = max_dis;
     Real cpoly_far_dmin = max_dis - Real(1.5);
 
@@ -126,6 +117,7 @@ struct lk_isotropic_pair {
 
     if (dist > cpoly_far_dmax) {
       lk = 0.0;
+      return weight * lk;
     } else if (dist > cpoly_far_dmin) {
       auto f_desolv_at_dmin = f_desolv<Real>::V_dV_precomputed(
           cpoly_far_dmin,
@@ -140,7 +132,19 @@ struct lk_isotropic_pair {
           f_desolv_at_dmin.V,
           f_desolv_at_dmin.dV_ddist,
           cpoly_far_dmax);
-    } else if (dist > cpoly_close_dmax) {
+      return weight * lk;
+    }
+
+    Real d_min = lj_sigma_ij * .89;
+    if (is_cc_pair)
+      d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
+
+    // close-spline knots lie on etable bins spaced 1/20 A^2 apart
+    Real const n = std::floor(Real(20) * d_min * d_min);
+    Real cpoly_close_dmin = std::sqrt(std::max(Real(0), n - 29) / 20);
+    Real cpoly_close_dmax = std::sqrt(std::min(n + 21, Real(405)) / 20);
+
+    if (dist > cpoly_close_dmax) {
       lk = f_desolv<Real>::V_precomputed(
           dist, lj_radius_i, lk_coeff_i, lk_inv_lambda2_i, lk_volume_j);
     } else if (dist > cpoly_close_dmin) {
@@ -272,18 +276,6 @@ struct lk_isotropic_score {
       return 0.0;
     }
 
-    Real lj_sigma_ij = lj_sigma<Real>(i, j, global);
-
-    bool is_cc_pair = i.is_carbon_lk && j.is_carbon_lk;
-    Real d_min = lj_sigma_ij * .89;
-    if (is_cc_pair)
-      d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
-
-    // close-spline knots lie on etable bins spaced 1/20 A^2 apart
-    Real const n = std::floor(Real(20) * d_min * d_min);
-    Real cpoly_close_dmin = std::sqrt(std::max(Real(0), n - 29) / 20);
-    Real cpoly_close_dmax = std::sqrt(std::min(n + 21, Real(405)) / 20);
-
     Real cpoly_far_dmax = global.max_dis;
     Real cpoly_far_dmin = global.max_dis - Real(1.5);
 
@@ -315,7 +307,22 @@ struct lk_isotropic_score {
           f_desolv_at_dmin.V,
           f_desolv_at_dmin.dV_ddist,
           cpoly_far_dmax);
-    } else if (dist > cpoly_close_dmax) {
+      return weight * lk;
+    }
+
+    Real lj_sigma_ij = lj_sigma<Real>(i, j, global);
+
+    bool is_cc_pair = i.is_carbon_lk && j.is_carbon_lk;
+    Real d_min = lj_sigma_ij * .89;
+    if (is_cc_pair)
+      d_min = std::max(d_min, Real(4.2));  // C-C modifypot flatten
+
+    // close-spline knots lie on etable bins spaced 1/20 A^2 apart
+    Real const n = std::floor(Real(20) * d_min * d_min);
+    Real cpoly_close_dmin = std::sqrt(std::max(Real(0), n - 29) / 20);
+    Real cpoly_close_dmax = std::sqrt(std::min(n + 21, Real(405)) / 20);
+
+    if (dist > cpoly_close_dmax) {
       lk = f_desolv<Real>::V_precomputed(
                dist, i.lj_radius, i.lk_coeff, i.lk_inv_lambda2, j.lk_volume)
            + f_desolv<Real>::V_precomputed(

--- a/tmol/score/lk_ball/_lk_ball_energy_term.py
+++ b/tmol/score/lk_ball/_lk_ball_energy_term.py
@@ -231,6 +231,15 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
 
     def setup_poses(self, pose_stack: PoseStack):
         super(LKBallEnergyTerm, self).setup_poses(pose_stack)
+        # Plan once before graph capture; padding can greatly overstate the
+        # useful work in the two specialized derivative kernels.
+        blocks = pose_stack.max_n_blocks
+        pose_stack._lk_ball_allow_split_backward = (
+            pose_stack.device.type == "cuda"
+            and pose_stack.block_type_ind.numel() >= 512
+            and pose_stack.n_poses * blocks * (blocks + 1) // 2 >= 32768
+            and int((pose_stack.block_type_ind >= 0).sum()) >= 512
+        )
 
     def pose_score_lk_ball(self, *args):
         from tmol.score.lk_ball.potentials import (
@@ -290,6 +299,7 @@ class LKBallEnergyTerm(AtomTypeDependentTerm, HBondDependentTerm):
             water_coords,
             block_pair_scoring,
             shared_block_neighbors,
+            getattr(pose_stack, "_lk_ball_allow_split_backward", False),
         ]
         if common_args[0].dtype == torch.float64:
             convert_float64(args)

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -498,10 +498,17 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
     auto returned_neighbors = shared_compact_block_neighbors.numel() != 0
                                   ? shared_compact_block_neighbors
                                   : block_neighbors;
+    // The integer neighbor output has no derivative. Do not allocate an
+    // unused zero gradient for it when differentiating the score.
+    ctx->set_materialize_grads(false);
     return {score, returned_neighbors};
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    tensor_list gradients(30);
+    if (!grad_outputs[0].defined()) {
+      return gradients;
+    }
     auto saved = ctx->get_saved_variables();
 
     int i = 0;
@@ -600,7 +607,6 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
           dV_d_water_coords = std::get<1>(result).tensor;
         }));
 
-    tensor_list gradients(30);
     gradients[0] = dV_d_pose_coords;
     gradients[26] = dV_d_water_coords;
     return gradients;

--- a/tmol/score/lk_ball/potentials/compiled.ops.cpp
+++ b/tmol/score/lk_ball/potentials/compiled.ops.cpp
@@ -395,7 +395,8 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
       double max_dis,  // host scalar; needed by detect-neighbors call
       Tensor water_coords,
       bool output_block_pair_energies,
-      Tensor shared_compact_block_neighbors) {
+      Tensor shared_compact_block_neighbors,
+      bool allow_split_backward) {
     at::Tensor score;
     at::Tensor block_neighbors;
 
@@ -492,6 +493,7 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
          shared_compact_block_neighbors});
 
     ctx->saved_data["block_pair_scoring"] = output_block_pair_energies;
+    ctx->saved_data["allow_split_backward"] = allow_split_backward;
 
     auto returned_neighbors = shared_compact_block_neighbors.numel() != 0
                                   ? shared_compact_block_neighbors
@@ -591,22 +593,17 @@ class LKBallPoseScoreOp : public torch::autograd::Function<LKBallPoseScoreOp> {
                   TCAST(block_neighbors),
                   TCAST(compact_block_neighbors),
                   TCAST(dTdV),
-                  block_pair_scoring);
+                  block_pair_scoring,
+                  ctx->saved_data["allow_split_backward"].toBool());
 
           dV_d_pose_coords = std::get<0>(result).tensor;
           dV_d_water_coords = std::get<1>(result).tensor;
         }));
 
-    return {
-        dV_d_pose_coords, torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), torch::Tensor(),   torch::Tensor(),
-        torch::Tensor(),  torch::Tensor(), dV_d_water_coords, torch::Tensor(),
-        torch::Tensor(),
-    };
+    tensor_list gradients(30);
+    gradients[0] = dV_d_pose_coords;
+    gradients[26] = dV_d_water_coords;
+    return gradients;
   }
 };
 
@@ -878,7 +875,8 @@ std::vector<Tensor> lkball_pose_score(
     double max_dis,
     Tensor water_coords,
     bool output_block_pair_energies,
-    Tensor shared_compact_block_neighbors) {
+    Tensor shared_compact_block_neighbors,
+    bool allow_split_backward = false) {
   return LKBallPoseScoreOp::apply(
       // common params
       rot_coords,
@@ -912,7 +910,8 @@ std::vector<Tensor> lkball_pose_score(
       max_dis,
       water_coords,
       output_block_pair_energies,
-      shared_compact_block_neighbors);
+      shared_compact_block_neighbors,
+      allow_split_backward);
 }
 
 std::vector<Tensor> lkball_rotamer_score(
@@ -1062,7 +1061,15 @@ std::vector<Tensor> lkball_rotamer_score_shared(
 }
 
 TORCH_LIBRARY(tmol_lk_ball, m) {
-  m.def("lk_ball_pose_score", &lkball_pose_score);
+  // Keep the existing inferred argument names when adding the optional hint.
+  m.def(
+      "lk_ball_pose_score(Tensor _0, Tensor _1, Tensor _2, Tensor _3, Tensor "
+      "_4, Tensor _5, Tensor _6, Tensor _7, Tensor _8, Tensor _9, Tensor _10, "
+      "Tensor _11, int _12, Tensor _13, Tensor _14, Tensor _15, Tensor _16, "
+      "Tensor _17, Tensor _18, Tensor _19, Tensor _20, Tensor _21, Tensor _22, "
+      "Tensor _23, Tensor _24, float _25, Tensor _26, bool _27, Tensor _28, "
+      "bool allow_split_backward=False) -> Tensor[] _0",
+      &lkball_pose_score);
   m.def("lk_ball_rotamer_score", &lkball_rotamer_score);
   m.def("lk_ball_rotamer_score_shared", &lkball_rotamer_score_shared);
   m.def("gen_pose_waters", &pose_watergen_op);

--- a/tmol/score/lk_ball/potentials/lk_ball.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball.hh
@@ -518,6 +518,7 @@ struct lk_ball_score {
             frac_IJ_water_overlap.dV.dWJ / 2}};
   }
 
+  template <bool UseSharedScratch = false>
   static def weighted_dV(
       Real3 I,
       Real3 J,
@@ -549,8 +550,25 @@ struct lk_ball_score {
         global.distance_threshold,
         i.is_carbon_lk && j.is_carbon_lk);
 
-    auto const frac_desolv =
-        lk_fraction<Real, MAX_WATER>::V_dV(WI, J, j.lj_radius);
+    auto frac_desolv = lk_fraction<Real, MAX_WATER>::V_dV(WI, J, j.lj_radius);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 900
+    // Hopper has enough shared memory to keep occupancy while these values
+    // leave registers during the bridge calculation. Each lane owns its
+    // column; volatile stores and reloads shorten the register lifetimes.
+    __shared__ volatile Real desolv_scratch[4 + MAX_WATER * 3][32];
+    if constexpr (UseSharedScratch) {
+      desolv_scratch[0][threadIdx.x] = frac_desolv.V;
+#pragma unroll
+      for (int d = 0; d < 3; ++d) {
+        desolv_scratch[1 + d][threadIdx.x] = frac_desolv.dV.dJ[d];
+#pragma unroll
+        for (int w = 0; w < MAX_WATER; ++w) {
+          desolv_scratch[4 + d * MAX_WATER + w][threadIdx.x] =
+              frac_desolv.dV.dWI(w, d);
+        }
+      }
+    }
+#endif
 
     typename lk_bridge_fraction<Real, MAX_WATER>::V_dV_t frac_bridge;
     if (j.is_donor || j.is_acceptor) {
@@ -559,6 +577,21 @@ struct lk_ball_score {
     } else {
       frac_bridge = {0.0, decltype(frac_bridge.dV)::Zero()};
     }
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 900
+    if constexpr (UseSharedScratch) {
+      frac_desolv.V = desolv_scratch[0][threadIdx.x];
+#pragma unroll
+      for (int d = 0; d < 3; ++d) {
+        frac_desolv.dV.dJ[d] = desolv_scratch[1 + d][threadIdx.x];
+#pragma unroll
+        for (int w = 0; w < MAX_WATER; ++w) {
+          frac_desolv.dV.dWI(w, d) =
+              desolv_scratch[4 + d * MAX_WATER + w][threadIdx.x];
+        }
+      }
+    }
+#endif
 
     Real const iso_scale = weights[w_lk_ball_iso]
                            + weights[w_lk_ball] * frac_desolv.V
@@ -1250,7 +1283,12 @@ TMOL_DEVICE_FUNC lk_ball_Vt<Real> lk_ball_atom_energy_full(
 
 // Calculate and write to global memory only the derivatives for the two
 // indicated atoms. Does not return the score
-template <int TILE_SIZE, int MAX_N_WATER, typename Real, tmol::Device Dev>
+template <
+    int TILE_SIZE,
+    int MAX_N_WATER,
+    typename Real,
+    tmol::Device Dev,
+    bool UseSharedScratch = false>
 TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
     int polar_ind,               // in [0:n_polar)
     int occluder_ind,            // in [0:n_occluders)
@@ -1295,16 +1333,17 @@ TMOL_DEVICE_FUNC void lk_ball_atom_derivs_full(
         MAX_N_WATER * occluder_atom_tile_ind + wi);
   }
 
-  auto dV = lk_ball_score<Real, MAX_N_WATER>::weighted_dV(
-      polar_xyz,
-      occluder_xyz,
-      wmat_polar,
-      wmat_occluder,
-      cp_separation,
-      polar_block_dat.lk_ball_params[polar_ind],
-      occluder_block_dat.lk_ball_params[occluder_ind],
-      block_pair_dat.global_params,
-      dTdV);
+  auto dV =
+      lk_ball_score<Real, MAX_N_WATER>::template weighted_dV<UseSharedScratch>(
+          polar_xyz,
+          occluder_xyz,
+          wmat_polar,
+          wmat_occluder,
+          cp_separation,
+          polar_block_dat.lk_ball_params[polar_ind],
+          occluder_block_dat.lk_ball_params[occluder_ind],
+          block_pair_dat.global_params,
+          dTdV);
 
   auto accum_derivs = ([&] TMOL_DEVICE_FUNC(
                            LKBallSingleResData<Real> const& block_dat,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.hh
@@ -166,7 +166,8 @@ struct LKBallPoseScoreDispatch {
       TView<Int, 3, Dev> block_neighbors,  // from forward pass
       TView<Int, 1, Dev> compact_block_neighbors,
       TView<Real, 4, Dev> dTdV,
-      bool block_pair_scoring)
+      bool block_pair_scoring,
+      bool allow_split_pairs = false)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>>;
 };
 

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -335,8 +335,10 @@ namespace potentials {
 template <typename Real, int N>
 using Vec = Eigen::Matrix<Real, N, 1>;
 
-template <common::TilePairMode Mode>
-using TilePairModeTag = std::integral_constant<common::TilePairMode, Mode>;
+template <common::TilePairMode Mode, common::TilePairMode IndexMode = Mode>
+struct TilePairModeTag : std::integral_constant<common::TilePairMode, Mode> {
+  static constexpr auto index_mode = IndexMode;
+};
 
 // TO DO: standardize tiled inter-block count pair
 template <int TILE, typename InterEnergyData>
@@ -416,6 +418,52 @@ void launch_lk_ball_pose_pair_workgroups(
       mgr, n_poses, n_pairs, eval);
 #endif
 }
+
+#ifdef __NVCC__
+template <
+    template <tmol::Device> class DeviceDispatch,
+    tmol::Device Dev,
+    typename Launch,
+    typename Int,
+    typename Eval>
+void launch_lk_ball_compact_pose_pair_workgroups(
+    ContextManager& mgr,
+    TView<Int, 1, Dev> neighbors,
+    int n_poses,
+    int max_n_blocks,
+    Eval eval) {
+  using common::TilePairMode;
+  constexpr int min_split_workgroups = 1 << 15;
+  if (max_n_blocks > 1 && neighbors.size(0) - 1 >= min_split_workgroups) {
+    // Keep both passes on the original list, including caller-provided
+    // subsets. Specialize the scoring body while retaining its triangular
+    // candidate IDs, so each pass excludes the other kind of pair.
+    auto eval_inter = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval(
+          cta,
+          TilePairModeTag<TilePairMode::Inter, TilePairMode::InterAndIntra>{});
+    });
+    auto eval_intra = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval(
+          cta,
+          TilePairModeTag<TilePairMode::Intra, TilePairMode::InterAndIntra>{});
+    });
+    common::sphere_overlap::
+        launch_precomputed_block_neighbors<DeviceDispatch, Dev, Launch, Int>(
+            mgr, neighbors, n_poses, max_n_blocks, eval_inter);
+    common::sphere_overlap::
+        launch_precomputed_block_neighbors<DeviceDispatch, Dev, Launch, Int>(
+            mgr, neighbors, n_poses, max_n_blocks, eval_intra);
+  } else {
+    auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
+      eval(cta, TilePairModeTag<TilePairMode::InterAndIntra>{});
+    });
+    common::sphere_overlap::
+        launch_precomputed_block_neighbors<DeviceDispatch, Dev, Launch, Int>(
+            mgr, neighbors, n_poses, max_n_blocks, eval_all);
+  }
+}
+#endif
 
 template <
     template <tmol::Device> class DeviceDispatch,
@@ -538,8 +586,8 @@ class LKBallPoseScoreDispatch {
     }
     auto output = output_t.view;
 
-    // This kernel is latency- and register-bound. A 16-warp occupancy target
-    // reduces its register footprint without introducing local-memory spills.
+    // A 16-warp occupancy target balances register pressure and occupancy
+    // for these scoring kernels.
     LAUNCH_BOX_32_OCC(16);
     // Define nt and reduce_t
     CTA_REAL_REDUCE_T_TYPEDEF;
@@ -548,9 +596,11 @@ class LKBallPoseScoreDispatch {
 #ifdef __NVCC__
                                        int cta, auto pair_mode_tag) {
       constexpr auto pair_mode = decltype(pair_mode_tag)::value;
+      constexpr auto index_mode = decltype(pair_mode_tag)::index_mode;
 #else
                                        int cta) {
       constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
+      constexpr auto index_mode = pair_mode;
 #endif
       auto score_inter_lk_ball_atom_pair =
           ([=] TMOL_DEVICE_FUNC(
@@ -629,11 +679,18 @@ class LKBallPoseScoreDispatch {
 
       int const max_important_bond_separation = 4;
 
-      auto pair_indices = lk_ball_pose_pair_indices<pair_mode>(
+      auto pair_indices = lk_ball_pose_pair_indices<index_mode>(
           cta, max_n_blocks, n_block_pairs);
       int const pose_ind = common::get<0>(pair_indices);
       int const block_ind1 = common::get<1>(pair_indices);
       int const block_ind2 = common::get<2>(pair_indices);
+      if constexpr (pair_mode != index_mode) {
+        if constexpr (pair_mode == common::TilePairMode::Inter) {
+          if (block_ind1 == block_ind2) return;
+        } else {
+          if (block_ind1 != block_ind2) return;
+        }
+      }
 
       // We still kill CTAs targetting non-neighboring block pairs, though,
       // and that can be a lot
@@ -743,16 +800,16 @@ class LKBallPoseScoreDispatch {
     }
 #ifdef __NVCC__
     if (!output_block_pair_energies && use_shared_compact_block_neighbors) {
-      auto eval_all = ([=] TMOL_DEVICE_FUNC(int cta) {
-        eval_energies_by_block(
-            cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
-      });
-      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+      launch_lk_ball_compact_pose_pair_workgroups<
           DeviceDispatch,
           Dev,
           launch_t,
           Int>(
-          mgr, shared_compact_block_neighbors, n_poses, max_n_blocks, eval_all);
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_energies_by_block);
     } else if (
         !output_block_pair_energies
         && score::common::sphere_overlap::should_compact_block_neighbors(

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -1012,7 +1012,12 @@ class LKBallPoseScoreDispatch {
                LKBallSingleResData<Real> const& occ_dat,
                LKBallResPairData<Real> const& respair_dat,
                int cp_separation) {
-            lk_ball_atom_derivs_full<TILE_SIZE, MAX_N_WATER>(
+            lk_ball_atom_derivs_full<
+                TILE_SIZE,
+                MAX_N_WATER,
+                Real,
+                Dev,
+                (Dev == tmol::Device::CUDA)>(
                 pol_ind,
                 occ_ind,
                 pol_tile_ind,

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -431,10 +431,12 @@ void launch_lk_ball_compact_pose_pair_workgroups(
     TView<Int, 1, Dev> neighbors,
     int n_poses,
     int max_n_blocks,
-    Eval eval) {
+    Eval eval,
+    bool allow_split_pairs = true) {
   using common::TilePairMode;
   constexpr int min_split_workgroups = 1 << 15;
-  if (max_n_blocks > 1 && neighbors.size(0) - 1 >= min_split_workgroups) {
+  if (allow_split_pairs && max_n_blocks > 1
+      && neighbors.size(0) - 1 >= min_split_workgroups) {
     // Keep both passes on the original list, including caller-provided
     // subsets. Specialize the scoring body while retaining its triangular
     // candidate IDs, so each pass excludes the other kind of pair.
@@ -912,7 +914,8 @@ class LKBallPoseScoreDispatch {
       TView<Int, 3, Dev> scratch_rot_neighbors,  // from forward pass
       TView<Int, 1, Dev> compact_block_neighbors,
       TView<Real, 4, Dev> dTdV,
-      bool block_pair_scoring)
+      bool block_pair_scoring,
+      bool allow_split_pairs)
       -> std::tuple<TPack<Vec<Real, 3>, 1, Dev>, TPack<Vec<Real, 3>, 2, Dev>> {
     // std::cout << "d lkball start" << std::endl;
     using tmol::score::common::accumulate;
@@ -950,15 +953,22 @@ class LKBallPoseScoreDispatch {
 #ifdef __NVCC__
                             int cta, auto pair_mode_tag) {
       constexpr auto pair_mode = decltype(pair_mode_tag)::value;
+      constexpr auto index_mode = decltype(pair_mode_tag)::index_mode;
 #else
                             int cta) {
       constexpr auto pair_mode = common::TilePairMode::InterAndIntra;
+      constexpr auto index_mode = pair_mode;
 #endif
-      auto pair_indices = lk_ball_pose_pair_indices<pair_mode>(
+      auto pair_indices = lk_ball_pose_pair_indices<index_mode>(
           cta, max_n_blocks, n_block_pairs);
       int const pose_ind = common::get<0>(pair_indices);
       int const block_ind1 = common::get<1>(pair_indices);
       int const block_ind2 = common::get<2>(pair_indices);
+      if constexpr (pair_mode == common::TilePairMode::Inter) {
+        if (block_ind1 == block_ind2) return;
+      } else if constexpr (pair_mode == common::TilePairMode::Intra) {
+        if (block_ind1 != block_ind2) return;
+      }
 
       // Reject empty work before setting up the derivative machinery below.
       if (!use_compact_block_neighbors
@@ -1163,16 +1173,17 @@ class LKBallPoseScoreDispatch {
     // capture in a CUDA graph.
 #ifdef __NVCC__
     if (use_compact_block_neighbors) {
-      auto eval_compact = ([=] TMOL_DEVICE_FUNC(int cta) {
-        eval_derivs(
-            cta, TilePairModeTag<common::TilePairMode::InterAndIntra>{});
-      });
-      score::common::sphere_overlap::launch_precomputed_block_neighbors<
+      launch_lk_ball_compact_pose_pair_workgroups<
           DeviceDispatch,
           Dev,
           launch_t,
           Int>(
-          mgr, compact_block_neighbors, n_poses, max_n_blocks, eval_compact);
+          mgr,
+          compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_derivs,
+          allow_split_pairs);
       return {dV_d_pose_coords_t, dV_d_water_coords_t};
     }
     int const n_pairs = score::common::checked_triangular_size(

--- a/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
+++ b/tmol/score/lk_ball/potentials/lk_ball_pose_score.impl.hh
@@ -751,7 +751,8 @@ class LKBallPoseScoreDispatch {
           DeviceDispatch,
           Dev,
           launch_t,
-          Int>(mgr, shared_compact_block_neighbors, eval_all);
+          Int>(
+          mgr, shared_compact_block_neighbors, n_poses, max_n_blocks, eval_all);
     } else if (
         !output_block_pair_energies
         && score::common::sphere_overlap::should_compact_block_neighbors(
@@ -773,7 +774,12 @@ class LKBallPoseScoreDispatch {
           DeviceDispatch,
           Dev,
           launch_t,
-          Int>(mgr, shared_compact_block_neighbors, eval_energies_by_block);
+          Int>(
+          mgr,
+          shared_compact_block_neighbors,
+          n_poses,
+          max_n_blocks,
+          eval_energies_by_block);
     } else {
       launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
           mgr, n_poses, max_n_blocks, eval_energies_by_block);
@@ -1108,7 +1114,8 @@ class LKBallPoseScoreDispatch {
           DeviceDispatch,
           Dev,
           launch_t,
-          Int>(mgr, compact_block_neighbors, eval_compact);
+          Int>(
+          mgr, compact_block_neighbors, n_poses, max_n_blocks, eval_compact);
       return {dV_d_pose_coords_t, dV_d_water_coords_t};
     }
     int const n_pairs = score::common::checked_triangular_size(
@@ -1134,7 +1141,8 @@ class LKBallPoseScoreDispatch {
           DeviceDispatch,
           Dev,
           launch_t,
-          Int>(mgr, compact_block_neighbors, eval_derivs);
+          Int>(
+          mgr, compact_block_neighbors, n_poses, max_n_blocks, eval_derivs);
     } else {
       launch_lk_ball_pose_pair_workgroups<DeviceDispatch, Dev, launch_t>(
           mgr, n_poses, max_n_blocks, eval_derivs);

--- a/tmol/score/ref/_ref_energy_term.py
+++ b/tmol/score/ref/_ref_energy_term.py
@@ -37,8 +37,7 @@ class RefEnergyTerm(EnergyTerm):
         return 1
 
     def set_options(self, options: dict):
-        if "ref_weights" in options:
-            self.weights_override = options["ref_weights"]
+        self.weights_override = options.get("ref_weights")
 
     def _resolved_weights(self) -> dict:
         """The ref-weight map this term scores with (override beats the db default)."""

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -194,3 +194,36 @@ def test_lbfgs_armijo_short_history():
     score_stop = closure()
 
     assert score_start > score_stop
+
+
+def test_lbfgs_armijo_wrapped_segment_histories(torch_device):
+    # Unequal segments exercise padded history rows after a short ring wraps.
+    x = torch.nn.Parameter(
+        torch.linspace(-2, 2, 12, dtype=torch.float64, device=torch_device)
+    )
+    segment_ids = torch.tensor([0] * 7 + [1] * 5, device=torch_device)
+    curvature = torch.tensor(
+        [1, 2, 4, 8, 1, 2, 4, 8, 4, 2, 1, 8],
+        dtype=x.dtype,
+        device=torch_device,
+    )
+    optimizer = LBFGS_Armijo(
+        [x],
+        segment_ids=segment_ids,
+        history_size=2,
+        max_iter=80,
+        rtol=0,
+        atol=0,
+        gradtol=1e-8,
+    )
+
+    def closure():
+        optimizer.zero_grad()
+        terms = curvature * (x - 1).square()
+        energies = torch.stack((terms[:7].sum(), terms[7:].sum()))
+        energies.sum().backward()
+        return energies
+
+    optimizer.step(closure)
+    assert optimizer.state[x]["n_iter"] > 4
+    torch.testing.assert_close(x, torch.ones_like(x), atol=1e-6, rtol=0)

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -1,7 +1,30 @@
+import weakref
+
 import torch
 import pytest
 
 from tmol.optimization import LBFGS_Armijo
+
+
+def test_lbfgs_releases_closure_after_step(torch_device):
+    x = torch.nn.Parameter(torch.tensor([2.0, -3.0], device=torch_device))
+    optimizer = LBFGS_Armijo([x], max_iter=3)
+    optimizer_ref = weakref.ref(optimizer)
+
+    class Closure:
+        def __call__(self):
+            optimizer_ref().zero_grad()
+            loss = x.square().sum()
+            loss.backward()
+            return loss
+
+    closure = Closure()
+    closure_ref = weakref.ref(closure)
+    optimizer.step(closure)
+    del closure
+    assert closure_ref() is None
+    del optimizer
+    assert optimizer_ref() is None
 
 
 class SimpleLJScore:

--- a/tmol/tests/optimization/test_lbfgs_armijo.py
+++ b/tmol/tests/optimization/test_lbfgs_armijo.py
@@ -196,12 +196,15 @@ def test_lbfgs_armijo_short_history():
     assert score_start > score_stop
 
 
-def test_lbfgs_armijo_wrapped_segment_histories(torch_device):
-    # Unequal segments exercise padded history rows after a short ring wraps.
+@pytest.mark.parametrize("first_segment_size", [6, 7])
+def test_lbfgs_armijo_wrapped_segment_histories(torch_device, first_segment_size):
+    # Equal and unequal segments exercise dense and padded history writes.
     x = torch.nn.Parameter(
         torch.linspace(-2, 2, 12, dtype=torch.float64, device=torch_device)
     )
-    segment_ids = torch.tensor([0] * 7 + [1] * 5, device=torch_device)
+    segment_ids = torch.tensor(
+        [0] * first_segment_size + [1] * (12 - first_segment_size), device=torch_device
+    )
     curvature = torch.tensor(
         [1, 2, 4, 8, 1, 2, 4, 8, 4, 2, 1, 8],
         dtype=x.dtype,
@@ -220,7 +223,9 @@ def test_lbfgs_armijo_wrapped_segment_histories(torch_device):
     def closure():
         optimizer.zero_grad()
         terms = curvature * (x - 1).square()
-        energies = torch.stack((terms[:7].sum(), terms[7:].sum()))
+        energies = torch.stack(
+            (terms[:first_segment_size].sum(), terms[first_segment_size:].sum())
+        )
         energies.sum().backward()
         return energies
 

--- a/tmol/tests/optimization/test_lbfgs_compact_semantics.py
+++ b/tmol/tests/optimization/test_lbfgs_compact_semantics.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from tmol.optimization import lbfgs_two_loop
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("negative_curvature", [False, True])
+@pytest.mark.parametrize("differentiable", [False, True])
+@pytest.mark.parametrize("layout", ["single", "batched", "broadcast"])
+def test_compact_history_matches_dense_updates(
+    dtype, negative_curvature, differentiable, layout, torch_device
+):
+    # Include coupled updates, a nonzero orthogonal pair, and an absent slot.
+    steps = torch.tensor(
+        [[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]],
+        dtype=dtype,
+        device=torch_device,
+    )
+    directions = torch.tensor(
+        [[2, 1, 0, 0], [0, 4, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0]],
+        dtype=dtype,
+        device=torch_device,
+    )
+    if negative_curvature:
+        directions[1].neg_()
+    grad = torch.arange(1, 13, dtype=dtype, device=torch_device).reshape(3, 4)
+    if layout == "single":
+        grad = grad[0]
+    grad.requires_grad_(differentiable)
+    steps.requires_grad_(differentiable)
+    directions.requires_grad_(differentiable)
+
+    # Build H with dense rank-two updates, independently of the compact solves.
+    identity = torch.eye(4, dtype=torch.float64, device=torch_device)
+    hessian = identity
+    for step, direction in zip(steps.double(), directions.double()):
+        curvature = step.dot(direction)
+        diagonal = torch.where(curvature == 0, 1, curvature)
+        left = identity - torch.outer(step, direction) / diagonal
+        hessian = (
+            left @ hessian @ left.T
+            + curvature * torch.outer(step, step) / diagonal.square()
+        )
+    expected = (-grad.double() @ hessian.T).to(dtype)
+    if layout == "single":
+        actual = lbfgs_two_loop(grad, directions, steps)
+    else:
+        batches = 3 if layout == "batched" else 1
+        actual = lbfgs_two_loop(
+            grad,
+            directions[:, None].expand(-1, batches, -1),
+            steps[:, None].expand(-1, batches, -1),
+        )
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    if differentiable:
+        inputs = grad, directions, steps
+        actual_grads = torch.autograd.grad(actual.sum(), inputs)
+        expected_grads = torch.autograd.grad(expected.sum(), inputs)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)

--- a/tmol/tests/optimization/test_lbfgs_compact_semantics.py
+++ b/tmol/tests/optimization/test_lbfgs_compact_semantics.py
@@ -59,3 +59,13 @@ def test_compact_history_matches_dense_updates(
         expected_grads = torch.autograd.grad(expected.sum(), inputs)
         for actual_grad, expected_grad in zip(actual_grads, expected_grads):
             torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batch,history_batch", [(1, 1), (2, 2), (2, 1)])
+def test_compact_second_derivatives(torch_device, batch, history_batch):
+    torch.manual_seed(491)
+    grad = torch.randn(batch, 7, dtype=torch.float64, device=torch_device)
+    steps = torch.randn(3, history_batch, 7, dtype=torch.float64, device=torch_device)
+    directions = steps + 0.1 * torch.randn_like(steps)
+    inputs = tuple(value.requires_grad_() for value in (grad, directions, steps))
+    assert torch.autograd.gradgradcheck(lbfgs_two_loop, inputs, fast_mode=True)

--- a/tmol/tests/optimization/test_lbfgs_two_loop.py
+++ b/tmol/tests/optimization/test_lbfgs_two_loop.py
@@ -45,6 +45,32 @@ def test_lbfgs_two_loop_matches_reference(N, m, dtype, torch_device):
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("layout", ["contiguous", "strided", "broadcast", "single"])
+@pytest.mark.parametrize("differentiable", [False, True])
+def test_lbfgs_two_loop_diagonal_history(dtype, layout, differentiable, torch_device):
+    # Orthogonal updates give a known diagonal inverse Hessian. Two unused
+    # history slots must leave both the direction and its derivative intact.
+    batch = 1 if layout == "single" else 3
+    history_batch = 1 if layout == "broadcast" else batch
+    stride = 2 if layout in ("strided", "single") else 1
+    steps = torch.zeros(5, history_batch, 7 * stride, dtype=dtype, device=torch_device)
+    steps = steps[..., ::stride]
+    diagonal = torch.tensor([2, 4, 8, 1, 1, 1, 1], dtype=dtype, device=torch_device)
+    for index in range(3):
+        steps[index, :, index] = 1
+    directions = steps * diagonal
+    grad = torch.arange(1, batch * 7 + 1, dtype=dtype, device=torch_device)
+    grad = grad.reshape(batch, 7).requires_grad_(differentiable)
+    result = lbfgs_two_loop(grad, directions, steps)
+    torch.testing.assert_close(result, -grad / diagonal, atol=0, rtol=0)
+    if differentiable:
+        (derivative,) = torch.autograd.grad(result.sum(), grad)
+        torch.testing.assert_close(
+            derivative, (-1 / diagonal).expand_as(grad), atol=0, rtol=0
+        )
+
+
 @pytest.mark.parametrize(
     "dtype", [torch.float32, torch.float64], ids=["float32", "float64"]
 )

--- a/tmol/tests/pack/test_annealer_assignment_cache.py
+++ b/tmol/tests/pack/test_annealer_assignment_cache.py
@@ -48,11 +48,15 @@ def independent_minimum_tables(counts, chunk_size, device):
 
 @requires_cuda
 @pytest.mark.parametrize("chunk_size", [7, 16, 32])
-@pytest.mark.parametrize("n_res", [3, 128, 129])
+@pytest.mark.parametrize("n_res", [1, 2, 3, 128, 129])
 def test_cuda_annealer_assignment_cache_boundaries(chunk_size, n_res):
     from tmol.pack.compiled import pack_anneal
 
-    counts = [35, 36, 17] if n_res == 3 else [2] * n_res
+    counts = [2] * n_res
+    if n_res <= 2:
+        counts = [1] * n_res
+    elif n_res == 3:
+        counts = [35, 36, 17]
     inputs = independent_minimum_tables(counts, chunk_size, torch.device("cuda"))
     torch.manual_seed(20260911)
     scores, assignments = pack_anneal(*inputs)

--- a/tmol/tests/pack/test_annealer_assignment_cache.py
+++ b/tmol/tests/pack/test_annealer_assignment_cache.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from tmol.tests import requires_cuda
+
+
+def independent_minimum_tables(counts, chunk_size, device):
+    """A chain with a unique all-zero minimum and a fully frozen first pose."""
+    n_res = len(counts)
+    n_rots = sum(counts)
+    counts_t = torch.tensor(counts, dtype=torch.int32)
+    n_for_res = torch.zeros((2, n_res), dtype=torch.int32)
+    n_for_res[1] = counts_t
+    oneb_offsets = torch.zeros_like(n_for_res)
+    oneb_offsets[1, 1:] = counts_t.cumsum(0)[:-1]
+    res_for_rot = torch.repeat_interleave(
+        torch.arange(n_res, dtype=torch.int32), counts_t
+    )
+    energy1b = torch.cat([torch.arange(n, dtype=torch.float32) for n in counts])
+    chunk_offset_offsets = torch.full((2, n_res, n_res), -1, dtype=torch.int64)
+    chunk_offsets = []
+    energies = []
+    for i in range(n_res - 1):
+        for a, b in ((i, i + 1), (i + 1, i)):
+            chunk_offset_offsets[1, a, b] = len(chunk_offsets)
+            for first in range(0, counts[a], chunk_size):
+                for second in range(0, counts[b], chunk_size):
+                    chunk_offsets.append(len(energies))
+                    rows = torch.arange(first, min(first + chunk_size, counts[a]))
+                    cols = torch.arange(second, min(second + chunk_size, counts[b]))
+                    energies.extend((rows[:, None] + cols[None, :]).flatten().tolist())
+    values = (
+        n_rots,
+        torch.tensor([0, n_res], dtype=torch.int32),
+        torch.tensor([0, n_rots], dtype=torch.int32),
+        torch.zeros(2, dtype=torch.int32),
+        n_for_res,
+        oneb_offsets,
+        res_for_rot,
+        chunk_size,
+        chunk_offset_offsets,
+        torch.tensor(chunk_offsets, dtype=torch.int64),
+        energy1b,
+        torch.tensor(energies, dtype=torch.float32),
+    )
+    return tuple(x.to(device) if isinstance(x, torch.Tensor) else x for x in values)
+
+
+@requires_cuda
+@pytest.mark.parametrize("chunk_size", [7, 16, 32])
+@pytest.mark.parametrize("n_res", [3, 128, 129])
+def test_cuda_annealer_assignment_cache_boundaries(chunk_size, n_res):
+    from tmol.pack.compiled import pack_anneal
+
+    counts = [35, 36, 17] if n_res == 3 else [2] * n_res
+    inputs = independent_minimum_tables(counts, chunk_size, torch.device("cuda"))
+    torch.manual_seed(20260911)
+    scores, assignments = pack_anneal(*inputs)
+    assert scores.shape == (2, 312)
+    assert assignments.shape == (2, 312, n_res)
+    # Every pair contribution and one-body term has its unique minimum at zero.
+    # Full quenching must find it for every trajectory, including the fallback
+    # above the shared-cache capacity and dynamic chunk sizes.
+    assert torch.count_nonzero(scores).item() == 0
+    assert torch.count_nonzero(assignments).item() == 0

--- a/tmol/tests/pack/test_pack_rotamers.py
+++ b/tmol/tests/pack/test_pack_rotamers.py
@@ -371,6 +371,7 @@ def test_shared_rotamer_dispatch_matches_independent_lk_ball_layout(
     (shared_grad,) = torch.autograd.grad(shared.values().sum(), shared_coords)
 
     lk_ball = next(term for term in scorer.term_modules if term.classname == "LKBall")
+    shared_cutoff = lk_ball.block_neighbor_cutoff
     lk_ball.block_neighbor_cutoff += 0.5
     fallback_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
     fallback = scorer(fallback_coords).coalesce()
@@ -378,15 +379,25 @@ def test_shared_rotamer_dispatch_matches_independent_lk_ball_layout(
 
     torch.testing.assert_close(shared.to_dense(), fallback.to_dense())
     if torch_device.type == "cuda":
-        # Rotamer gradients use atomics, so even two independent evaluations
-        # need not be elementwise deterministic. Fused and independent layouts
-        # also sum terms in different orders; retain the repeat envelope with a
-        # small, scale-aware rounding floor for that expected reassociation.
-        repeat_coords = rotamer_set.coords.detach().clone().requires_grad_(True)
-        repeat = scorer(repeat_coords).coalesce()
-        (repeat_grad,) = torch.autograd.grad(repeat.values().sum(), repeat_coords)
-        torch.testing.assert_close(fallback.to_dense(), repeat.to_dense())
-        repeat_error = torch.max(torch.abs(fallback_grad - repeat_grad))
+        # Atomic reductions vary within either layout. A single repeat can
+        # underestimate that variation, so measure each layout's range over
+        # four samples while retaining the same envelope and rounding floor.
+        repeat_errors = []
+        for cutoff, expected, initial_grad in (
+            (shared_cutoff, shared, shared_grad),
+            (shared_cutoff + 0.5, fallback, fallback_grad),
+        ):
+            lk_ball.block_neighbor_cutoff = cutoff
+            gradients = [initial_grad]
+            for _ in range(3):
+                coords = rotamer_set.coords.detach().clone().requires_grad_(True)
+                scores = scorer(coords).coalesce()
+                (grad,) = torch.autograd.grad(scores.values().sum(), coords)
+                torch.testing.assert_close(expected.to_dense(), scores.to_dense())
+                gradients.append(grad)
+            samples = torch.stack(gradients)
+            repeat_errors.append((samples.amax(0) - samples.amin(0)).amax())
+        repeat_error = torch.maximum(*repeat_errors)
         shared_error = torch.max(torch.abs(shared_grad - fallback_grad))
         gradient_scale = torch.maximum(
             torch.max(torch.abs(shared_grad)), torch.max(torch.abs(fallback_grad))

--- a/tmol/tests/score/common/test_autograd_materialization.py
+++ b/tmol/tests/score/common/test_autograd_materialization.py
@@ -1,0 +1,44 @@
+"""Unused native neighbor outputs must not allocate backward gradients."""
+
+import pytest
+import torch
+
+from tmol import pose_stack_from_pdb
+from tmol.score.lk_ball import LKBallEnergyTerm
+
+
+def test_lk_ball_backward_does_not_materialize_neighbor_gradient(
+    ubq_pdb, default_database, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA allocator statistics required")
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    term = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+    for block_type in pose.packed_block_types.active_block_types:
+        term.setup_block_type(block_type)
+    term.setup_packed_block_types(pose.packed_block_types)
+    term.setup_poses(pose)
+    scorer = term.render_whole_pose_scoring_module(pose)
+    coords = pose.coords.detach().requires_grad_(True)
+    neighbors = scorer.build_compact_block_neighbors(
+        coords, scorer.block_neighbor_cutoff
+    )
+    # Capacity can greatly exceed the number of live pairs. Only the counted
+    # prefix participates in scoring, and the integer output has no gradient.
+    oversized = torch.full((1 << 20,), -1, dtype=torch.int32, device=torch_device)
+    oversized[: neighbors.numel()].copy_(neighbors)
+    expected = scorer(coords, neighbors)
+    (expected_grad,) = torch.autograd.grad(expected.sum(), coords)
+    for _ in range(2):
+        warm = scorer(coords, oversized)
+        torch.autograd.grad(warm.sum(), coords)
+    actual = scorer(coords, oversized)
+    torch.cuda.synchronize(torch_device)
+    before = torch.cuda.memory_allocated(torch_device)
+    torch.cuda.reset_peak_memory_stats(torch_device)
+    (actual_grad,) = torch.autograd.grad(actual.sum(), coords)
+    torch.cuda.synchronize(torch_device)
+    peak = torch.cuda.max_memory_allocated(torch_device) - before
+    assert peak < oversized.numel() * oversized.element_size()
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_grad, expected_grad)

--- a/tmol/tests/score/common/test_compact_neighbors.py
+++ b/tmol/tests/score/common/test_compact_neighbors.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+from tmol.score.ljlk.potentials import build_compact_block_neighbors
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize(
+    "shape", [(1, 1), (3, 17), (4, 127), (5, 128), (2, 129), (2, 256)]
+)
+def test_cpu_compact_neighbors_preserve_chunk_and_pose_boundaries(dtype, shape):
+    n_poses, n_blocks = shape
+    atom = torch.arange(n_blocks)
+    one_pose = torch.stack(
+        (2 * (atom % 17), 2 * ((atom // 17) % 5), atom % 3), dim=-1
+    ).to(dtype)
+    coords = one_pose.expand(n_poses, -1, -1).contiguous()
+    types = torch.zeros(shape, dtype=torch.int32)
+    types.reshape(-1)[::13] = -1
+    offsets = torch.arange(n_poses * n_blocks, dtype=torch.int32)
+    block_ids = torch.arange(n_blocks, dtype=torch.int32).repeat(n_poses)
+    pose_ids = torch.arange(n_poses, dtype=torch.int32).repeat_interleave(n_blocks)
+    rotamer_types = torch.zeros(n_poses * n_blocks, dtype=torch.int32)
+    atom_counts = torch.ones(1, dtype=torch.int32)
+    left, right = torch.triu_indices(n_blocks, n_blocks)
+    within_reach = (coords[:, left] - coords[:, right]).square().sum(-1) < 36
+    valid = (types[:, left] >= 0) & (types[:, right] >= 0) & within_reach
+    expected = torch.arange(valid.numel(), dtype=torch.int32)[valid.reshape(-1)]
+    original_threads = torch.get_num_threads()
+    try:
+        for threads in (1, 4):
+            torch.set_num_threads(threads)
+            (neighbors,) = build_compact_block_neighbors(
+                coords.reshape(-1, 3),
+                offsets,
+                types,
+                block_ids,
+                pose_ids,
+                rotamer_types,
+                atom_counts,
+                6.0,
+            )
+            assert int(neighbors[0]) == expected.numel()
+            torch.testing.assert_close(
+                neighbors[1 : expected.numel() + 1], expected, rtol=0, atol=0
+            )
+    finally:
+        torch.set_num_threads(original_threads)

--- a/tmol/tests/score/common/test_cuda_graph.py
+++ b/tmol/tests/score/common/test_cuda_graph.py
@@ -1,0 +1,214 @@
+import gc
+import weakref
+
+import pytest
+import torch
+
+from tmol.score.common._cuda_graph import CapturedScoringGraph
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The AccumulateGrad node's stream does not match"
+)
+
+
+class _ScoringExample(torch.nn.Module):
+    def __init__(self, device, dtype, trainable=True, unused_coords=False):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.arange(1, 6, device=device, dtype=dtype) / 4,
+            requires_grad=trainable,
+        )
+        self.register_buffer("offset", torch.ones(5, device=device, dtype=dtype) / 2)
+        self.unused_coords = unused_coords
+
+    def forward(self, coords):
+        if self.unused_coords:
+            return self.weight.unsqueeze(0).expand(3, -1) + self.offset
+        if self.training:
+            return coords.square() * self.weight + self.offset
+        return coords * self.weight - self.offset
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("trainable", [False, True])
+@pytest.mark.parametrize("layout", ["contiguous", "strided", "negative"])
+def test_cuda_scoring_capture_replays_values_and_parameter_gradients(
+    torch_device, dtype, trainable, layout
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, dtype, trainable)
+    sample = torch.zeros((3, 5), device=torch_device, dtype=dtype, requires_grad=True)
+    capture = CapturedScoringGraph(module, sample)
+    for shift in (0, 1, -2):
+        coords = (
+            torch.arange(15, device=torch_device, dtype=dtype).reshape(3, 5) + shift
+        ) / 8
+        if layout == "strided":
+            coords = coords.T.contiguous().T
+        elif layout == "negative":
+            coords = torch._neg_view(coords)
+        coords = coords.detach().requires_grad_(True)
+        actual = capture(coords).clone()
+        expected = coords.square() * module.weight + module.offset
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        inputs = (coords, module.weight) if trainable else (coords,)
+        actual_grads = torch.autograd.grad(actual.sum(), inputs)
+        expected_grads = torch.autograd.grad(expected.sum(), inputs)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
+
+    capture.eval()
+    torch.testing.assert_close(
+        capture(coords), coords * module.weight - module.offset, atol=0, rtol=0
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cuda_scoring_capture_preserves_unused_coordinate_gradients(
+    torch_device, dtype
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, dtype, unused_coords=True)
+    sample = torch.zeros((3, 5), device=torch_device, dtype=dtype, requires_grad=True)
+    capture = CapturedScoringGraph(module, sample)
+    coords = torch.ones_like(sample, requires_grad=True)
+    coord_grad, weight_grad = torch.autograd.grad(
+        capture(coords).sum(), (coords, module.weight), allow_unused=True
+    )
+    assert coord_grad is None
+    torch.testing.assert_close(
+        weight_grad, torch.full_like(module.weight, 3), atol=0, rtol=0
+    )
+
+
+def test_cuda_scoring_capture_lives_until_pending_backward_finishes(torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        module = _ScoringExample(torch_device, torch.float64)
+        sample = torch.zeros(
+            (3, 5), device=torch_device, dtype=torch.float64, requires_grad=True
+        )
+        capture = CapturedScoringGraph(module, sample)
+        capture_ref = weakref.ref(capture)
+        module_ref = weakref.ref(module)
+        coords = torch.ones_like(sample, requires_grad=True)
+        output = capture(coords).clone()
+        weight = module.weight
+        del capture, module, sample
+        assert capture_ref() is not None
+        assert module_ref() is not None
+        coord_grad, weight_grad = torch.autograd.grad(output.sum(), (coords, weight))
+        del output
+        assert capture_ref() is None
+        assert module_ref() is None
+        # Returned gradients own their storage even after the graphs die.
+        torch.testing.assert_close(
+            coord_grad, 2 * weight.expand_as(coords), atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            weight_grad, torch.full_like(weight, 3), atol=0, rtol=0
+        )
+    finally:
+        if gc_enabled:
+            gc.enable()
+
+
+@pytest.mark.parametrize("device_index", [0, 1])
+def test_cuda_scoring_capture_preserves_device_and_caller_stream(device_index):
+    if torch.cuda.device_count() <= device_index:
+        pytest.skip("Requested CUDA device is unavailable")
+    original_device = torch.cuda.current_device()
+    device = torch.device("cuda", device_index)
+    module = _ScoringExample(device, torch.float32)
+    sample = torch.zeros((3, 5), device=device, requires_grad=True)
+    capture = CapturedScoringGraph(module, sample)
+    assert torch.cuda.current_device() == original_device
+    stream = torch.cuda.Stream(device=device)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        coords = torch.full_like(sample, 2, requires_grad=True)
+        score = capture(coords)
+        (grad,) = torch.autograd.grad(score.sum(), coords)
+    stream.synchronize()
+    torch.testing.assert_close(
+        score, 4 * module.weight.expand_as(coords) + module.offset, atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        grad, 4 * module.weight.expand_as(coords), atol=0, rtol=0
+    )
+    assert torch.cuda.current_device() == original_device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_cuda_scoring_capture_preserves_uncached_autocast(torch_device, dtype):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = torch.nn.Linear(5, 3, bias=False, device=torch_device)
+    with torch.no_grad():
+        module.weight.copy_(torch.arange(15, device=torch_device).reshape(3, 5) / 8)
+    sample = torch.zeros((4, 5), device=torch_device, requires_grad=True)
+    with torch.autocast("cuda", dtype=dtype, cache_enabled=False):
+        capture = CapturedScoringGraph(module, sample)
+    for shift in (0, 1, -2):
+        coords = (
+            (torch.arange(20, device=torch_device).reshape(4, 5) + shift) / 8
+        ).requires_grad_(True)
+        with torch.autocast("cuda", dtype=dtype, cache_enabled=False):
+            actual = capture(coords).clone()
+            expected = torch.nn.functional.linear(coords, module.weight)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        actual_grads = torch.autograd.grad(actual.sum(), (coords, module.weight))
+        expected_grads = torch.autograd.grad(expected.sum(), (coords, module.weight))
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
+
+
+def test_cuda_scoring_capture_rejects_autocast_cache(torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, torch.float32)
+    sample = torch.zeros((3, 5), device=torch_device, requires_grad=True)
+    with torch.autocast("cuda", cache_enabled=True):
+        with pytest.raises(RuntimeError, match="cache_enabled=False"):
+            CapturedScoringGraph(module, sample)
+
+
+@pytest.mark.parametrize("hook", ["forward", "forward_pre", "full_backward"])
+def test_cuda_scoring_capture_rejects_existing_hooks(torch_device, hook):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, torch.float32)
+    getattr(module, f"register_{hook}_hook")(lambda *args: None)
+    sample = torch.zeros((3, 5), device=torch_device, requires_grad=True)
+    with pytest.raises(AssertionError, match="must not have hooks"):
+        CapturedScoringGraph(module, sample)
+
+
+def test_cuda_scoring_capture_rejects_trainable_buffers(torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, torch.float32)
+    module.offset.requires_grad_(True)
+    sample = torch.zeros((3, 5), device=torch_device, requires_grad=True)
+    with pytest.raises(AssertionError, match="buffers must have requires_grad=False"):
+        CapturedScoringGraph(module, sample)
+
+
+def test_cuda_scoring_capture_retains_double_backward_restriction(torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA scoring capture")
+    module = _ScoringExample(torch_device, torch.float32)
+    sample = torch.zeros((3, 5), device=torch_device, requires_grad=True)
+    capture = CapturedScoringGraph(module, sample)
+    coords = torch.ones_like(sample, requires_grad=True)
+    score = capture(coords)
+    upstream = torch.ones_like(score, requires_grad=True)
+    (grad,) = torch.autograd.grad(score, coords, upstream, create_graph=True)
+    with pytest.raises(RuntimeError, match="once_differentiable"):
+        grad.sum().backward()

--- a/tmol/tests/score/common/test_native_inference.py
+++ b/tmol/tests/score/common/test_native_inference.py
@@ -1,5 +1,7 @@
 """Direct native term inference preserves values without discarded derivatives."""
 
+import gc
+
 import pytest
 import torch
 
@@ -79,11 +81,20 @@ def test_tracked_inference_allocates_no_derivative_scratch(
         torch.cuda.synchronize(torch_device)
         return result, torch.cuda.max_memory_allocated(torch_device) - before
 
-    with torch.inference_mode() if inference else torch.no_grad():
-        scorer(detached)
-        scorer(tracked)
-        expected, detached_peak = allocation(detached)
-        actual, tracked_peak = allocation(tracked)
+    # Unrelated cyclic garbage can release CUDA tensors between reading the
+    # baseline allocation and resetting the peak, yielding a negative delta.
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        with torch.inference_mode() if inference else torch.no_grad():
+            scorer(detached)
+            scorer(tracked)
+            expected, detached_peak = allocation(detached)
+            actual, tracked_peak = allocation(tracked)
+    finally:
+        if gc_enabled:
+            gc.enable()
     torch.testing.assert_close(actual, expected)
     assert tracked_peak <= detached_peak
     assert tracked.requires_grad

--- a/tmol/tests/score/common/test_native_inference.py
+++ b/tmol/tests/score/common/test_native_inference.py
@@ -1,0 +1,89 @@
+"""Direct native term inference preserves values without discarded derivatives."""
+
+import pytest
+import torch
+
+from tmol import pose_stack_from_pdb
+from tmol.pose import PoseStackBuilder
+from tmol.score.disulfide import DisulfideEnergyTerm
+from tmol.score.elec import ElecEnergyTerm
+from tmol.score.genbonded import GenBondedEnergyTerm
+from tmol.score.hbond import HBondEnergyTerm
+
+TERMS = [
+    DisulfideEnergyTerm,
+    ElecEnergyTerm,
+    GenBondedEnergyTerm,
+    HBondEnergyTerm,
+]
+
+
+def make_scorer(term_class, ubq_pdb, disulfide_pdb, database, device):
+    pose = PoseStackBuilder.from_poses(
+        [
+            pose_stack_from_pdb(disulfide_pdb, device),
+            pose_stack_from_pdb(ubq_pdb, device, residue_end=15),
+        ],
+        device,
+    )
+    term = term_class(param_db=database, device=device)
+    for block_type in pose.packed_block_types.active_block_types:
+        term.setup_block_type(block_type)
+    term.setup_packed_block_types(pose.packed_block_types)
+    term.setup_poses(pose)
+    return pose, term.render_whole_pose_scoring_module(pose)
+
+
+@pytest.mark.parametrize("term_class", TERMS, ids=lambda cls: cls.__name__)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("inference", [False, True])
+def test_direct_inference_preserves_values_and_later_gradients(
+    term_class, dtype, inference, ubq_pdb, disulfide_pdb, default_database, torch_device
+):
+    pose, scorer = make_scorer(
+        term_class, ubq_pdb, disulfide_pdb, default_database, torch_device
+    )
+    coords = pose.coords.to(dtype).detach().requires_grad_(True)
+    expected = scorer(coords)
+    (expected_grad,) = torch.autograd.grad(expected.sum(), coords)
+    with torch.inference_mode() if inference else torch.no_grad():
+        actual = scorer(coords)
+    assert coords.requires_grad
+    assert not actual.requires_grad
+    tolerance = {"rtol": 0, "atol": 0} if torch_device.type == "cpu" else {}
+    torch.testing.assert_close(actual, expected, **tolerance)
+    after = scorer(coords)
+    (after_grad,) = torch.autograd.grad(after.sum(), coords)
+    torch.testing.assert_close(after, expected, **tolerance)
+    torch.testing.assert_close(after_grad, expected_grad, **tolerance)
+
+
+@pytest.mark.parametrize("term_class", TERMS, ids=lambda cls: cls.__name__)
+@pytest.mark.parametrize("inference", [False, True])
+def test_tracked_inference_allocates_no_derivative_scratch(
+    term_class, inference, ubq_pdb, disulfide_pdb, default_database, torch_device
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA allocator statistics required")
+    pose, scorer = make_scorer(
+        term_class, ubq_pdb, disulfide_pdb, default_database, torch_device
+    )
+    tracked = pose.coords.detach().requires_grad_(True)
+    detached = tracked.detach()
+
+    def allocation(coords):
+        torch.cuda.synchronize(torch_device)
+        before = torch.cuda.memory_allocated(torch_device)
+        torch.cuda.reset_peak_memory_stats(torch_device)
+        result = scorer(coords)
+        torch.cuda.synchronize(torch_device)
+        return result, torch.cuda.max_memory_allocated(torch_device) - before
+
+    with torch.inference_mode() if inference else torch.no_grad():
+        scorer(detached)
+        scorer(tracked)
+        expected, detached_peak = allocation(detached)
+        actual, tracked_peak = allocation(tracked)
+    torch.testing.assert_close(actual, expected)
+    assert tracked_peak <= detached_peak
+    assert tracked.requires_grad

--- a/tmol/tests/score/common/test_scoring_module.py
+++ b/tmol/tests/score/common/test_scoring_module.py
@@ -2,7 +2,8 @@
 
 import torch
 
-from tmol.score.common import TermScoringModule
+from tmol import pose_stack_from_pdb
+from tmol.score.common import TermScoringModule, TermWholePoseScoringModule
 
 
 def test_float64_static_parameters_are_built_lazily() -> None:
@@ -25,3 +26,20 @@ def test_float64_static_parameters_are_built_lazily() -> None:
     assert (
         module._static_tail_for_coords(torch.zeros(1, dtype=torch.float64)) is tail_f64
     )
+
+
+def test_custom_scorer_can_enable_grad_in_no_grad(ubq_pdb, torch_device):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=2)
+
+    def custom_score(coords, *args):
+        with torch.enable_grad():
+            score = coords.square().sum()
+            (derivative,) = torch.autograd.grad(score, coords)
+        return derivative.sum(), None
+
+    module = TermWholePoseScoringModule("custom", pose, [], custom_score)
+    coords = pose.coords.reshape(-1, 3).detach().requires_grad_(True)
+    with torch.no_grad():
+        actual = module(coords)
+    torch.testing.assert_close(actual, 2 * coords.detach().sum())
+    assert coords.requires_grad

--- a/tmol/tests/score/common/test_whole_pose_gradients.py
+++ b/tmol/tests/score/common/test_whole_pose_gradients.py
@@ -1,0 +1,196 @@
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def gradient_module():
+    from tmol._load_ext import load_module
+
+    return load_module(
+        __name__,
+        __file__,
+        [
+            "whole_pose_gradients.pybind.cpp",
+            "../../../score/common/whole_pose_scoring.cuda.cu",
+        ],
+        "tmol.tests.score.common._whole_pose_gradients",
+    )
+
+
+def reference(saved, weights):
+    channels, atoms, xyz = saved.shape
+    poses = weights.shape[1]
+    weighted = saved.reshape(channels, poses, atoms // poses, xyz) * weights.reshape(
+        channels, poses, 1, 1
+    )
+    return (weighted[0] if channels == 1 else weighted.sum(0)).reshape(atoms, xyz)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("channels", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize(
+    "layout",
+    [
+        "contiguous",
+        "weight_stride",
+        "broadcast",
+        "saved_stride",
+        "negative_weight",
+        "negative_saved",
+    ],
+)
+def test_weighted_gradient_layouts(
+    gradient_module, torch_device, dtype, channels, layout
+):
+    generator = torch.Generator(device=torch_device).manual_seed(20260911)
+    saved = (
+        torch.randn(
+            channels, 17 * 103, 3, device=torch_device, dtype=dtype, generator=generator
+        )
+        * 1000
+    )
+    weights = torch.randn(
+        channels, 17, device=torch_device, dtype=dtype, generator=generator
+    )
+    if layout == "weight_stride":
+        backing = torch.empty((17, channels * 2 + 1), device=torch_device, dtype=dtype)
+        view = backing[:, 1::2].t()
+        view.copy_(weights)
+        weights = view
+    elif layout == "broadcast":
+        weights = weights[:1, :1].expand(channels, 17)
+    elif layout == "saved_stride":
+        backing = torch.empty((*saved.shape[:2], 7), device=torch_device, dtype=dtype)
+        view = backing[..., 1::2]
+        view.copy_(saved)
+        saved = view
+    if layout == "negative_weight":
+        weights = torch._neg_view(weights)
+    elif layout == "negative_saved":
+        saved = torch._neg_view(saved)
+    with torch.no_grad():
+        expected = reference(saved, weights)
+        actual = gradient_module.accumulate(saved, weights)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_weighted_gradient_special_values(gradient_module, torch_device, dtype):
+    tiny = torch.finfo(dtype).tiny
+    values = torch.tensor(
+        [
+            0.0,
+            -0.0,
+            tiny / 2,
+            -tiny / 2,
+            float("inf"),
+            -float("inf"),
+            float("nan"),
+            1e20,
+            1.0,
+            -1e20,
+        ],
+        device=torch_device,
+        dtype=dtype,
+    )
+    saved = torch.stack([values.roll(i) for i in range(5)]).reshape(5, 10, 1)
+    weights = torch.tensor(
+        [[1.0], [-1.0], [0.5], [2.0], [-0.0]], device=torch_device, dtype=dtype
+    )
+    with torch.no_grad():
+        expected = reference(saved, weights)
+        actual = gradient_module.accumulate(saved, weights)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0, equal_nan=True)
+    finite = torch.isfinite(expected)
+    assert torch.equal(torch.signbit(actual[finite]), torch.signbit(expected[finite]))
+
+
+def test_weighted_gradient_preserves_derivative_graph(gradient_module, torch_device):
+    saved = torch.randn(
+        3, 30, 3, device=torch_device, dtype=torch.float64, requires_grad=True
+    )
+    weights = torch.randn(
+        3, 2, device=torch_device, dtype=torch.float64, requires_grad=True
+    )
+    upstream = torch.randn(30, 3, device=torch_device, dtype=torch.float64)
+    actual = gradient_module.accumulate(saved, weights)
+    expected = reference(saved, weights)
+    actual_grad = torch.autograd.grad(
+        actual, (saved, weights), upstream, create_graph=True
+    )
+    expected_grad = torch.autograd.grad(
+        expected, (saved, weights), upstream, create_graph=True
+    )
+    for a, e in zip(actual_grad, expected_grad):
+        torch.testing.assert_close(a, e, atol=0, rtol=0)
+    (actual_second,) = torch.autograd.grad(actual_grad[0].sum(), weights)
+    (expected_second,) = torch.autograd.grad(expected_grad[0].sum(), weights)
+    torch.testing.assert_close(actual_second, expected_second, atol=0, rtol=0)
+
+
+def test_weighted_gradient_empty_and_mixed_dtype(gradient_module, torch_device):
+    for atoms in (0, 30):
+        saved = torch.randn(3, atoms, 3, device=torch_device, dtype=torch.float32)
+        weights = torch.randn(3, 2, device=torch_device, dtype=torch.float64)
+        with torch.no_grad():
+            actual = gradient_module.accumulate(saved, weights)
+            expected = reference(saved, weights)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_weighted_gradient_cuda_memory_and_graph(gradient_module, torch_device):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA allocation and graph regression")
+    saved = torch.randn(5, 64 * 5000, 3, device=torch_device)
+    weights = torch.randn(5, 64, device=torch_device)
+
+    def run():
+        with torch.no_grad():
+            return gradient_module.accumulate(saved, weights)
+
+    def peak(fn):
+        for _ in range(3):
+            fn()
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        before = torch.cuda.memory_allocated()
+        result = fn()
+        torch.cuda.synchronize()
+        return torch.cuda.max_memory_allocated() - before, result
+
+    expected_peak, expected = peak(lambda: reference(saved, weights))
+    actual_peak, actual = peak(run)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert actual_peak < expected_peak / 2
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        captured = run()
+    weights.mul_(-2)
+    graph.replay()
+    torch.testing.assert_close(captured, reference(saved, weights), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("channels", [2, 3, 4, 5])
+@pytest.mark.parametrize("output_values", [1, 2, 3, 31, 32, 33, 1025])
+def test_weighted_gradient_short_outputs(
+    gradient_module, torch_device, dtype, channels, output_values
+):
+    saved = (
+        torch.tensor(
+            [1e20, 1, -1e20, 2, -2][:channels], device=torch_device, dtype=dtype
+        )[:, None, None]
+        .expand(channels, output_values, 1)
+        .contiguous()
+    )
+    weights = torch.ones(channels, 1, device=torch_device, dtype=dtype)
+    with torch.no_grad():
+        expected = reference(saved, weights)
+        actual = gradient_module.accumulate(saved, weights)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tmol/tests/score/common/whole_pose_gradients.pybind.cpp
+++ b/tmol/tests/score/common/whole_pose_gradients.pybind.cpp
@@ -1,0 +1,6 @@
+#include <torch/extension.h>
+#include <tmol/score/common/whole_pose_scoring.hh>
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("accumulate", &tmol::score::common::accumulate_whole_pose_gradients);
+}

--- a/tmol/tests/score/dunbrack/dihedral.pybind.cpp
+++ b/tmol/tests/score/dunbrack/dihedral.pybind.cpp
@@ -1,0 +1,25 @@
+#include <limits>
+#include <tuple>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <tmol/score/dunbrack/potentials/potentials.hh>
+
+template <typename Real>
+auto measure_default_dihedral(Real default_angle) {
+  Eigen::Vector4i atom_indices = Eigen::Vector4i::Constant(-1);
+  Eigen::Matrix<Real, 4, 3> derivatives = Eigen::Matrix<Real, 4, 3>::Constant(
+      std::numeric_limits<Real>::quiet_NaN());
+  Real angle = std::numeric_limits<Real>::quiet_NaN();
+  tmol::score::dunbrack::potentials::measure_dihedral_V_dV(
+      tmol::TensorAccessor<Eigen::Matrix<Real, 3, 1>, 1, tmol::Device::CPU>(),
+      atom_indices,
+      default_angle,
+      angle,
+      derivatives);
+  return std::make_tuple(angle, derivatives);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("measure_default_float", &measure_default_dihedral<float>);
+  m.def("measure_default_double", &measure_default_dihedral<double>);
+}

--- a/tmol/tests/score/dunbrack/test_default_dihedral.py
+++ b/tmol/tests/score/dunbrack/test_default_dihedral.py
@@ -1,0 +1,29 @@
+import numpy
+import pytest
+
+
+@pytest.fixture(scope="module")
+def dihedral_module():
+    from tmol._load_ext import load_module
+
+    return load_module(
+        __name__,
+        __file__,
+        "dihedral.pybind.cpp",
+        "tmol.tests.score.dunbrack._dihedral",
+    )
+
+
+@pytest.mark.parametrize("dtype", [numpy.float32, numpy.float64])
+@pytest.mark.parametrize("default_angle", [-numpy.pi / 3, 0.0, numpy.pi / 3])
+def test_default_dihedral_overwrites_derivative_scratch(
+    dihedral_module, dtype, default_angle
+):
+    measure = (
+        dihedral_module.measure_default_float
+        if dtype == numpy.float32
+        else dihedral_module.measure_default_double
+    )
+    angle, derivatives = measure(default_angle)
+    assert angle == dtype(default_angle)
+    numpy.testing.assert_array_equal(derivatives, numpy.zeros((4, 3), dtype=dtype))

--- a/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
+++ b/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 import torch
 
@@ -88,12 +90,20 @@ def test_score_only_tracked_input_uses_no_derivative_scratch(
         peak = torch.cuda.max_memory_allocated(torch_device) - before
         return result, peak
 
-    with torch.inference_mode() if inference else torch.no_grad():
-        # Warm both paths before measuring only the scoring allocations.
-        scorer(detached)
-        scorer(tracked)
-        expected, detached_peak = peak_allocation(detached)
-        actual, tracked_peak = peak_allocation(tracked)
+    # Isolate these allocations from cyclic garbage left by earlier tests.
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        with torch.inference_mode() if inference else torch.no_grad():
+            # Warm both paths before measuring only the scoring allocations.
+            scorer(detached)
+            scorer(tracked)
+            expected, detached_peak = peak_allocation(detached)
+            actual, tracked_peak = peak_allocation(tracked)
+    finally:
+        if gc_enabled:
+            gc.enable()
     torch.testing.assert_close(actual, expected)
     assert tracked.requires_grad
     assert not actual.requires_grad

--- a/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
+++ b/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
@@ -56,6 +56,7 @@ def test_score_only_matches_derivative_scoring(
     with torch.inference_mode() if inference else torch.no_grad():
         actual = scorer(coords)
     assert not actual.requires_grad
+    assert coords.requires_grad
     torch.testing.assert_close(actual, expected)
 
     # Switching modes must leave the derivative-enabled path usable.
@@ -63,6 +64,59 @@ def test_score_only_matches_derivative_scoring(
     (after_grad,) = torch.autograd.grad(after.sum(), coords)
     torch.testing.assert_close(after, expected)
     torch.testing.assert_close(after_grad, expected_grad)
+
+
+@pytest.mark.parametrize("inference", [False, True])
+def test_score_only_tracked_input_uses_no_derivative_scratch(
+    ubq_pdb, default_database, torch_device, inference
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA allocator statistics required")
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device)
+    scorer = TestDunbrackEnergyTerm.get_whole_pose_scorer(
+        pose, default_database, torch_device
+    )
+    tracked = pose.coords.detach().requires_grad_(True)
+    detached = tracked.detach()
+
+    def peak_allocation(coords):
+        torch.cuda.synchronize(torch_device)
+        before = torch.cuda.memory_allocated(torch_device)
+        torch.cuda.reset_peak_memory_stats(torch_device)
+        result = scorer(coords)
+        torch.cuda.synchronize(torch_device)
+        peak = torch.cuda.max_memory_allocated(torch_device) - before
+        return result, peak
+
+    with torch.inference_mode() if inference else torch.no_grad():
+        # Warm both paths before measuring only the scoring allocations.
+        scorer(detached)
+        scorer(tracked)
+        expected, detached_peak = peak_allocation(detached)
+        actual, tracked_peak = peak_allocation(tracked)
+    torch.testing.assert_close(actual, expected)
+    assert tracked.requires_grad
+    assert not actual.requires_grad
+    assert tracked_peak <= detached_peak
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_native_derivative_output_preserved_in_no_grad(
+    ubq_pdb, default_database, torch_device, dtype
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    scorer = TestDunbrackEnergyTerm.get_whole_pose_scorer(
+        pose, default_database, torch_device
+    )
+    coords = pose.coords.to(dtype).detach().requires_grad_(True)
+    flat = coords.flatten(start_dim=0, end_dim=-2)
+    tail = scorer._static_tail_for_coords(coords)
+    expected = scorer.term_score_poses(flat, *tail)
+    with torch.no_grad():
+        actual = scorer.term_score_poses(flat, *tail)
+    assert torch.count_nonzero(expected[1]) > 0
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        torch.testing.assert_close(actual_tensor, expected_tensor)
 
 
 class TestDunbrackEnergyTerm(EnergyTermTestBase):

--- a/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
+++ b/tmol/tests/score/dunbrack/test_dunbrack_energy_term.py
@@ -1,5 +1,8 @@
+import pytest
 import torch
 
+from tmol import pose_stack_from_pdb
+from tmol.pose import PoseStackBuilder
 from tmol.score.dunbrack import DunbrackEnergyTerm
 
 from tmol.tests.score.common import EnergyTermTestBase
@@ -30,6 +33,36 @@ def test_annotate_block_types(
     assert first_tensor.device == torch_device
     dunbrack_energy.setup_packed_block_types(pbt)
     assert first_tensor is pbt.dunbrack_packed_block_data[0]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("inference", [False, True])
+def test_score_only_matches_derivative_scoring(
+    ubq_pdb, default_database, torch_device, dtype, inference
+):
+    poses = [
+        pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=n) for n in (10, 15)
+    ]
+    pose = PoseStackBuilder.from_poses(poses, torch_device)
+    scorer = TestDunbrackEnergyTerm.get_whole_pose_scorer(
+        pose, default_database, torch_device
+    )
+    coords = pose.coords.to(dtype).detach().requires_grad_(True)
+    expected = scorer(coords)
+    (expected_grad,) = torch.autograd.grad(expected.sum(), coords)
+
+    # Score-only calls must tolerate absent derivative scratch, including
+    # padded blocks and residues whose backbone dihedrals are unresolved.
+    with torch.inference_mode() if inference else torch.no_grad():
+        actual = scorer(coords)
+    assert not actual.requires_grad
+    torch.testing.assert_close(actual, expected)
+
+    # Switching modes must leave the derivative-enabled path usable.
+    after = scorer(coords)
+    (after_grad,) = torch.autograd.grad(after.sum(), coords)
+    torch.testing.assert_close(after, expected)
+    torch.testing.assert_close(after_grad, expected_grad)
 
 
 class TestDunbrackEnergyTerm(EnergyTermTestBase):

--- a/tmol/tests/score/hbond/test_hbond_energy_term.py
+++ b/tmol/tests/score/hbond/test_hbond_energy_term.py
@@ -1,7 +1,9 @@
 import numpy
+import pytest
 import torch
 
 from tmol.io import pose_stack_from_pdb
+from tmol.pose import PoseStackBuilder
 from tmol.score.hbond import HBondEnergyTerm
 from tmol.score import (
     ScoreFunction,
@@ -129,3 +131,77 @@ class TestHBondEnergyTerm(EnergyTermTestBase):
             torch_device,
             resnums=resnums,
         )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_compact_specialization_preserves_subsets(
+    ubq_pdb, default_database, torch_device, dtype, monkeypatch
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA compact interaction specialization")
+    full = pose_stack_from_pdb(ubq_pdb, torch_device)
+    short = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    pose = PoseStackBuilder.from_poses([full, short] * 32, torch_device)
+    energy = HBondEnergyTerm(param_db=default_database, device=torch_device)
+    for bt in pose.packed_block_types.active_block_types:
+        energy.setup_block_type(bt)
+    energy.setup_packed_block_types(pose.packed_block_types)
+    energy.setup_poses(pose)
+    term = energy.render_whole_pose_scoring_module(pose)
+    coords = pose.coords.to(dtype).detach()
+    neighbors = term.build_compact_block_neighbors(coords, term.block_neighbor_cutoff)
+    assert pose.block_type_ind.numel() >= 4096
+    assert pose._hbond_allow_split_pairs
+    assert neighbors.numel() - 1 >= 32768
+
+    # Reversed custom subsets with identical entries and different spare
+    # capacity exercise split and combined kernels without rebuilding the list.
+    subset = neighbors[1 : int(neighbors[0]) + 1 : 4].flip(0).clone()
+    neighbors[0] = subset.numel()
+    neighbors[1 : subset.numel() + 1] = subset
+    compact = neighbors[: subset.numel() + 1].clone()
+    assert compact.numel() - 1 < 32768
+    weights = torch.linspace(-1, 2, 64, device=torch_device, dtype=dtype)[None, :]
+    tolerance = 1e-10 if dtype == torch.float64 else 1e-5
+    for gradient in (False, True):
+        coords.requires_grad_(gradient)
+        expected = term(coords, compact)
+        actual = term(coords, neighbors)
+        torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
+        # Low-level callers may omit the new optional dispatch hint.
+        import tmol.score.hbond.potentials as potentials
+
+        native = potentials.hbond_pose_scores
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                potentials, "hbond_pose_scores", lambda *args: native(*args[:-1])
+            )
+            legacy = term(coords, neighbors)
+        torch.testing.assert_close(legacy, expected, atol=tolerance, rtol=tolerance)
+        if gradient:
+            (expected_grad,) = torch.autograd.grad(expected, coords, weights)
+            (actual_grad,) = torch.autograd.grad(actual, coords, weights)
+            (legacy_grad,) = torch.autograd.grad(legacy, coords, weights)
+            torch.testing.assert_close(
+                legacy_grad, expected_grad, atol=tolerance, rtol=tolerance
+            )
+            torch.testing.assert_close(
+                actual_grad, expected_grad, atol=tolerance, rtol=tolerance
+            )
+
+
+@pytest.mark.parametrize("short_residues, expected_split", [(1, False), (40, True)])
+def test_specialization_uses_actual_residue_count(
+    ubq_pdb, default_database, torch_device, short_residues, expected_split
+):
+    full = pose_stack_from_pdb(ubq_pdb, torch_device)
+    short = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=short_residues)
+    pose = PoseStackBuilder.from_poses([full] + [short] * 63, torch_device)
+    energy = HBondEnergyTerm(param_db=default_database, device=torch_device)
+    for bt in pose.packed_block_types.active_block_types:
+        energy.setup_block_type(bt)
+    energy.setup_packed_block_types(pose.packed_block_types)
+    energy.setup_poses(pose)
+    assert pose._hbond_allow_split_pairs == (
+        expected_split and torch_device.type == "cuda"
+    )

--- a/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
+++ b/tmol/tests/score/lk_ball/test_lk_ball_energy_term.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy
 import torch
 
@@ -137,3 +138,22 @@ class TestLKBallEnergyTerm(EnergyTermTestBase):
             resnums=resnums,
             nondet_tol=1e-6,  # fd this is necessary here...
         )
+
+
+@pytest.mark.parametrize("short_residues, expected_split", [(1, False), (10, True)])
+def test_backward_specialization_uses_actual_residues(
+    ubq_pdb, default_database, torch_device, short_residues, expected_split
+):
+    from tmol.pose import PoseStackBuilder
+
+    full = pose_stack_from_pdb(ubq_pdb, torch_device)
+    short = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=short_residues)
+    pose = PoseStackBuilder.from_poses([full] + [short] * 63, torch_device)
+    energy = LKBallEnergyTerm(param_db=default_database, device=torch_device)
+    for bt in pose.packed_block_types.active_block_types:
+        energy.setup_block_type(bt)
+    energy.setup_packed_block_types(pose.packed_block_types)
+    energy.setup_poses(pose)
+    assert pose._lk_ball_allow_split_backward == (
+        expected_split and torch_device.type == "cuda"
+    )

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -80,6 +80,86 @@ def test_shared_block_neighbors_preserve_scores_and_gradients(ubq_pdb, torch_dev
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("weighted", [False, True])
+def test_fused_compact_specialization_preserves_subsets(
+    ubq_pdb, torch_device, dtype, weighted
+):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA compact interaction specialization")
+    single = pose_stack_from_pdb(ubq_pdb, torch_device)
+    short = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    pose = PoseStackBuilder.from_poses([single, short] * 32, torch_device)
+    scorer = _non_memoized_beta2016(torch_device).render_whole_pose_scoring_module(pose)
+    term = scorer._execution_modules[scorer._fused_ljlk_elec_module_index]
+    assert term.n_valid_rots == 32 * (single.max_n_blocks + short.max_n_blocks)
+    assert term.n_valid_rots < pose.block_type_ind.numel()
+    coords = pose.coords.to(dtype).detach().requires_grad_(True)
+    neighbors = scorer._build_shared_block_neighbors(coords)
+    assert neighbors.numel() - 1 >= 32768
+    subset = neighbors[1 : int(neighbors[0]) + 1 : 4].clone().flip(0)
+    neighbors[0] = subset.numel()
+    neighbors[1 : subset.numel() + 1] = subset
+    compact = neighbors[: subset.numel() + 1].clone()
+    assert compact.numel() - 1 < 32768
+    score_weights = torch.tensor(
+        [0.7, -0.2, 0.0, 1.3], device=torch_device, dtype=dtype
+    )
+    from tmol.score.ljlk.potentials import (
+        ljlk_elec_pose_scores,
+        ljlk_elec_weighted_pose_scores,
+    )
+
+    arguments = term._native_arguments(coords, neighbors)
+    operation = ljlk_elec_pose_scores
+    if weighted:
+        operation = ljlk_elec_weighted_pose_scores
+        arguments = (*arguments, score_weights)
+    for invalid_count in (-2, pose.block_type_ind.numel() + 1):
+        with pytest.raises(RuntimeError, match="valid rotamer count"):
+            operation(*arguments, invalid_count)
+
+    def evaluate(neighbor_list, gradient, legacy=False):
+        coords.requires_grad_(gradient)
+        with torch.set_grad_enabled(gradient):
+            if legacy:
+                arguments = term._native_arguments(coords, neighbor_list)
+                scores = (
+                    ljlk_elec_weighted_pose_scores(*arguments, score_weights)[0]
+                    if weighted
+                    else ljlk_elec_pose_scores(*arguments)[0]
+                )
+            else:
+                scores = (
+                    term.forward_weighted(coords, neighbor_list, score_weights)
+                    if weighted
+                    else term(coords, neighbor_list)
+                )
+            if not gradient:
+                return scores, None
+            upstream = torch.linspace(
+                -1, 2, scores.numel(), device=torch_device, dtype=dtype
+            ).reshape_as(scores)
+            (grad,) = torch.autograd.grad(scores, coords, upstream)
+            return scores, grad
+
+    tolerance = 1e-10 if dtype == torch.float64 else 1e-5
+    for gradient in (False, True):
+        expected, expected_grad = evaluate(compact, gradient)
+        actual, actual_grad = evaluate(neighbors, gradient)
+        legacy, legacy_grad = evaluate(neighbors, gradient, legacy=True)
+        torch.testing.assert_close(legacy, expected, atol=tolerance, rtol=tolerance)
+        if gradient:
+            torch.testing.assert_close(
+                legacy_grad, expected_grad, atol=tolerance, rtol=tolerance
+            )
+        torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
+        if gradient:
+            torch.testing.assert_close(
+                actual_grad, expected_grad, atol=tolerance, rtol=tolerance
+            )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 @pytest.mark.parametrize("reverse_neighbors", [False, True])
 @pytest.mark.parametrize("strided_neighbors", [False, True])
 def test_cpu_compact_neighbors_preserve_pose_accumulation_order(

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -122,6 +122,35 @@ def test_cpu_compact_neighbors_preserve_pose_accumulation_order(
     torch.testing.assert_close(parallel, serial, rtol=0, atol=0)
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_lk_ball_compact_specialization_preserves_subsets(ubq_pdb, torch_device, dtype):
+    if torch_device.type != "cuda":
+        pytest.skip("CUDA compact interaction specialization")
+    single_pose = pose_stack_from_pdb(ubq_pdb, torch_device)
+    pose = PoseStackBuilder.from_poses([single_pose] * 16, torch_device)
+    scorer = _non_memoized_beta2016(torch_device).render_whole_pose_scoring_module(pose)
+    term = next(t for t in scorer.term_modules if t.classname == "LKBall")
+    coords = pose.coords.to(dtype).detach().requires_grad_(True)
+    neighbors = scorer._build_shared_block_neighbors(coords)
+    assert neighbors.numel() - 1 >= 32768
+
+    # Identical custom subsets with different spare capacity exercise both
+    # dispatch paths, without permitting either path to rebuild the list.
+    subset = neighbors[1 : int(neighbors[0]) + 1 : 4].clone()
+    neighbors[0] = subset.numel()
+    neighbors[1 : subset.numel() + 1] = subset
+    compact = neighbors[: subset.numel() + 1].clone()
+    assert compact.numel() - 1 < 32768
+    weights = torch.linspace(-1, 2, 64, device=torch_device, dtype=dtype).reshape(4, 16)
+
+    expected = term(coords, compact)
+    (expected_grad,) = torch.autograd.grad(expected, coords, weights)
+    actual = term(coords, neighbors)
+    (actual_grad,) = torch.autograd.grad(actual, coords, weights)
+    torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(actual_grad, expected_grad, atol=1e-5, rtol=1e-5)
+
+
 def test_shared_block_neighbors_follow_active_terms(
     ubq_pdb, default_database, torch_device
 ):

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -203,20 +203,24 @@ def test_cpu_compact_neighbors_preserve_pose_accumulation_order(
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def test_lk_ball_compact_specialization_preserves_subsets(ubq_pdb, torch_device, dtype):
+def test_lk_ball_compact_specialization_preserves_subsets(
+    ubq_pdb, torch_device, dtype, monkeypatch
+):
     if torch_device.type != "cuda":
         pytest.skip("CUDA compact interaction specialization")
     single_pose = pose_stack_from_pdb(ubq_pdb, torch_device)
-    pose = PoseStackBuilder.from_poses([single_pose] * 16, torch_device)
+    short_pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
+    pose = PoseStackBuilder.from_poses([single_pose, short_pose] * 8, torch_device)
     scorer = _non_memoized_beta2016(torch_device).render_whole_pose_scoring_module(pose)
     term = next(t for t in scorer.term_modules if t.classname == "LKBall")
     coords = pose.coords.to(dtype).detach().requires_grad_(True)
     neighbors = scorer._build_shared_block_neighbors(coords)
     assert neighbors.numel() - 1 >= 32768
+    assert pose._lk_ball_allow_split_backward
 
     # Identical custom subsets with different spare capacity exercise both
     # dispatch paths, without permitting either path to rebuild the list.
-    subset = neighbors[1 : int(neighbors[0]) + 1 : 4].clone()
+    subset = neighbors[1 : int(neighbors[0]) + 1 : 4].flip(0).clone()
     neighbors[0] = subset.numel()
     neighbors[1 : subset.numel() + 1] = subset
     compact = neighbors[: subset.numel() + 1].clone()
@@ -227,8 +231,25 @@ def test_lk_ball_compact_specialization_preserves_subsets(ubq_pdb, torch_device,
     (expected_grad,) = torch.autograd.grad(expected, coords, weights)
     actual = term(coords, neighbors)
     (actual_grad,) = torch.autograd.grad(actual, coords, weights)
-    torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
-    torch.testing.assert_close(actual_grad, expected_grad, atol=1e-5, rtol=1e-5)
+    tolerance = 1e-10 if dtype == torch.float64 else 1e-5
+    torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
+    torch.testing.assert_close(
+        actual_grad, expected_grad, atol=tolerance, rtol=tolerance
+    )
+
+    import tmol.score.lk_ball.potentials as potentials
+
+    native = potentials.lk_ball_pose_score
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            potentials, "lk_ball_pose_score", lambda *args: native(*args[:-1])
+        )
+        legacy = term(coords, neighbors)
+    (legacy_grad,) = torch.autograd.grad(legacy, coords, weights)
+    torch.testing.assert_close(legacy, expected, atol=tolerance, rtol=tolerance)
+    torch.testing.assert_close(
+        legacy_grad, expected_grad, atol=tolerance, rtol=tolerance
+    )
 
 
 def test_shared_block_neighbors_follow_active_terms(

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -2,6 +2,7 @@ import torch
 import numpy
 import os
 import threading
+import weakref
 import attr
 import pytest
 
@@ -112,7 +113,9 @@ def test_fused_ljlk_elec_preserves_term_lanes_weights_and_gradients(
 ):
     pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
 
-    fused = beta2016_score_function(torch_device).render_whole_pose_scoring_module(pose)
+    # This test edits the rendered weight buffer, which shares storage with
+    # its score function. Keep those edits out of the memoized beta2016 object.
+    fused = _non_memoized_beta2016(torch_device).render_whole_pose_scoring_module(pose)
 
     assert [term.classname for term in fused.term_modules][:2] == ["LJLK", "Elec"]
     assert fused._execution_modules[0].classname == "LJLK+Elec"
@@ -545,6 +548,33 @@ def test_packed_block_annotation_reuse_survives_option_changes(
     assert second_pose.packed_block_types.ref_weights is overridden_weights
 
 
+@pytest.mark.parametrize("score_type", [ScoreType.ref, ScoreType.fa_ljrep])
+def test_replacing_options_restores_default_scores(
+    ubq_pdb, default_database, torch_device, score_type
+):
+    pose = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=4)
+    score_function = ScoreFunction(default_database, torch_device)
+    score_function.set_weight(score_type, 1.0)
+
+    def score():
+        scorer = score_function.render_whole_pose_scoring_module(pose)
+        return scorer(pose.coords).detach().clone()
+
+    original = score()
+    override = {
+        name: weight + 123.0
+        for name, weight in default_database.scoring.ref.weights.items()
+    }
+    score_function.set_options({"ref_weights": override, "soft_rep": True})
+    assert not torch.allclose(score(), original)
+
+    # set_options replaces the entire dictionary, including options already
+    # applied to constructed terms and cached packed-block annotations.
+    score_function.set_options({})
+    torch.testing.assert_close(score(), original)
+    torch.testing.assert_close(score(), original)
+
+
 def test_no_grad_scoring_detaches_coordinates():
     class RecordingTerm(torch.nn.Module):
         def forward(self, coords):
@@ -783,6 +813,37 @@ def test_rotamer_scorer_combines_identical_sparse_layouts(
     torch.testing.assert_close(coords.grad, torch.tensor(61.0, device=torch_device))
 
 
+def test_sequential_rotamer_scoring_releases_consumed_scores(torch_device, monkeypatch):
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 1)
+    score_refs = []
+    indices = torch.tensor(
+        [[0, 0], [0, 1], [1, 0]], device=torch_device, dtype=torch.int32
+    )
+
+    class SparseTerm(torch.nn.Module):
+        n_poses = 1
+        n_rots = 2
+
+        def __init__(self, n_score_types):
+            super().__init__()
+            self.n_score_types = n_score_types
+
+        def forward(self, coords):
+            # A raw multi-lane table must be released before allocating the
+            # next one; only its weighted values and indices remain live.
+            assert all(ref() is None for ref in score_refs)
+            scores = coords.new_ones((self.n_score_types, 2))
+            score_refs.append(weakref.ref(scores))
+            return scores, indices
+
+    scorer = RotamerScoringModule(
+        torch.ones(8, device=torch_device), [SparseTerm(n) for n in (3, 1, 4)]
+    )
+    _, values = scorer.forward_sparse_entries(torch.ones((), device=torch_device))
+    assert all(ref() is None for ref in score_refs)
+    torch.testing.assert_close(values, torch.full_like(values, 8.0))
+
+
 def test_rotamer_scorer_raw_entries_keep_int32_and_uncoalesced_duplicates() -> None:
     class SparseTerm(torch.nn.Module):
         n_poses = 1
@@ -929,7 +990,8 @@ def test_cuda_graphed_protein_score_matches_eager(ubq_pdb, torch_device):
         pytest.skip("CUDA graph test")
 
     pose_stack = pose_stack_from_pdb(ubq_pdb, torch_device, residue_end=10)
-    sfxn = beta2016_score_function(torch_device)
+    # Reweighting the graph below must not alter later tests' beta2016 scores.
+    sfxn = _non_memoized_beta2016(torch_device)
     eager = sfxn.render_whole_pose_scoring_module(pose_stack)
 
     eager_coords = pose_stack.coords.detach().clone().requires_grad_(True)

--- a/tmol/tests/score/test_score_function.py
+++ b/tmol/tests/score/test_score_function.py
@@ -79,6 +79,49 @@ def test_shared_block_neighbors_preserve_scores_and_gradients(ubq_pdb, torch_dev
     torch.testing.assert_close(shared_grad, legacy_grad, atol=1e-5, rtol=1e-5)
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("reverse_neighbors", [False, True])
+@pytest.mark.parametrize("strided_neighbors", [False, True])
+def test_cpu_compact_neighbors_preserve_pose_accumulation_order(
+    ubq_pdb, request, dtype, reverse_neighbors, strided_neighbors
+):
+    device = torch.device("cpu")
+    short = pose_stack_from_pdb(ubq_pdb, device, residue_end=3)
+    longer = pose_stack_from_pdb(ubq_pdb, device, residue_end=5)
+    pose = PoseStackBuilder.from_poses([short, longer, longer, short], device)
+    scorer = _non_memoized_beta2016(device).render_whole_pose_scoring_module(pose)
+    original_threads = torch.get_num_threads()
+    request.addfinalizer(lambda: torch.set_num_threads(original_threads))
+
+    def evaluate(threads):
+        torch.set_num_threads(threads)
+        coords = pose.coords.to(dtype=dtype).detach().requires_grad_(True)
+        neighbors = scorer._build_shared_block_neighbors(coords)
+        if reverse_neighbors:
+            count = int(neighbors[0])
+            neighbors[1 : count + 1] = neighbors[1 : count + 1].flip(0)
+        if strided_neighbors:
+            storage = neighbors.new_empty(neighbors.numel() * 2)
+            storage[::2] = neighbors
+            neighbors = storage[::2]
+        scores = torch.cat(
+            [
+                term(coords, neighbors)
+                for term in scorer.term_modules
+                if getattr(term, "block_neighbor_cutoff", None) is not None
+            ]
+        )
+        # Distinct signs and zero upstream weights expose writes to another
+        # pose's gradient, including the padded poses at either end.
+        upstream = torch.tensor([0.5, -2.0, 0.0, 3.0], dtype=dtype).expand_as(scores)
+        (gradient,) = torch.autograd.grad(scores, coords, upstream)
+        return scores, gradient
+
+    serial = evaluate(1)
+    parallel = evaluate(4)
+    torch.testing.assert_close(parallel, serial, rtol=0, atol=0)
+
+
 def test_shared_block_neighbors_follow_active_terms(
     ubq_pdb, default_database, torch_device
 ):

--- a/tmol/tests/types/test_functional.py
+++ b/tmol/tests/types/test_functional.py
@@ -1,3 +1,6 @@
+import gc
+import weakref
+
 import numpy
 import pytest
 
@@ -9,6 +12,108 @@ from tmol.types import (
     convert_args,
     NDArray,
 )
+from tmol.types._validators import get_validator
+from tmol.types._converters import get_converter
+
+
+@pytest.mark.parametrize("first_branch", [NDArray[int][:], NDArray[float][:, 3]])
+@pytest.mark.parametrize("nested", [False, True])
+def test_successful_union_releases_value_and_caller(first_branch, nested):
+    annotation = Union[first_branch, NDArray[float][:]]
+    if nested:
+        annotation = Union[List[int], List[annotation]]
+
+    @validate_args
+    def consume(value: annotation):
+        pass
+
+    def invoke():
+        value = numpy.arange(32, dtype=float)
+        value_ref = weakref.ref(value)
+        consume([value] if nested else value)
+        return value_ref
+
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        value_ref = invoke()
+        assert value_ref() is None
+    finally:
+        if gc_enabled:
+            gc.enable()
+
+
+def test_rejected_union_preserves_last_error_cause():
+    annotation = Union[int, str]
+    with pytest.raises(TypeError) as error:
+        get_validator(annotation)(1.5)
+    assert str(error.value) == f"expected {annotation}, received <class 'float'>"
+    cause = error.value.__cause__
+    assert isinstance(cause, TypeError)
+    assert str(cause) == "expected <class 'str'>, received <class 'float'>"
+    assert cause.__traceback__ is not None
+
+
+def test_successful_union_conversion_releases_original_value():
+    class Convertible:
+        def __int__(self):
+            raise ValueError("Only floating-point conversion is supported")
+
+        def __float__(self):
+            return 1.25
+
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        value = Convertible()
+        value_ref = weakref.ref(value)
+        converted = get_converter(Union[int, float])(value)
+        del value
+        assert converted == 1.25
+        assert value_ref() is None
+    finally:
+        if gc_enabled:
+            gc.enable()
+
+
+def test_rejected_union_conversion_preserves_error_message():
+    annotation = Union[int, float]
+    value = 1j
+    with pytest.raises(TypeError) as error:
+        get_converter(annotation)(value)
+    assert str(error.value) == (
+        f"Unable to convert to any union subtype: {annotation} value: {value!r}"
+    )
+    assert error.value.__cause__ is None
+
+
+@pytest.mark.parametrize("factory", [get_validator, get_converter])
+def test_rejected_union_releases_value_after_error_is_handled(factory):
+    class Value:
+        pass
+
+    def invoke():
+        value = Value()
+        value_ref = weakref.ref(value)
+        try:
+            factory(Union[int, float])(value)
+        except TypeError:
+            pass
+        else:
+            pytest.fail("The value must be rejected by both union branches")
+        return value_ref
+
+    gc.collect()
+    gc_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        value_ref = invoke()
+        assert value_ref() is None
+    finally:
+        if gc_enabled:
+            gc.enable()
 
 
 def f(*args, **kwargs):

--- a/tmol/tests/utility/tensor/test_torch_context.py
+++ b/tmol/tests/utility/tensor/test_torch_context.py
@@ -1,0 +1,75 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def context_module():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA context allocator")
+    from tmol._load_ext import load_module
+
+    return load_module(
+        __name__,
+        __file__,
+        ["torch_context.pybind.cpp", "torch_context.cuda.cu"],
+        "tmol.tests.utility.tensor._torch_context",
+    )
+
+
+def test_cuda_context_accounts_for_temporary_storage(context_module):
+    values = torch.arange(1 << 20, dtype=torch.float32, device="cuda")
+    context_module.copy(values)
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    before = torch.cuda.memory_allocated()
+    result = context_module.copy(values)
+    peak = torch.cuda.max_memory_allocated() - before
+    torch.testing.assert_close(result, values, atol=0, rtol=0)
+    assert peak >= 2 * values.numel() * values.element_size()
+    assert context_module.copy(values[:0]).numel() == 0
+
+
+def test_cuda_context_capture_preserves_stream_order(context_module):
+    values = torch.arange(1024, dtype=torch.int64, device="cuda")
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        context_module.copy(values)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        result = context_module.copy(values)
+    for value in (7, -13, 29):
+        values.fill_(value)
+        graph.replay()
+        torch.testing.assert_close(result, values, atol=0, rtol=0)
+
+
+def test_cuda_context_concurrent_streams(context_module):
+    streams = [torch.cuda.Stream() for _ in range(8)]
+
+    def run(index):
+        stream = streams[index]
+        with torch.cuda.stream(stream):
+            values = torch.full((4096,), index, dtype=torch.int32, device="cuda")
+            for _ in range(8):
+                result = context_module.copy(values)
+        stream.synchronize()
+        torch.testing.assert_close(result, values, atol=0, rtol=0)
+
+    with ThreadPoolExecutor(max_workers=len(streams)) as pool:
+        list(pool.map(run, range(len(streams))))
+
+
+def test_cuda_context_preserves_caller_device(context_module):
+    if torch.cuda.device_count() < 2:
+        pytest.skip("Two CUDA devices required")
+    original_device = torch.cuda.current_device()
+    for target_device in (0, 1):
+        values = torch.arange(1024, device=f"cuda:{target_device}", dtype=torch.int32)
+        result = context_module.copy(values)
+        assert result.device == values.device
+        assert torch.cuda.current_device() == original_device
+        torch.testing.assert_close(result, values, atol=0, rtol=0)

--- a/tmol/tests/utility/tensor/torch_context.cuda.cu
+++ b/tmol/tests/utility/tensor/torch_context.cuda.cu
@@ -1,0 +1,27 @@
+#include <ATen/ATen.h>
+#include <c10/cuda/CUDAException.h>
+#include <tmol/utility/tensor/torch_context.hh>
+
+at::Tensor copy_via_context(at::Tensor const& input) {
+  TORCH_CHECK(input.is_cuda() && input.is_contiguous());
+  c10::cuda::CUDAGuard guard(input.device());
+  static tmol::ContextManager manager;
+  auto context = tmol::current_context(manager);
+  mgpu::mem_t<unsigned char> scratch(input.nbytes(), *context);
+  auto output = at::empty_like(input);
+  if (input.nbytes() != 0) {
+    C10_CUDA_CHECK(cudaMemcpyAsync(
+        scratch.data(),
+        input.const_data_ptr(),
+        input.nbytes(),
+        cudaMemcpyDeviceToDevice,
+        context->stream()));
+    C10_CUDA_CHECK(cudaMemcpyAsync(
+        output.mutable_data_ptr(),
+        scratch.data(),
+        input.nbytes(),
+        cudaMemcpyDeviceToDevice,
+        context->stream()));
+  }
+  return output;
+}

--- a/tmol/tests/utility/tensor/torch_context.pybind.cpp
+++ b/tmol/tests/utility/tensor/torch_context.pybind.cpp
@@ -1,0 +1,10 @@
+#include <torch/extension.h>
+
+at::Tensor copy_via_context(at::Tensor const& input);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "copy",
+      &copy_via_context,
+      pybind11::call_guard<pybind11::gil_scoped_release>());
+}

--- a/tmol/types/_converters.py
+++ b/tmol/types/_converters.py
@@ -46,12 +46,11 @@ def union_convert(union_annotation, value):
         except (TypeError, ValueError):
             pass
 
-    errors = []
     for subtype in union_annotation.__args__:
         try:
             return get_converter(subtype)(value)
-        except (TypeError, ValueError) as ex:
-            errors.append(ex)
+        except (TypeError, ValueError):
+            pass
 
     raise TypeError(
         f"Unable to convert to any union subtype: {union_annotation} value: {value!r}"

--- a/tmol/types/_validators.py
+++ b/tmol/types/_validators.py
@@ -92,17 +92,21 @@ def validate_union(union, value):
     assert union.__args__
 
     last_ex = None
+    try:
+        for ut in union.__args__:
+            validator = get_validator(ut)
 
-    for ut in union.__args__:
-        validator = get_validator(ut)
+            try:
+                validator(value)
+                return
+            except (ValueError, TypeError) as ex:
+                last_ex = ex
 
-        try:
-            validator(value)
-            return
-        except (ValueError, TypeError) as ex:
-            last_ex = ex
-
-    raise TypeError(f"expected {union}, received {type(value)!r}") from last_ex
+        raise TypeError(f"expected {union}, received {type(value)!r}") from last_ex
+    finally:
+        # The last branch's traceback points back to this frame. Drop this
+        # local reference on every exit; a raised error still owns its cause.
+        last_ex = None
 
 
 @toolz.curry

--- a/tmol/utility/tensor/context_manager.hh
+++ b/tmol/utility/tensor/context_manager.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <mutex>
 

--- a/tmol/utility/tensor/torch_context.hh
+++ b/tmol/utility/tensor/torch_context.hh
@@ -2,6 +2,8 @@
 
 #include <moderngpu/context.hxx>
 #include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <tmol/utility/tensor/context_manager.hh>
 
 #include <memory>
@@ -9,12 +11,33 @@
 
 namespace tmol {
 
-struct ContextDeleter {
-  inline void operator()(void* ctxt) {
-    mgpu::standard_context_t* std_ctxt =
-        static_cast<mgpu::standard_context_t*>(ctxt);
-    delete std_ctxt;
+// Route temporary device storage through Torch's stream-aware allocator.
+// Host-pinned allocations retain ModernGPU's allocator.
+class TorchCudaContext : public mgpu::standard_context_t {
+ public:
+  TorchCudaContext(cudaStream_t stream, c10::DeviceIndex device)
+      : mgpu::standard_context_t(false, stream), device_(device) {}
+
+  void* alloc(size_t size, mgpu::memory_space_t space) override {
+    if (space != mgpu::memory_space_device) {
+      return mgpu::standard_context_t::alloc(size, space);
+    }
+    if (size == 0) return nullptr;
+    c10::cuda::CUDAGuard guard(device_);
+    return c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(
+        size, stream());
   }
+
+  void free(void* pointer, mgpu::memory_space_t space) override {
+    if (space != mgpu::memory_space_device) {
+      mgpu::standard_context_t::free(pointer, space);
+    } else if (pointer != nullptr) {
+      c10::cuda::CUDACachingAllocator::raw_delete(pointer);
+    }
+  }
+
+ private:
+  c10::DeviceIndex device_;
 };
 
 // Get a pointer to an mgpu::standard_context_t that uses the
@@ -29,16 +52,11 @@ inline std::shared_ptr<mgpu::standard_context_t> current_context(
   std::pair<int, void*> device_index_and_stream_address(
       std::make_pair(device_index, cuda_stream_address));
 
-  // We lock the mutex because writing to a std::map changes it.
-  // This code is overly safe; a more complex strategy of obtaining
-  // read locks for the general case and write locks for the specific
-  // instances when new context objects must be allocated and stored
-  // in the manager could be created, but such cases can lead to
-  // deadlock if not done carefully, and our use case is basically
-  // that a single python thread is calling the C++
-  std::lock_guard(mgr.get_mutex());
+  // Hold the mutex through lookup and insertion: calls on different Python
+  // threads may create contexts for different streams concurrently.
+  std::lock_guard lock(mgr.get_mutex());
 
-  // We are will accumulate new standard_context_t objects over the lifetime
+  // We accumulate new standard_context_t objects over the lifetime
   // of execution and none of these objects will be deallocated until
   // the program ends. That means that repeated allocation of cuda stream
   // objects would be problematic. Torch does not do that: it allocates
@@ -61,9 +79,9 @@ inline std::shared_ptr<mgpu::standard_context_t> current_context(
   // Args to standar_context_t ctor:
   // 1. false: do not print the device properties to std::cout
   // 2. the cuda stream we're sending this to
-  ContextDeleter dstor_functor_instance;
-  std::shared_ptr<mgpu::standard_context_t> new_context(
-      new mgpu::standard_context_t(false, cuda_stream), dstor_functor_instance);
+  // The base destructor is nonvirtual; retain the concrete shared deleter.
+  std::shared_ptr<mgpu::standard_context_t> new_context =
+      std::make_shared<TorchCudaContext>(cuda_stream, device_index);
   mgr.set(
       device_index_and_stream_address,
       std::static_pointer_cast<void>(new_context));


### PR DESCRIPTION
Superseded by **#507**, the single consolidated performance PR against `master`. All commits from this PR are included in its validated head `56a061161`. This PR is closed without merging; its branch is preserved. Frank's generalized-chemistry PR #503 remains separate.

<details>
<summary>Archived description and measurements from this earlier revision</summary>

Repeated graph-captured scoring and discarded validation errors can retain tensors and caller frames until cyclic garbage collection runs. This change gives scoring captures explicit ownership and releases discarded validation errors promptly. It also removes an unnecessary L-BFGS matrix product, reuses accepted line-search coordinates and existing matrix views, and simplifies CUDA launch inheritance and annealer quench indexing. Relative to #504, production code grows by 44 lines overall; the optimizer is nine lines shorter.

Performance stack: #504 → #506 → #507, all targeting `master`. The workflow percentages below describe elapsed-time changes against #504; #507 reports its own increment over this PR. Component results and different windows are not additive, and there is no measured cumulative speedup against master. GPU runtime results are from H200; architecture compilation coverage is separate from runtime performance.

This branch builds on #504 and should be reviewed and merged after that base. The first-window branch remains unchanged. [Incremental diff after #504](https://github.com/kierandidi/tmol/compare/d1e14d4028911a34ef17937c51d2a3faa3b2613a...6586b75074a96d760d33f42cc21bc209005ffa81).

Against first-window d1e14d402, four reversed H200 rounds (ubiquitin, batch 16; 24 samples per arm and workflow) measured minimization 2.44% faster and FastRelax 1.00% faster; every round was faster. After six FastRelax runs, retained allocation fell from about 269 MB to zero and extra peak allocation fell from 838–840 MB to 794–796 MB. These are complete-workflow measurements. Pure graph replay has a small Python overhead; the ownership change is a memory-lifetime fix. Two reversed CPU rounds (ubiquitin, batch 4, four physical threads; eight samples per arm and workflow) measured minimization 1.13% slower and FastRelax 0.57% faster, with consistent round directions; all 48 saved output tensors were bitwise identical.

Compact L-BFGS keeps float64 arithmetic and the existing differentiable and broadcast paths, while eliminating explicit Y-transpose-Y through an equivalent vector formulation. Floating-point association changes: fixed small float32 trajectories remain exact, float64 trajectory differences are below 4.8e-11, and a wider float32 case differs by one ULP in one final derived-direction element with identical coordinates and losses. An independent high-precision calculation selects the new direction value as correctly rounded. No existing checker or test tolerance was relaxed.

Validation: final full suites passed on PyTorch 2.13 and 2.14 (3,174 tests each); 180 CPU score tensors are exact and 90 CUDA float64 tensors pass the existing 1e-10 comparison on each runtime. All 464 approved compact optimizer reference tensors match exactly. The actual Python implementation also passed 106 contract tests on minimum PyTorch 2.5. The first final 2.14 run hit an unchanged Hypothesis slow-input-generation health check; its reported seed and the subsequent complete suite passed with no test suppression.

Native validation includes fresh CPU/CUDA JIT checks and annealer sanitizers. An SM80-only core passed 1,219 CUDA tests through forward PTX on H200; accepted pack code compiled for SM100/103/120/121. No new GPU-name dispatch or precision reduction is introduced. Blackwell runtime performance has not been measured.


</details>
